### PR TITLE
fix(session): preserve tool results across resume

### DIFF
--- a/src/agent/AgentLoop.ts
+++ b/src/agent/AgentLoop.ts
@@ -434,21 +434,6 @@ export async function* agentLoop(
       };
     }
 
-    // 写入 assistant 消息
-    convState.append({
-      role: 'assistant',
-      content: turnResult.content || '',
-      reasoningContent: turnResult.reasoningContent,
-      tool_calls: turnResult.toolCalls,
-    });
-
-    await messageHooks?.onAssistant?.({
-      content: turnResult.content || '',
-      reasoningContent: turnResult.reasoningContent,
-      toolCalls: turnResult.toolCalls,
-      turn: turnsCount,
-    });
-
     // 工具执行：流式已执行 or 非流式在此执行
     let executionResults = streamingExecutionResults;
 
@@ -487,37 +472,63 @@ export async function* agentLoop(
       });
     }
 
-    // 处理结果
-    for (const { toolCall, result, toolUseUuid } of executionResults) {
-      if (epoch && !epoch.isValid) break;
+    const resultByToolCallId = new Map(
+      executionResults.map((executionResult) => [executionResult.toolCall.id, executionResult]),
+    );
+    const orderedExecutionResults = turnResult.toolCalls.flatMap((toolCall) => {
+      const executionResult = resultByToolCallId.get(toolCall.id);
+      return executionResult ? [executionResult] : [];
+    });
 
+    if (epoch && !epoch.isValid) {
+      for (const { toolCall, toolUseUuid } of orderedExecutionResults) {
+        await toolHooks?.afterExecEpochDiscard?.({
+          toolCall,
+          toolUseUuid,
+          reason: 'execution epoch invalidated',
+        });
+      }
+      continue;
+    }
+
+    if (orderedExecutionResults.length !== turnResult.toolCalls.length) {
+      const missing = turnResult.toolCalls
+        .filter((toolCall) => !resultByToolCallId.has(toolCall.id))
+        .map((toolCall) => `${toolCall.function.name}(${toolCall.id})`);
+      throw new Error(
+        `Tool execution completed without results for every declared tool call: ${missing.join(', ')}`,
+      );
+    }
+
+    // Persist the assistant declaration before any tool results in both
+    // streaming and non-streaming modes.
+    convState.append({
+      role: 'assistant',
+      content: turnResult.content || '',
+      reasoningContent: turnResult.reasoningContent,
+      tool_calls: turnResult.toolCalls,
+    });
+
+    await messageHooks?.onAssistant?.({
+      content: turnResult.content || '',
+      reasoningContent: turnResult.reasoningContent,
+      toolCalls: turnResult.toolCalls,
+      turn: turnsCount,
+    });
+
+    let exitResult: typeof orderedExecutionResults[number] | undefined;
+    // 处理结果
+    for (const { toolCall, result, toolUseUuid } of orderedExecutionResults) {
       recordToolResult(result);
 
-      if (result.metadata?.shouldExitLoop) {
-        const finalMessage =
-          typeof result.llmContent === 'string' ? result.llmContent : '循环已退出';
-        if (!streamingExecutionResults) {
-          yield { type: 'tool_result', toolCall, result };
-        }
-        yield { type: 'turn_end', turn: turnsCount, hasToolCalls: true };
-        yield { type: 'agent_end' };
-        return {
-          success: result.success,
-          finalMessage,
-          metadata: {
-            turnsCount,
-            toolCallsCount: totalToolCalls,
-            duration: Date.now() - startTime,
-            shouldExitLoop: true,
-            targetMode: result.metadata?.targetMode as PermissionMode | undefined,
-          },
-        };
+      if (result.metadata?.shouldExitLoop && !exitResult) {
+        exitResult = { toolCall, result, toolUseUuid };
       }
 
       if (!streamingExecutionResults) {
         yield { type: 'tool_result', toolCall, result };
-        await toolHooks?.afterExec?.({ toolCall, result, toolUseUuid });
       }
+      await toolHooks?.afterExec?.({ toolCall, result, toolUseUuid });
 
       // 写入 tool 消息
       let toolResultContent = result.success
@@ -536,7 +547,9 @@ export async function* agentLoop(
           ? toolResultContent
           : JSON.stringify(toolResultContent),
       });
+    }
 
+    for (const { result } of orderedExecutionResults) {
       if (result.newMessages && result.newMessages.length > 0) {
         convState.append(
           ...result.newMessages.map((message) => ({
@@ -555,6 +568,25 @@ export async function* agentLoop(
     }
 
     yield { type: 'turn_end', turn: turnsCount, hasToolCalls: true };
+
+    if (exitResult) {
+      const finalMessage =
+        typeof exitResult.result.llmContent === 'string'
+          ? exitResult.result.llmContent
+          : '循环已退出';
+      yield { type: 'agent_end' };
+      return {
+        success: exitResult.result.success,
+        finalMessage,
+        metadata: {
+          turnsCount,
+          toolCallsCount: totalToolCalls,
+          duration: Date.now() - startTime,
+          shouldExitLoop: true,
+          targetMode: exitResult.result.metadata?.targetMode as PermissionMode | undefined,
+        },
+      };
+    }
 
     if (signal?.aborted) {
       yield { type: 'agent_end' };

--- a/src/agent/LoopHookBuilder.ts
+++ b/src/agent/LoopHookBuilder.ts
@@ -87,6 +87,9 @@ export function buildLoopConfig(deps: LoopHookBuilderDeps): AgentLoopConfig {
   } = deps;
 
   let progressToolUseCount = 0;
+  let pendingToolResultCount = 0;
+  let pendingInjectedMessages: Message[] = [];
+  let currentAssistantMessageId: string | null = null;
 
   const hooks: AgentLoopHooks = {
     turn: {
@@ -157,32 +160,21 @@ export function buildLoopConfig(deps: LoopHookBuilderDeps): AgentLoopConfig {
     },
 
     tool: {
-      async beforeExec(ctx) {
-        try {
-          const contextMgr = modelManager.getContextManager();
-          if (contextMgr && context.sessionId) {
-            return await contextMgr.saveToolUse(
-              context.sessionId, ctx.toolCall.function.name,
-              ctx.params,
-              getLastUuid(), context.subagentInfo,
-              ctx.toolCall.id,
-            );
-          }
-        } catch (error) {
-          logger.warn('[LoopHookBuilder] 保存工具调用失败:', error);
-        }
+      async beforeExec(_ctx) {
         return null;
       },
 
       async afterExec(ctx) {
         const { toolCall, result, toolUseUuid } = ctx;
+        const normalizedEffects = normalizeToolEffects(result);
+        const injectedMessages = normalizedEffects
+          .filter((effect): effect is Extract<ToolEffect, { type: 'newMessages' }> =>
+            effect.type === 'newMessages')
+          .flatMap((effect) => effect.messages);
+        pendingInjectedMessages.push(...injectedMessages);
 
         await persistToJsonl(modelManager, context.sessionId, logger, async (contextMgr, sessionId) => {
           const metadata = result.metadata;
-          const normalizedEffects = normalizeToolEffects(result);
-          const injectedMessages = normalizedEffects
-            .filter((effect): effect is Extract<ToolEffect, { type: 'newMessages' }> => effect.type === 'newMessages')
-            .flatMap((effect) => effect.messages);
           const isSubagentStatus = (v: unknown): v is 'running' | 'completed' | 'failed' | 'cancelled' =>
             v === 'running' || v === 'completed' || v === 'failed' || v === 'cancelled';
           const subagentStatus = isSubagentStatus(metadata?.subagentStatus)
@@ -200,14 +192,18 @@ export function buildLoopConfig(deps: LoopHookBuilderDeps): AgentLoopConfig {
           const uuid = await contextMgr.saveToolResult(
             sessionId, toolCall.id, toolCall.function.name,
             result.success ? toJsonValue(result.llmContent) : null,
-            toolUseUuid, result.success ? undefined : result.error?.message,
+            getLastUuid(), result.success ? undefined : result.error?.message,
             context.subagentInfo, subagentRef,
           );
           setLastUuid(uuid);
+        });
 
-          if (injectedMessages.length > 0) {
-            let parentUuid = uuid;
-            for (const injectedMessage of injectedMessages) {
+        pendingToolResultCount = Math.max(0, pendingToolResultCount - 1);
+        if (pendingToolResultCount === 0 && pendingInjectedMessages.length > 0) {
+          const messagesToPersist = pendingInjectedMessages;
+          pendingInjectedMessages = [];
+          await persistToJsonl(modelManager, context.sessionId, logger, async (contextMgr, sessionId) => {
+            for (const injectedMessage of messagesToPersist) {
               const customMeta = (() => {
                 const isRec = (v: unknown): v is Record<string, unknown> =>
                   typeof v === 'object' && v !== null && !Array.isArray(v);
@@ -224,17 +220,15 @@ export function buildLoopConfig(deps: LoopHookBuilderDeps): AgentLoopConfig {
                 sessionId,
                 injectedMessage.role,
                 injectedMessage.content,
-                parentUuid,
+                getLastUuid(),
                 customMeta ? { customMetadata: customMeta } : undefined,
                 context.subagentInfo,
               );
-              parentUuid = injectedUuid;
+              setLastUuid(injectedUuid);
             }
-            setLastUuid(parentUuid);
-          }
-        });
+          });
+        }
 
-        const normalizedEffects = normalizeToolEffects(result);
         for (const effect of normalizedEffects) {
           if (effect.type === 'contextPatch') {
             runtimePatchManager.applyRuntimeContextPatch(effect.patch);
@@ -251,7 +245,7 @@ export function buildLoopConfig(deps: LoopHookBuilderDeps): AgentLoopConfig {
           runtimePatchManager.applyRuntimePatch(runtimePatch, loopState, {
             toolName: toolCall.function.name,
             toolCallId: toolCall.id,
-            toolUseUuid,
+            toolUseUuid: currentAssistantMessageId ?? toolUseUuid,
           });
         }
 
@@ -275,26 +269,13 @@ export function buildLoopConfig(deps: LoopHookBuilderDeps): AgentLoopConfig {
           }
         }
       },
-
-      async afterExecEpochDiscard(ctx) {
-        const toolUseUuid = ctx.toolUseUuid;
-        if (!toolUseUuid) return;
-        await persistToJsonl(modelManager, context.sessionId, logger, async (contextMgr, sessionId) => {
-          await contextMgr.saveToolResult(
-            sessionId,
-            ctx.toolCall.id,
-            ctx.toolCall.function.name,
-            null,
-            toolUseUuid,
-            ctx.reason,
-            context.subagentInfo,
-          );
-        });
-      },
     },
 
     message: {
       async onAssistant(ctx) {
+        pendingToolResultCount = ctx.toolCalls?.length ?? 0;
+        pendingInjectedMessages = [];
+        currentAssistantMessageId = null;
         await persistToJsonl(modelManager, context.sessionId, logger, async (contextMgr, sessionId) => {
           if (ctx.content.trim() !== '' || ctx.reasoningContent || (ctx.toolCalls?.length ?? 0) > 0) {
             const uuid = await contextMgr.saveMessage(
@@ -309,6 +290,7 @@ export function buildLoopConfig(deps: LoopHookBuilderDeps): AgentLoopConfig {
               context.subagentInfo,
             );
             setLastUuid(uuid);
+            currentAssistantMessageId = uuid;
           }
         });
       },

--- a/src/agent/__tests__/AgentLoop.streaming.test.ts
+++ b/src/agent/__tests__/AgentLoop.streaming.test.ts
@@ -155,7 +155,13 @@ describe('agentLoop streaming integration', () => {
       throw new Error('streamResponse should not be used when tools are present');
     });
     void streamResponse;
-    const onAfterToolExec = vi.fn();
+    const hookOrder: string[] = [];
+    const onAssistantMessage = vi.fn(async () => {
+      hookOrder.push('assistant');
+    });
+    const onAfterToolExec = vi.fn(async () => {
+      hookOrder.push('tool-result');
+    });
 
     const loopPromise = collectEvents(
       agentLoop(
@@ -167,6 +173,7 @@ describe('agentLoop streaming integration', () => {
             }),
             execute,
           } as unknown as AgentLoopConfig['executionPipeline'],
+          onAssistantMessage,
           onAfterToolExec,
           turnState: {
             chatService: {
@@ -204,6 +211,7 @@ describe('agentLoop streaming integration', () => {
     expect(result.success).toBe(true);
     expect(result.finalMessage).toBe('exit now');
     expect(onAfterToolExec).toHaveBeenCalledTimes(1);
+    expect(hookOrder).toEqual(['assistant', 'tool-result']);
 
     const eventTypes = events.map((event) => event.type);
     expect(eventTypes.filter((type) => type === 'stream_end')).toHaveLength(1);

--- a/src/agent/__tests__/LoopRunner.test.ts
+++ b/src/agent/__tests__/LoopRunner.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, it, type Mock, vi } from 'vitest';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { z } from 'zod';
+import { ContextManager } from '../../context/ContextManager.js';
 import * as FileAnalyzerModule from '../../context/FileAnalyzer.js';
 import { HookRuntime } from '../../hooks/HookRuntime.js';
 import type { RuntimePatch } from '../../runtime/RuntimePatch.js';
 import type { Message } from '../../services/ChatServiceInterface.js';
+import { JsonlSessionStore } from '../../session/SessionStore.js';
 import { ToolCatalog } from '../../tools/catalog/ToolCatalog.js';
 import { createTool } from '../../tools/core/createTool.js';
 import type { ExecutionPipeline } from '../../tools/execution/ExecutionPipeline.js';
@@ -132,6 +137,105 @@ describe('LoopRunner', () => {
       await runner.runLoop('Test message', context);
 
       expect(mm._contextMgr.saveMessage).toHaveBeenCalled();
+    });
+
+    it('persists streaming tool turns in provider-compatible order', async () => {
+      const workspaceRoot = mkdtempSync(join(tmpdir(), 'loop-runner-persistence-'));
+      const sessionId = SessionId('streaming-tool-session');
+      const contextManager = new ContextManager({
+        projectPath: workspaceRoot,
+        storage: {
+          maxMemorySize: 1000,
+          persistentPath: workspaceRoot,
+          cacheSize: 100,
+          compressionEnabled: true,
+        },
+      });
+      await contextManager.initialize();
+      await contextManager.createSession(undefined, {}, { sessionId });
+
+      let turn = 0;
+      const streamChat = vi.fn(async function* () {
+        turn += 1;
+        if (turn === 1) {
+          yield {
+            toolCalls: [
+              {
+                index: 0,
+                id: 'call-first',
+                function: { name: 'Search', arguments: '{"query":"first"}' },
+              },
+              {
+                index: 1,
+                id: 'call-second',
+                function: { name: 'Search', arguments: '{"query":"second"}' },
+              },
+            ],
+          };
+          yield { finishReason: 'tool_calls' };
+          return;
+        }
+        yield { content: 'done' };
+        yield { finishReason: 'stop' };
+      });
+      const modelManager = {
+        getChatService: () => ({
+          chat: vi.fn(),
+          streamChat,
+          getConfig: () => ({
+            model: 'test-model',
+            maxContextTokens: 128000,
+          }),
+          updateConfig: vi.fn(),
+        }),
+        getContextManager: () => contextManager,
+        getMaxContextTokens: () => 128000,
+        switchModelIfNeeded: vi.fn(async () => {}),
+      } as unknown as ModelManager;
+      const pipeline = {
+        getCatalog: () => undefined,
+        getRegistry: () => ({
+          getAll: () => [],
+          getFunctionDeclarationsByMode: () => [
+            { name: 'Search', description: 'Search', parameters: {} },
+          ],
+          get: (name: string) => ({ kind: 'readonly', name }),
+        }),
+        execute: vi.fn(async (toolName: string, params: Record<string, unknown>) => ({
+          success: true,
+          llmContent: `${toolName}:${String(params.query)}`,
+        })),
+      } as unknown as ExecutionPipeline;
+      const runner = new LoopRunner(
+        baseConfig,
+        baseOptions,
+        modelManager,
+        pipeline,
+        workspaceRoot,
+        undefined,
+        true,
+      );
+
+      const result = await runner.runLoop('run both searches', createContext({ sessionId }));
+      const state = await new JsonlSessionStore(workspaceRoot).loadState(sessionId);
+
+      expect(result.success).toBe(true);
+      expect(state?.messages.map((message) => message.role)).toEqual([
+        'user',
+        'assistant',
+        'tool',
+        'tool',
+        'assistant',
+      ]);
+      expect(state?.messages[1]?.tool_calls?.map((toolCall) => toolCall.id)).toEqual([
+        'call-first',
+        'call-second',
+      ]);
+      expect(state?.messages.slice(2, 4).map((message) => message.tool_call_id)).toEqual([
+        'call-first',
+        'call-second',
+      ]);
+      expect(new Set(state?.messageIds).size).toBe(state?.messageIds.length);
     });
 
     it('should return error when maxTurns is 0', async () => {
@@ -1858,14 +1962,14 @@ describe('LoopRunner', () => {
           provenance: expect.objectContaining({
             toolName: 'PatchEnvA',
             toolCallId: 'patch-env-a-call',
-            toolUseUuid: 'tool-use-a',
+            toolUseUuid: 'uuid-1',
           }),
         }),
         expect.objectContaining({
           provenance: expect.objectContaining({
             toolName: 'PatchEnvB',
             toolCallId: 'patch-env-b-call',
-            toolUseUuid: 'tool-use-b',
+            toolUseUuid: 'uuid-1',
           }),
         }),
       ]);
@@ -2023,6 +2127,7 @@ describe('LoopRunner', () => {
         });
 
       const saveMessage = vi.fn(async () => 'msg-uuid');
+      const saveToolUse = vi.fn(async () => 'tool-use-uuid');
       const saveToolResult = vi.fn(async () => 'tool-result-uuid');
       const mm = {
         getChatService: () => ({
@@ -2039,7 +2144,7 @@ describe('LoopRunner', () => {
         }),
         getContextManager: () => ({
           saveMessage,
-          saveToolUse: vi.fn(async () => 'uuid-2'),
+          saveToolUse,
           saveToolResult,
           saveCompaction: vi.fn(async () => {}),
         }),
@@ -2070,7 +2175,20 @@ describe('LoopRunner', () => {
       const result = await runner.runLoop('Hello', createContext({ sessionId: SessionId('sess-1') }));
 
       expect(result.success).toBe(true);
+      expect(saveToolUse).not.toHaveBeenCalled();
       expect(saveToolResult).toHaveBeenCalled();
+      const saveMessageCalls = saveMessage.mock.calls as unknown as Array<readonly unknown[]>;
+      const assistantToolCallIndex = saveMessageCalls.findIndex((call) => {
+        const metadata = call[4] as { toolCalls?: unknown[] } | undefined;
+        return Boolean(metadata?.toolCalls?.length);
+      });
+      const injectedMessageIndex = saveMessageCalls.findIndex(
+        (call) => call[2] === 'Injected assistant context',
+      );
+      expect(saveMessage.mock.invocationCallOrder[assistantToolCallIndex])
+        .toBeLessThan(saveToolResult.mock.invocationCallOrder[0] ?? 0);
+      expect(saveToolResult.mock.invocationCallOrder[0])
+        .toBeLessThan(saveMessage.mock.invocationCallOrder[injectedMessageIndex] ?? 0);
       expect(saveMessage).toHaveBeenCalledWith(
         'sess-1',
         'assistant',

--- a/src/agent/loop/runTurn.ts
+++ b/src/agent/loop/runTurn.ts
@@ -175,7 +175,6 @@ async function* runStreamingWithTools(
       hooks: {
         onBeforeToolExec: toolHooks.onBeforeExec,
       },
-      onAfterToolExec: toolHooks.onAfterExec,
       onAfterToolExecEpochDiscard: toolHooks.onAfterExecEpochDiscard,
       onContentDelta: (delta) => queue.enqueue({ type: 'content_delta', delta }),
       onThinkingDelta: (delta) => queue.enqueue({ type: 'thinking_delta', delta }),

--- a/src/context/ContextManager.ts
+++ b/src/context/ContextManager.ts
@@ -14,7 +14,11 @@ import { ContextCompressor } from './processors/ContextCompressor.js';
 import { ContextFilter } from './processors/ContextFilter.js';
 import { CacheStore } from './storage/CacheStore.js';
 import { MemoryStore } from './storage/MemoryStore.js';
-import { NoopPersistentStore, PersistentStore } from './storage/PersistentStore.js';
+import {
+  NoopPersistentStore,
+  PersistentStore,
+  type PersistedToolUse,
+} from './storage/PersistentStore.js';
 import type {
   CompressedContext,
   ContextData,
@@ -54,6 +58,7 @@ export class ContextManager {
   private readonly projectPath?: string;
 
   private currentSessionId: SessionId | null = null;
+  private readonly pendingToolUses = new Map<string, string[]>();
   private initialized = false;
 
   constructor(options: Partial<ContextManagerOptions> = {}) {
@@ -267,21 +272,33 @@ export class ContextManager {
       throw new Error('没有活动会话');
     }
 
+    const pendingToolUseKey = `${this.currentSessionId}\0${toolCall.id}`;
     if (toolCall.status === 'pending') {
-      const toolUseId = await this.persistent.saveToolUse(
+      const persisted = await this.persistent.saveToolUse(
         this.currentSessionId,
         toolCall.name,
         toolCall.input,
         null,
+        undefined,
+        toolCall.id,
       );
-      toolCall = { ...toolCall, id: toolUseId };
+      const pendingMessageIds = this.pendingToolUses.get(pendingToolUseKey) ?? [];
+      pendingMessageIds.push(persisted.messageId);
+      this.pendingToolUses.set(pendingToolUseKey, pendingMessageIds);
     } else {
+      const pendingMessageIds = this.pendingToolUses.get(pendingToolUseKey) ?? [];
+      const parentMessageId = pendingMessageIds.shift() ?? null;
+      if (pendingMessageIds.length > 0) {
+        this.pendingToolUses.set(pendingToolUseKey, pendingMessageIds);
+      } else {
+        this.pendingToolUses.delete(pendingToolUseKey);
+      }
       await this.persistent.saveToolResult(
         this.currentSessionId,
         toolCall.id,
         toolCall.name,
         toolCall.output ?? null,
-        toolCall.id,
+        parentMessageId,
         toolCall.error,
       );
     }
@@ -339,7 +356,7 @@ export class ContextManager {
       isSidechain: boolean;
     },
     requestedToolCallId?: string,
-  ): Promise<string> {
+  ): Promise<PersistedToolUse> {
     return this.persistent.saveToolUse(
       sessionId,
       toolName,

--- a/src/context/__tests__/ContextManager.test.ts
+++ b/src/context/__tests__/ContextManager.test.ts
@@ -29,19 +29,19 @@ describe('ContextManager', () => {
 
     const sessionId = SessionId('session-1');
     await persistentStore.saveMessage(sessionId, 'user', 'hello');
-    const toolCallId = await persistentStore.saveToolUse(sessionId, 'Read', { file_path: 'README.md' });
-    await persistentStore.saveToolResult(
+    const toolUse = await persistentStore.saveToolUse(sessionId, 'Read', { file_path: 'README.md' });
+    const toolResultMessageId = await persistentStore.saveToolResult(
       sessionId,
-      toolCallId,
+      toolUse.toolCallId,
       'Read',
       'file contents',
-      toolCallId,
+      toolUse.messageId,
     );
     await persistentStore.saveCompaction(
       sessionId,
       'Compacted summary',
       { trigger: 'auto', preTokens: 42, postTokens: 20 },
-      toolCallId,
+      toolResultMessageId,
     );
 
     await contextManager.initialize();
@@ -58,5 +58,55 @@ describe('ContextManager', () => {
     expect(formatted.context.layers.conversation.summary).toBe('Compacted summary');
     expect(formatted.context.layers.tool.recentCalls).toHaveLength(1);
     expect(formatted.context.layers.tool.recentCalls[0]?.status).toBe('success');
+  });
+
+  it('keeps pending tool-use message IDs scoped to their session', async () => {
+    const workspaceRoot = createWorkspaceRoot();
+    const contextManager = new ContextManager({
+      projectPath: workspaceRoot,
+      storage: {
+        maxMemorySize: 1000,
+        persistentPath: workspaceRoot,
+        cacheSize: 100,
+        compressionEnabled: true,
+      },
+    });
+    await contextManager.initialize();
+
+    const firstSessionId = SessionId('session-first');
+    await contextManager.createSession(undefined, {}, { sessionId: firstSessionId });
+    await contextManager.addToolCall({
+      id: 'call-reused',
+      name: 'Search',
+      input: { query: 'first' },
+      timestamp: Date.now(),
+      status: 'pending',
+    });
+
+    const secondSessionId = SessionId('session-second');
+    await contextManager.createSession(undefined, {}, { sessionId: secondSessionId });
+    await contextManager.addToolCall({
+      id: 'call-reused',
+      name: 'Search',
+      input: { query: 'second' },
+      timestamp: Date.now(),
+      status: 'pending',
+    });
+    await contextManager.addToolCall({
+      id: 'call-reused',
+      name: 'Search',
+      input: { query: 'second' },
+      output: 'second result',
+      timestamp: Date.now(),
+      status: 'success',
+    });
+
+    const state = await new JsonlSessionStore(workspaceRoot).loadState(secondSessionId);
+
+    assertDefined(state);
+    expect(state.messages.map((message) => message.role)).toEqual(['assistant', 'tool']);
+    expect(state.messages[0]?.tool_calls?.[0]?.id).toBe('call-reused');
+    expect(state.messages[1]?.tool_call_id).toBe('call-reused');
+    expect(state.timeline[1]?.parentMessageId).toBe(state.timeline[0]?.id);
   });
 });

--- a/src/context/storage/PersistentStore.ts
+++ b/src/context/storage/PersistentStore.ts
@@ -58,6 +58,11 @@ function parseToolCallArguments(value: string): JsonValue {
   }
 }
 
+export interface PersistedToolUse {
+  messageId: string;
+  toolCallId: string;
+}
+
 /**
  * 持久化存储实现 - JSONL 格式
  * 存储路径: {storageRoot}/projects/{escaped-path}/{sessionId}.jsonl
@@ -226,24 +231,23 @@ export class PersistentStore {
       isSidechain: boolean;
     },
     requestedToolCallId?: string,
-  ): Promise<string> {
+  ): Promise<PersistedToolUse> {
     try {
       const filePath = getSessionFilePathFromStorageRoot(this.storageRoot, sessionId);
       const store = new JSONLStore(filePath);
       await this.ensureSessionCreated(sessionId, subagentInfo);
       const now = new Date().toISOString();
-      const messageId = parentUuid ? MessageId(parentUuid) : MessageId(nanoid());
-      const entries: SessionEvent[] = [];
-      if (!parentUuid) {
-        const messageInfo: MessageInfo = {
-          messageId,
-          role: 'assistant',
-          parentMessageId: undefined,
-          createdAt: now,
-        };
-        entries.push(this.createEvent('message_created', sessionId, messageInfo));
-      }
       const toolCallId = requestedToolCallId ?? nanoid();
+      const messageId = MessageId(nanoid());
+      const messageInfo: MessageInfo = {
+        messageId,
+        role: 'assistant',
+        parentMessageId: parentUuid ?? undefined,
+        createdAt: now,
+      };
+      const entries: SessionEvent[] = [
+        this.createEvent('message_created', sessionId, messageInfo),
+      ];
       const partInfo: PartInfo = {
         partId: toolCallId,
         messageId,
@@ -283,7 +287,7 @@ export class PersistentStore {
         }
       }
       await store.appendBatch(entries);
-      return toolCallId;
+      return { messageId, toolCallId };
     } catch (error) {
       console.error(
         `[PersistentStore] 保存工具调用失败 (session: ${sessionId}):`,
@@ -320,17 +324,16 @@ export class PersistentStore {
       const store = new JSONLStore(filePath);
       await this.ensureSessionCreated(sessionId, subagentInfo);
       const now = new Date().toISOString();
-      const messageId = parentUuid ? MessageId(parentUuid) : MessageId(nanoid());
-      const entries: SessionEvent[] = [];
-      if (!parentUuid) {
-        const messageInfo: MessageInfo = {
-          messageId,
-          role: 'assistant',
-          parentMessageId: undefined,
-          createdAt: now,
-        };
-        entries.push(this.createEvent('message_created', sessionId, messageInfo));
-      }
+      const messageId = MessageId(nanoid());
+      const messageInfo: MessageInfo = {
+        messageId,
+        role: 'tool',
+        parentMessageId: parentUuid ?? undefined,
+        createdAt: now,
+      };
+      const entries: SessionEvent[] = [
+        this.createEvent('message_created', sessionId, messageInfo),
+      ];
       const toolResultPart: PartInfo = {
         partId: toolId,
         messageId,
@@ -359,7 +362,7 @@ export class PersistentStore {
         entries.push(this.createEvent('part_created', sessionId, subtaskPart));
       }
       await store.appendBatch(entries);
-      return toolId;
+      return messageId;
     } catch (error) {
       console.error(
         `[PersistentStore] 保存工具结果失败 (session: ${sessionId}):`,
@@ -766,13 +769,17 @@ export class NoopPersistentStore {
       subagentType: string;
       isSidechain: boolean;
     },
-  ): Promise<string> {
-    return nanoid();
+    requestedToolCallId?: string,
+  ): Promise<PersistedToolUse> {
+    return {
+      messageId: nanoid(),
+      toolCallId: requestedToolCallId ?? nanoid(),
+    };
   }
 
   async saveToolResult(
     _sessionId: SessionId,
-    toolId: string,
+    _toolId: string,
     _toolName: string,
     _toolOutput: JsonValue,
     _parentUuid: string | null = null,
@@ -789,7 +796,7 @@ export class NoopPersistentStore {
       subagentSummary?: string;
     },
   ): Promise<string> {
-    return toolId;
+    return nanoid();
   }
 
   async saveCompaction(

--- a/src/session/SessionStore.ts
+++ b/src/session/SessionStore.ts
@@ -181,22 +181,92 @@ function inferRole(partType: string): MessageRole {
   }
 }
 
+function isEmptyAssistantMessage(message: Message): boolean {
+  return message.role === 'assistant'
+    && message.content === ''
+    && !message.reasoningContent
+    && !message.tool_calls?.length;
+}
+
+interface ToolCallOccurrence {
+  key: string;
+  sourceMessageId: string;
+  toolCallId: string;
+  matched: boolean;
+}
+
+interface ToolOccurrencePlan {
+  callsByEventId: Map<string, ToolCallOccurrence>;
+  resultsByEventId: Map<string, ToolCallOccurrence>;
+}
+
+function getPartToolCallId(part: PartInfo): string {
+  const payload = isRecord(part.payload) ? part.payload : {};
+  return typeof payload.toolCallId === 'string' ? payload.toolCallId : part.partId;
+}
+
+function createToolOccurrencePlan(entries: SessionEvent[]): ToolOccurrencePlan {
+  const callsByEventId = new Map<string, ToolCallOccurrence>();
+  const resultsByEventId = new Map<string, ToolCallOccurrence>();
+  const callsBySource = new Map<string, ToolCallOccurrence>();
+  const latestResultBySource = new Map<string, ToolCallOccurrence>();
+  const unmatchedByToolCallId = new Map<string, ToolCallOccurrence[]>();
+  let occurrenceIndex = 0;
+
+  for (const entry of entries) {
+    if (entry.type !== 'part_created' && entry.type !== 'part_updated') continue;
+    const part = entry.data;
+    if (part.partType !== 'tool_call' && part.partType !== 'tool_result') continue;
+
+    const toolCallId = getPartToolCallId(part);
+    const sourceKey = `${part.messageId}\0${toolCallId}`;
+
+    if (part.partType === 'tool_call') {
+      let occurrence = callsBySource.get(sourceKey);
+      if (!occurrence) {
+        occurrence = {
+          key: `tool-call:${occurrenceIndex++}`,
+          sourceMessageId: part.messageId,
+          toolCallId,
+          matched: false,
+        };
+        callsBySource.set(sourceKey, occurrence);
+        const unmatched = unmatchedByToolCallId.get(toolCallId) ?? [];
+        unmatched.push(occurrence);
+        unmatchedByToolCallId.set(toolCallId, unmatched);
+      }
+      callsByEventId.set(entry.id, occurrence);
+      continue;
+    }
+
+    let occurrence = entry.type === 'part_updated'
+      ? latestResultBySource.get(sourceKey)
+      : undefined;
+    if (!occurrence) {
+      const unmatched = unmatchedByToolCallId.get(toolCallId) ?? [];
+      occurrence = unmatched.shift();
+      if (!occurrence) continue;
+      occurrence.matched = true;
+      latestResultBySource.set(sourceKey, occurrence);
+    }
+    resultsByEventId.set(entry.id, occurrence);
+  }
+
+  return { callsByEventId, resultsByEventId };
+}
+
 function getToolCallState(
   toolCalls: Map<string, SessionToolCallState>,
-  toolCallId: string,
-  defaults: Omit<SessionToolCallState, 'id'>,
+  stateKey: string,
+  defaults: SessionToolCallState,
 ): SessionToolCallState {
-  const existing = toolCalls.get(toolCallId);
+  const existing = toolCalls.get(stateKey);
   if (existing) {
     return existing;
   }
 
-  const created: SessionToolCallState = {
-    id: toolCallId,
-    ...defaults,
-  };
-  toolCalls.set(toolCallId, created);
-  return created;
+  toolCalls.set(stateKey, defaults);
+  return defaults;
 }
 
 export class JsonlSessionStore implements SessionStore {
@@ -217,6 +287,11 @@ export class JsonlSessionStore implements SessionStore {
     const orderedMessageIds: string[] = [];
     const summaryMessageIds = new Set<string>();
     const toolCalls = new Map<string, SessionToolCallState>();
+    const toolOccurrencePlan = createToolOccurrencePlan(entries);
+    const projectedCallMessageIds = new Map<string, MessageId>();
+    const callMessageIdsByOccurrence = new Map<string, MessageId>();
+    const resultMessageIdsByOccurrence = new Map<string, MessageId>();
+    const resultOccurrenceByMessageId = new Map<string, string>();
     const subagentRefs: SessionSubagentRef[] = [];
     let sessionInfo: Partial<SessionInfo> = { sessionId };
     let createdAt = toTimestamp(undefined, entries[0]?.timestamp ?? new Date().toISOString());
@@ -301,10 +376,53 @@ export class JsonlSessionStore implements SessionStore {
       }
 
       const data = entry.data;
+      const occurrence = data.partType === 'tool_call'
+        ? toolOccurrencePlan.callsByEventId.get(entry.id)
+        : data.partType === 'tool_result'
+          ? toolOccurrencePlan.resultsByEventId.get(entry.id)
+          : undefined;
+      if ((data.partType === 'tool_call' || data.partType === 'tool_result') && !occurrence) {
+        continue;
+      }
+      if (data.partType === 'tool_call' && !occurrence?.matched) {
+        continue;
+      }
+
+      let messageId = data.messageId;
+      let inferredParentMessageId: string | undefined;
+      if (data.partType === 'tool_call' && occurrence) {
+        const sourceRecord = messageRecords.get(data.messageId);
+        if (sourceRecord && sourceRecord.message.role !== 'assistant') {
+          messageId = projectedCallMessageIds.get(data.messageId)
+            ?? MessageId(`${data.messageId}:tool-calls`);
+          projectedCallMessageIds.set(data.messageId, messageId);
+          inferredParentMessageId = data.messageId;
+        }
+        callMessageIdsByOccurrence.set(occurrence.key, messageId);
+      } else if (data.partType === 'tool_result' && occurrence) {
+        const projectedMessageId = resultMessageIdsByOccurrence.get(occurrence.key);
+        if (projectedMessageId) {
+          messageId = projectedMessageId;
+        } else {
+          const sourceRecord = messageRecords.get(data.messageId);
+          const currentOwner = resultOccurrenceByMessageId.get(data.messageId);
+          if (
+            (sourceRecord && sourceRecord.message.role !== 'tool')
+            || (currentOwner && currentOwner !== occurrence.key)
+          ) {
+            messageId = MessageId(`${data.messageId}:tool-result:${occurrence.key}`);
+          }
+          resultMessageIdsByOccurrence.set(occurrence.key, messageId);
+          resultOccurrenceByMessageId.set(messageId, occurrence.key);
+        }
+        inferredParentMessageId = callMessageIdsByOccurrence.get(occurrence.key);
+      }
+
       const record = ensureMessageRecord(
-        data.messageId,
+        messageId,
         inferRole(data.partType),
         entry.timestamp,
+        messageRecords.has(messageId) ? undefined : inferredParentMessageId,
       );
 
       this.applyPartToMessage({
@@ -312,6 +430,7 @@ export class JsonlSessionStore implements SessionStore {
         record,
         contentParts,
         toolCalls,
+        toolOccurrenceKey: occurrence?.key,
         subagentRefs,
         summaryMessageIds,
         onSummary: (value) => {
@@ -322,9 +441,16 @@ export class JsonlSessionStore implements SessionStore {
 
     // Build the timeline directly from the mutable builder records (no clone).
     // `messages` is cloned from the same records so the two arrays are independent.
-    const timeline = orderedMessageIds
+    const records = orderedMessageIds
       .map((messageId) => messageRecords.get(messageId))
-      .filter((record): record is MessageRecord => record !== undefined)
+      .filter((record): record is MessageRecord => record !== undefined);
+    const referencedMessageIds = new Set([
+      ...records.flatMap((record) => record.parentMessageId ? [record.parentMessageId] : []),
+      ...subagentRefs.map((ref) => String(ref.messageId)),
+    ]);
+    const timeline = records
+      .filter((record) => !isEmptyAssistantMessage(record.message)
+        || referencedMessageIds.has(record.id))
       .map((record) => ({
         id: record.id,
         parentMessageId: record.parentMessageId,
@@ -351,7 +477,9 @@ export class JsonlSessionStore implements SessionStore {
       toolCalls: Array.from(toolCalls.values()).map((toolCall) => ({
         ...toolCall,
       })),
-      subagentRefs: subagentRefs.map((ref) => ({ ...ref })),
+      subagentRefs: subagentRefs
+        .filter((ref) => messageIds.includes(String(ref.messageId)))
+        .map((ref) => ({ ...ref })),
     };
   }
 
@@ -438,6 +566,7 @@ export class JsonlSessionStore implements SessionStore {
     record: MessageRecord;
     contentParts: Map<string, Array<{ partId: string; content: ContentPart }>>;
     toolCalls: Map<string, SessionToolCallState>;
+    toolOccurrenceKey?: string;
     subagentRefs: SessionSubagentRef[];
     summaryMessageIds: Set<string>;
     onSummary: (summary: string) => void;
@@ -447,6 +576,7 @@ export class JsonlSessionStore implements SessionStore {
       record,
       contentParts,
       toolCalls,
+      toolOccurrenceKey,
       subagentRefs,
       summaryMessageIds,
       onSummary,
@@ -515,7 +645,8 @@ export class JsonlSessionStore implements SessionStore {
           toolCall,
         ];
 
-        const toolCallState = getToolCallState(toolCalls, toolCallId, {
+        const toolCallState = getToolCallState(toolCalls, toolOccurrenceKey ?? toolCallId, {
+          id: toolCallId,
           name: toolName,
           input,
           messageId: record.id,
@@ -540,7 +671,8 @@ export class JsonlSessionStore implements SessionStore {
         record.message.name = toolName;
         record.message.content = error ? `Error: ${error}` : stringifyContent(output);
 
-        const toolCallState = getToolCallState(toolCalls, toolCallId, {
+        const toolCallState = getToolCallState(toolCalls, toolOccurrenceKey ?? toolCallId, {
+          id: toolCallId,
           name: toolName,
           input: {},
           messageId: record.id,

--- a/src/session/__tests__/SessionPersistence.test.ts
+++ b/src/session/__tests__/SessionPersistence.test.ts
@@ -3,13 +3,29 @@ import type { LogEntry } from '../../types/logging.js';
 import { existsSync, mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { JSONLStore } from '../../context/storage/JSONLStore.js';
+import { getSessionFilePathFromStorageRoot } from '../../context/storage/pathUtils.js';
 import { PersistentStore } from '../../context/storage/PersistentStore.js';
+import type { SessionEvent } from '../../context/types.js';
 import type { ContentPart } from '../../services/ChatServiceInterface.js';
 import { createSession, forkSession, resumeSession } from '../Session.js';
-import { SessionId } from '../../types/branded.js';
+import { MessageId, SessionId } from '../../types/branded.js';
 
 function createWorkspaceRoot(): string {
   return mkdtempSync(join(tmpdir(), 'session-persistence-test-'));
+}
+
+function sessionEvent<T extends SessionEvent['type']>(
+  sessionId: SessionId,
+  timestamp: string,
+  id: string,
+  type: T,
+  data: Extract<SessionEvent, { type: T }>['data'],
+): Extract<SessionEvent, { type: T }> {
+  return { id, sessionId, timestamp, type, version: '1.1.2', data } as Extract<
+    SessionEvent,
+    { type: T }
+  >;
 }
 
 function createOptions(workspaceRoot: string) {
@@ -35,13 +51,19 @@ describe('Session persistence', () => {
 
     const sessionId = SessionId('session-1');
     await persistentStore.saveMessage(sessionId, 'user', 'hello');
-    const toolCallId = await persistentStore.saveToolUse(sessionId, 'Read', { file_path: 'README.md' });
-    await persistentStore.saveToolResult(sessionId, toolCallId, 'Read', 'contents', toolCallId);
+    const toolUse = await persistentStore.saveToolUse(sessionId, 'Read', { file_path: 'README.md' });
+    const toolResultMessageId = await persistentStore.saveToolResult(
+      sessionId,
+      toolUse.toolCallId,
+      'Read',
+      'contents',
+      toolUse.messageId,
+    );
     const summaryId = await persistentStore.saveCompaction(
       sessionId,
       'Compacted summary',
       { trigger: 'auto', preTokens: 12 },
-      toolCallId,
+      toolResultMessageId,
     );
 
     const session = await resumeSession({
@@ -55,6 +77,95 @@ describe('Session persistence', () => {
     expect(session.messages[2]?.role).toBe('tool');
     expect(session.messages[3]?.id).toBe(summaryId);
     expect(session.messages[3]?.role).toBe('system');
+
+    await session.close();
+  });
+
+  it('should resume provider-compatible history from a legacy collided ledger', async () => {
+    const workspaceRoot = createWorkspaceRoot();
+    const sessionId = SessionId('legacy-collided-session');
+    const now = new Date().toISOString();
+    const entries = [
+      sessionEvent(sessionId, now, 'session', 'session_created', {
+        sessionId,
+        rootId: sessionId,
+        status: 'running',
+        createdAt: now,
+        updatedAt: now,
+      }),
+      sessionEvent(sessionId, now, 'user', 'message_created', {
+        messageId: MessageId('user-1'),
+        role: 'user',
+        createdAt: now,
+      }),
+      sessionEvent(sessionId, now, 'user-text', 'part_created', {
+        partId: 'user-text',
+        messageId: MessageId('user-1'),
+        partType: 'text',
+        payload: { text: 'run two tools' },
+        createdAt: now,
+      }),
+      sessionEvent(sessionId, now, 'first-call', 'part_created', {
+        partId: 'call-first',
+        messageId: MessageId('user-1'),
+        partType: 'tool_call',
+        payload: { toolCallId: 'call-first', toolName: 'Search', input: { query: 'first' } },
+        createdAt: now,
+      }),
+      sessionEvent(sessionId, now, 'first-result', 'part_created', {
+        partId: 'call-first',
+        messageId: MessageId('call-first'),
+        partType: 'tool_result',
+        payload: { toolCallId: 'call-first', toolName: 'Search', output: 'first result' },
+        createdAt: now,
+      }),
+      sessionEvent(sessionId, now, 'second-call', 'part_created', {
+        partId: 'call-second',
+        messageId: MessageId('call-first'),
+        partType: 'tool_call',
+        payload: { toolCallId: 'call-second', toolName: 'Search', input: { query: 'second' } },
+        createdAt: now,
+      }),
+      sessionEvent(sessionId, now, 'second-result', 'part_created', {
+        partId: 'call-second',
+        messageId: MessageId('call-second'),
+        partType: 'tool_result',
+        payload: { toolCallId: 'call-second', toolName: 'Search', output: 'second result' },
+        createdAt: now,
+      }),
+      sessionEvent(sessionId, now, 'final', 'message_created', {
+        messageId: MessageId('assistant-final'),
+        role: 'assistant',
+        parentMessageId: 'call-second',
+        createdAt: now,
+      }),
+      sessionEvent(sessionId, now, 'final-text', 'part_created', {
+        partId: 'final-text',
+        messageId: MessageId('assistant-final'),
+        partType: 'text',
+        payload: { text: 'done' },
+        createdAt: now,
+      }),
+    ];
+    await new JSONLStore(getSessionFilePathFromStorageRoot(workspaceRoot, sessionId))
+      .appendBatch(entries);
+
+    const session = await resumeSession({
+      sessionId,
+      ...createOptions(workspaceRoot),
+    });
+
+    expect(session.messages.map((message) => message.role)).toEqual([
+      'user',
+      'assistant',
+      'tool',
+      'assistant',
+      'tool',
+      'assistant',
+    ]);
+    expect(session.messages.filter((message) => message.role === 'tool').map(
+      (message) => message.tool_call_id,
+    )).toEqual(['call-first', 'call-second']);
 
     await session.close();
   });

--- a/src/session/__tests__/SessionStore.test.ts
+++ b/src/session/__tests__/SessionStore.test.ts
@@ -2,17 +2,56 @@ import { describe, expect, it } from 'vitest';
 import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { PersistentStore } from '../../context/storage/PersistentStore.js';
+import { JSONLStore } from '../../context/storage/JSONLStore.js';
+import { getSessionFilePathFromStorageRoot } from '../../context/storage/pathUtils.js';
+import { NoopPersistentStore, PersistentStore } from '../../context/storage/PersistentStore.js';
+import type { SessionEvent } from '../../context/types.js';
 import { JsonlSessionStore } from '../SessionStore.js';
 import type { ContentPart } from '../../services/ChatServiceInterface.js';
 import { assertDefined } from '../../__tests__/helpers/assertDefined.js';
-import { SessionId } from '../../types/branded.js';
+import { MessageId, SessionId } from '../../types/branded.js';
 
 function createWorkspaceRoot(): string {
   return mkdtempSync(join(tmpdir(), 'session-store-test-'));
 }
 
+function sessionEvent<T extends SessionEvent['type']>(
+  sessionId: SessionId,
+  timestamp: string,
+  id: string,
+  type: T,
+  data: Extract<SessionEvent, { type: T }>['data'],
+): Extract<SessionEvent, { type: T }> {
+  return { id, sessionId, timestamp, type, version: '1.1.2', data } as Extract<
+    SessionEvent,
+    { type: T }
+  >;
+}
+
 describe('JsonlSessionStore', () => {
+  it('keeps persisted message IDs distinct from provider tool-call IDs', async () => {
+    const store = new NoopPersistentStore();
+    const toolUse = await store.saveToolUse(
+      SessionId('session-noop'),
+      'Search',
+      { query: 'needle' },
+      null,
+      undefined,
+      'call-noop',
+    );
+    const toolResultMessageId = await store.saveToolResult(
+      SessionId('session-noop'),
+      toolUse.toolCallId,
+      'Search',
+      'result',
+      toolUse.messageId,
+    );
+
+    expect(toolUse.toolCallId).toBe('call-noop');
+    expect(toolUse.messageId).not.toBe(toolUse.toolCallId);
+    expect(toolResultMessageId).not.toBe(toolUse.toolCallId);
+  });
+
   it('should reconstruct full session state from JSONL events', async () => {
     const workspaceRoot = createWorkspaceRoot();
     const persistentStore = new PersistentStore(workspaceRoot);
@@ -20,7 +59,7 @@ describe('JsonlSessionStore', () => {
 
     const sessionId = SessionId('session-1');
     const userMessageId = await persistentStore.saveMessage(sessionId, 'user', 'hello');
-    const toolCallId = await persistentStore.saveToolUse(
+    const toolUse = await persistentStore.saveToolUse(
       sessionId,
       'Task',
       {
@@ -29,12 +68,12 @@ describe('JsonlSessionStore', () => {
         description: 'Inspect repository',
       },
     );
-    await persistentStore.saveToolResult(
+    const toolResultMessageId = await persistentStore.saveToolResult(
       sessionId,
-      toolCallId,
+      toolUse.toolCallId,
       'Task',
       { status: 'done' },
-      toolCallId,
+      toolUse.messageId,
       undefined,
       undefined,
       {
@@ -48,7 +87,7 @@ describe('JsonlSessionStore', () => {
       sessionId,
       'Compacted summary',
       { trigger: 'auto', preTokens: 100, postTokens: 40 },
-      toolCallId,
+      toolResultMessageId,
     );
 
     const state = await sessionStore.loadState(sessionId);
@@ -59,9 +98,9 @@ describe('JsonlSessionStore', () => {
     expect(state.messages[0]?.id).toBe(userMessageId);
     expect(state.messages[0]?.role).toBe('user');
     expect(state.messages[1]?.role).toBe('assistant');
-    expect(state.messages[1]?.tool_calls?.[0]?.id).toBe(toolCallId);
+    expect(state.messages[1]?.tool_calls?.[0]?.id).toBe(toolUse.toolCallId);
     expect(state.messages[2]?.role).toBe('tool');
-    expect(state.messages[2]?.tool_call_id).toBe(toolCallId);
+    expect(state.messages[2]?.tool_call_id).toBe(toolUse.toolCallId);
     expect(state.messages[3]?.role).toBe('system');
     expect(state.messages[3]?.id).toBe(summaryMessageId);
     expect(state.messages[3]?.content).toBe('Compacted summary');
@@ -70,6 +109,240 @@ describe('JsonlSessionStore', () => {
     expect(state.toolCalls[0]?.status).toBe('success');
     expect(state.subagentRefs).toHaveLength(2);
     expect(state.subagentRefs[1]?.status).toBe('completed');
+  });
+
+  it('should preserve sequential tool results with distinct message IDs', async () => {
+    const workspaceRoot = createWorkspaceRoot();
+    const persistentStore = new PersistentStore(workspaceRoot);
+    const sessionStore = new JsonlSessionStore(workspaceRoot);
+
+    const sessionId = SessionId('session-sequential-tools');
+    const userMessageId = await persistentStore.saveMessage(sessionId, 'user', 'hello');
+    const firstToolUse = await persistentStore.saveToolUse(
+      sessionId,
+      'Search',
+      { query: 'first' },
+      userMessageId,
+      undefined,
+      'call-first',
+    );
+    const firstResultId = await persistentStore.saveToolResult(
+      sessionId,
+      firstToolUse.toolCallId,
+      'Search',
+      'first result',
+      firstToolUse.messageId,
+    );
+    const secondToolUse = await persistentStore.saveToolUse(
+      sessionId,
+      'Search',
+      { query: 'second' },
+      firstResultId,
+      undefined,
+      'call-second',
+    );
+    await persistentStore.saveToolResult(
+      sessionId,
+      secondToolUse.toolCallId,
+      'Search',
+      'second result',
+      secondToolUse.messageId,
+    );
+
+    const state = await sessionStore.loadState(sessionId);
+
+    assertDefined(state);
+    expect(state.messages.map((message) => message.role)).toEqual([
+      'user',
+      'assistant',
+      'tool',
+      'assistant',
+      'tool',
+    ]);
+    expect(state.messages[1]?.tool_calls?.[0]?.id).toBe('call-first');
+    expect(state.messages[2]?.tool_call_id).toBe('call-first');
+    expect(state.messages[3]?.tool_calls?.[0]?.id).toBe('call-second');
+    expect(state.messages[4]?.tool_call_id).toBe('call-second');
+    expect(new Set(state.messageIds).size).toBe(state.messageIds.length);
+    expect(state.timeline[1]?.parentMessageId).toBe(userMessageId);
+    expect(state.timeline[2]?.parentMessageId).toBe(firstToolUse.messageId);
+    expect(state.timeline[3]?.parentMessageId).toBe(firstResultId);
+    expect(state.timeline[4]?.parentMessageId).toBe(secondToolUse.messageId);
+  });
+
+  it('should repair legacy message ID collisions and duplicate tool calls', async () => {
+    const workspaceRoot = createWorkspaceRoot();
+    const sessionId = SessionId('session-legacy-tool-collision');
+    const now = new Date().toISOString();
+    const entries = [
+      sessionEvent(sessionId, now, 'session', 'session_created', {
+        sessionId,
+        rootId: sessionId,
+        status: 'running',
+        createdAt: now,
+        updatedAt: now,
+      }),
+      sessionEvent(sessionId, now, 'user', 'message_created', {
+        messageId: MessageId('user-1'),
+        role: 'user',
+        createdAt: now,
+      }),
+      sessionEvent(sessionId, now, 'user-text', 'part_created', {
+        partId: 'user-text',
+        messageId: MessageId('user-1'),
+        partType: 'text',
+        payload: { text: 'hello' },
+        createdAt: now,
+      }),
+      sessionEvent(sessionId, now, 'first-call', 'part_created', {
+        partId: 'call-first',
+        messageId: MessageId('user-1'),
+        partType: 'tool_call',
+        payload: { toolCallId: 'call-first', toolName: 'Search', input: { query: 'first' } },
+        createdAt: now,
+      }),
+      sessionEvent(sessionId, now, 'first-result', 'part_created', {
+        partId: 'call-first',
+        messageId: MessageId('call-first'),
+        partType: 'tool_result',
+        payload: { toolCallId: 'call-first', toolName: 'Search', output: 'first result' },
+        createdAt: now,
+      }),
+      sessionEvent(sessionId, now, 'second-call', 'part_created', {
+        partId: 'call-second',
+        messageId: MessageId('call-first'),
+        partType: 'tool_call',
+        payload: { toolCallId: 'call-second', toolName: 'Search', input: { query: 'second' } },
+        createdAt: now,
+      }),
+      sessionEvent(sessionId, now, 'assistant', 'message_created', {
+        messageId: MessageId('assistant-1'),
+        role: 'assistant',
+        createdAt: now,
+      }),
+      sessionEvent(sessionId, now, 'duplicate-first-call', 'part_created', {
+        partId: 'call-first',
+        messageId: MessageId('assistant-1'),
+        partType: 'tool_call',
+        payload: { toolCallId: 'call-first', toolName: 'Search', input: { query: 'first' } },
+        createdAt: now,
+      }),
+      sessionEvent(sessionId, now, 'duplicate-second-call', 'part_created', {
+        partId: 'call-second',
+        messageId: MessageId('assistant-1'),
+        partType: 'tool_call',
+        payload: { toolCallId: 'call-second', toolName: 'Search', input: { query: 'second' } },
+        createdAt: now,
+      }),
+      sessionEvent(sessionId, now, 'second-result', 'part_created', {
+        partId: 'call-second',
+        messageId: MessageId('call-second'),
+        partType: 'tool_result',
+        payload: { toolCallId: 'call-second', toolName: 'Search', output: 'second result' },
+        createdAt: now,
+      }),
+    ];
+    await new JSONLStore(getSessionFilePathFromStorageRoot(workspaceRoot, sessionId))
+      .appendBatch(entries);
+
+    const state = await new JsonlSessionStore(workspaceRoot).loadState(sessionId);
+
+    assertDefined(state);
+    expect(state.messages.map((message) => message.role)).toEqual([
+      'user',
+      'assistant',
+      'tool',
+      'assistant',
+      'tool',
+    ]);
+    expect(state.messages[0]?.content).toBe('hello');
+    expect(state.messages.flatMap((message) => message.tool_calls ?? []).map((call) => call.id))
+      .toEqual(['call-first', 'call-second']);
+    expect(state.messages.filter((message) => message.role === 'tool').map(
+      (message) => message.tool_call_id,
+    )).toEqual(['call-first', 'call-second']);
+  });
+
+  it('should preserve repeated provider tool-call IDs across legacy turns', async () => {
+    const workspaceRoot = createWorkspaceRoot();
+    const sessionId = SessionId('session-repeated-tool-call-id');
+    const now = new Date().toISOString();
+    const entries = [
+      sessionEvent(sessionId, now, 'session', 'session_created', {
+        sessionId,
+        rootId: sessionId,
+        status: 'running',
+        createdAt: now,
+        updatedAt: now,
+      }),
+      sessionEvent(sessionId, now, 'user', 'message_created', {
+        messageId: MessageId('user-1'),
+        role: 'user',
+        createdAt: now,
+      }),
+      sessionEvent(sessionId, now, 'first-call', 'part_created', {
+        partId: 'call-repeated',
+        messageId: MessageId('user-1'),
+        partType: 'tool_call',
+        payload: { toolCallId: 'call-repeated', toolName: 'Search', input: { query: 'first' } },
+        createdAt: now,
+      }),
+      sessionEvent(sessionId, now, 'first-result', 'part_created', {
+        partId: 'call-repeated',
+        messageId: MessageId('call-repeated'),
+        partType: 'tool_result',
+        payload: { toolCallId: 'call-repeated', toolName: 'Search', output: 'first result' },
+        createdAt: now,
+      }),
+      sessionEvent(sessionId, now, 'second-assistant', 'message_created', {
+        messageId: MessageId('assistant-2'),
+        role: 'assistant',
+        parentMessageId: 'call-repeated',
+        createdAt: now,
+      }),
+      sessionEvent(sessionId, now, 'second-call', 'part_created', {
+        partId: 'call-repeated',
+        messageId: MessageId('assistant-2'),
+        partType: 'tool_call',
+        payload: { toolCallId: 'call-repeated', toolName: 'Search', input: { query: 'second' } },
+        createdAt: now,
+      }),
+      sessionEvent(sessionId, now, 'second-result', 'part_created', {
+        partId: 'call-repeated',
+        messageId: MessageId('call-repeated'),
+        partType: 'tool_result',
+        payload: { toolCallId: 'call-repeated', toolName: 'Search', output: 'second result' },
+        createdAt: now,
+      }),
+      sessionEvent(sessionId, now, 'second-result-update', 'part_updated', {
+        partId: 'call-repeated',
+        messageId: MessageId('call-repeated'),
+        partType: 'tool_result',
+        payload: { toolCallId: 'call-repeated', toolName: 'Search', output: 'second result updated' },
+        createdAt: now,
+      }),
+    ];
+    await new JSONLStore(getSessionFilePathFromStorageRoot(workspaceRoot, sessionId))
+      .appendBatch(entries);
+
+    const state = await new JsonlSessionStore(workspaceRoot).loadState(sessionId);
+
+    assertDefined(state);
+    expect(state.messages.map((message) => message.role)).toEqual([
+      'user',
+      'assistant',
+      'tool',
+      'assistant',
+      'tool',
+    ]);
+    expect(state.messages.filter((message) => message.tool_calls?.[0]?.id === 'call-repeated'))
+      .toHaveLength(2);
+    expect(state.messages.filter((message) => message.tool_call_id === 'call-repeated'))
+      .toHaveLength(2);
+    expect(state.toolCalls.map((toolCall) => toolCall.output)).toEqual([
+      'first result',
+      'second result updated',
+    ]);
   });
 
   it('should preserve assistant reasoning content with tool calls for resume', async () => {
@@ -103,7 +376,7 @@ describe('JsonlSessionStore', () => {
       'call-search',
       'Search',
       'result',
-      'call-search',
+      assistantMessageId,
     );
 
     const state = await sessionStore.loadState(sessionId);


### PR DESCRIPTION
## Summary

- separate persisted message IDs from provider tool-call IDs
- persist assistant tool declarations before ordered tool results in both streaming and non-streaming paths
- repair legacy JSONL collisions while preserving repeated provider tool-call IDs across turns
- keep injected messages after the complete tool-result block
- add regression coverage for streaming persistence, legacy ledgers, repeated IDs, and session-scoped pending calls

## Validation

- `pnpm test` (1074 passed, 62 live tests skipped because external credentials are not configured)
- `pnpm run type-check`
- `pnpm run lint`
- `pnpm run build`
- `git diff --check`

Fixes #7