### PR TITLE
refactor: discriminated unions for internal result types (F4, F5, F7)

### DIFF
--- a/src/agent/AttachmentHandler.ts
+++ b/src/agent/AttachmentHandler.ts
@@ -74,7 +74,7 @@ export class AttachmentHandler {
 
     for (const att of attachments) {
       if (att.type === 'file') {
-        const lineInfo = att.metadata?.lineRange
+        const lineInfo = att.metadata.lineRange
           ? ` (lines ${att.metadata.lineRange.start}${att.metadata.lineRange.end ? `-${att.metadata.lineRange.end}` : ''})`
           : '';
 
@@ -134,7 +134,7 @@ export class AttachmentHandler {
 
     for (const att of attachments) {
       if (att.type === 'file') {
-        const lineInfo = att.metadata?.lineRange
+        const lineInfo = att.metadata.lineRange
           ? ` (lines ${att.metadata.lineRange.start}${att.metadata.lineRange.end ? `-${att.metadata.lineRange.end}` : ''})`
           : '';
 

--- a/src/hooks/HookExecutor.ts
+++ b/src/hooks/HookExecutor.ts
@@ -77,27 +77,22 @@ export class HookExecutor {
         const result = await this.executeHook(hook, hookInput as HookInput, context);
 
         // 处理结果
-        if (!result.success) {
-          if (result.blocking) {
-            // 阻塞错误 - 立即返回 deny
-            return {
-              decision: 'deny',
-              reason: result.error,
-            };
-          }
+        if (result.status === 'blocked') {
+          return {
+            decision: 'deny',
+            reason: result.error,
+          };
+        }
 
-          if (result.needsConfirmation) {
-            // 需要确认 - 返回 ask
-            return {
-              decision: 'ask',
-              reason: result.warning || result.error,
-            };
-          }
+        if (result.status === 'needs_confirmation') {
+          return {
+            decision: 'ask',
+            reason: result.warning,
+          };
+        }
 
-          // 非阻塞错误 - 记录警告,继续
-          if (result.warning) {
-            warnings.push(result.warning);
-          }
+        if (result.status === 'warning') {
+          warnings.push(result.warning);
           continue;
         }
 
@@ -188,8 +183,11 @@ export class HookExecutor {
     const warnings: string[] = [];
 
     for (const result of results) {
-      if (!result.success && result.warning) {
+      if (result.status === 'warning') {
         warnings.push(result.warning);
+        continue;
+      }
+      if (result.status !== 'success') {
         continue;
       }
 
@@ -235,10 +233,10 @@ export class HookExecutor {
       try {
         const result = await this.executeHook(hook, input, context);
 
-        if (!result.success) {
-          if (result.warning) {
-            warnings.push(result.warning);
-          }
+        if (result.status === 'warning') {
+          warnings.push(result.warning);
+        }
+        if (result.status !== 'success') {
           continue;
         }
 
@@ -283,16 +281,16 @@ export class HookExecutor {
       try {
         const result = await this.executeHook(hook, input, context);
 
-        if (!result.success) {
-          if (result.blocking) {
-            return {
-              proceed: false,
-              warning: result.error,
-            };
-          }
-          if (result.warning) {
-            warnings.push(result.warning);
-          }
+        if (result.status === 'blocked') {
+          return {
+            proceed: false,
+            warning: result.error,
+          };
+        }
+        if (result.status === 'warning') {
+          warnings.push(result.warning);
+        }
+        if (result.status !== 'success') {
           continue;
         }
 
@@ -333,10 +331,10 @@ export class HookExecutor {
       try {
         const result = await this.executeHook(hook, input, context);
 
-        if (!result.success) {
-          if (result.warning) {
-            warnings.push(result.warning);
-          }
+        if (result.status === 'warning') {
+          warnings.push(result.warning);
+        }
+        if (result.status !== 'success') {
           continue;
         }
 
@@ -387,17 +385,17 @@ export class HookExecutor {
       try {
         const result = await this.executeHook(hook, input, context);
 
-        if (!result.success) {
-          if (result.blocking) {
-            return {
-              allowCompletion: false,
-              blockReason: result.error,
-              warning: warnings.length > 0 ? warnings.join('\n') : undefined,
-            };
-          }
-          if (result.warning) {
-            warnings.push(result.warning);
-          }
+        if (result.status === 'blocked') {
+          return {
+            allowCompletion: false,
+            blockReason: result.error,
+            warning: warnings.length > 0 ? warnings.join('\n') : undefined,
+          };
+        }
+        if (result.status === 'warning') {
+          warnings.push(result.warning);
+        }
+        if (result.status !== 'success') {
           continue;
         }
 
@@ -441,10 +439,10 @@ export class HookExecutor {
       try {
         const result = await this.executeHook(hook, input, context);
 
-        if (!result.success) {
-          if (result.warning) {
-            warnings.push(result.warning);
-          }
+        if (result.status === 'warning') {
+          warnings.push(result.warning);
+        }
+        if (result.status !== 'success') {
           continue;
         }
 
@@ -493,17 +491,17 @@ export class HookExecutor {
       try {
         const result = await this.executeHook(hook, input, context);
 
-        if (!result.success) {
-          if (result.blocking) {
-            // 阻塞错误，停止处理
-            return {
-              proceed: false,
-              warning: result.error,
-            };
-          }
-          if (result.warning) {
-            warnings.push(result.warning);
-          }
+        if (result.status === 'blocked') {
+          // 阻塞错误，停止处理
+          return {
+            proceed: false,
+            warning: result.error,
+          };
+        }
+        if (result.status === 'warning') {
+          warnings.push(result.warning);
+        }
+        if (result.status !== 'success') {
           continue;
         }
 
@@ -557,16 +555,16 @@ export class HookExecutor {
       try {
         const result = await this.executeHook(hook, input, context);
 
-        if (!result.success) {
-          if (result.blocking) {
-            return {
-              proceed: false,
-              warning: result.error,
-            };
-          }
-          if (result.warning) {
-            warnings.push(result.warning);
-          }
+        if (result.status === 'blocked') {
+          return {
+            proceed: false,
+            warning: result.error,
+          };
+        }
+        if (result.status === 'warning') {
+          warnings.push(result.warning);
+        }
+        if (result.status !== 'success') {
           continue;
         }
 
@@ -611,7 +609,7 @@ export class HookExecutor {
     );
 
     for (const result of results) {
-      if (!result.success && result.warning) {
+      if (result.status === 'warning') {
         warnings.push(result.warning);
       }
     }
@@ -645,7 +643,7 @@ export class HookExecutor {
     );
 
     for (const result of results) {
-      if (!result.success && result.warning) {
+      if (result.status === 'warning') {
         warnings.push(result.warning);
         continue;
       }
@@ -685,10 +683,10 @@ export class HookExecutor {
       try {
         const result = await this.executeHook(hook, input, context);
 
-        if (!result.success) {
-          if (result.warning) {
-            warnings.push(result.warning);
-          }
+        if (result.status === 'warning') {
+          warnings.push(result.warning);
+        }
+        if (result.status !== 'success') {
           continue;
         }
 
@@ -733,10 +731,10 @@ export class HookExecutor {
       try {
         const result = await this.executeHook(hook, input, context);
 
-        if (!result.success) {
-          if (result.warning) {
-            warnings.push(result.warning);
-          }
+        if (result.status === 'warning') {
+          warnings.push(result.warning);
+        }
+        if (result.status !== 'success') {
           continue;
         }
 
@@ -780,10 +778,10 @@ export class HookExecutor {
       try {
         const result = await this.executeHook(hook, input, context);
 
-        if (!result.success) {
-          if (result.warning) {
-            warnings.push(result.warning);
-          }
+        if (result.status === 'warning') {
+          warnings.push(result.warning);
+        }
+        if (result.status !== 'success') {
           continue;
         }
 
@@ -827,10 +825,10 @@ export class HookExecutor {
       try {
         const result = await this.executeHook(hook, input, context);
 
-        if (!result.success) {
-          if (result.warning) {
-            warnings.push(result.warning);
-          }
+        if (result.status === 'warning') {
+          warnings.push(result.warning);
+        }
+        if (result.status !== 'success') {
           continue;
         }
 
@@ -874,10 +872,10 @@ export class HookExecutor {
       try {
         const result = await this.executeHook(hook, input, context);
 
-        if (!result.success) {
-          if (result.warning) {
-            warnings.push(result.warning);
-          }
+        if (result.status === 'warning') {
+          warnings.push(result.warning);
+        }
+        if (result.status !== 'success') {
           continue;
         }
 
@@ -919,10 +917,8 @@ export class HookExecutor {
       try {
         const result = await this.executeHook(hook, input, context);
 
-        if (!result.success) {
-          if (result.warning) {
-            warnings.push(result.warning);
-          }
+        if (result.status === 'warning') {
+          warnings.push(result.warning);
         }
       } catch (err) {
         const errorMsg = err instanceof Error ? err.message : String(err);
@@ -956,10 +952,10 @@ export class HookExecutor {
       try {
         const result = await this.executeHook(hook, input, context);
 
-        if (!result.success) {
-          if (result.warning) {
-            warnings.push(result.warning);
-          }
+        if (result.status === 'warning') {
+          warnings.push(result.warning);
+        }
+        if (result.status !== 'success') {
           continue;
         }
 
@@ -1003,10 +999,10 @@ export class HookExecutor {
       try {
         const result = await this.executeHook(hook, input, context);
 
-        if (!result.success) {
-          if (result.warning) {
-            warnings.push(result.warning);
-          }
+        if (result.status === 'warning') {
+          warnings.push(result.warning);
+        }
+        if (result.status !== 'success') {
           continue;
         }
 
@@ -1047,10 +1043,10 @@ export class HookExecutor {
       try {
         const result = await this.executeHook(hook, input, context);
 
-        if (!result.success) {
-          if (result.warning) {
-            warnings.push(result.warning);
-          }
+        if (result.status === 'warning') {
+          warnings.push(result.warning);
+        }
+        if (result.status !== 'success') {
           continue;
         }
 
@@ -1097,8 +1093,11 @@ export class HookExecutor {
     );
 
     for (const result of results) {
-      if (!result.success && result.warning) {
+      if (result.status === 'warning') {
         warnings.push(result.warning);
+        continue;
+      }
+      if (result.status !== 'success') {
         continue;
       }
 
@@ -1138,7 +1137,7 @@ export class HookExecutor {
     );
 
     for (const result of results) {
-      if (!result.success && result.warning) {
+      if (result.status === 'warning') {
         warnings.push(result.warning);
       }
     }
@@ -1189,9 +1188,8 @@ export class HookExecutor {
       });
     } catch (err) {
       return {
-        success: false,
-        blocking: false,
-        error: err instanceof Error ? err.message : String(err),
+        status: 'warning',
+        warning: err instanceof Error ? err.message : String(err),
         hook,
       };
     }
@@ -1218,9 +1216,8 @@ export class HookExecutor {
 
       // 创建新的 hook 执行 Promise
       const promise = this.executeHook(hook, input, context).catch((err) => ({
-        success: false,
-        blocking: false,
-        error: err instanceof Error ? err.message : String(err),
+        status: 'warning' as const,
+        warning: err instanceof Error ? err.message : String(err),
         hook,
       }));
 

--- a/src/hooks/OutputParser.ts
+++ b/src/hooks/OutputParser.ts
@@ -7,12 +7,12 @@
 import type { JsonValue } from '../types/common.js';
 import { safeParseHookOutput } from './schemas/HookSchemas.js';
 import {
-    type Hook,
-    type HookConfig,
-    type HookExecutionResult,
-    HookExitCode,
-    type HookOutput,
-    type ProcessResult,
+  type Hook,
+  type HookConfig,
+  type HookExecutionResult,
+  HookExitCode,
+  type HookOutput,
+  type ProcessResult,
 } from './types/HookTypes.js';
 
 const VALID_EXIT_CODES = new Set(Object.values(HookExitCode).filter((v): v is number => typeof v === 'number'));
@@ -72,10 +72,8 @@ export class OutputParser {
       // 检查 decision.behavior
       if (output.decision?.behavior === 'block') {
         return {
-          success: false,
-          blocking: true,
+          status: 'blocked',
           error: output.systemMessage || 'Hook blocked execution',
-          output,
           stdout: result.stdout,
           stderr: result.stderr,
           exitCode: result.exitCode,
@@ -86,7 +84,7 @@ export class OutputParser {
       // async behavior - 不阻塞
       if (output.decision?.behavior === 'async') {
         return {
-          success: true,
+          status: 'success',
           output,
           stdout: result.stdout,
           stderr: result.stderr,
@@ -97,7 +95,7 @@ export class OutputParser {
 
       // approve - 成功
       return {
-        success: true,
+        status: 'success',
         output,
         stdout: result.stdout,
         stderr: result.stderr,
@@ -123,7 +121,7 @@ export class OutputParser {
     switch (exitCode) {
       case 0: // SUCCESS
         return {
-          success: true,
+          status: 'success',
           stdout: result.stdout,
           stderr: result.stderr,
           exitCode,
@@ -132,8 +130,7 @@ export class OutputParser {
 
       case 2: // BLOCKING_ERROR
         return {
-          success: false,
-          blocking: true,
+          status: 'blocked',
           error: result.stderr || result.stdout || 'Hook returned exit code 2',
           stdout: result.stdout,
           stderr: result.stderr,
@@ -186,20 +183,18 @@ export class OutputParser {
     };
 
     if (behavior === 'deny') {
-      return { success: false, blocking: true, error: errorMsg, ...common };
+      return { status: 'blocked', error: errorMsg, ...common };
     }
 
     if (behavior === 'ask') {
       return {
-        success: false,
-        blocking: false,
-        needsConfirmation: true,
+        status: 'needs_confirmation',
         warning: `${errorMsg}. Continue?`,
         ...common,
       };
     }
 
-    return { success: false, blocking: false, warning: errorMsg, ...common };
+    return { status: 'warning', warning: errorMsg, ...common };
   }
 
   /**

--- a/src/hooks/__tests__/OutputParser.test.ts
+++ b/src/hooks/__tests__/OutputParser.test.ts
@@ -21,8 +21,7 @@ describe('OutputParser', () => {
       };
 
       const parsed = parser.parse(result, mockHook);
-      expect(parsed.success).toBe(true);
-      expect(parsed.blocking).toBeUndefined();
+      expect(parsed.status).toBe('success');
     });
 
     it('should return blocking error for exit code 2', () => {
@@ -34,9 +33,8 @@ describe('OutputParser', () => {
       };
 
       const parsed = parser.parse(result, mockHook);
-      expect(parsed.success).toBe(false);
-      expect(parsed.blocking).toBe(true);
-      expect(parsed.error).toBe('Blocked by hook');
+      expect(parsed.status).toBe('blocked');
+      expect(parsed.status === 'blocked' && parsed.error).toBe('Blocked by hook');
     });
 
     it('should return non-blocking error for other exit codes with ignore behavior', () => {
@@ -48,9 +46,8 @@ describe('OutputParser', () => {
       };
 
       const parsed = parser.parse(result, mockHook, { failureBehavior: 'ignore' });
-      expect(parsed.success).toBe(false);
-      expect(parsed.blocking).toBe(false);
-      expect(parsed.warning).toBe('Some error');
+      expect(parsed.status).toBe('warning');
+      expect(parsed.status === 'warning' && parsed.warning).toBe('Some error');
     });
 
     it('should return blocking error for other exit codes with deny behavior', () => {
@@ -63,9 +60,8 @@ describe('OutputParser', () => {
 
       const config: Pick<HookConfig, 'failureBehavior'> = { failureBehavior: 'deny' };
       const parsed = parser.parse(result, mockHook, config);
-      expect(parsed.success).toBe(false);
-      expect(parsed.blocking).toBe(true);
-      expect(parsed.error).toBe('Some error');
+      expect(parsed.status).toBe('blocked');
+      expect(parsed.status === 'blocked' && parsed.error).toBe('Some error');
     });
 
     it('should request confirmation for other exit codes with ask behavior', () => {
@@ -78,9 +74,7 @@ describe('OutputParser', () => {
 
       const config: Pick<HookConfig, 'failureBehavior'> = { failureBehavior: 'ask' };
       const parsed = parser.parse(result, mockHook, config);
-      expect(parsed.success).toBe(false);
-      expect(parsed.blocking).toBe(false);
-      expect(parsed.needsConfirmation).toBe(true);
+      expect(parsed.status).toBe('needs_confirmation');
     });
   });
 
@@ -94,9 +88,8 @@ describe('OutputParser', () => {
       };
 
       const parsed = parser.parse(result, mockHook, { timeoutBehavior: 'ignore' });
-      expect(parsed.success).toBe(false);
-      expect(parsed.blocking).toBe(false);
-      expect(parsed.warning).toBe('Hook timeout');
+      expect(parsed.status).toBe('warning');
+      expect(parsed.status === 'warning' && parsed.warning).toBe('Hook timeout');
     });
 
     it('should handle timeout with deny behavior', () => {
@@ -108,9 +101,8 @@ describe('OutputParser', () => {
       };
 
       const parsed = parser.parse(result, mockHook, { timeoutBehavior: 'deny' });
-      expect(parsed.success).toBe(false);
-      expect(parsed.blocking).toBe(true);
-      expect(parsed.error).toBe('Hook timeout');
+      expect(parsed.status).toBe('blocked');
+      expect(parsed.status === 'blocked' && parsed.error).toBe('Hook timeout');
     });
 
     it('should handle timeout with ask behavior', () => {
@@ -122,9 +114,7 @@ describe('OutputParser', () => {
       };
 
       const parsed = parser.parse(result, mockHook, { timeoutBehavior: 'ask' });
-      expect(parsed.success).toBe(false);
-      expect(parsed.blocking).toBe(false);
-      expect(parsed.needsConfirmation).toBe(true);
+      expect(parsed.status).toBe('needs_confirmation');
     });
   });
 
@@ -140,8 +130,8 @@ describe('OutputParser', () => {
       };
 
       const parsed = parser.parse(result, mockHook);
-      expect(parsed.success).toBe(true);
-      expect(parsed.output).toBeDefined();
+      expect(parsed.status).toBe('success');
+      expect(parsed.status === 'success' && parsed.output).toBeDefined();
     });
 
     it('should parse JSON output with block decision', () => {
@@ -156,9 +146,8 @@ describe('OutputParser', () => {
       };
 
       const parsed = parser.parse(result, mockHook);
-      expect(parsed.success).toBe(false);
-      expect(parsed.blocking).toBe(true);
-      expect(parsed.error).toBe('Operation blocked');
+      expect(parsed.status).toBe('blocked');
+      expect(parsed.status === 'blocked' && parsed.error).toBe('Operation blocked');
     });
 
     it('should parse JSON output with async decision', () => {
@@ -172,7 +161,7 @@ describe('OutputParser', () => {
       };
 
       const parsed = parser.parse(result, mockHook);
-      expect(parsed.success).toBe(true);
+      expect(parsed.status).toBe('success');
     });
 
     it('should parse JSON with hookSpecificOutput', () => {
@@ -190,8 +179,8 @@ describe('OutputParser', () => {
       };
 
       const parsed = parser.parse(result, mockHook);
-      expect(parsed.success).toBe(true);
-      expect(parsed.output?.hookSpecificOutput).toBeDefined();
+      expect(parsed.status).toBe('success');
+      expect(parsed.status === 'success' && parsed.output?.hookSpecificOutput).toBeDefined();
     });
 
     it('should handle invalid JSON gracefully', () => {
@@ -203,7 +192,7 @@ describe('OutputParser', () => {
       };
 
       const parsed = parser.parse(result, mockHook);
-      expect(parsed.success).toBe(true);
+      expect(parsed.status).toBe('success');
     });
 
     it('should handle empty stdout', () => {
@@ -215,7 +204,7 @@ describe('OutputParser', () => {
       };
 
       const parsed = parser.parse(result, mockHook);
-      expect(parsed.success).toBe(true);
+      expect(parsed.status).toBe('success');
     });
 
     it('should handle JSON with extra whitespace', () => {
@@ -231,7 +220,7 @@ describe('OutputParser', () => {
       };
 
       const parsed = parser.parse(result, mockHook);
-      expect(parsed.success).toBe(true);
+      expect(parsed.status).toBe('success');
     });
   });
 
@@ -245,7 +234,10 @@ describe('OutputParser', () => {
       };
 
       const parsed = parser.parse(result, mockHook);
-      expect(parsed.error).toBe('stderr error');
+      expect(parsed.status).toBe('blocked');
+      if (parsed.status === 'blocked') {
+        expect(parsed.error).toBe('stderr error');
+      }
     });
 
     it('should use stdout as error message when stderr is empty', () => {
@@ -257,7 +249,10 @@ describe('OutputParser', () => {
       };
 
       const parsed = parser.parse(result, mockHook);
-      expect(parsed.error).toBe('stdout error');
+      expect(parsed.status).toBe('blocked');
+      if (parsed.status === 'blocked') {
+        expect(parsed.error).toBe('stdout error');
+      }
     });
 
     it('should use default message when both are empty', () => {
@@ -269,7 +264,10 @@ describe('OutputParser', () => {
       };
 
       const parsed = parser.parse(result, mockHook);
-      expect(parsed.error).toBe('Hook returned exit code 2');
+      expect(parsed.status).toBe('blocked');
+      if (parsed.status === 'blocked') {
+        expect(parsed.error).toBe('Hook returned exit code 2');
+      }
     });
   });
 });

--- a/src/hooks/types/HookTypes.ts
+++ b/src/hooks/types/HookTypes.ts
@@ -884,25 +884,7 @@ export interface ProcessResult {
 /**
  * Hook 执行结果
  */
-export interface HookExecutionResult {
-  /** 是否成功 */
-  success: boolean;
-
-  /** 是否阻塞 */
-  blocking?: boolean;
-
-  /** 是否需要用户确认 (ask 行为) */
-  needsConfirmation?: boolean;
-
-  /** 错误信息 */
-  error?: string;
-
-  /** 警告信息 */
-  warning?: string;
-
-  /** 解析后的输出 */
-  output?: HookOutput;
-
+interface HookExecutionResultBase {
   /** 原始标准输出 */
   stdout?: string;
 
@@ -915,6 +897,21 @@ export interface HookExecutionResult {
   /** Hook 配置 */
   hook?: Hook;
 }
+
+/**
+ * Hook 执行结果（判别联合）。
+ *
+ * - success: 执行成功，可能携带解析后的 output
+ * - blocked: 阻塞性错误，应拒绝执行
+ * - needs_confirmation: 需要用户确认后继续
+ * - warning: 非阻塞警告，记录后继续
+ */
+export type HookExecutionResult = HookExecutionResultBase & (
+  | { status: 'success'; output?: HookOutput }
+  | { status: 'blocked'; error: string }
+  | { status: 'needs_confirmation'; warning: string }
+  | { status: 'warning'; warning: string }
+);
 
 /**
  * PreToolUse Hook 执行结果

--- a/src/prompts/processors/types.ts
+++ b/src/prompts/processors/types.ts
@@ -29,9 +29,14 @@ export interface AtMention {
 }
 
 /**
- * 附件类型
+ * 文件附件
  */
-export type AttachmentType = 'file' | 'directory' | 'error';
+export interface FileAttachment {
+  type: 'file';
+  path: string;
+  content: string;
+  metadata: AttachmentMetadata;
+}
 
 /**
  * 附件元数据
@@ -48,20 +53,29 @@ export interface AttachmentMetadata {
 }
 
 /**
- * 附件对象
+ * 目录附件
  */
-export interface Attachment {
-  /** 附件类型 */
-  type: AttachmentType;
-  /** 相对路径 */
+export interface DirectoryAttachment {
+  type: 'directory';
   path: string;
-  /** 文件内容 */
   content: string;
-  /** 元数据 */
   metadata?: AttachmentMetadata;
-  /** 错误信息（type='error' 时使用） */
-  error?: string;
 }
+
+/**
+ * 错误附件（读取失败时）
+ */
+export interface ErrorAttachment {
+  type: 'error';
+  path: string;
+  content: '';
+  error: string;
+}
+
+/**
+ * 附件对象（判别联合）
+ */
+export type Attachment = FileAttachment | DirectoryAttachment | ErrorAttachment;
 
 /**
  * 附件收集器选项

--- a/src/tools/builtin/web/searchProviders.ts
+++ b/src/tools/builtin/web/searchProviders.ts
@@ -10,9 +10,15 @@ import { getErrorName } from '../../../utils/errorUtils.js';
 import type { WebSearchResult } from './webSearch.js';
 
 /**
- * 搜索提供商接口
+ * 搜索提供商（判别联合）
+ *
+ * - http: 通过 HTTP 请求调用搜索 API
+ * - sdk:  通过内置 SDK 函数直接搜索（绕过 HTTP）
  */
-export interface SearchProvider {
+export type SearchProvider = HttpSearchProvider | SdkSearchProvider;
+
+export interface HttpSearchProvider {
+  kind: 'http';
   /** 提供商名称（用于日志显示） */
   name: string;
   /** API 端点 */
@@ -27,8 +33,14 @@ export interface SearchProvider {
   parseResponse: (data: JsonValue) => WebSearchResult[];
   /** 获取请求头 */
   getHeaders: () => Record<string, string>;
-  /** 可选的 SDK 搜索函数（优先使用，绕过 HTTP 请求） */
-  searchFn?: (query: string) => Promise<WebSearchResult[]>;
+}
+
+export interface SdkSearchProvider {
+  kind: 'sdk';
+  /** 提供商名称（用于日志显示） */
+  name: string;
+  /** SDK 搜索函数 */
+  searchFn: (query: string) => Promise<WebSearchResult[]>;
 }
 
 // ============================================================================
@@ -148,6 +160,7 @@ function transformDuckDuckGoResponse(data: JsonValue): WebSearchResult[] {
 }
 
 const duckDuckGoProvider: SearchProvider = {
+  kind: 'http',
   name: 'DuckDuckGo',
   endpoint: 'https://duckduckgo.com/',
   buildUrl: (query: string) => {
@@ -231,6 +244,7 @@ function createSearXNGProvider(instanceUrl: string): SearchProvider {
   })();
 
   return {
+    kind: 'http',
     name: `SearXNG(${hostname})`,
     endpoint: instanceUrl,
     buildUrl: (query: string) => {
@@ -357,8 +371,8 @@ function parseExaMcpResponse(text: string): WebSearchResult[] {
  */
 function createExaProvider(): SearchProvider {
   return {
+    kind: 'sdk',
     name: 'Exa',
-    endpoint: `${EXA_MCP_CONFIG.BASE_URL}${EXA_MCP_CONFIG.ENDPOINT}`,
 
     // 使用 MCP 搜索函数
     searchFn: async (query: string): Promise<WebSearchResult[]> => {
@@ -430,11 +444,6 @@ function createExaProvider(): SearchProvider {
         throw error;
       }
     },
-
-    // 兼容性字段
-    buildUrl: () => `${EXA_MCP_CONFIG.BASE_URL}${EXA_MCP_CONFIG.ENDPOINT}`,
-    parseResponse: () => [],
-    getHeaders: () => ({}),
   };
 }
 

--- a/src/tools/builtin/web/webSearch.ts
+++ b/src/tools/builtin/web/webSearch.ts
@@ -181,8 +181,8 @@ async function searchWithProvider(
     };
   }
 
-  // 如果提供商有 SDK 搜索函数，优先使用
-  if (provider.searchFn) {
+  // SDK 提供商（如 Exa）直接调用 searchFn，绕过 HTTP
+  if (provider.kind === 'sdk') {
     try {
       updateOutput?.(`🔍 搜索中 (${provider.name})...`);
       const results = await provider.searchFn(query);
@@ -196,7 +196,7 @@ async function searchWithProvider(
     }
   }
 
-  // 否则使用 HTTP 请求（兼容旧提供商）
+  // HTTP 提供商
   updateOutput?.(`🔍 搜索中 (${provider.name})...`);
 
   const url = provider.buildUrl(query);


### PR DESCRIPTION
## Summary

Second batch from the [codebase simplification audit](docs/simplification-audit.md). Three internal type tightenings that make invalid states unrepresentable. Each is a separate commit.

| Commit | Finding | Change |
|--------|---------|--------|
| `877bb95c` | F4 | `HookExecutionResult` → discriminated union (`status: success/blocked/needs_confirmation/warning`) |
| `894874a7` | F5 | `SearchProvider` → `HttpSearchProvider \| SdkSearchProvider` discriminated by `kind` |
| `94b0e4e2` | F7 | `Attachment` → `FileAttachment \| DirectoryAttachment \| ErrorAttachment` |

### F4 — HookExecutionResult
The flat interface used `success`/`blocking?`/`needsConfirmation?` booleans that encoded four mutually exclusive outcomes but permitted eight combinations (e.g. `success+blocking`). Every consumer in `HookExecutor` re-derived the state through nested `if` cascades. Consumers now switch on `result.status`. The two `catch` blocks that previously returned `{ success:false, blocking:false, error }` (silently dropped) now map to `status:'warning'` so the failure message surfaces.

### F5 — SearchProvider
The flat interface mixed HTTP fields with an optional `searchFn`. The Exa SDK provider was forced to supply dead stubs (`buildUrl: ()=>''`, `parseResponse: ()=>[]`, `getHeaders: ()=>({})`). Split into `kind:'http'` and `kind:'sdk'` variants; the consumer narrows on `provider.kind`.

### F7 — Attachment
The flat `Attachment` shared optional `metadata?`/`error?` across all variants. File attachments always have metadata but consumers used defensive optional chaining; error attachments always have `error` but it was typed optional. Split into three variants with required fields where appropriate. `AttachmentHandler` now accesses `att.metadata.lineRange` directly after narrowing to `type:'file'`.

## Validation

- `tsc --noEmit` — passes
- `biome lint src` — 337 files, 0 warnings/errors
- All affected test suites pass: `OutputParser.test.ts` (18), `AtMentionParser.test.ts` (20), `webFetch.test.ts` (2)
- Full suite: 1067 passed

No public API changes. No dependency changes. Builds on batch 1 (PR #9, already merged).