### PR TITLE
fix: preserve tool results across session resume

### DIFF
--- a/src/agent/AgentLoop.ts
+++ b/src/agent/AgentLoop.ts
@@ -434,21 +434,6 @@ export async function* agentLoop(
       };
     }
 
-    // 写入 assistant 消息
-    convState.append({
-      role: 'assistant',
-      content: turnResult.content || '',
-      reasoningContent: turnResult.reasoningContent,
-      tool_calls: turnResult.toolCalls,
-    });
-
-    await messageHooks?.onAssistant?.({
-      content: turnResult.content || '',
-      reasoningContent: turnResult.reasoningContent,
-      toolCalls: turnResult.toolCalls,
-      turn: turnsCount,
-    });
-
     // 工具执行：流式已执行 or 非流式在此执行
     let executionResults = streamingExecutionResults;
 
@@ -487,31 +472,48 @@ export async function* agentLoop(
       });
     }
 
+    const resultByToolCallId = new Map(
+      executionResults.map((executionResult) => [executionResult.toolCall.id, executionResult]),
+    );
+    const orderedExecutionResults = turnResult.toolCalls.flatMap((toolCall) => {
+      const executionResult = resultByToolCallId.get(toolCall.id);
+      return executionResult ? [executionResult] : [];
+    });
+
+    if (epoch && !epoch.isValid) {
+      for (const { toolCall, toolUseUuid } of orderedExecutionResults) {
+        await toolHooks?.afterExecEpochDiscard?.({
+          toolCall,
+          toolUseUuid,
+          reason: 'execution epoch invalidated',
+        });
+      }
+      continue;
+    }
+    if (orderedExecutionResults.length !== turnResult.toolCalls.length) {
+      throw new Error('Tool execution completed without results for every declared tool call');
+    }
+
+    convState.append({
+      role: 'assistant',
+      content: turnResult.content || '',
+      reasoningContent: turnResult.reasoningContent,
+      tool_calls: turnResult.toolCalls,
+    });
+
+    await messageHooks?.onAssistant?.({
+      content: turnResult.content || '',
+      reasoningContent: turnResult.reasoningContent,
+      toolCalls: turnResult.toolCalls,
+      turn: turnsCount,
+    });
+
+    let exitResult: typeof orderedExecutionResults[number] | undefined;
     // 处理结果
-    for (const { toolCall, result, toolUseUuid } of executionResults) {
-      if (epoch && !epoch.isValid) break;
-
+    for (const { toolCall, result, toolUseUuid } of orderedExecutionResults) {
       recordToolResult(result);
-
-      if (result.metadata?.shouldExitLoop) {
-        const finalMessage =
-          typeof result.llmContent === 'string' ? result.llmContent : '循环已退出';
-        if (!streamingExecutionResults) {
-          yield { type: 'tool_result', toolCall, result };
-        }
-        yield { type: 'turn_end', turn: turnsCount, hasToolCalls: true };
-        yield { type: 'agent_end' };
-        return {
-          success: result.success,
-          finalMessage,
-          metadata: {
-            turnsCount,
-            toolCallsCount: totalToolCalls,
-            duration: Date.now() - startTime,
-            shouldExitLoop: true,
-            targetMode: result.metadata?.targetMode as PermissionMode | undefined,
-          },
-        };
+      if (result.metadata?.shouldExitLoop && !exitResult) {
+        exitResult = { toolCall, result, toolUseUuid };
       }
 
       if (!streamingExecutionResults) {
@@ -537,24 +539,44 @@ export async function* agentLoop(
           : JSON.stringify(toolResultContent),
       });
 
-      if (result.newMessages && result.newMessages.length > 0) {
-        convState.append(
-          ...result.newMessages.map((message) => ({
-            ...message,
-            ...(message.role === 'system'
-              ? {
-                  metadata: {
-                    ...(isRecord(message.metadata) ? message.metadata : {}),
-                    _systemSource: 'tool_injection' as const,
-                  },
-                }
-              : {}),
-          })),
-        );
-      }
+    }
+
+    for (const { result } of orderedExecutionResults) {
+      if (!result.newMessages?.length) continue;
+      convState.append(
+        ...result.newMessages.map((message) => ({
+          ...message,
+          ...(message.role === 'system'
+            ? {
+                metadata: {
+                  ...(isRecord(message.metadata) ? message.metadata : {}),
+                  _systemSource: 'tool_injection' as const,
+                },
+              }
+            : {}),
+        })),
+      );
     }
 
     yield { type: 'turn_end', turn: turnsCount, hasToolCalls: true };
+
+    if (exitResult) {
+      const finalMessage = typeof exitResult.result.llmContent === 'string'
+        ? exitResult.result.llmContent
+        : '循环已退出';
+      yield { type: 'agent_end' };
+      return {
+        success: exitResult.result.success,
+        finalMessage,
+        metadata: {
+          turnsCount,
+          toolCallsCount: totalToolCalls,
+          duration: Date.now() - startTime,
+          shouldExitLoop: true,
+          targetMode: exitResult.result.metadata?.targetMode as PermissionMode | undefined,
+        },
+      };
+    }
 
     if (signal?.aborted) {
       yield { type: 'agent_end' };

--- a/src/agent/AgentLoop.ts
+++ b/src/agent/AgentLoop.ts
@@ -491,7 +491,12 @@ export async function* agentLoop(
       continue;
     }
     if (orderedExecutionResults.length !== turnResult.toolCalls.length) {
-      throw new Error('Tool execution completed without results for every declared tool call');
+      const missing = turnResult.toolCalls
+        .filter((toolCall) => !resultByToolCallId.has(toolCall.id))
+        .map((toolCall) => `${toolCall.function.name}(${toolCall.id})`);
+      throw new Error(
+        `Tool execution completed without results for every declared tool call: ${missing.join(', ')}`,
+      );
     }
 
     convState.append({

--- a/src/agent/LoopHookBuilder.ts
+++ b/src/agent/LoopHookBuilder.ts
@@ -15,7 +15,9 @@ import type { ExecutionPipeline } from '../tools/execution/ExecutionPipeline.js'
 import {
   normalizeToolEffects,
   type ToolEffect,
+  type ToolResult,
 } from '../tools/types/index.js';
+import type { FunctionToolCall } from './loop/types.js';
 import type { SessionId } from '../types/branded.js';
 import type { JsonValue } from '../types/common.js';
 import type { AgentLoopConfig, AgentLoopHooks } from './AgentLoop.js';
@@ -87,6 +89,58 @@ export function buildLoopConfig(deps: LoopHookBuilderDeps): AgentLoopConfig {
   } = deps;
 
   let progressToolUseCount = 0;
+  let assistantToolCallIds: string[] = [];
+  const pendingToolResults = new Map<string, {
+    toolCall: FunctionToolCall;
+    result: ToolResult;
+    injectedMessages: Message[];
+    subagentRef?: {
+      subagentSessionId: string;
+      subagentType: string;
+      subagentStatus: 'running' | 'completed' | 'failed' | 'cancelled';
+      subagentSummary?: string;
+    };
+  }>();
+
+  const persistToolResultsIfReady = async (): Promise<void> => {
+    if (!assistantToolCallIds.length
+      || assistantToolCallIds.some((toolCallId) => !pendingToolResults.has(toolCallId))) return;
+    const ready = assistantToolCallIds
+      .map((toolCallId) => pendingToolResults.get(toolCallId))
+      .filter((pending): pending is NonNullable<typeof pending> => pending !== undefined);
+    assistantToolCallIds = [];
+    await persistToJsonl(modelManager, context.sessionId, logger, async (contextMgr, sessionId) => {
+      for (const pending of ready) {
+        const uuid = await contextMgr.saveToolResult(
+          sessionId, pending.toolCall.id, pending.toolCall.function.name,
+          pending.result.success ? toJsonValue(pending.result.llmContent) : null,
+          getLastUuid(), pending.result.success ? undefined : pending.result.error?.message,
+          context.subagentInfo, pending.subagentRef,
+        );
+        setLastUuid(uuid);
+      }
+      for (const pending of ready) {
+        for (const injectedMessage of pending.injectedMessages) {
+          const isRec = (v: unknown): v is Record<string, unknown> =>
+            typeof v === 'object' && v !== null && !Array.isArray(v);
+          const customMetadata = isRec(injectedMessage.metadata)
+            ? { ...injectedMessage.metadata }
+            : {};
+          if (injectedMessage.role === 'system') customMetadata._systemSource = 'tool_injection';
+          const uuid = await contextMgr.saveMessage(
+            sessionId,
+            injectedMessage.role,
+            injectedMessage.content,
+            getLastUuid(),
+            Object.keys(customMetadata).length ? { customMetadata } : undefined,
+            context.subagentInfo,
+          );
+          setLastUuid(uuid);
+        }
+      }
+    });
+    for (const pending of ready) pendingToolResults.delete(pending.toolCall.id);
+  };
 
   const hooks: AgentLoopHooks = {
     turn: {
@@ -157,84 +211,39 @@ export function buildLoopConfig(deps: LoopHookBuilderDeps): AgentLoopConfig {
     },
 
     tool: {
-      async beforeExec(ctx) {
-        try {
-          const contextMgr = modelManager.getContextManager();
-          if (contextMgr && context.sessionId) {
-            return await contextMgr.saveToolUse(
-              context.sessionId, ctx.toolCall.function.name,
-              ctx.params,
-              getLastUuid(), context.subagentInfo,
-              ctx.toolCall.id,
-            );
-          }
-        } catch (error) {
-          logger.warn('[LoopHookBuilder] 保存工具调用失败:', error);
-        }
+      async beforeExec(_ctx) {
         return null;
       },
 
       async afterExec(ctx) {
-        const { toolCall, result, toolUseUuid } = ctx;
-
-        await persistToJsonl(modelManager, context.sessionId, logger, async (contextMgr, sessionId) => {
-          const metadata = result.metadata;
-          const normalizedEffects = normalizeToolEffects(result);
-          const injectedMessages = normalizedEffects
-            .filter((effect): effect is Extract<ToolEffect, { type: 'newMessages' }> => effect.type === 'newMessages')
-            .flatMap((effect) => effect.messages);
-          const isSubagentStatus = (v: unknown): v is 'running' | 'completed' | 'failed' | 'cancelled' =>
-            v === 'running' || v === 'completed' || v === 'failed' || v === 'cancelled';
-          const subagentStatus = isSubagentStatus(metadata?.subagentStatus)
-            ? metadata.subagentStatus : 'completed';
-          const subagentRef = metadata && typeof metadata.subagentSessionId === 'string'
-            ? {
-                subagentSessionId: metadata.subagentSessionId,
-                subagentType: typeof metadata.subagentType === 'string'
-                  ? metadata.subagentType : toolCall.function.name,
-                subagentStatus,
-                subagentSummary: typeof metadata.subagentSummary === 'string'
-                  ? metadata.subagentSummary : undefined,
-              }
-            : undefined;
-          const uuid = await contextMgr.saveToolResult(
-            sessionId, toolCall.id, toolCall.function.name,
-            result.success ? toJsonValue(result.llmContent) : null,
-            toolUseUuid, result.success ? undefined : result.error?.message,
-            context.subagentInfo, subagentRef,
-          );
-          setLastUuid(uuid);
-
-          if (injectedMessages.length > 0) {
-            let parentUuid = uuid;
-            for (const injectedMessage of injectedMessages) {
-              const customMeta = (() => {
-                const isRec = (v: unknown): v is Record<string, unknown> =>
-                  typeof v === 'object' && v !== null && !Array.isArray(v);
-                const base = isRec(injectedMessage.metadata)
-                  ? { ...injectedMessage.metadata }
-                  : {};
-                if (injectedMessage.role === 'system') {
-                  base._systemSource = 'tool_injection';
-                }
-                return Object.keys(base).length > 0 ? base : undefined;
-              })();
-
-              const injectedUuid = await contextMgr.saveMessage(
-                sessionId,
-                injectedMessage.role,
-                injectedMessage.content,
-                parentUuid,
-                customMeta ? { customMetadata: customMeta } : undefined,
-                context.subagentInfo,
-              );
-              parentUuid = injectedUuid;
-            }
-            setLastUuid(parentUuid);
-          }
-        });
-
+        const { toolCall, result } = ctx;
         const normalizedEffects = normalizeToolEffects(result);
+        const metadata = result.metadata;
+        const injectedMessages = normalizedEffects
+          .filter((effect): effect is Extract<ToolEffect, { type: 'newMessages' }> => effect.type === 'newMessages')
+          .flatMap((effect) => effect.messages);
+        const isSubagentStatus = (v: unknown): v is 'running' | 'completed' | 'failed' | 'cancelled' =>
+          v === 'running' || v === 'completed' || v === 'failed' || v === 'cancelled';
+        const subagentStatus = isSubagentStatus(metadata?.subagentStatus)
+          ? metadata.subagentStatus : 'completed';
+        const subagentRef = metadata && typeof metadata.subagentSessionId === 'string'
+          ? {
+              subagentSessionId: metadata.subagentSessionId,
+              subagentType: typeof metadata.subagentType === 'string'
+                ? metadata.subagentType : toolCall.function.name,
+              subagentStatus,
+              subagentSummary: typeof metadata.subagentSummary === 'string'
+                ? metadata.subagentSummary : undefined,
+            }
+          : undefined;
+        pendingToolResults.set(toolCall.id, {
+          toolCall,
+          result,
+          injectedMessages,
+          subagentRef,
+        });
+        await persistToolResultsIfReady();
+
         for (const effect of normalizedEffects) {
           if (effect.type === 'contextPatch') {
             runtimePatchManager.applyRuntimeContextPatch(effect.patch);
@@ -251,7 +260,7 @@ export function buildLoopConfig(deps: LoopHookBuilderDeps): AgentLoopConfig {
           runtimePatchManager.applyRuntimePatch(runtimePatch, loopState, {
             toolName: toolCall.function.name,
             toolCallId: toolCall.id,
-            toolUseUuid,
+            toolUseUuid: null,
           });
         }
 
@@ -277,19 +286,7 @@ export function buildLoopConfig(deps: LoopHookBuilderDeps): AgentLoopConfig {
       },
 
       async afterExecEpochDiscard(ctx) {
-        const toolUseUuid = ctx.toolUseUuid;
-        if (!toolUseUuid) return;
-        await persistToJsonl(modelManager, context.sessionId, logger, async (contextMgr, sessionId) => {
-          await contextMgr.saveToolResult(
-            sessionId,
-            ctx.toolCall.id,
-            ctx.toolCall.function.name,
-            null,
-            toolUseUuid,
-            ctx.reason,
-            context.subagentInfo,
-          );
-        });
+        pendingToolResults.delete(ctx.toolCall.id);
       },
     },
 
@@ -311,6 +308,8 @@ export function buildLoopConfig(deps: LoopHookBuilderDeps): AgentLoopConfig {
             setLastUuid(uuid);
           }
         });
+        assistantToolCallIds = (ctx.toolCalls ?? []).map((toolCall) => toolCall.id);
+        await persistToolResultsIfReady();
       },
 
       async onComplete(ctx) {
@@ -347,6 +346,8 @@ export function buildLoopConfig(deps: LoopHookBuilderDeps): AgentLoopConfig {
 
       onStateChange(recovery) {
         if (recovery.phase === 'started') {
+          assistantToolCallIds = [];
+          pendingToolResults.clear();
           loopState.startRecovery(recovery.reason ?? 'recovery_started');
           return;
         }

--- a/src/agent/LoopHookBuilder.ts
+++ b/src/agent/LoopHookBuilder.ts
@@ -140,6 +140,13 @@ export function buildLoopConfig(deps: LoopHookBuilderDeps): AgentLoopConfig {
       }
     });
     for (const pending of ready) pendingToolResults.delete(pending.toolCall.id);
+    if (pendingToolResults.size) {
+      logger.warn(
+        '[LoopHookBuilder] Dropping tool results with no declared tool call:',
+        Array.from(pendingToolResults.keys()),
+      );
+      pendingToolResults.clear();
+    }
   };
 
   const hooks: AgentLoopHooks = {

--- a/src/agent/__tests__/LoopRunner.test.ts
+++ b/src/agent/__tests__/LoopRunner.test.ts
@@ -1858,14 +1858,14 @@ describe('LoopRunner', () => {
           provenance: expect.objectContaining({
             toolName: 'PatchEnvA',
             toolCallId: 'patch-env-a-call',
-            toolUseUuid: 'tool-use-a',
+            toolUseUuid: null,
           }),
         }),
         expect.objectContaining({
           provenance: expect.objectContaining({
             toolName: 'PatchEnvB',
             toolCallId: 'patch-env-b-call',
-            toolUseUuid: 'tool-use-b',
+            toolUseUuid: null,
           }),
         }),
       ]);
@@ -2071,6 +2071,16 @@ describe('LoopRunner', () => {
 
       expect(result.success).toBe(true);
       expect(saveToolResult).toHaveBeenCalled();
+      const saveMessageCalls = saveMessage.mock.calls as unknown as Array<readonly unknown[]>;
+      const assistantToolCallIndex = saveMessageCalls.findIndex((call) => {
+        const metadata = call[4] as { toolCalls?: unknown[] } | undefined;
+        return Boolean(metadata?.toolCalls?.length);
+      });
+      const injectedMessageIndex = saveMessageCalls.findIndex((call) => call[2] === 'Injected assistant context');
+      expect(saveMessage.mock.invocationCallOrder[assistantToolCallIndex])
+        .toBeLessThan(saveToolResult.mock.invocationCallOrder[0] ?? 0);
+      expect(saveToolResult.mock.invocationCallOrder[0])
+        .toBeLessThan(saveMessage.mock.invocationCallOrder[injectedMessageIndex] ?? 0);
       expect(saveMessage).toHaveBeenCalledWith(
         'sess-1',
         'assistant',

--- a/src/context/ContextManager.ts
+++ b/src/context/ContextManager.ts
@@ -14,7 +14,11 @@ import { ContextCompressor } from './processors/ContextCompressor.js';
 import { ContextFilter } from './processors/ContextFilter.js';
 import { CacheStore } from './storage/CacheStore.js';
 import { MemoryStore } from './storage/MemoryStore.js';
-import { NoopPersistentStore, PersistentStore } from './storage/PersistentStore.js';
+import {
+  NoopPersistentStore,
+  PersistentStore,
+  type PersistedToolUse,
+} from './storage/PersistentStore.js';
 import type {
   CompressedContext,
   ContextData,
@@ -54,6 +58,7 @@ export class ContextManager {
   private readonly projectPath?: string;
 
   private currentSessionId: SessionId | null = null;
+  private readonly pendingToolUses = new Map<string, string[]>();
   private initialized = false;
 
   constructor(options: Partial<ContextManagerOptions> = {}) {
@@ -268,20 +273,28 @@ export class ContextManager {
     }
 
     if (toolCall.status === 'pending') {
-      const toolUseId = await this.persistent.saveToolUse(
+      const persisted = await this.persistent.saveToolUse(
         this.currentSessionId,
         toolCall.name,
         toolCall.input,
         null,
+        undefined,
+        toolCall.id,
       );
-      toolCall = { ...toolCall, id: toolUseId };
+      const pendingMessageIds = this.pendingToolUses.get(persisted.toolCallId) ?? [];
+      pendingMessageIds.push(persisted.messageId);
+      this.pendingToolUses.set(persisted.toolCallId, pendingMessageIds);
     } else {
+      const pendingMessageIds = this.pendingToolUses.get(toolCall.id) ?? [];
+      const parentMessageId = pendingMessageIds.shift() ?? null;
+      if (pendingMessageIds.length) this.pendingToolUses.set(toolCall.id, pendingMessageIds);
+      else this.pendingToolUses.delete(toolCall.id);
       await this.persistent.saveToolResult(
         this.currentSessionId,
         toolCall.id,
         toolCall.name,
         toolCall.output ?? null,
-        toolCall.id,
+        parentMessageId,
         toolCall.error,
       );
     }
@@ -339,7 +352,7 @@ export class ContextManager {
       isSidechain: boolean;
     },
     requestedToolCallId?: string,
-  ): Promise<string> {
+  ): Promise<PersistedToolUse> {
     return this.persistent.saveToolUse(
       sessionId,
       toolName,

--- a/src/context/__tests__/ContextManager.test.ts
+++ b/src/context/__tests__/ContextManager.test.ts
@@ -29,19 +29,19 @@ describe('ContextManager', () => {
 
     const sessionId = SessionId('session-1');
     await persistentStore.saveMessage(sessionId, 'user', 'hello');
-    const toolCallId = await persistentStore.saveToolUse(sessionId, 'Read', { file_path: 'README.md' });
-    await persistentStore.saveToolResult(
+    const toolUse = await persistentStore.saveToolUse(sessionId, 'Read', { file_path: 'README.md' });
+    const toolResultMessageId = await persistentStore.saveToolResult(
       sessionId,
-      toolCallId,
+      toolUse.toolCallId,
       'Read',
       'file contents',
-      toolCallId,
+      toolUse.messageId,
     );
     await persistentStore.saveCompaction(
       sessionId,
       'Compacted summary',
       { trigger: 'auto', preTokens: 42, postTokens: 20 },
-      toolCallId,
+      toolResultMessageId,
     );
 
     await contextManager.initialize();

--- a/src/context/storage/PersistentStore.ts
+++ b/src/context/storage/PersistentStore.ts
@@ -62,6 +62,11 @@ function parseToolCallArguments(value: string): JsonValue {
  * 持久化存储实现 - JSONL 格式
  * 存储路径: {storageRoot}/projects/{escaped-path}/{sessionId}.jsonl
  */
+export interface PersistedToolUse {
+  messageId: string;
+  toolCallId: string;
+}
+
 export class PersistentStore {
   private readonly storageRoot: string;
   private readonly projectPath?: string;
@@ -226,14 +231,14 @@ export class PersistentStore {
       isSidechain: boolean;
     },
     requestedToolCallId?: string,
-  ): Promise<string> {
+  ): Promise<PersistedToolUse> {
     try {
       const filePath = getSessionFilePathFromStorageRoot(this.storageRoot, sessionId);
       const store = new JSONLStore(filePath);
       await this.ensureSessionCreated(sessionId, subagentInfo);
       const now = new Date().toISOString();
       const toolCallId = requestedToolCallId ?? nanoid();
-      const messageId = MessageId(toolCallId);
+      const messageId = MessageId(nanoid());
       const messageInfo: MessageInfo = {
         messageId,
         role: 'assistant',
@@ -282,7 +287,7 @@ export class PersistentStore {
         }
       }
       await store.appendBatch(entries);
-      return toolCallId;
+      return { messageId, toolCallId };
     } catch (error) {
       console.error(
         `[PersistentStore] 保存工具调用失败 (session: ${sessionId}):`,
@@ -764,13 +769,17 @@ export class NoopPersistentStore {
       subagentType: string;
       isSidechain: boolean;
     },
-  ): Promise<string> {
-    return nanoid();
+    requestedToolCallId?: string,
+  ): Promise<PersistedToolUse> {
+    return {
+      messageId: nanoid(),
+      toolCallId: requestedToolCallId ?? nanoid(),
+    };
   }
 
   async saveToolResult(
     _sessionId: SessionId,
-    toolId: string,
+    _toolId: string,
     _toolName: string,
     _toolOutput: JsonValue,
     _parentUuid: string | null = null,
@@ -787,7 +796,7 @@ export class NoopPersistentStore {
       subagentSummary?: string;
     },
   ): Promise<string> {
-    return toolId;
+    return nanoid();
   }
 
   async saveCompaction(

--- a/src/context/storage/PersistentStore.ts
+++ b/src/context/storage/PersistentStore.ts
@@ -232,18 +232,17 @@ export class PersistentStore {
       const store = new JSONLStore(filePath);
       await this.ensureSessionCreated(sessionId, subagentInfo);
       const now = new Date().toISOString();
-      const messageId = parentUuid ? MessageId(parentUuid) : MessageId(nanoid());
-      const entries: SessionEvent[] = [];
-      if (!parentUuid) {
-        const messageInfo: MessageInfo = {
-          messageId,
-          role: 'assistant',
-          parentMessageId: undefined,
-          createdAt: now,
-        };
-        entries.push(this.createEvent('message_created', sessionId, messageInfo));
-      }
       const toolCallId = requestedToolCallId ?? nanoid();
+      const messageId = MessageId(toolCallId);
+      const messageInfo: MessageInfo = {
+        messageId,
+        role: 'assistant',
+        parentMessageId: parentUuid ?? undefined,
+        createdAt: now,
+      };
+      const entries: SessionEvent[] = [
+        this.createEvent('message_created', sessionId, messageInfo),
+      ];
       const partInfo: PartInfo = {
         partId: toolCallId,
         messageId,
@@ -320,17 +319,16 @@ export class PersistentStore {
       const store = new JSONLStore(filePath);
       await this.ensureSessionCreated(sessionId, subagentInfo);
       const now = new Date().toISOString();
-      const messageId = parentUuid ? MessageId(parentUuid) : MessageId(nanoid());
-      const entries: SessionEvent[] = [];
-      if (!parentUuid) {
-        const messageInfo: MessageInfo = {
-          messageId,
-          role: 'assistant',
-          parentMessageId: undefined,
-          createdAt: now,
-        };
-        entries.push(this.createEvent('message_created', sessionId, messageInfo));
-      }
+      const messageId = MessageId(nanoid());
+      const messageInfo: MessageInfo = {
+        messageId,
+        role: 'tool',
+        parentMessageId: parentUuid ?? undefined,
+        createdAt: now,
+      };
+      const entries: SessionEvent[] = [
+        this.createEvent('message_created', sessionId, messageInfo),
+      ];
       const toolResultPart: PartInfo = {
         partId: toolId,
         messageId,
@@ -359,7 +357,7 @@ export class PersistentStore {
         entries.push(this.createEvent('part_created', sessionId, subtaskPart));
       }
       await store.appendBatch(entries);
-      return toolId;
+      return messageId;
     } catch (error) {
       console.error(
         `[PersistentStore] 保存工具结果失败 (session: ${sessionId}):`,

--- a/src/session/SessionStore.ts
+++ b/src/session/SessionStore.ts
@@ -181,6 +181,35 @@ function inferRole(partType: string): MessageRole {
   }
 }
 
+function isEmptyAssistantMessage(message: Message): boolean {
+  return message.role === 'assistant'
+    && message.content === ''
+    && !message.reasoningContent
+    && !message.tool_calls?.length;
+}
+
+function getPartMessageId(
+  part: PartInfo,
+  messageRecords: Map<string, MessageRecord>,
+): MessageId {
+  const existing = messageRecords.get(part.messageId);
+  if (!existing) {
+    return part.messageId;
+  }
+
+  if (part.partType === 'tool_call' && existing.message.role !== 'assistant') {
+    return MessageId(`${part.messageId}:tool-call`);
+  }
+  if (part.partType === 'tool_result' && existing.message.role !== 'tool') {
+    const payload = isRecord(part.payload) ? part.payload : {};
+    const toolCallId = typeof payload.toolCallId === 'string'
+      ? payload.toolCallId
+      : part.partId;
+    return MessageId(`${part.messageId}:tool-result:${toolCallId}`);
+  }
+  return part.messageId;
+}
+
 function getToolCallState(
   toolCalls: Map<string, SessionToolCallState>,
   toolCallId: string,
@@ -217,6 +246,10 @@ export class JsonlSessionStore implements SessionStore {
     const orderedMessageIds: string[] = [];
     const summaryMessageIds = new Set<string>();
     const toolCalls = new Map<string, SessionToolCallState>();
+    const projectedToolCalls = new Map<string, {
+      sourceMessageId: string;
+      projectedMessageId: MessageId;
+    }>();
     const subagentRefs: SessionSubagentRef[] = [];
     let sessionInfo: Partial<SessionInfo> = { sessionId };
     let createdAt = toTimestamp(undefined, entries[0]?.timestamp ?? new Date().toISOString());
@@ -301,10 +334,21 @@ export class JsonlSessionStore implements SessionStore {
       }
 
       const data = entry.data;
+      let messageId = getPartMessageId(data, messageRecords);
+      if (data.partType === 'tool_call') {
+        const payload = isRecord(data.payload) ? data.payload : {};
+        const toolCallId = typeof payload.toolCallId === 'string'
+          ? payload.toolCallId
+          : data.partId;
+        const projected = projectedToolCalls.get(toolCallId);
+        if (projected && projected.sourceMessageId !== data.messageId) continue;
+        if (projected) messageId = projected.projectedMessageId;
+      }
       const record = ensureMessageRecord(
-        data.messageId,
+        messageId,
         inferRole(data.partType),
         entry.timestamp,
+        messageId === data.messageId ? undefined : data.messageId,
       );
 
       this.applyPartToMessage({
@@ -312,6 +356,7 @@ export class JsonlSessionStore implements SessionStore {
         record,
         contentParts,
         toolCalls,
+        projectedToolCalls,
         subagentRefs,
         summaryMessageIds,
         onSummary: (value) => {
@@ -325,6 +370,7 @@ export class JsonlSessionStore implements SessionStore {
     const timeline = orderedMessageIds
       .map((messageId) => messageRecords.get(messageId))
       .filter((record): record is MessageRecord => record !== undefined)
+      .filter((record) => !isEmptyAssistantMessage(record.message))
       .map((record) => ({
         id: record.id,
         parentMessageId: record.parentMessageId,
@@ -438,6 +484,10 @@ export class JsonlSessionStore implements SessionStore {
     record: MessageRecord;
     contentParts: Map<string, Array<{ partId: string; content: ContentPart }>>;
     toolCalls: Map<string, SessionToolCallState>;
+    projectedToolCalls: Map<string, {
+      sourceMessageId: string;
+      projectedMessageId: MessageId;
+    }>;
     subagentRefs: SessionSubagentRef[];
     summaryMessageIds: Set<string>;
     onSummary: (summary: string) => void;
@@ -447,6 +497,7 @@ export class JsonlSessionStore implements SessionStore {
       record,
       contentParts,
       toolCalls,
+      projectedToolCalls,
       subagentRefs,
       summaryMessageIds,
       onSummary,
@@ -514,6 +565,10 @@ export class JsonlSessionStore implements SessionStore {
           ...(record.message.tool_calls ?? []).filter((call) => call.id !== toolCall.id),
           toolCall,
         ];
+        projectedToolCalls.set(toolCallId, {
+          sourceMessageId: part.messageId,
+          projectedMessageId: MessageId(record.id),
+        });
 
         const toolCallState = getToolCallState(toolCalls, toolCallId, {
           name: toolName,

--- a/src/session/SessionStore.ts
+++ b/src/session/SessionStore.ts
@@ -188,44 +188,97 @@ function isEmptyAssistantMessage(message: Message): boolean {
     && !message.tool_calls?.length;
 }
 
+interface ToolCallOccurrence {
+  key: string;
+  sourceMessageId: string;
+  toolCallId: string;
+  matched: boolean;
+}
+
+interface ToolOccurrencePlan {
+  callsByEventId: Map<string, ToolCallOccurrence>;
+  resultsByEventId: Map<string, ToolCallOccurrence>;
+}
+
+function getPartToolCallId(part: PartInfo): string {
+  const payload = isRecord(part.payload) ? part.payload : {};
+  return typeof payload.toolCallId === 'string' ? payload.toolCallId : part.partId;
+}
+
+function createToolOccurrencePlan(entries: SessionEvent[]): ToolOccurrencePlan {
+  const callsByEventId = new Map<string, ToolCallOccurrence>();
+  const resultsByEventId = new Map<string, ToolCallOccurrence>();
+  const callsBySource = new Map<string, ToolCallOccurrence>();
+  const resultsBySource = new Map<string, ToolCallOccurrence>();
+  const unmatchedByToolCallId = new Map<string, ToolCallOccurrence[]>();
+  let occurrenceIndex = 0;
+
+  for (const entry of entries) {
+    if (entry.type !== 'part_created' && entry.type !== 'part_updated') continue;
+    const part = entry.data;
+    if (part.partType !== 'tool_call' && part.partType !== 'tool_result') continue;
+    const toolCallId = getPartToolCallId(part);
+    const sourceKey = `${part.messageId}\0${toolCallId}`;
+
+    if (part.partType === 'tool_call') {
+      let occurrence = callsBySource.get(sourceKey);
+      if (!occurrence) {
+        occurrence = {
+          key: `tool-call:${occurrenceIndex++}`,
+          sourceMessageId: part.messageId,
+          toolCallId,
+          matched: false,
+        };
+        callsBySource.set(sourceKey, occurrence);
+        const unmatched = unmatchedByToolCallId.get(toolCallId) ?? [];
+        unmatched.push(occurrence);
+        unmatchedByToolCallId.set(toolCallId, unmatched);
+      }
+      callsByEventId.set(entry.id, occurrence);
+      continue;
+    }
+
+    let occurrence = resultsBySource.get(sourceKey);
+    if (!occurrence) {
+      const unmatched = unmatchedByToolCallId.get(toolCallId) ?? [];
+      occurrence = unmatched.shift();
+      if (!occurrence) continue;
+      occurrence.matched = true;
+      resultsBySource.set(sourceKey, occurrence);
+    }
+    resultsByEventId.set(entry.id, occurrence);
+  }
+
+  return { callsByEventId, resultsByEventId };
+}
+
 function getPartMessageId(
   part: PartInfo,
   messageRecords: Map<string, MessageRecord>,
+  occurrence?: ToolCallOccurrence,
 ): MessageId {
   const existing = messageRecords.get(part.messageId);
-  if (!existing) {
-    return part.messageId;
-  }
+  if (!existing) return part.messageId;
 
   if (part.partType === 'tool_call' && existing.message.role !== 'assistant') {
-    return MessageId(`${part.messageId}:tool-call`);
+    return MessageId(`${part.messageId}:${occurrence?.key ?? 'tool-call'}`);
   }
   if (part.partType === 'tool_result' && existing.message.role !== 'tool') {
-    const payload = isRecord(part.payload) ? part.payload : {};
-    const toolCallId = typeof payload.toolCallId === 'string'
-      ? payload.toolCallId
-      : part.partId;
-    return MessageId(`${part.messageId}:tool-result:${toolCallId}`);
+    return MessageId(`${part.messageId}:tool-result:${occurrence?.key ?? getPartToolCallId(part)}`);
   }
   return part.messageId;
 }
 
 function getToolCallState(
   toolCalls: Map<string, SessionToolCallState>,
-  toolCallId: string,
-  defaults: Omit<SessionToolCallState, 'id'>,
+  stateKey: string,
+  defaults: SessionToolCallState,
 ): SessionToolCallState {
-  const existing = toolCalls.get(toolCallId);
-  if (existing) {
-    return existing;
-  }
+  const existing = toolCalls.get(stateKey);
+  if (existing) return existing;
 
-  const created: SessionToolCallState = {
-    id: toolCallId,
-    ...defaults,
-  };
-  toolCalls.set(toolCallId, created);
-  return created;
+  toolCalls.set(stateKey, defaults);
+  return defaults;
 }
 
 export class JsonlSessionStore implements SessionStore {
@@ -246,10 +299,7 @@ export class JsonlSessionStore implements SessionStore {
     const orderedMessageIds: string[] = [];
     const summaryMessageIds = new Set<string>();
     const toolCalls = new Map<string, SessionToolCallState>();
-    const projectedToolCalls = new Map<string, {
-      sourceMessageId: string;
-      projectedMessageId: MessageId;
-    }>();
+    const toolOccurrencePlan = createToolOccurrencePlan(entries);
     const subagentRefs: SessionSubagentRef[] = [];
     let sessionInfo: Partial<SessionInfo> = { sessionId };
     let createdAt = toTimestamp(undefined, entries[0]?.timestamp ?? new Date().toISOString());
@@ -334,16 +384,14 @@ export class JsonlSessionStore implements SessionStore {
       }
 
       const data = entry.data;
-      let messageId = getPartMessageId(data, messageRecords);
-      if (data.partType === 'tool_call') {
-        const payload = isRecord(data.payload) ? data.payload : {};
-        const toolCallId = typeof payload.toolCallId === 'string'
-          ? payload.toolCallId
-          : data.partId;
-        const projected = projectedToolCalls.get(toolCallId);
-        if (projected && projected.sourceMessageId !== data.messageId) continue;
-        if (projected) messageId = projected.projectedMessageId;
-      }
+      const occurrence = data.partType === 'tool_call'
+        ? toolOccurrencePlan.callsByEventId.get(entry.id)
+        : data.partType === 'tool_result'
+          ? toolOccurrencePlan.resultsByEventId.get(entry.id)
+          : undefined;
+      if ((data.partType === 'tool_call' || data.partType === 'tool_result') && !occurrence) continue;
+      if (data.partType === 'tool_call' && !occurrence?.matched) continue;
+      const messageId = getPartMessageId(data, messageRecords, occurrence);
       const record = ensureMessageRecord(
         messageId,
         inferRole(data.partType),
@@ -356,7 +404,7 @@ export class JsonlSessionStore implements SessionStore {
         record,
         contentParts,
         toolCalls,
-        projectedToolCalls,
+        toolOccurrenceKey: occurrence?.key,
         subagentRefs,
         summaryMessageIds,
         onSummary: (value) => {
@@ -367,10 +415,15 @@ export class JsonlSessionStore implements SessionStore {
 
     // Build the timeline directly from the mutable builder records (no clone).
     // `messages` is cloned from the same records so the two arrays are independent.
-    const timeline = orderedMessageIds
+    const records = orderedMessageIds
       .map((messageId) => messageRecords.get(messageId))
-      .filter((record): record is MessageRecord => record !== undefined)
-      .filter((record) => !isEmptyAssistantMessage(record.message))
+      .filter((record): record is MessageRecord => record !== undefined);
+    const referencedMessageIds = new Set([
+      ...records.flatMap((record) => record.parentMessageId ? [record.parentMessageId] : []),
+      ...subagentRefs.map((ref) => String(ref.messageId)),
+    ]);
+    const timeline = records
+      .filter((record) => !isEmptyAssistantMessage(record.message) || referencedMessageIds.has(record.id))
       .map((record) => ({
         id: record.id,
         parentMessageId: record.parentMessageId,
@@ -397,7 +450,9 @@ export class JsonlSessionStore implements SessionStore {
       toolCalls: Array.from(toolCalls.values()).map((toolCall) => ({
         ...toolCall,
       })),
-      subagentRefs: subagentRefs.map((ref) => ({ ...ref })),
+      subagentRefs: subagentRefs
+        .filter((ref) => messageIds.includes(String(ref.messageId)))
+        .map((ref) => ({ ...ref })),
     };
   }
 
@@ -484,10 +539,7 @@ export class JsonlSessionStore implements SessionStore {
     record: MessageRecord;
     contentParts: Map<string, Array<{ partId: string; content: ContentPart }>>;
     toolCalls: Map<string, SessionToolCallState>;
-    projectedToolCalls: Map<string, {
-      sourceMessageId: string;
-      projectedMessageId: MessageId;
-    }>;
+    toolOccurrenceKey?: string;
     subagentRefs: SessionSubagentRef[];
     summaryMessageIds: Set<string>;
     onSummary: (summary: string) => void;
@@ -497,7 +549,7 @@ export class JsonlSessionStore implements SessionStore {
       record,
       contentParts,
       toolCalls,
-      projectedToolCalls,
+      toolOccurrenceKey,
       subagentRefs,
       summaryMessageIds,
       onSummary,
@@ -565,12 +617,9 @@ export class JsonlSessionStore implements SessionStore {
           ...(record.message.tool_calls ?? []).filter((call) => call.id !== toolCall.id),
           toolCall,
         ];
-        projectedToolCalls.set(toolCallId, {
-          sourceMessageId: part.messageId,
-          projectedMessageId: MessageId(record.id),
-        });
 
-        const toolCallState = getToolCallState(toolCalls, toolCallId, {
+        const toolCallState = getToolCallState(toolCalls, toolOccurrenceKey ?? toolCallId, {
+          id: toolCallId,
           name: toolName,
           input,
           messageId: record.id,
@@ -595,7 +644,8 @@ export class JsonlSessionStore implements SessionStore {
         record.message.name = toolName;
         record.message.content = error ? `Error: ${error}` : stringifyContent(output);
 
-        const toolCallState = getToolCallState(toolCalls, toolCallId, {
+        const toolCallState = getToolCallState(toolCalls, toolOccurrenceKey ?? toolCallId, {
+          id: toolCallId,
           name: toolName,
           input: {},
           messageId: record.id,

--- a/src/session/__tests__/SessionPersistence.test.ts
+++ b/src/session/__tests__/SessionPersistence.test.ts
@@ -35,13 +35,19 @@ describe('Session persistence', () => {
 
     const sessionId = SessionId('session-1');
     await persistentStore.saveMessage(sessionId, 'user', 'hello');
-    const toolCallId = await persistentStore.saveToolUse(sessionId, 'Read', { file_path: 'README.md' });
-    await persistentStore.saveToolResult(sessionId, toolCallId, 'Read', 'contents', toolCallId);
+    const toolUse = await persistentStore.saveToolUse(sessionId, 'Read', { file_path: 'README.md' });
+    const toolResultMessageId = await persistentStore.saveToolResult(
+      sessionId,
+      toolUse.toolCallId,
+      'Read',
+      'contents',
+      toolUse.messageId,
+    );
     const summaryId = await persistentStore.saveCompaction(
       sessionId,
       'Compacted summary',
       { trigger: 'auto', preTokens: 12 },
-      toolCallId,
+      toolResultMessageId,
     );
 
     const session = await resumeSession({

--- a/src/session/__tests__/SessionStore.test.ts
+++ b/src/session/__tests__/SessionStore.test.ts
@@ -4,18 +4,51 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { JSONLStore } from '../../context/storage/JSONLStore.js';
 import { getSessionFilePathFromStorageRoot } from '../../context/storage/pathUtils.js';
-import { PersistentStore } from '../../context/storage/PersistentStore.js';
+import { NoopPersistentStore, PersistentStore } from '../../context/storage/PersistentStore.js';
 import type { SessionEvent } from '../../context/types.js';
 import { JsonlSessionStore } from '../SessionStore.js';
 import type { ContentPart } from '../../services/ChatServiceInterface.js';
 import { assertDefined } from '../../__tests__/helpers/assertDefined.js';
-import { SessionId } from '../../types/branded.js';
+import { MessageId, SessionId } from '../../types/branded.js';
 
 function createWorkspaceRoot(): string {
   return mkdtempSync(join(tmpdir(), 'session-store-test-'));
 }
 
+function sessionEvent<T extends SessionEvent['type']>(
+  sessionId: SessionId,
+  timestamp: string,
+  id: string,
+  type: T,
+  data: Extract<SessionEvent, { type: T }>['data'],
+): Extract<SessionEvent, { type: T }> {
+  return { id, sessionId, timestamp, type, version: '1.1.1', data } as Extract<SessionEvent, { type: T }>;
+}
+
 describe('JsonlSessionStore', () => {
+  it('should keep no-op persistence message IDs distinct from tool-call IDs', async () => {
+    const store = new NoopPersistentStore();
+    const toolUse = await store.saveToolUse(
+      SessionId('session-noop'),
+      'Search',
+      { query: 'needle' },
+      null,
+      undefined,
+      'call-noop',
+    );
+    const toolResultMessageId = await store.saveToolResult(
+      SessionId('session-noop'),
+      toolUse.toolCallId,
+      'Search',
+      'result',
+      toolUse.messageId,
+    );
+
+    expect(toolUse.toolCallId).toBe('call-noop');
+    expect(toolUse.messageId).not.toBe(toolUse.toolCallId);
+    expect(toolResultMessageId).not.toBe(toolUse.toolCallId);
+  });
+
   it('should reconstruct full session state from JSONL events', async () => {
     const workspaceRoot = createWorkspaceRoot();
     const persistentStore = new PersistentStore(workspaceRoot);
@@ -23,7 +56,7 @@ describe('JsonlSessionStore', () => {
 
     const sessionId = SessionId('session-1');
     const userMessageId = await persistentStore.saveMessage(sessionId, 'user', 'hello');
-    const toolCallId = await persistentStore.saveToolUse(
+    const toolUse = await persistentStore.saveToolUse(
       sessionId,
       'Task',
       {
@@ -32,12 +65,12 @@ describe('JsonlSessionStore', () => {
         description: 'Inspect repository',
       },
     );
-    await persistentStore.saveToolResult(
+    const toolResultMessageId = await persistentStore.saveToolResult(
       sessionId,
-      toolCallId,
+      toolUse.toolCallId,
       'Task',
       { status: 'done' },
-      toolCallId,
+      toolUse.messageId,
       undefined,
       undefined,
       {
@@ -51,7 +84,7 @@ describe('JsonlSessionStore', () => {
       sessionId,
       'Compacted summary',
       { trigger: 'auto', preTokens: 100, postTokens: 40 },
-      toolCallId,
+      toolResultMessageId,
     );
 
     const state = await sessionStore.loadState(sessionId);
@@ -62,9 +95,9 @@ describe('JsonlSessionStore', () => {
     expect(state.messages[0]?.id).toBe(userMessageId);
     expect(state.messages[0]?.role).toBe('user');
     expect(state.messages[1]?.role).toBe('assistant');
-    expect(state.messages[1]?.tool_calls?.[0]?.id).toBe(toolCallId);
+    expect(state.messages[1]?.tool_calls?.[0]?.id).toBe(toolUse.toolCallId);
     expect(state.messages[2]?.role).toBe('tool');
-    expect(state.messages[2]?.tool_call_id).toBe(toolCallId);
+    expect(state.messages[2]?.tool_call_id).toBe(toolUse.toolCallId);
     expect(state.messages[3]?.role).toBe('system');
     expect(state.messages[3]?.id).toBe(summaryMessageId);
     expect(state.messages[3]?.content).toBe('Compacted summary');
@@ -83,7 +116,7 @@ describe('JsonlSessionStore', () => {
     const sessionId = SessionId('session-sequential-tools');
     const userMessageId = await persistentStore.saveMessage(sessionId, 'user', 'hello');
     const firstToolCallId = 'call-first';
-    const firstAssistantId = await persistentStore.saveToolUse(
+    const firstToolUse = await persistentStore.saveToolUse(
       sessionId,
       'Search',
       { query: 'first' },
@@ -93,13 +126,13 @@ describe('JsonlSessionStore', () => {
     );
     const firstResultId = await persistentStore.saveToolResult(
       sessionId,
-      firstToolCallId,
+      firstToolUse.toolCallId,
       'Search',
       'first result',
-      firstAssistantId,
+      firstToolUse.messageId,
     );
     const secondToolCallId = 'call-second';
-    const secondAssistantId = await persistentStore.saveToolUse(
+    const secondToolUse = await persistentStore.saveToolUse(
       sessionId,
       'Search',
       { query: 'second' },
@@ -109,10 +142,10 @@ describe('JsonlSessionStore', () => {
     );
     await persistentStore.saveToolResult(
       sessionId,
-      secondToolCallId,
+      secondToolUse.toolCallId,
       'Search',
       'second result',
-      secondAssistantId,
+      secondToolUse.messageId,
     );
 
     const state = await sessionStore.loadState(sessionId);
@@ -131,66 +164,58 @@ describe('JsonlSessionStore', () => {
     expect(state.messages[4]?.tool_call_id).toBe(secondToolCallId);
     expect(new Set(state.messageIds).size).toBe(state.messageIds.length);
     expect(state.timeline[1]?.parentMessageId).toBe(userMessageId);
-    expect(state.timeline[2]?.parentMessageId).toBe(firstAssistantId);
+    expect(state.timeline[2]?.parentMessageId).toBe(firstToolUse.messageId);
     expect(state.timeline[3]?.parentMessageId).toBe(firstResultId);
-    expect(state.timeline[4]?.parentMessageId).toBe(secondAssistantId);
+    expect(state.timeline[4]?.parentMessageId).toBe(secondToolUse.messageId);
   });
 
   it('should repair legacy message ID collisions and duplicate tool calls', async () => {
     const workspaceRoot = createWorkspaceRoot();
     const sessionId = SessionId('session-legacy-tool-collision');
     const now = new Date().toISOString();
-    const event = (id: string, type: string, data: object): SessionEvent => ({
-      id,
-      sessionId,
-      timestamp: now,
-      type,
-      version: '1.1.1',
-      data,
-    }) as SessionEvent;
     const entries = [
-      event('session', 'session_created', {
+      sessionEvent(sessionId, now,'session', 'session_created', {
         sessionId,
         rootId: sessionId,
         status: 'running',
         createdAt: now,
         updatedAt: now,
       }),
-      event('user', 'message_created', { messageId: 'user-1', role: 'user', createdAt: now }),
-      event('user-text', 'part_created', {
-        partId: 'user-text', messageId: 'user-1', partType: 'text',
+      sessionEvent(sessionId, now,'user', 'message_created', { messageId: MessageId('user-1'), role: 'user', createdAt: now }),
+      sessionEvent(sessionId, now,'user-text', 'part_created', {
+        partId: 'user-text', messageId: MessageId('user-1'), partType: 'text',
         payload: { text: 'hello' }, createdAt: now,
       }),
-      event('first-call', 'part_created', {
-        partId: 'call-first', messageId: 'user-1', partType: 'tool_call',
+      sessionEvent(sessionId, now,'first-call', 'part_created', {
+        partId: 'call-first', messageId: MessageId('user-1'), partType: 'tool_call',
         payload: { toolCallId: 'call-first', toolName: 'Search', input: { query: 'first' } },
         createdAt: now,
       }),
-      event('first-result', 'part_created', {
-        partId: 'call-first', messageId: 'call-first', partType: 'tool_result',
+      sessionEvent(sessionId, now,'first-result', 'part_created', {
+        partId: 'call-first', messageId: MessageId('call-first'), partType: 'tool_result',
         payload: { toolCallId: 'call-first', toolName: 'Search', output: 'first result', error: null },
         createdAt: now,
       }),
-      event('second-call', 'part_created', {
-        partId: 'call-second', messageId: 'call-first', partType: 'tool_call',
+      sessionEvent(sessionId, now,'second-call', 'part_created', {
+        partId: 'call-second', messageId: MessageId('call-first'), partType: 'tool_call',
         payload: { toolCallId: 'call-second', toolName: 'Search', input: { query: 'second' } },
         createdAt: now,
       }),
-      event('assistant', 'message_created', {
-        messageId: 'assistant-1', role: 'assistant', createdAt: now,
+      sessionEvent(sessionId, now,'assistant', 'message_created', {
+        messageId: MessageId('assistant-1'), role: 'assistant', createdAt: now,
       }),
-      event('duplicate-first-call', 'part_created', {
-        partId: 'call-first', messageId: 'assistant-1', partType: 'tool_call',
+      sessionEvent(sessionId, now,'duplicate-first-call', 'part_created', {
+        partId: 'call-first', messageId: MessageId('assistant-1'), partType: 'tool_call',
         payload: { toolCallId: 'call-first', toolName: 'Search', input: { query: 'first' } },
         createdAt: now,
       }),
-      event('duplicate-second-call', 'part_created', {
-        partId: 'call-second', messageId: 'assistant-1', partType: 'tool_call',
+      sessionEvent(sessionId, now,'duplicate-second-call', 'part_created', {
+        partId: 'call-second', messageId: MessageId('assistant-1'), partType: 'tool_call',
         payload: { toolCallId: 'call-second', toolName: 'Search', input: { query: 'second' } },
         createdAt: now,
       }),
-      event('second-result', 'part_created', {
-        partId: 'call-second', messageId: 'call-second', partType: 'tool_result',
+      sessionEvent(sessionId, now,'second-result', 'part_created', {
+        partId: 'call-second', messageId: MessageId('call-second'), partType: 'tool_result',
         payload: { toolCallId: 'call-second', toolName: 'Search', output: 'second result', error: null },
         createdAt: now,
       }),
@@ -214,6 +239,66 @@ describe('JsonlSessionStore', () => {
       .toBe('first result');
     expect(state.messages.find((message) => message.tool_call_id === 'call-second')?.content)
       .toBe('second result');
+  });
+
+  it('should preserve repeated provider tool-call IDs across turns', async () => {
+    const workspaceRoot = createWorkspaceRoot();
+    const persistentStore = new PersistentStore(workspaceRoot);
+    const sessionStore = new JsonlSessionStore(workspaceRoot);
+    const sessionId = SessionId('session-repeated-tool-call-id');
+    const repeatedToolCallId = 'call-repeated';
+
+    const userMessageId = await persistentStore.saveMessage(sessionId, 'user', 'first');
+    const firstUse = await persistentStore.saveToolUse(
+      sessionId,
+      'Search',
+      { query: 'first' },
+      userMessageId,
+      undefined,
+      repeatedToolCallId,
+    );
+    const firstResultId = await persistentStore.saveToolResult(
+      sessionId,
+      firstUse.toolCallId,
+      'Search',
+      'first result',
+      firstUse.messageId,
+    );
+    const secondUse = await persistentStore.saveToolUse(
+      sessionId,
+      'Search',
+      { query: 'second' },
+      firstResultId,
+      undefined,
+      repeatedToolCallId,
+    );
+    await persistentStore.saveToolResult(
+      sessionId,
+      secondUse.toolCallId,
+      'Search',
+      'second result',
+      secondUse.messageId,
+    );
+
+    const state = await sessionStore.loadState(sessionId);
+
+    assertDefined(state);
+    expect(state.messages.map((message) => message.role)).toEqual([
+      'user',
+      'assistant',
+      'tool',
+      'assistant',
+      'tool',
+    ]);
+    expect(state.messages.filter((message) => message.tool_calls?.[0]?.id === repeatedToolCallId))
+      .toHaveLength(2);
+    expect(state.messages.filter((message) => message.tool_call_id === repeatedToolCallId))
+      .toHaveLength(2);
+    expect(state.toolCalls).toHaveLength(2);
+    expect(state.toolCalls.map((toolCall) => toolCall.output)).toEqual([
+      'first result',
+      'second result',
+    ]);
   });
 
   it('should preserve assistant reasoning content with tool calls for resume', async () => {
@@ -247,7 +332,7 @@ describe('JsonlSessionStore', () => {
       'call-search',
       'Search',
       'result',
-      'call-search',
+      assistantMessageId,
     );
 
     const state = await sessionStore.loadState(sessionId);
@@ -274,6 +359,61 @@ describe('JsonlSessionStore', () => {
       role: 'tool',
       tool_call_id: 'call-search',
     });
+  });
+
+  it('should retain empty assistant messages referenced by children and subagent refs', async () => {
+    const workspaceRoot = createWorkspaceRoot();
+    const sessionId = SessionId('session-referenced-empty-assistant');
+    const now = new Date().toISOString();
+    const emptyAssistantId = MessageId('assistant-empty');
+    const entries: SessionEvent[] = [
+      sessionEvent(sessionId, now, 'session', 'session_created', {
+        sessionId,
+        rootId: sessionId,
+        status: 'running',
+        createdAt: now,
+        updatedAt: now,
+      }),
+      sessionEvent(sessionId, now, 'empty', 'message_created', {
+        messageId: emptyAssistantId,
+        role: 'assistant',
+        createdAt: now,
+      }),
+      sessionEvent(sessionId, now, 'subtask', 'part_created', {
+        partId: 'subtask',
+        messageId: emptyAssistantId,
+        partType: 'subtask_ref',
+        payload: {
+          childSessionId: 'child-1',
+          agentType: 'research',
+          status: 'running',
+        },
+        createdAt: now,
+      }),
+      sessionEvent(sessionId, now, 'child', 'message_created', {
+        messageId: MessageId('assistant-child'),
+        role: 'assistant',
+        parentMessageId: emptyAssistantId,
+        createdAt: now,
+      }),
+      sessionEvent(sessionId, now, 'child-text', 'part_created', {
+        partId: 'child-text',
+        messageId: MessageId('assistant-child'),
+        partType: 'text',
+        payload: { text: 'child answer' },
+        createdAt: now,
+      }),
+    ];
+    await new JSONLStore(getSessionFilePathFromStorageRoot(workspaceRoot, sessionId))
+      .appendBatch(entries);
+
+    const state = await new JsonlSessionStore(workspaceRoot).loadState(sessionId);
+
+    assertDefined(state);
+    expect(state.messageIds).toContain(emptyAssistantId);
+    expect(state.timeline.find((entry) => entry.id === 'assistant-child')?.parentMessageId)
+      .toBe(emptyAssistantId);
+    expect(state.subagentRefs[0]?.messageId).toBe(emptyAssistantId);
   });
 
   it('should fork state by linear message boundary', async () => {

--- a/src/session/__tests__/SessionStore.test.ts
+++ b/src/session/__tests__/SessionStore.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from 'vitest';
 import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { JSONLStore } from '../../context/storage/JSONLStore.js';
+import { getSessionFilePathFromStorageRoot } from '../../context/storage/pathUtils.js';
 import { PersistentStore } from '../../context/storage/PersistentStore.js';
+import type { SessionEvent } from '../../context/types.js';
 import { JsonlSessionStore } from '../SessionStore.js';
 import type { ContentPart } from '../../services/ChatServiceInterface.js';
 import { assertDefined } from '../../__tests__/helpers/assertDefined.js';
@@ -70,6 +73,147 @@ describe('JsonlSessionStore', () => {
     expect(state.toolCalls[0]?.status).toBe('success');
     expect(state.subagentRefs).toHaveLength(2);
     expect(state.subagentRefs[1]?.status).toBe('completed');
+  });
+
+  it('should preserve sequential tool results across resume', async () => {
+    const workspaceRoot = createWorkspaceRoot();
+    const persistentStore = new PersistentStore(workspaceRoot);
+    const sessionStore = new JsonlSessionStore(workspaceRoot);
+
+    const sessionId = SessionId('session-sequential-tools');
+    const userMessageId = await persistentStore.saveMessage(sessionId, 'user', 'hello');
+    const firstToolCallId = 'call-first';
+    const firstAssistantId = await persistentStore.saveToolUse(
+      sessionId,
+      'Search',
+      { query: 'first' },
+      userMessageId,
+      undefined,
+      firstToolCallId,
+    );
+    const firstResultId = await persistentStore.saveToolResult(
+      sessionId,
+      firstToolCallId,
+      'Search',
+      'first result',
+      firstAssistantId,
+    );
+    const secondToolCallId = 'call-second';
+    const secondAssistantId = await persistentStore.saveToolUse(
+      sessionId,
+      'Search',
+      { query: 'second' },
+      firstResultId,
+      undefined,
+      secondToolCallId,
+    );
+    await persistentStore.saveToolResult(
+      sessionId,
+      secondToolCallId,
+      'Search',
+      'second result',
+      secondAssistantId,
+    );
+
+    const state = await sessionStore.loadState(sessionId);
+
+    assertDefined(state);
+    expect(state.messages.map((message) => message.role)).toEqual([
+      'user',
+      'assistant',
+      'tool',
+      'assistant',
+      'tool',
+    ]);
+    expect(state.messages[1]?.tool_calls?.[0]?.id).toBe(firstToolCallId);
+    expect(state.messages[2]?.tool_call_id).toBe(firstToolCallId);
+    expect(state.messages[3]?.tool_calls?.[0]?.id).toBe(secondToolCallId);
+    expect(state.messages[4]?.tool_call_id).toBe(secondToolCallId);
+    expect(new Set(state.messageIds).size).toBe(state.messageIds.length);
+    expect(state.timeline[1]?.parentMessageId).toBe(userMessageId);
+    expect(state.timeline[2]?.parentMessageId).toBe(firstAssistantId);
+    expect(state.timeline[3]?.parentMessageId).toBe(firstResultId);
+    expect(state.timeline[4]?.parentMessageId).toBe(secondAssistantId);
+  });
+
+  it('should repair legacy message ID collisions and duplicate tool calls', async () => {
+    const workspaceRoot = createWorkspaceRoot();
+    const sessionId = SessionId('session-legacy-tool-collision');
+    const now = new Date().toISOString();
+    const event = (id: string, type: string, data: object): SessionEvent => ({
+      id,
+      sessionId,
+      timestamp: now,
+      type,
+      version: '1.1.1',
+      data,
+    }) as SessionEvent;
+    const entries = [
+      event('session', 'session_created', {
+        sessionId,
+        rootId: sessionId,
+        status: 'running',
+        createdAt: now,
+        updatedAt: now,
+      }),
+      event('user', 'message_created', { messageId: 'user-1', role: 'user', createdAt: now }),
+      event('user-text', 'part_created', {
+        partId: 'user-text', messageId: 'user-1', partType: 'text',
+        payload: { text: 'hello' }, createdAt: now,
+      }),
+      event('first-call', 'part_created', {
+        partId: 'call-first', messageId: 'user-1', partType: 'tool_call',
+        payload: { toolCallId: 'call-first', toolName: 'Search', input: { query: 'first' } },
+        createdAt: now,
+      }),
+      event('first-result', 'part_created', {
+        partId: 'call-first', messageId: 'call-first', partType: 'tool_result',
+        payload: { toolCallId: 'call-first', toolName: 'Search', output: 'first result', error: null },
+        createdAt: now,
+      }),
+      event('second-call', 'part_created', {
+        partId: 'call-second', messageId: 'call-first', partType: 'tool_call',
+        payload: { toolCallId: 'call-second', toolName: 'Search', input: { query: 'second' } },
+        createdAt: now,
+      }),
+      event('assistant', 'message_created', {
+        messageId: 'assistant-1', role: 'assistant', createdAt: now,
+      }),
+      event('duplicate-first-call', 'part_created', {
+        partId: 'call-first', messageId: 'assistant-1', partType: 'tool_call',
+        payload: { toolCallId: 'call-first', toolName: 'Search', input: { query: 'first' } },
+        createdAt: now,
+      }),
+      event('duplicate-second-call', 'part_created', {
+        partId: 'call-second', messageId: 'assistant-1', partType: 'tool_call',
+        payload: { toolCallId: 'call-second', toolName: 'Search', input: { query: 'second' } },
+        createdAt: now,
+      }),
+      event('second-result', 'part_created', {
+        partId: 'call-second', messageId: 'call-second', partType: 'tool_result',
+        payload: { toolCallId: 'call-second', toolName: 'Search', output: 'second result', error: null },
+        createdAt: now,
+      }),
+    ];
+    await new JSONLStore(getSessionFilePathFromStorageRoot(workspaceRoot, sessionId))
+      .appendBatch(entries);
+
+    const state = await new JsonlSessionStore(workspaceRoot).loadState(sessionId);
+
+    assertDefined(state);
+    expect(state.messages.map((message) => message.role)).toEqual([
+      'user',
+      'assistant',
+      'tool',
+      'assistant',
+      'tool',
+    ]);
+    const projectedCalls = state.messages.flatMap((message) => message.tool_calls ?? []);
+    expect(projectedCalls.map((call) => call.id)).toEqual(['call-first', 'call-second']);
+    expect(state.messages.find((message) => message.tool_call_id === 'call-first')?.content)
+      .toBe('first result');
+    expect(state.messages.find((message) => message.tool_call_id === 'call-second')?.content)
+      .toBe('second result');
   });
 
   it('should preserve assistant reasoning content with tool calls for resume', async () => {


### PR DESCRIPTION
## Summary

- persist assistant tool calls once per model turn and write each tool result as a distinct `role: tool` message
- preserve provider tool-call order for parallel/mixed execution and delay early exit until the whole declared batch is recorded
- repair legacy JSONL message-ID collisions, duplicate tool-call declarations, empty reconstructed assistants, and legacy part updates during resume

## Why

Older JSONL histories can reuse a tool-call ID as a message ID. A later `tool_call` part then mutates the reconstructed tool-result record back to `role: assistant`, causing resumed provider requests to fail with `Tool results are missing for tool calls ...`.

This fixes both new persistence and existing affected histories.

Closes #7.

## Test plan

- [x] `pnpm exec vitest run src/session/__tests__/SessionStore.test.ts src/session/__tests__/SessionPersistence.test.ts src/context/__tests__/ContextManager.test.ts src/agent/__tests__/LoopRunner.test.ts src/agent/__tests__/AgentLoop.test.ts src/agent/__tests__/AgentLoop.streaming.test.ts` (74 passed)
<img width="1049" height="434" alt="image" src="https://github.com/user-attachments/assets/ec84a237-dd17-4465-b382-c83215f102b5" />
- [x] `pnpm run type-check`
- [x] `pnpm run lint`
- [x] `pnpm run build`

The full `pnpm test` suite was also run on Windows. Tests covering the changed persistence and loop paths passed; unrelated existing Windows-specific tests failed because they expect POSIX path separators, require symlink privileges, or execute inline shell commands unavailable in this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved tool execution reliability by validating and ordering results correctly.
  - Ensured incomplete or invalid executions are safely discarded and retried.
  - Preserved the correct order of assistant requests, tool results, and injected messages.
  - Improved session recovery and reconstruction across resumed or repaired conversations.
  - Prevented duplicate or empty messages from appearing in conversation history.
  - Improved message tracking when tool calls reuse identifiers across conversation turns.

- **Tests**
  - Added coverage for execution ordering, persistence, session recovery, and legacy conversation repair.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->