### PR TITLE
refactor(sandbox)!: SandboxCheckResult outcome discriminant (F6)

### DIFF
--- a/src/sandbox/SandboxService.ts
+++ b/src/sandbox/SandboxService.ts
@@ -7,11 +7,16 @@ export interface SandboxExecutionContext {
   workDir?: string;
 }
 
+export type SandboxCheckOutcome =
+  | 'disabled'
+  | 'excluded'
+  | 'sandboxed'
+  | 'requires_permission'
+  | 'denied';
+
 export interface SandboxCheckResult {
-  allowed: boolean;
-  reason?: string;
-  requiresPermission?: boolean;
-  isExcluded?: boolean;
+  outcome: SandboxCheckOutcome;
+  reason: string;
 }
 
 export class SandboxService {
@@ -67,29 +72,27 @@ export class SandboxService {
     const { command, dangerouslyDisableSandbox } = ctx;
 
     if (!this.isEnabled()) {
-      return { allowed: true, reason: 'Sandbox is disabled' };
+      return { outcome: 'disabled', reason: 'Sandbox is disabled' };
     }
 
     if (this.isCommandExcluded(command)) {
-      return { allowed: true, reason: 'Command is in excluded list', isExcluded: true };
+      return { outcome: 'excluded', reason: 'Command is in excluded list' };
     }
 
     if (dangerouslyDisableSandbox) {
       if (this.allowsUnsandboxedCommands()) {
         return {
-          allowed: false,
+          outcome: 'requires_permission',
           reason: 'Command requests unsandboxed execution',
-          requiresPermission: true,
-        };
-      } else {
-        return {
-          allowed: false,
-          reason: 'Unsandboxed commands are not allowed',
         };
       }
+      return {
+        outcome: 'denied',
+        reason: 'Unsandboxed commands are not allowed',
+      };
     }
 
-    return { allowed: true, reason: 'Command will run in sandbox' };
+    return { outcome: 'sandboxed', reason: 'Command will run in sandbox' };
   }
 
   shouldIgnoreFileViolation(filePath: string): boolean {

--- a/src/sandbox/__tests__/SandboxService.test.ts
+++ b/src/sandbox/__tests__/SandboxService.test.ts
@@ -139,7 +139,7 @@ describe('SandboxService', () => {
       const service = getSandboxService();
       service.configure({ enabled: false });
       const result = service.checkCommand({ command: 'rm -rf /' });
-      expect(result.allowed).toBe(true);
+      expect(result.outcome).toBe('disabled');
       expect(result.reason).toBe('Sandbox is disabled');
     });
 
@@ -147,15 +147,14 @@ describe('SandboxService', () => {
       const service = getSandboxService();
       service.configure({ enabled: true, excludedCommands: ['git'] });
       const result = service.checkCommand({ command: 'git push' });
-      expect(result.allowed).toBe(true);
-      expect(result.isExcluded).toBe(true);
+      expect(result.outcome).toBe('excluded');
     });
 
     it('should block unsandboxed command when not allowed', () => {
       const service = getSandboxService();
       service.configure({ enabled: true, allowUnsandboxedCommands: false });
       const result = service.checkCommand({ command: 'ls', dangerouslyDisableSandbox: true });
-      expect(result.allowed).toBe(false);
+      expect(result.outcome).toBe('denied');
       expect(result.reason).toBe('Unsandboxed commands are not allowed');
     });
 
@@ -163,15 +162,14 @@ describe('SandboxService', () => {
       const service = getSandboxService();
       service.configure({ enabled: true, allowUnsandboxedCommands: true });
       const result = service.checkCommand({ command: 'ls', dangerouslyDisableSandbox: true });
-      expect(result.allowed).toBe(false);
-      expect(result.requiresPermission).toBe(true);
+      expect(result.outcome).toBe('requires_permission');
     });
 
     it('should allow normal command in sandbox', () => {
       const service = getSandboxService();
       service.configure({ enabled: true });
       const result = service.checkCommand({ command: 'ls -la' });
-      expect(result.allowed).toBe(true);
+      expect(result.outcome).toBe('sandboxed');
       expect(result.reason).toBe('Command will run in sandbox');
     });
   });

--- a/src/tools/builtin/shell/bash.ts
+++ b/src/tools/builtin/shell/bash.ts
@@ -220,21 +220,22 @@ Before executing commands:
     const sandboxService = getSandboxService();
     const sandboxCheck = sandboxService.checkCommand({ command });
 
-    if (sandboxCheck.allowed) {
-      return undefined;
+    switch (sandboxCheck.outcome) {
+      case 'disabled':
+      case 'excluded':
+      case 'sandboxed':
+        return undefined;
+      case 'requires_permission':
+        return {
+          behavior: 'ask',
+          message: sandboxCheck.reason,
+        } as const;
+      case 'denied':
+        return {
+          behavior: 'deny',
+          message: sandboxCheck.reason,
+        } as const;
     }
-
-    if (sandboxCheck.requiresPermission) {
-      return {
-        behavior: 'ask',
-        message: sandboxCheck.reason || 'Command requires user permission',
-      } as const;
-    }
-
-    return {
-      behavior: 'deny',
-      message: sandboxCheck.reason || 'Blocked by sandbox',
-    } as const;
   },
 
   // 执行函数


### PR DESCRIPTION
## Summary

Final finding from the [codebase simplification audit](docs/simplification-audit.md) (F6). This is the only **breaking change** in the audit, isolated in its own PR for clear semver signaling.

`SandboxCheckResult` used `allowed`/`requiresPermission`/`isExcluded` booleans that encoded five outcomes but permitted contradictory combinations (e.g. `allowed: true` + `requiresPermission: true`). The `bash.ts` consumer cascaded through the booleans with fallback strings.

Replace the flat shape with a tagged union:

```ts
type SandboxCheckOutcome =
  | 'disabled'
  | 'excluded'
  | 'sandboxed'
  | 'requires_permission'
  | 'denied';

interface SandboxCheckResult {
  outcome: SandboxCheckOutcome;
  reason: string; // now required
}
```

`SandboxService.checkCommand` returns one outcome per branch and `bash.ts` uses an exhaustive `switch`. Impossible states are no longer representable and `reason` is always present.

## BREAKING CHANGE

`SandboxCheckResult` no longer has `allowed`, `requiresPermission`, or `isExcluded` boolean fields. Consumers must switch on `outcome`:

| Old | New |
|-----|-----|
| `result.allowed === true` | `result.outcome` is `'disabled' \| 'excluded' \| 'sandboxed'` |
| `result.requiresPermission === true` | `result.outcome === 'requires_permission'` |
| otherwise (blocked) | `result.outcome === 'denied'` |
| `result.reason` (optional) | `result.reason` (required) |

The `isExcluded` flag had no external consumer and is not carried forward.

## Validation

- `tsc --noEmit` — passes
- `biome lint src` — passes
- `SandboxService.test.ts` (35 tests) and `SandboxExecutor.test.ts` (15 tests) — all pass
- Full suite: 1067 passed