### PR TITLE
refactor: state machine hardening batch (F2, F3, F16, F17)

### DIFF
--- a/src/agent/AgentLoop.ts
+++ b/src/agent/AgentLoop.ts
@@ -149,10 +149,17 @@ export async function* agentLoop(
   let totalToolCalls = 0;
   let totalTokens = 0;
   let lastPromptTokens: number | undefined;
-  let recoveryAttemptedTurn: number | null = null;
-  let recoveryAttempt = 0;
-  /** 当前回合需要重试（不自增 turnsCount、不发 turn_end） */
-  let retryCurrentTurn = false;
+  /**
+   * 反应式压缩恢复状态机：
+   * - idle: 未在恢复中
+   * - retry_pending: 压缩成功，当前轮待重试（跳过 beforeTurn/turn_start/turnsCount）
+   * - in_retried_turn: 已消费重试，正在执行重试轮（再次溢出则判定 exhausted）
+   */
+  type RecoveryState =
+    | { phase: 'idle' }
+    | { phase: 'retry_pending'; turn: number; attempt: number }
+    | { phase: 'in_retried_turn'; turn: number; attempt: number };
+  let recovery: RecoveryState = { phase: 'idle' };
   let epoch: ExecutionEpoch | null = null;
 
   const recordToolResult = (result: ToolResult): void => {
@@ -174,7 +181,7 @@ export async function* agentLoop(
       return buildAbortResult(turnsCount, totalToolCalls, startTime);
     }
 
-    if (!retryCurrentTurn && turnHooks?.beforeTurn) {
+    if (recovery.phase !== 'retry_pending' && turnHooks?.beforeTurn) {
       const beforeTurnStream = turnHooks.beforeTurn({
         turn: turnsCount,
         messages: convState.toArray(),
@@ -187,11 +194,18 @@ export async function* agentLoop(
       }
     }
 
-    if (!retryCurrentTurn) {
+    if (recovery.phase !== 'retry_pending') {
       turnsCount++;
       yield { type: 'turn_start', turn: turnsCount, maxTurns: effectiveMaxTurns };
     }
-    retryCurrentTurn = false;
+    // 消费重试标记：retry_pending -> in_retried_turn
+    if (recovery.phase === 'retry_pending') {
+      recovery = {
+        phase: 'in_retried_turn',
+        turn: recovery.turn,
+        attempt: recovery.attempt,
+      };
+    }
 
     if (signal?.aborted) {
       yield { type: 'agent_end' };
@@ -250,19 +264,19 @@ export async function* agentLoop(
         throw llmError;
       }
 
-      // 反应式压缩：context 溢出时尝试恢复
+      // 反应式压缩：context 溢出时尝试恢复（仅从 idle 状态发起）
       if (
         isOverflowRecoverable(llmError)
         && recoveryHooks?.reactiveCompact
-        && recoveryAttemptedTurn !== turnsCount
+        && recovery.phase === 'idle'
       ) {
-        recoveryAttemptedTurn = turnsCount;
-        recoveryAttempt += 1;
+        const attempt = 1;
+        recovery = { phase: 'retry_pending', turn: turnsCount, attempt };
         recoveryHooks.onStateChange?.({
           turn: turnsCount,
           phase: 'started',
           reason: 'context_overflow',
-          attempt: recoveryAttempt,
+          attempt,
         });
         yield { type: 'recovery', phase: 'started', reason: 'context_overflow' };
         const compactStream = recoveryHooks.reactiveCompact({ messages: convState.toArray() });
@@ -280,7 +294,7 @@ export async function* agentLoop(
             turn: turnsCount,
             phase: 'failed',
             reason: 'reactive_compact_failed',
-            attempt: recoveryAttempt,
+            attempt,
           });
           yield { type: 'recovery', phase: 'failed', reason: 'reactive_compact' };
           throw llmError;
@@ -289,22 +303,21 @@ export async function* agentLoop(
           turn: turnsCount,
           phase: 'retrying',
           reason: 'reactive_compact_retry',
-          attempt: recoveryAttempt,
+          attempt,
         });
         yield { type: 'recovery', phase: 'retrying', reason: 'reactive_compact' };
         epoch?.invalidate();
         // 显式"重试当前轮"：不减 turnsCount，不发 turn_end
-        retryCurrentTurn = true;
         yield { type: 'turn_retry', turn: turnsCount, reason: 'reactive_compact' };
         continue;
       }
 
-      if (isOverflowRecoverable(llmError) && recoveryAttemptedTurn === turnsCount) {
+      if (isOverflowRecoverable(llmError) && recovery.phase === 'in_retried_turn') {
         recoveryHooks?.onStateChange?.({
           turn: turnsCount,
           phase: 'failed',
           reason: 'recovery_exhausted',
-          attempt: recoveryAttempt,
+          attempt: recovery.attempt,
         });
         yield { type: 'recovery', phase: 'failed', reason: 'recovery_exhausted' };
       }
@@ -315,14 +328,13 @@ export async function* agentLoop(
       throw new Error('Agent loop completed without a chat response');
     }
 
-    recoveryAttemptedTurn = null;
-    if (recoveryAttempt > 0) {
+    if (recovery.phase !== 'idle') {
       recoveryHooks?.onStateChange?.({
         turn: turnsCount,
         phase: 'reset',
         attempt: 0,
       });
-      recoveryAttempt = 0;
+      recovery = { phase: 'idle' };
     }
 
     // Token usage

--- a/src/agent/LoopHookBuilder.ts
+++ b/src/agent/LoopHookBuilder.ts
@@ -13,8 +13,8 @@ import type { InternalLogger } from '../logging/Logger.js';
 import type { Message } from '../services/ChatServiceInterface.js';
 import type { ExecutionPipeline } from '../tools/execution/ExecutionPipeline.js';
 import {
-  normalizeToolEffects,
-  type ToolEffect,
+    normalizeToolEffects,
+    type ToolEffect,
 } from '../tools/types/index.js';
 import type { SessionId } from '../types/branded.js';
 import type { JsonValue } from '../types/common.js';
@@ -25,8 +25,8 @@ import type { RuntimePatchManager } from './RuntimePatchManager.js';
 import type { LoopState } from './state/LoopState.js';
 import type { TokenBudget } from './TokenBudget.js';
 import type {
-  ChatContext,
-  LoopOptions,
+    ChatContext,
+    LoopOptions,
 } from './types.js';
 
 export interface LoopHookBuilderDeps {
@@ -252,7 +252,6 @@ export function buildLoopConfig(deps: LoopHookBuilderDeps): AgentLoopConfig {
         const modelId = runtimePatch?.modelOverride?.modelId?.trim() || undefined;
         if (modelId) {
           await modelManager.switchModelIfNeeded(modelId);
-          loopState.setTransitionReason('model_switched');
         }
 
         if (options?.onProgress) {
@@ -326,22 +325,6 @@ export function buildLoopConfig(deps: LoopHookBuilderDeps): AgentLoopConfig {
             return result;
           }
         : undefined,
-
-      onStateChange(recovery) {
-        if (recovery.phase === 'started') {
-          loopState.startRecovery(recovery.reason ?? 'recovery_started');
-          return;
-        }
-        if (recovery.phase === 'retrying') {
-          loopState.markRecoveryRetry(recovery.reason ?? 'recovery_retry');
-          return;
-        }
-        if (recovery.phase === 'failed') {
-          loopState.failRecovery(recovery.reason ?? 'recovery_failed');
-          return;
-        }
-        loopState.resetRecovery();
-      },
     },
 
     stop: {

--- a/src/agent/RuntimePatchManager.ts
+++ b/src/agent/RuntimePatchManager.ts
@@ -173,7 +173,6 @@ export class RuntimePatchManager {
       };
       this.runtimeSkillState = nextSkillContext;
       loopState.setActiveSkill(nextSkillContext);
-      loopState.setTransitionReason('skill_activated');
     }
   }
 

--- a/src/agent/state/LoopState.ts
+++ b/src/agent/state/LoopState.ts
@@ -4,7 +4,6 @@ import type { PermissionMode } from '../../types/common.js';
 import type { ConversationState } from './ConversationState.js';
 import type {
   LoopExecutionContext,
-  LoopRecoveryState,
   LoopSkillState,
   LlmToolDefinition,
   TurnState,
@@ -31,11 +30,6 @@ export class LoopState {
   private readonly resolveChatServiceFn: () => IChatService;
   private readonly resolveMaxContextTokensFn: () => number;
   private activeSkill?: LoopSkillState;
-  private recovery: LoopRecoveryState = {
-    attempt: 0,
-    hasAttemptedReactiveCompact: false,
-  };
-  private transitionReason?: string;
 
   constructor(options: LoopStateOptions) {
     this.conversationState = options.conversationState;
@@ -58,8 +52,6 @@ export class LoopState {
       permissionMode: this.permissionMode,
       executionContext: this.executionContext,
       activeSkill: this.activeSkill,
-      recovery: { ...this.recovery },
-      transitionReason: this.transitionReason,
     };
   }
 
@@ -89,45 +81,5 @@ export class LoopState {
 
   setActiveSkill(skill: LoopSkillState | undefined): void {
     this.activeSkill = skill;
-  }
-
-  setTransitionReason(reason: string | undefined): void {
-    this.transitionReason = reason;
-  }
-
-  getRecoveryState(): LoopRecoveryState {
-    return { ...this.recovery };
-  }
-
-  startRecovery(reason: string): void {
-    this.recovery = {
-      attempt: this.recovery.attempt + 1,
-      hasAttemptedReactiveCompact: true,
-      lastReason: reason,
-    };
-    this.transitionReason = reason;
-  }
-
-  markRecoveryRetry(reason: string): void {
-    this.recovery = {
-      ...this.recovery,
-      lastReason: reason,
-    };
-    this.transitionReason = reason;
-  }
-
-  failRecovery(reason: string): void {
-    this.recovery = {
-      ...this.recovery,
-      lastReason: reason,
-    };
-    this.transitionReason = reason;
-  }
-
-  resetRecovery(): void {
-    this.recovery = {
-      attempt: 0,
-      hasAttemptedReactiveCompact: false,
-    };
   }
 }

--- a/src/agent/state/TurnState.ts
+++ b/src/agent/state/TurnState.ts
@@ -23,12 +23,6 @@ export interface LoopSkillState {
   scope?: 'turn' | 'session';
 }
 
-export interface LoopRecoveryState {
-  attempt: number;
-  hasAttemptedReactiveCompact: boolean;
-  lastReason?: string;
-}
-
 export interface LoopExecutionContext {
   sessionId: SessionId;
   userId: string;
@@ -51,6 +45,4 @@ export interface TurnState {
   permissionMode?: PermissionMode;
   executionContext: LoopExecutionContext;
   activeSkill?: LoopSkillState;
-  recovery?: LoopRecoveryState;
-  transitionReason?: string;
 }

--- a/src/agent/subagents/AgentSessionStore.ts
+++ b/src/agent/subagents/AgentSessionStore.ts
@@ -217,7 +217,22 @@ export class AgentSessionStore {
   }
 
   /**
-   * 标记会话完成
+   * 更新运行中会话的可变字段（消息、进度）。
+   * 仅允许在 status === 'running' 时更新，避免终端状态后写入陈旧数据。
+   */
+  updateRunningSession(
+    agentId: AgentId,
+    updates: { messages?: Message[]; progress?: AgentProgress },
+  ): AgentSession | undefined {
+    const session = this.loadSession(agentId);
+    if (!session || session.status !== 'running') {
+      return undefined;
+    }
+    return this.updateSession(agentId, updates);
+  }
+
+  /**
+   * 标记会话完成（成功或失败）。
    */
   markCompleted(
     agentId: AgentId,
@@ -229,6 +244,24 @@ export class AgentSessionStore {
       result,
       stats,
       completedAt: Date.now(),
+      progress: undefined,
+    });
+  }
+
+  /**
+   * 标记会话已取消。
+   */
+  markCancelled(
+    agentId: AgentId,
+    result?: { success: false; message: string; error?: string },
+    stats?: AgentSession['stats'],
+  ): AgentSession | undefined {
+    return this.updateSession(agentId, {
+      status: 'cancelled',
+      result: result ?? { success: false, message: '' },
+      stats,
+      completedAt: Date.now(),
+      progress: undefined,
     });
   }
 

--- a/src/agent/subagents/BackgroundAgentManager.ts
+++ b/src/agent/subagents/BackgroundAgentManager.ts
@@ -17,8 +17,8 @@ import type { Message } from '../../services/ChatServiceInterface.js';
 import { AgentId } from '../../types/branded.js';
 import type { BladeConfig, PermissionMode } from '../../types/common.js';
 import type {
-    AgentSession,
-    AgentSessionStore,
+  AgentSession,
+  AgentSessionStore,
 } from './AgentSessionStore.js';
 import { runSubagent } from './runSubagent.js';
 import type { SubagentRegistry } from './SubagentRegistry.js';
@@ -130,15 +130,14 @@ export class BackgroundAgentManager {
 
         if (!isInMemory || age > maxOrphanAge) {
           this.logger.warn(`Cleaning up orphaned agent session: ${session.id}`);
-          this.sessionStore.updateSession(session.id, {
-            status: 'failed',
-            result: {
+          this.sessionStore.markCompleted(
+            session.id,
+            {
               success: false,
               message: '',
               error: 'Session was orphaned (process restart or timeout)',
             },
-            completedAt: now,
-          });
+          );
         }
       }
     }
@@ -268,11 +267,11 @@ export class BackgroundAgentManager {
         messages,
         signal: workSignal,
         onProgress: (progress) => {
-          this.sessionStore.updateSession(agentId, { progress });
+          this.sessionStore.updateRunningSession(agentId, { progress });
         },
       });
 
-      this.sessionStore.updateSession(agentId, {
+      this.sessionStore.updateRunningSession(agentId, {
         messages,
       });
 
@@ -301,16 +300,15 @@ export class BackgroundAgentManager {
           };
 
       if (wasCancelled && !result.success) {
-        this.sessionStore.updateSession(agentId, {
-          status: 'cancelled',
-          result: {
+        this.sessionStore.markCancelled(
+          agentId,
+          {
             success: false,
             message: result.message,
             error: result.error,
           },
-          stats: result.stats,
-          completedAt: Date.now(),
-        });
+          result.stats,
+        );
       } else {
         this.sessionStore.markCompleted(
           agentId,
@@ -345,16 +343,15 @@ export class BackgroundAgentManager {
         this.sessionStore.loadSession(agentId)?.status === 'cancelled';
 
       if (wasCancelled) {
-        this.sessionStore.updateSession(agentId, {
-          status: 'cancelled',
-          result: {
+        this.sessionStore.markCancelled(
+          agentId,
+          {
             success: false,
             message: '',
             error: errorMessage,
           },
-          stats: { duration },
-          completedAt: Date.now(),
-        });
+          { duration },
+        );
       } else {
         this.sessionStore.markCompleted(
           agentId,
@@ -485,7 +482,7 @@ export class BackgroundAgentManager {
       const session = this.sessionStore.loadSession(agentId);
       if (session && session.status === 'running') {
         // 更新状态为已取消
-        this.sessionStore.updateSession(agentId, { status: 'cancelled' });
+        this.sessionStore.markCancelled(agentId);
       }
       return false;
     }
@@ -494,7 +491,7 @@ export class BackgroundAgentManager {
     runtime.lifecycleController.abort();
 
     // 更新状态
-    this.sessionStore.updateSession(agentId, { status: 'cancelled' });
+    this.sessionStore.markCancelled(agentId);
 
     this.logger.info(`Background agent cancelled: ${agentId}`);
     return true;

--- a/src/session/Session.ts
+++ b/src/session/Session.ts
@@ -46,11 +46,20 @@ export interface ResumeOptions extends SessionOptions {
   sessionId: SessionId;
 }
 
+type RequestPhase =
+  | { phase: 'idle' }
+  | {
+      phase: 'pending';
+      message: UserMessageContent;
+      options: SendOptions | null;
+      snapshot: ContextSnapshot;
+    }
+  | { phase: 'streaming'; abortController: AbortController };
+
 class Session implements ISession {
   readonly sessionId: SessionId;
   private agent: Agent | null = null;
   private runtime: SessionRuntime | null = null;
-  private abortController: AbortController | null = null;
   private _messages: Message[] = [];
   private readonly options: SessionOptions;
   private readonly store: SessionStore;
@@ -66,9 +75,15 @@ class Session implements ISession {
   private cleanupHandle: CleanupHandle | null = null;
   private readonly traces: AgentTrace[] = [];
 
-  private pendingMessage: UserMessageContent | null = null;
-  private pendingSendOptions: SendOptions | null = null;
-  private pendingContextSnapshot: ContextSnapshot | null = null;
+  /**
+   * 请求阶段状态机：
+   * - idle: 无待处理请求
+   * - pending: send() 已调用，等待 stream() 消费
+   * - streaming: stream() 正在执行，持有 abortController
+   *
+   * 防止在 streaming 期间再次调用 send() 产生并发 generator 竞态。
+   */
+  private requestPhase: RequestPhase = { phase: 'idle' };
 
   constructor(options: SessionOptions, sessionId?: SessionId, isResume = false) {
     this.sessionId = sessionId || SessionId(nanoid());
@@ -241,37 +256,41 @@ class Session implements ISession {
   async send(message: UserMessageContent, options?: SendOptions): Promise<void> {
     await this.ensureInitialized();
 
-    if (this.pendingMessage !== null) {
+    if (this.requestPhase.phase !== 'idle') {
       throw new Error(
-        'Cannot send a new message while a previous message is pending. Call stream() first.',
+        this.requestPhase.phase === 'streaming'
+          ? 'Cannot send a new message while a previous stream() is active. Drain or abort it first.'
+          : 'Cannot send a new message while a previous message is pending. Call stream() first.',
       );
     }
 
-    this.pendingMessage = message;
-    this.pendingSendOptions = options || null;
-    this.pendingContextSnapshot = createContextSnapshot(
-      this.sessionId,
-      nanoid(),
-      this.defaultContext,
-      options?.context,
-    );
+    this.requestPhase = {
+      phase: 'pending',
+      message,
+      options: options || null,
+      snapshot: createContextSnapshot(
+        this.sessionId,
+        nanoid(),
+        this.defaultContext,
+        options?.context,
+      ),
+    };
   }
 
   async *stream(options?: StreamOptions): AsyncGenerator<StreamMessage> {
     await this.ensureInitialized();
     const runtime = this.getRuntime();
 
-    if (this.pendingMessage === null) {
+    if (this.requestPhase.phase !== 'pending') {
       throw new Error('No pending message. Call send() before stream().');
     }
 
-    let message = this.pendingMessage;
-    const sendOptions = this.pendingSendOptions;
-    const pendingSnapshot = this.pendingContextSnapshot;
-    this.pendingMessage = null;
-    this.pendingSendOptions = null;
-    this.pendingContextSnapshot = null;
+    const { message: initialMessage, options: sendOptions, snapshot: pendingSnapshot } = this.requestPhase;
 
+    const abortController = new AbortController();
+    this.requestPhase = { phase: 'streaming', abortController };
+
+    let message = initialMessage;
     const traceRecorder = this.createTraceRecorder(message);
     let traceFinished = false;
     const finishTrace = async (
@@ -304,15 +323,14 @@ class Session implements ISession {
       maxContextTokens: 0,
     };
 
-    this.abortController = new AbortController();
     let signalCleanup: (() => void) | undefined;
     let signal: AbortSignal;
     if (sendOptions?.signal) {
-      const combined = this.combineSignals(sendOptions.signal, this.abortController.signal);
+      const combined = this.combineSignals(sendOptions.signal, abortController.signal);
       signal = combined.signal;
       signalCleanup = combined.cleanup;
     } else {
-      signal = this.abortController.signal;
+      signal = abortController.signal;
     }
 
     const snapshot =
@@ -609,7 +627,7 @@ class Session implements ISession {
     } finally {
       runtime.getHookRuntime().setTraceCollector(undefined);
       signalCleanup?.();
-      this.abortController = null;
+      this.requestPhase = { phase: 'idle' };
     }
   }
 
@@ -621,11 +639,9 @@ class Session implements ISession {
     this.cleanupHandle?.unregister();
     this.cleanupHandle = null;
     this.abort();
+    this.requestPhase = { phase: 'idle' };
     this.agent = null;
     this.initialized = false;
-    this.pendingMessage = null;
-    this.pendingSendOptions = null;
-    this.pendingContextSnapshot = null;
     const runtime = this.runtime;
     this.runtime = null;
     if (runtime) {
@@ -639,9 +655,9 @@ class Session implements ISession {
   }
 
   abort(): void {
-    if (this.abortController) {
-      this.abortController.abort();
-      this.abortController = null;
+    if (this.requestPhase.phase === 'streaming') {
+      this.requestPhase.abortController.abort();
+      this.requestPhase = { phase: 'idle' };
     }
   }
 

--- a/src/tools/execution/ExecutionPipeline.ts
+++ b/src/tools/execution/ExecutionPipeline.ts
@@ -67,8 +67,6 @@ interface PipelineExecutionState {
   permissionCheckResult?: { reason?: string };
   affectedPaths: string[];
   needsConfirmation: boolean;
-  toolRequestedConfirmation: boolean;
-  confirmationReason?: string;
   confirmationReasons: ConfirmationReasonEntry[];
   permissionSignature?: string;
   hookToolUseId?: ToolUseId;
@@ -186,7 +184,6 @@ export class ExecutionPipeline {
       },
       affectedPaths: [],
       needsConfirmation: false,
-      toolRequestedConfirmation: false,
       confirmationReasons: [],
     };
 
@@ -429,7 +426,6 @@ export class ExecutionPipeline {
 
       if (toolPermissionResult?.behavior === 'ask') {
         state.needsConfirmation = true;
-        state.toolRequestedConfirmation = true;
         addConfirmationReason(state, 'tool', toolPermissionResult.message);
       }
 
@@ -704,10 +700,9 @@ export class ExecutionPipeline {
         }
         if (state.permissionSignature && this.sessionApprovals.has(state.permissionSignature)) {
           state.needsConfirmation = false;
-          state.confirmationReason = undefined;
           state.confirmationReasons = [];
         }
-        if (!state.toolRequestedConfirmation && !state.confirmationReason) {
+        if (!hasToolRequestedConfirmation(state) && !getConfirmationReason(state)) {
           state.needsConfirmation = false;
         }
         this.logger.debug(`permissionHandler allowed: ${state.toolName}`);
@@ -780,7 +775,7 @@ export class ExecutionPipeline {
 
       const confirmationDetails: ConfirmationDetails = {
         title: confirmationTitle,
-        message: state.confirmationReason || '此操作需要用户确认',
+        message: getConfirmationReason(state) || '此操作需要用户确认',
         kind: state.resolvedBehavior?.kind ?? state.tool.kind,
         details: this.generatePreviewForTool(state.tool.name, state.params),
         risks: this.extractRisksFromPermissionCheck(
@@ -1123,7 +1118,16 @@ function addConfirmationReason(
 ): void {
   const msg = message || defaultReasonMessage(source);
   state.confirmationReasons.push({ source, message: msg });
-  state.confirmationReason = combineConfirmationReasons(state.confirmationReasons);
+}
+
+/** Tool itself requested confirmation (vs. rule/path/hook/handler). */
+function hasToolRequestedConfirmation(state: PipelineExecutionState): boolean {
+  return state.confirmationReasons.some((r) => r.source === 'tool');
+}
+
+/** Combined, de-duplicated confirmation message derived from all reasons. */
+function getConfirmationReason(state: PipelineExecutionState): string | undefined {
+  return combineConfirmationReasons(state.confirmationReasons);
 }
 
 function defaultReasonMessage(source: ConfirmationReasonSource): string {


### PR DESCRIPTION
## Summary

Fourth batch from the [codebase simplification audit](docs/simplification-audit.md). This batch focuses on state representation — replacing implicit boolean state machines with explicit discriminated unions and naming terminal transitions. Includes one concurrency bug fix. Each change is a separate commit.

| Commit | Finding | Change |
|--------|---------|--------|
| `d2d45473` | F16 | Derive `confirmationReason`/`toolRequestedConfirmation` from `confirmationReasons` in `ExecutionPipeline` |
| `bd16d609` | F17 | Add `markCancelled`/`updateRunningSession` to `AgentSessionStore`; route all transitions through named methods |
| `b0966dad` | F3 | AgentLoop recovery state → discriminated union; remove dead `LoopState`/`TurnState` mirror (~98 LOC removed) |
| `91e4bcdd` | F2 | Session pending request + abortController → `RequestPhase` state machine; **fixes concurrent-send race** |

### F2 — Session RequestPhase (bug fix)
`send()` guarded against a pending message but `stream()` cleared the pending fields immediately on entry. A second `send()` during an active `stream()` could start a concurrent generator mutating shared `_messages` and overwriting the abort controller. The new `RequestPhase` (idle/pending/streaming) rejects `send()` in any non-idle state, including active streaming.

### F3 — AgentLoop RecoveryState
Three loosely-coupled locals (`recoveryAttemptedTurn`, `recoveryAttempt`, `retryCurrentTurn`) formed an implicit state machine permitting impossible combinations. The same state was mirrored into `LoopState`/`TurnState` via five methods that **no code consumed**. Replaced with an explicit union and removed ~98 lines of dead mirror state, dead `onStateChange` callback, and dead `setTransitionReason` writes.

### F16/F17 — Derived state and named transitions
- `ExecutionPipeline`: `confirmationReason` (cached combine) and `toolRequestedConfirmation` (derivable from a `'tool'` source entry) are now computed on demand from the single source of truth.
- `AgentSessionStore`: `updateSession(id, Partial<...>)` allowed `status: 'cancelled'` without `result`/`completedAt`. New `markCancelled`/`updateRunningSession` enforce required fields per transition and clear stale `progress` on terminal states.

## Validation

- `tsc --noEmit` — passes
- `biome lint src` — 335 files, 0 warnings/errors
- Full test suite: **1067 passed**, 62 skipped (live/integration)
- No public API changes in this batch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery from context-limit overflows, preventing repeated retries and reporting failures more reliably.
  * Prevented stale progress or messages from overwriting completed or cancelled agent sessions.
  * Improved session request handling with clearer errors when sending or streaming operations occur out of order.
  * Ensured progress is cleared when sessions complete or are cancelled.
  * Improved confirmation handling by consistently combining and deduplicating confirmation reasons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->