### PR TITLE
refactor: deduplication and performance batch (F9, F10, F15)

### DIFF
--- a/src/agent/subagents/BackgroundAgentManager.ts
+++ b/src/agent/subagents/BackgroundAgentManager.ts
@@ -14,13 +14,13 @@ import { join } from 'node:path';
 import { type InternalLogger, LogCategory, NOOP_LOGGER } from '../../logging/Logger.js';
 import type { ContextSnapshot } from '../../runtime/index.js';
 import type { Message } from '../../services/ChatServiceInterface.js';
-import { AgentId, SessionId } from '../../types/branded.js';
+import { AgentId } from '../../types/branded.js';
 import type { BladeConfig, PermissionMode } from '../../types/common.js';
-import { Agent } from '../Agent.js';
 import type {
-  AgentSession,
-  AgentSessionStore,
+    AgentSession,
+    AgentSessionStore,
 } from './AgentSessionStore.js';
+import { runSubagent } from './runSubagent.js';
 import type { SubagentRegistry } from './SubagentRegistry.js';
 import type { SubagentConfig, SubagentResult } from './types.js';
 
@@ -255,36 +255,17 @@ export class BackgroundAgentManager {
         throw new Error('Agent execution was cancelled');
       }
 
-      const systemPrompt = config.systemPrompt || '';
-      const modelId =
-        config.model && config.model !== 'inherit' ? config.model : undefined;
-      const agent = await Agent.create(bladeConfig, {
-        systemPrompt,
-        toolWhitelist: config.tools,
-        modelId,
-      }, {
+      const messages = existingMessages ?? [];
+      const loopResult = await runSubagent({
+        config,
+        bladeConfig,
         subagentRegistry,
-        defaultContext: snapshot
-          ? snapshot.context
-          : {},
-      });
-
-      const context = {
-        messages: existingMessages || [],
-        userId: 'subagent',
-        sessionId: SessionId(agentId),
-        snapshot,
+        prompt,
+        agentId,
+        parentSessionId,
         permissionMode,
-        subagentInfo: {
-          parentSessionId: parentSessionId || '',
-          subagentType: config.name,
-          // Background agents run in a separate session tree; mark as sidechain
-          // so their messages are not written into the parent session's store.
-          isSidechain: true,
-        },
-      };
-
-      const loopResult = await agent.runAgenticLoop(prompt, context, {
+        snapshot,
+        messages,
         signal: workSignal,
         onProgress: (progress) => {
           this.sessionStore.updateSession(agentId, { progress });
@@ -292,7 +273,7 @@ export class BackgroundAgentManager {
       });
 
       this.sessionStore.updateSession(agentId, {
-        messages: context.messages,
+        messages,
       });
 
       const duration = Date.now() - startTime;

--- a/src/agent/subagents/SubagentExecutor.ts
+++ b/src/agent/subagents/SubagentExecutor.ts
@@ -1,9 +1,8 @@
 import { nanoid } from 'nanoid';
-import { SessionId } from '../../types/branded.js';
 import type { BladeConfig } from '../../types/common.js';
-import { Agent } from '../Agent.js';
 import type { SubagentRegistry } from './SubagentRegistry.js';
 import type { SubagentConfig, SubagentContext, SubagentResult } from './types.js';
+import { runSubagent } from './runSubagent.js';
 
 /**
  * Subagent 执行器
@@ -31,54 +30,19 @@ export class SubagentExecutor {
     const agentId = context.subagentSessionId ?? nanoid();
 
     try {
-      const systemPrompt = this.buildSystemPrompt(context);
-
-      const modelId =
-        this.config.model && this.config.model !== 'inherit'
-          ? this.config.model
-          : undefined;
-      const agent = await Agent.create(this.bladeConfig, {
-        toolWhitelist: this.config.tools,
-        modelId,
-      }, {
+      const loopResult = await runSubagent({
+        config: this.config,
+        bladeConfig: this.bladeConfig,
         subagentRegistry: this.subagentRegistry,
-        defaultContext: context.snapshot
-          ? context.snapshot.context
-          : {},
+        prompt: context.prompt,
+        agentId,
+        parentSessionId: context.parentSessionId,
+        permissionMode: context.permissionMode,
+        snapshot: context.snapshot,
+        omitEnvironment: context.omitEnvironment ?? this.config.omitEnvironment,
       });
 
-      let finalMessage = '';
-      let toolCallCount = 0;
-      let tokensUsed = 0;
-
-      const subagentInfo = {
-        parentSessionId: context.parentSessionId || '',
-        subagentType: this.config.name,
-        // Mark as sidechain so the subagent's messages are stored in a
-        // separate session tree and do not pollute the parent session's
-        // persistent store.
-        isSidechain: true,
-      };
-      
-      const loopResult = await agent.runAgenticLoop(
-        context.prompt,
-        {
-          messages: [],
-          userId: 'subagent',
-          sessionId: SessionId(agentId),
-          snapshot: context.snapshot,
-          permissionMode: context.permissionMode,
-          systemPrompt,
-          subagentInfo,
-          omitEnvironment: context.omitEnvironment ?? this.config.omitEnvironment,
-        }
-      );
-
-      if (loopResult.success) {
-        finalMessage = loopResult.finalMessage || '';
-        toolCallCount = loopResult.metadata?.toolCallsCount || 0;
-        tokensUsed = loopResult.metadata?.tokensUsed || 0;
-      } else {
+      if (!loopResult.success) {
         throw new Error(loopResult.error?.message || 'Subagent execution failed');
       }
 
@@ -86,11 +50,11 @@ export class SubagentExecutor {
 
       return {
         success: true,
-        message: finalMessage,
+        message: loopResult.finalMessage || '',
         agentId,
         stats: {
-          tokens: tokensUsed,
-          toolCalls: toolCallCount,
+          tokens: loopResult.metadata?.tokensUsed || 0,
+          toolCalls: loopResult.metadata?.toolCallsCount || 0,
           duration,
         },
       };
@@ -106,9 +70,5 @@ export class SubagentExecutor {
         },
       };
     }
-  }
-
-  private buildSystemPrompt(_context: SubagentContext): string {
-    return this.config.systemPrompt || '';
   }
 }

--- a/src/agent/subagents/runSubagent.ts
+++ b/src/agent/subagents/runSubagent.ts
@@ -1,0 +1,89 @@
+import { SessionId } from '../../types/branded.js';
+import type { BladeConfig, PermissionMode } from '../../types/common.js';
+import type { ContextSnapshot } from '../../runtime/index.js';
+import type { Message } from '../../services/ChatServiceInterface.js';
+import { Agent } from '../Agent.js';
+import type { AgentProgress, LoopResult } from '../types.js';
+import type { SubagentRegistry } from './SubagentRegistry.js';
+import type { SubagentConfig } from './types.js';
+
+export interface RunSubagentOptions {
+  config: SubagentConfig;
+  bladeConfig: BladeConfig;
+  subagentRegistry?: SubagentRegistry;
+  prompt: string;
+  agentId: string;
+  parentSessionId?: string;
+  permissionMode?: PermissionMode;
+  snapshot?: ContextSnapshot;
+  messages?: Message[];
+  signal?: AbortSignal;
+  omitEnvironment?: boolean;
+  onProgress?: (progress: AgentProgress) => void;
+}
+
+function resolveModelId(config: SubagentConfig): string | undefined {
+  return config.model && config.model !== 'inherit' ? config.model : undefined;
+}
+
+/**
+ * 创建子 Agent 并运行一轮 agentic loop。
+ *
+ * SubagentExecutor 和 BackgroundAgentManager 共用此函数，
+ * 统一 modelId 推导、Agent.create 配置、subagentInfo 构造以及
+ * systemPrompt 传递方式（统一通过 ChatContext 传入，而非已废弃的 AgentOptions）。
+ */
+export async function runSubagent(options: RunSubagentOptions): Promise<LoopResult> {
+  const {
+    config,
+    bladeConfig,
+    subagentRegistry,
+    prompt,
+    agentId,
+    parentSessionId,
+    permissionMode,
+    snapshot,
+    messages,
+    signal,
+    omitEnvironment,
+    onProgress,
+  } = options;
+
+  const agent = await Agent.create(
+    bladeConfig,
+    {
+      toolWhitelist: config.tools,
+      modelId: resolveModelId(config),
+    },
+    {
+      subagentRegistry,
+      defaultContext: snapshot ? snapshot.context : {},
+    },
+  );
+
+  const loopOptions = signal || onProgress
+    ? {
+        ...(signal ? { signal } : {}),
+        ...(onProgress ? { onProgress } : {}),
+      }
+    : undefined;
+
+  const chatContext = {
+    messages: messages ?? [],
+    userId: 'subagent',
+    sessionId: SessionId(agentId),
+    snapshot,
+    permissionMode,
+    systemPrompt: config.systemPrompt || '',
+    subagentInfo: {
+      parentSessionId: parentSessionId ?? '',
+      subagentType: config.name,
+      isSidechain: true,
+    },
+    omitEnvironment,
+  };
+
+  return loopOptions
+    ? agent.runAgenticLoop(prompt, chatContext, loopOptions)
+    : agent.runAgenticLoop(prompt, chatContext);
+}

--- a/src/context/storage/PersistentStore.ts
+++ b/src/context/storage/PersistentStore.ts
@@ -6,20 +6,20 @@ import { JsonlSessionStore } from '../../session/SessionStore.js';
 import { MessageId, SessionId } from '../../types/branded.js';
 import type { JsonObject, JsonValue, MessageRole } from '../../types/common.js';
 import type {
-  ContextData,
-  ConversationContext,
-  MessageInfo,
-  PartInfo,
-  SessionContext,
-  SessionEvent,
-  SessionInfo,
+    ContextData,
+    ConversationContext,
+    MessageInfo,
+    PartInfo,
+    SessionContext,
+    SessionEvent,
+    SessionInfo,
 } from '../types.js';
 import { JSONLStore } from './JSONLStore.js';
 import {
-  detectGitBranch,
-  getSessionFilePathFromStorageRoot,
-  listProjectDirectories,
-  normalizeSessionStorageRoot
+    detectGitBranch,
+    getSessionFilePathFromStorageRoot,
+    listProjectDirectories,
+    normalizeSessionStorageRoot
 } from './pathUtils.js';
 
 function extractMimeType(url: string): string | undefined {
@@ -67,6 +67,11 @@ export class PersistentStore {
   private readonly projectPath?: string;
   private readonly maxSessions: number;
   private readonly version: string;
+  /**
+   * 已确认存在（已创建或已检测到文件）的会话 ID 集合。
+   * 避免每次写入都全量读取 JSONL 文件来判断 session_created 是否已写入。
+   */
+  private readonly knownSessions = new Set<string>();
 
   constructor(
     storageRoot: string,
@@ -101,10 +106,20 @@ export class PersistentStore {
     sessionId: SessionId,
     subagentInfo?: { parentSessionId: string; subagentType: string; isSidechain: boolean }
   ): Promise<void> {
+    if (this.knownSessions.has(sessionId)) return;
+
     const filePath = getSessionFilePathFromStorageRoot(this.storageRoot, sessionId);
     const store = new JSONLStore(filePath);
-    const stats = await store.getStats();
-    if (stats.lineCount > 0) return;
+
+    // 冷路径：用单次 access 检查文件是否已存在，而非读取整个文件
+    try {
+      await fs.access(filePath);
+      this.knownSessions.add(sessionId);
+      return;
+    } catch {
+      // 文件不存在，需要写入 session_created 事件
+    }
+
     const now = new Date().toISOString();
     const sessionInfo: SessionInfo = {
       sessionId,
@@ -121,6 +136,7 @@ export class PersistentStore {
     };
     const entry = this.createEvent('session_created', sessionId, sessionInfo);
     await store.append(entry);
+    this.knownSessions.add(sessionId);
   }
 
   private buildCompactionMetadata(metadata: {
@@ -513,6 +529,7 @@ export class PersistentStore {
    * 删除会话数据
    */
   async deleteSession(sessionId: SessionId): Promise<void> {
+    this.knownSessions.delete(sessionId);
     try {
       const filePath = getSessionFilePathFromStorageRoot(this.storageRoot, sessionId);
       const store = new JSONLStore(filePath);

--- a/src/tools/builtin/file/edit.ts
+++ b/src/tools/builtin/file/edit.ts
@@ -5,24 +5,23 @@ import { getFileSystemService } from '../../../services/FileSystemService.js';
 import { getErrorCode, getErrorMessage, getErrorName } from '../../../utils/errorUtils.js';
 import { createTool } from '../../core/createTool.js';
 import type {
-    EditErrorMetadata,
-    EditMetadata,
-    ExecutionContext,
-    ToolResult,
+  EditErrorMetadata,
+  EditMetadata,
+  ExecutionContext,
+  ToolResult,
 } from '../../types/index.js';
 import { ToolErrorType, ToolKind } from '../../types/index.js';
 import { lazySchema } from '../../validation/lazySchema.js';
 import { ToolSchemas } from '../../validation/zodSchemas.js';
 import { generateDiffSnippetWithMatch } from './diffUtils.js';
 import {
-    flexibleMatch,
-    type MatchResult,
-    MatchStrategy,
-    unescapeString,
+  flexibleMatch,
+  type MatchResult,
+  MatchStrategy,
+  unescapeString,
 } from './editCorrector.js';
-import { FileAccessTracker } from './FileAccessTracker.js';
 import { isSensitivePath } from './sensitivePathCheck.js';
-import { SnapshotManager } from './SnapshotManager.js';
+import { recordWriteComplete, runWriteGuard } from './writeGuard.js';
 
 /**
  * EditTool - File edit tool
@@ -126,50 +125,16 @@ export const editTool = createTool({
         signal.throwIfAborted();
       }
 
-      // Read-Before-Write 验证（对齐 Claude Code 官方：强制模式）
-      if (sessionId) {
-        const tracker = FileAccessTracker.getInstance();
-
-        // 检查文件是否已读取（强制失败）
-        if (!tracker.hasFileBeenRead(file_path, sessionId)) {
-          return {
-            success: false,
-            llmContent: `You must use your Read tool at least once in the conversation before editing. This tool will error if you attempt an edit without reading the file.`,
-            error: {
-              type: ToolErrorType.VALIDATION_ERROR,
-              message: 'File not read before edit',
-            },
-            metadata: {
-              requiresRead: true,
-            },
-          };
-        }
-
-        // 🔴 检查文件是否被外部程序修改
-        const externalModCheck = await tracker.checkExternalModification(file_path);
-        if (externalModCheck.isExternal) {
-          return {
-            success: false,
-            llmContent: `The file has been modified by an external program since you last read it. You must use the Read tool again to see the current content before editing.\n\nDetails: ${externalModCheck.message}`,
-            error: {
-              type: ToolErrorType.VALIDATION_ERROR,
-              message: 'File modified externally',
-              details: { externalModification: externalModCheck.message },
-            },
-          };
-        }
-      }
-
-      // 创建快照（如果有 sessionId 和 messageId）
-      if (sessionId && messageId) {
-        try {
-          const snapshotManager = new SnapshotManager({ sessionId });
-          await snapshotManager.initialize();
-          await snapshotManager.createSnapshot(file_path, messageId);
-        } catch (error) {
-          console.warn('[EditTool] 创建快照失败:', error);
-          // 快照失败不中断编辑操作，只记录警告
-        }
+      // Read-before-write、外部修改检查、快照创建
+      const guard = await runWriteGuard({
+        filePath: file_path,
+        sessionId,
+        messageId,
+        operation: 'edit',
+        fileExists: true,
+      });
+      if (guard.blocked) {
+        return guard.blocked;
       }
 
       // 智能匹配并查找匹配项
@@ -298,11 +263,8 @@ export const editTool = createTool({
       // 写入文件（统一使用 FileSystemService）
       await fsService.writeTextFile(file_path, newContent);
 
-      // 🔴 更新文件访问记录（记录编辑操作）
-      if (sessionId) {
-        const tracker = FileAccessTracker.getInstance();
-        await tracker.recordFileEdit(file_path, sessionId, 'edit');
-      }
+      // 更新文件访问记录（记录编辑操作）
+      await recordWriteComplete(file_path, sessionId, 'edit');
 
       // 验证写入成功（统一使用 FileSystemService）
       const stats = await fsService.stat(file_path);

--- a/src/tools/builtin/file/write.ts
+++ b/src/tools/builtin/file/write.ts
@@ -14,9 +14,8 @@ import { ToolErrorType, ToolKind } from '../../types/index.js';
 import { lazySchema } from '../../validation/lazySchema.js';
 import { ToolSchemas } from '../../validation/zodSchemas.js';
 import { generateDiffSnippet } from './diffUtils.js';
-import { FileAccessTracker } from './FileAccessTracker.js';
+import { recordWriteComplete, runWriteGuard } from './writeGuard.js';
 import { isSensitivePath } from './sensitivePathCheck.js';
-import { SnapshotManager } from './SnapshotManager.js';
 
 /**
  * WriteTool - File writer
@@ -121,53 +120,18 @@ export const writeTool = createTool({
         // 检查失败，假设文件不存在
       }
 
-      // Read-Before-Write 验证（对齐 Claude Code 官方：强制模式）
-      if (fileExists && sessionId) {
-        const tracker = FileAccessTracker.getInstance();
-
-        // 检查文件是否已读取（强制失败）
-        if (!tracker.hasFileBeenRead(file_path, sessionId)) {
-          return {
-            success: false,
-            llmContent: `If this is an existing file, you MUST use the Read tool first to read the file's contents. This tool will fail if you did not read the file first.`,
-            error: {
-              type: ToolErrorType.VALIDATION_ERROR,
-              message: 'File not read before write',
-            },
-            metadata: {
-              requiresRead: true,
-            },
-          };
-        }
-
-        // 🔴 检查文件是否被外部程序修改（强制失败）
-        const externalModCheck = await tracker.checkExternalModification(file_path);
-        if (externalModCheck.isExternal) {
-          return {
-            success: false,
-            llmContent: `The file has been modified by an external program since you last read it. You must use the Read tool again to see the current content before writing.\n\nDetails: ${externalModCheck.message}`,
-            error: {
-              type: ToolErrorType.VALIDATION_ERROR,
-              message: 'File modified externally',
-              details: { externalModification: externalModCheck.message },
-            },
-          };
-        }
+      // Read-before-write、外部修改检查、快照创建（仅对已存在文件）
+      const guard = await runWriteGuard({
+        filePath: file_path,
+        sessionId,
+        messageId,
+        operation: 'write',
+        fileExists,
+      });
+      if (guard.blocked) {
+        return guard.blocked;
       }
-
-      // 创建快照（如果文件存在且有 sessionId 和 messageId）
-      let snapshotCreated = false;
-      if (fileExists && sessionId && messageId) {
-        try {
-          const snapshotManager = new SnapshotManager({ sessionId });
-          await snapshotManager.initialize();
-          await snapshotManager.createSnapshot(file_path, messageId);
-          snapshotCreated = true;
-        } catch (error) {
-          console.warn('[WriteTool] 创建快照失败:', error);
-          // 快照失败不中断写入操作
-        }
-      }
+      const snapshotCreated = guard.snapshotCreated;
 
       if (typeof signal.throwIfAborted === 'function') {
         signal.throwIfAborted();
@@ -192,11 +156,8 @@ export const writeTool = createTool({
         await fs.writeFile(file_path, writeBuffer);
       }
 
-      // 🔴 更新文件访问记录（记录写入操作）
-      if (sessionId) {
-        const tracker = FileAccessTracker.getInstance();
-        await tracker.recordFileEdit(file_path, sessionId, 'write');
-      }
+      // 更新文件访问记录（记录写入操作）
+      await recordWriteComplete(file_path, sessionId, 'write');
 
       if (typeof signal.throwIfAborted === 'function') {
         signal.throwIfAborted();

--- a/src/tools/builtin/file/writeGuard.ts
+++ b/src/tools/builtin/file/writeGuard.ts
@@ -1,0 +1,119 @@
+/**
+ * Write guard — edit/write 工具共享的写入前校验协议。
+ *
+ * 统一处理：
+ * 1. Read-before-write 检查（必须先 Read 才能写）
+ * 2. 外部修改检查（自上次 Read 后文件被外部修改则拒绝）
+ * 3. 快照创建（用于撤销/对比，失败不阻断写入）
+ * 4. 写入后记录文件访问
+ */
+
+import type { MessageId, SessionId } from '../../../types/branded.js';
+import { ToolErrorType } from '../../types/ToolResult.js';
+import type { ToolResult } from '../../types/ToolResult.js';
+import { FileAccessTracker } from './FileAccessTracker.js';
+import { SnapshotManager } from './SnapshotManager.js';
+
+export type WriteOperation = 'edit' | 'write';
+
+export interface WriteGuardParams {
+  filePath: string;
+  sessionId?: SessionId;
+  messageId?: MessageId;
+  operation: WriteOperation;
+  /**
+   * 目标文件是否已存在。write 工具新建文件时为 false，此时跳过 read-before-write
+   * 与外部修改检查（仅对已存在文件强制）。edit 工具始终为 true。
+   */
+  fileExists: boolean;
+}
+
+export interface WriteGuardResult {
+  /** 非 null 表示校验未通过，应直接返回该 ToolResult */
+  blocked: ToolResult | null;
+  /** 是否成功创建了快照 */
+  snapshotCreated: boolean;
+}
+
+const NOT_READ_MESSAGES: Record<WriteOperation, string> = {
+  edit: 'You must use your Read tool at least once in the conversation before editing. This tool will error if you attempt to edit without reading the file.',
+  write: 'If this is an existing file, you MUST use the Read tool first to read the file\'s contents. This tool will fail if you did not read the file first.',
+};
+
+const NOT_READ_ERROR_MESSAGES: Record<WriteOperation, string> = {
+  edit: 'File not read before edit',
+  write: 'File not read before write',
+};
+
+const EXTERNAL_MOD_DETAIL: Record<WriteOperation, string> = {
+  edit: 'before editing',
+  write: 'before writing',
+};
+
+/**
+ * 执行写入前校验。返回 blocked 结果（应直接返回给调用方）或 snapshotCreated 状态。
+ */
+export async function runWriteGuard(params: WriteGuardParams): Promise<WriteGuardResult> {
+  const { filePath, sessionId, messageId, operation, fileExists } = params;
+
+  if (fileExists && sessionId) {
+    const tracker = FileAccessTracker.getInstance();
+
+    if (!tracker.hasFileBeenRead(filePath, sessionId)) {
+      return {
+        blocked: {
+          success: false,
+          llmContent: NOT_READ_MESSAGES[operation],
+          error: {
+            type: ToolErrorType.VALIDATION_ERROR,
+            message: NOT_READ_ERROR_MESSAGES[operation],
+          },
+          metadata: { requiresRead: true },
+        },
+        snapshotCreated: false,
+      };
+    }
+
+    const externalModCheck = await tracker.checkExternalModification(filePath);
+    if (externalModCheck.isExternal) {
+      return {
+        blocked: {
+          success: false,
+          llmContent: `The file has been modified by an external program since you last read it. You must use the Read tool again to see the current content ${EXTERNAL_MOD_DETAIL[operation]}.\n\nDetails: ${externalModCheck.message}`,
+          error: {
+            type: ToolErrorType.VALIDATION_ERROR,
+            message: 'File modified externally',
+            details: { externalModification: externalModCheck.message },
+          },
+        },
+        snapshotCreated: false,
+      };
+    }
+  }
+
+  if (fileExists && sessionId && messageId) {
+    try {
+      const snapshotManager = new SnapshotManager({ sessionId });
+      await snapshotManager.initialize();
+      await snapshotManager.createSnapshot(filePath, messageId);
+      return { blocked: null, snapshotCreated: true };
+    } catch (error) {
+      console.warn(`[${operation === 'edit' ? 'EditTool' : 'WriteTool'}] 创建快照失败:`, error);
+    }
+  }
+
+  return { blocked: null, snapshotCreated: false };
+}
+
+/**
+ * 写入完成后记录文件访问追踪。
+ */
+export async function recordWriteComplete(
+  filePath: string,
+  sessionId: SessionId | undefined,
+  operation: WriteOperation,
+): Promise<void> {
+  if (!sessionId) return;
+  const tracker = FileAccessTracker.getInstance();
+  await tracker.recordFileEdit(filePath, sessionId, operation);
+}


### PR DESCRIPTION
## Summary

Third batch from the [codebase simplification audit](docs/simplification-audit.md). Three independent changes — two deduplications and one I/O performance fix. Each is a separate commit.

| Commit | Finding | Change |
|--------|---------|--------|
| `41062aef` | F9 | Extract shared `runSubagent` helper used by `SubagentExecutor` and `BackgroundAgentManager` |
| `fff96861` | F10 | Extract shared `runWriteGuard`/`recordWriteComplete` for edit/write tools |
| `3b9d776c` | F15 | Cache known sessions in `PersistentStore` to avoid full JSONL reads on every write |

### F9 — runSubagent helper
Both subagent execution paths independently derived `modelId`, called `Agent.create` with identical options, built an identical `subagentInfo`, and invoked `runAgenticLoop`. This also fixes an inconsistency: `BackgroundAgentManager` passed `systemPrompt` through the **deprecated** `Agent.create` options path, while `SubagentExecutor` correctly passed it via `ChatContext`. Both now use the non-deprecated `ChatContext` path consistently.

### F10 — write-guard protocol
`edit.ts` and `write.ts` duplicated the same three-step pre-write validation (read-before-write check, external-modification check, snapshot creation) plus post-write `recordFileEdit`. The two copies had already drifted in how they tracked `snapshot_created`. Extracted into `writeGuard.ts` with operation-specific messages; each tool shrinks by ~40 lines.

### F15 — PersistentStore knownSessions cache
`ensureSessionCreated` ran at the start of every write and called `JSONLStore.getStats()`, which read the **entire** session file and split every line just to confirm the `session_created` event existed — O(n) I/O on every append. A `Set<string>` makes the hot path O(1), with a single `fs.access` on cold encounter.

## Validation

- `tsc --noEmit` — passes
- `biome lint src` — 337 files, 0 warnings/errors
- Affected suites pass: subagents (10), file tools + context (87)
- Full suite: 1067 passed

No public API changes. No dependency changes.