### PR TITLE
fix: declare repository for npm provenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "1.0.12",
   "private": false,
   "description": "Blade AI Agent SDK",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/echoVic/blade-agent-sdk"
+  },
   "type": "module",
   "engines": {
     "node": ">=22.14.0"

--- a/scripts/__tests__/semantic-release-config.test.ts
+++ b/scripts/__tests__/semantic-release-config.test.ts
@@ -27,6 +27,17 @@ describe('semantic-release configuration', () => {
   });
 });
 
+describe('package provenance metadata', () => {
+  it('declares the GitHub repository URL expected by npm provenance', () => {
+    const packageJson = JSON.parse(readFileSync(resolve('package.json'), 'utf8'));
+
+    expect(packageJson.repository).toEqual({
+      type: 'git',
+      url: 'https://github.com/echoVic/blade-agent-sdk',
+    });
+  });
+});
+
 describe('release workflow', () => {
   it('runs after pushes to main and grants the release permissions', () => {
     const workflow = parse(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added repository metadata to the package information, including the project’s Git source and URL.
* **Tests**
  * Added coverage to verify the package repository metadata is present and correctly formatted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->