### PR TITLE
fix(sandbox): fail closed when executor is unavailable

### DIFF
--- a/.changes/sandbox-fail-closed.json
+++ b/.changes/sandbox-fail-closed.json
@@ -1,0 +1,5 @@
+{
+  "type": "fix",
+  "en": "Fail closed when Sandbox is enabled but no supported OS sandbox executor is available.",
+  "zh-CN": "启用 Sandbox 但系统缺少受支持的沙箱执行器时拒绝运行，避免静默降级。"
+}

--- a/docs/en/sandbox.md
+++ b/docs/en/sandbox.md
@@ -2,8 +2,10 @@
 
 Sandbox support provides best-effort operating-system isolation for the built-in `Bash` tool. Linux uses Bubblewrap and macOS uses Seatbelt (`sandbox-exec`). Permissions decide whether a call may proceed; the sandbox attempts to restrict an approved command.
 
-::: danger Check runtime availability
-`sandbox.enabled: true` does not guarantee that a sandbox executor exists on the host. When none is available, the current implementation executes the original command. Production applications must inspect `getSandboxService().getCapabilities().available` and fail closed or disable `Bash`.
+::: danger Enabling sandbox is a hard requirement
+`sandbox.enabled: true` requires a supported sandbox executor. Session
+initialization throws `ConfigError` when none is available, and the lower-level
+command wrapper also rejects execution instead of running the original command.
 :::
 
 ## Safe initialization
@@ -48,9 +50,9 @@ interface SandboxSettings {
 
 | Option | Default | Current behavior |
 |--------|---------|------------------|
-| `enabled` | `false` | Request OS sandboxing for `Bash`. |
+| `enabled` | `false` | Require OS sandboxing for `Bash`; throw `ConfigError` when unavailable. |
 | `autoAllowBashIfSandboxed` | `false` | Queryable configuration metadata. The current execution pipeline does not consume it, so it does not guarantee automatic approval. |
-| `excludedCommands` | `[]` | Affects sandbox classification; the command wrapper may still sandbox these commands. Do not rely on it as a bypass. |
+| `excludedCommands` | `[]` | Explicitly bypass sandbox wrapping for matching commands. They execute on the host and should be used sparingly. |
 | `allowUnsandboxedCommands` | `false` | Allow an explicit unsandboxed request passed to `SandboxService.checkCommand()` to enter permission review. Built-in Bash does not currently expose that request flag. |
 | `network` | unset | Network options passed to the command wrapper. |
 | `ignoreViolations` | unset | Queryable metadata; the current command wrapper does not apply these rules. |
@@ -66,7 +68,9 @@ console.log(capabilities.type); // 'bubblewrap' | 'seatbelt' | 'none'
 console.log(capabilities.features);
 ```
 
-Treat `available === false` as a deployment configuration failure when isolation is required. The SDK does not currently fail closed.
+`available === false` is a deployment configuration error. The SDK fails closed
+when Sandbox is enabled. Applications can still perform the capability check
+before creating a Session to provide a custom error or disable `Bash`.
 
 ## Filesystem boundary
 
@@ -142,7 +146,8 @@ console.log(service.isEnabled());
 console.log(service.getCapabilities());
 ```
 
-If `available` is false, the original command is executed.
+If `available` is false, enabling Sandbox fails Session initialization. Calling
+the lower-level wrapper directly also throws `ConfigError`.
 
 ### All network access is blocked
 

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -2,8 +2,10 @@
 
 Sandbox 为内置 `Bash` 工具提供尽力而为的操作系统隔离。Linux 使用 Bubblewrap，macOS 使用 Seatbelt (`sandbox-exec`)。权限系统决定是否批准调用；Sandbox 尝试限制批准后的命令。
 
-::: danger 先检查运行时能力
-`sandbox.enabled: true` 不保证当前机器具备沙箱执行器。执行器不可用时，当前实现会原样执行命令。生产环境必须在启动时检查 `getSandboxService().getCapabilities().available`，并在不可用时拒绝启动或禁用 `Bash`。
+::: danger 显式启用即为强约束
+`sandbox.enabled: true` 要求当前机器具备支持的沙箱执行器。执行器不可用时，
+Session 初始化会抛出 `ConfigError`；低层命令包装也会拒绝执行，不会降级为
+原样运行命令。
 :::
 
 ## 安全初始化
@@ -51,9 +53,9 @@ interface SandboxSettings {
 
 | 字段 | 默认值 | 当前行为 |
 |------|--------|----------|
-| `enabled` | `false` | 请求对 `Bash` 使用可用的 OS 沙箱 |
+| `enabled` | `false` | 强制 `Bash` 使用 OS 沙箱；执行器不可用时抛出 `ConfigError` |
 | `autoAllowBashIfSandboxed` | `false` | 可查询的配置标记；当前执行管道未读取，不能据此假设 Bash 会自动批准 |
-| `excludedCommands` | `[]` | 影响 Sandbox 检查结果；当前命令包装器仍可能包装这些命令，不应依赖它绕过沙箱 |
+| `excludedCommands` | `[]` | 显式跳过指定命令的沙箱包装；这些命令会在宿主环境直接执行，应谨慎使用 |
 | `allowUnsandboxedCommands` | `false` | 允许 `SandboxService.checkCommand()` 的显式无沙箱请求进入权限确认；当前内置 Bash 不暴露该请求参数 |
 | `network` | 未设置 | 传给命令包装器的网络选项 |
 | `ignoreViolations` | 未设置 | 可供上层查询的忽略规则；当前命令包装器不会应用这些规则 |
@@ -71,7 +73,8 @@ console.log(capabilities.type); // 'bubblewrap' | 'seatbelt' | 'none'
 console.log(capabilities.features);
 ```
 
-建议把 `available === false` 当作部署配置错误，而不是降级路径。SDK 目前不会自动 fail closed。
+`available === false` 是部署配置错误。启用 Sandbox 后，SDK 会 fail closed；
+应用仍可在创建 Session 前检查能力，以提供自定义错误或禁用 `Bash`。
 
 ## 文件系统边界
 
@@ -149,7 +152,8 @@ console.log(service.isEnabled());
 console.log(service.getCapabilities());
 ```
 
-如果 `available` 为 `false`，命令不会被包装。
+如果 `available` 为 `false`，启用 Sandbox 会导致 Session 初始化失败；直接
+调用低层 wrapper 也会抛出 `ConfigError`。
 
 ### 网络被完全禁用
 

--- a/scripts/__tests__/semantic-release-config.test.ts
+++ b/scripts/__tests__/semantic-release-config.test.ts
@@ -50,10 +50,12 @@ describe('package provenance metadata', () => {
     });
   });
 
-  it('uses the latest released version and a single release entry point', () => {
+  it('aligns package and changelog versions with a single release entry point', () => {
     const packageJson = JSON.parse(readFileSync(resolve('package.json'), 'utf8'));
+    const changelog = readFileSync(resolve('CHANGELOG.md'), 'utf8');
+    const latestVersion = /^## \[([^\]]+)\]/m.exec(changelog)?.[1];
 
-    expect(packageJson.version).toBe('3.0.0');
+    expect(packageJson.version).toBe(latestVersion);
     expect(packageJson.scripts.release).toBe('semantic-release');
     expect(packageJson.scripts).not.toHaveProperty('release:legacy');
   });

--- a/src/sandbox/SandboxExecutor.ts
+++ b/src/sandbox/SandboxExecutor.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { type InternalLogger, LogCategory, NOOP_LOGGER } from '../logging/Logger.js';
 import type { NetworkSandboxSettings, SandboxSettings } from '../types/common.js';
+import { createSandboxUnavailableError } from './sandboxErrors.js';
 
 export interface SandboxExecutionOptions {
   workDir: string;
@@ -155,11 +156,14 @@ export class SandboxExecutor {
   }
 
   wrapCommand(command: string, options: SandboxExecutionOptions): string {
-    if (!this.canUseSandbox()) {
+    if (!this.isEnabled()) {
       return command;
     }
 
     const capabilities = this.getCapabilities();
+    if (!capabilities.available) {
+      throw createSandboxUnavailableError();
+    }
 
     if (capabilities.type === 'bubblewrap') {
       return this.wrapWithBubblewrap(command, options);
@@ -167,7 +171,7 @@ export class SandboxExecutor {
       return this.wrapWithSeatbelt(command, options);
     }
 
-    return command;
+    throw createSandboxUnavailableError();
   }
 
   private wrapWithBubblewrap(command: string, options: SandboxExecutionOptions): string {

--- a/src/sandbox/SandboxService.ts
+++ b/src/sandbox/SandboxService.ts
@@ -1,5 +1,6 @@
 import type { SandboxSettings } from '../types/common.js';
 import { getSandboxExecutor } from './SandboxExecutor.js';
+import { createSandboxUnavailableError } from './sandboxErrors.js';
 
 export interface SandboxExecutionContext {
   command: string;
@@ -10,6 +11,7 @@ export interface SandboxExecutionContext {
 export type SandboxCheckOutcome =
   | 'disabled'
   | 'excluded'
+  | 'unavailable'
   | 'sandboxed'
   | 'requires_permission'
   | 'denied';
@@ -38,7 +40,11 @@ export class SandboxService {
 
   configure(settings: SandboxSettings): void {
     this.settings = { ...settings };
-    getSandboxExecutor().configure(settings);
+    const executor = getSandboxExecutor();
+    executor.configure(settings);
+    if (this.isEnabled() && !executor.getCapabilities().available) {
+      throw createSandboxUnavailableError();
+    }
   }
 
   getSettings(): SandboxSettings {
@@ -50,7 +56,11 @@ export class SandboxService {
   }
 
   shouldAutoAllowBash(): boolean {
-    return this.isEnabled() && this.settings.autoAllowBashIfSandboxed === true;
+    return (
+      this.isEnabled() &&
+      this.settings.autoAllowBashIfSandboxed === true &&
+      getSandboxExecutor().canUseSandbox()
+    );
   }
 
   isCommandExcluded(command: string): boolean {
@@ -60,7 +70,7 @@ export class SandboxService {
 
     const commandName = this.extractCommandName(command);
     return this.settings.excludedCommands.some(
-      (excluded) => commandName === excluded || command.startsWith(`${excluded} `)
+      (excluded) => commandName === excluded || command.startsWith(`${excluded} `),
     );
   }
 
@@ -89,6 +99,13 @@ export class SandboxService {
       return {
         outcome: 'denied',
         reason: 'Unsandboxed commands are not allowed',
+      };
+    }
+
+    if (!getSandboxExecutor().canUseSandbox()) {
+      return {
+        outcome: 'unavailable',
+        reason: createSandboxUnavailableError().message,
       };
     }
 
@@ -159,11 +176,11 @@ export class SandboxService {
       return command;
     }
 
-    const executor = getSandboxExecutor();
-    if (!executor.canUseSandbox()) {
+    if (this.isCommandExcluded(command)) {
       return command;
     }
 
+    const executor = getSandboxExecutor();
     const options = executor.buildExecutionOptions(workDir, this.settings.network);
     return executor.wrapCommand(command, options);
   }

--- a/src/sandbox/__tests__/SandboxExecutor.test.ts
+++ b/src/sandbox/__tests__/SandboxExecutor.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { SandboxExecutor, getSandboxExecutor } from '../SandboxExecutor.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getSandboxExecutor, SandboxExecutor } from '../SandboxExecutor.js';
 
 describe('SandboxExecutor', () => {
   beforeEach(() => {
@@ -92,6 +92,24 @@ describe('SandboxExecutor', () => {
       executor.configure({ enabled: false });
       const result = executor.wrapCommand('ls -la', { workDir: '/home/test' });
       expect(result).toBe('ls -la');
+    });
+
+    it('should fail closed when sandbox is enabled but unavailable', () => {
+      const executor = getSandboxExecutor();
+      executor.configure({ enabled: true });
+      vi.spyOn(executor, 'getCapabilities').mockReturnValue({
+        available: false,
+        type: 'none',
+        features: {
+          fileSystemIsolation: false,
+          networkIsolation: false,
+          processIsolation: false,
+        },
+      });
+
+      expect(() => executor.wrapCommand('echo unsafe', { workDir: '/home/test' })).toThrow(
+        'Sandbox is enabled, but no supported sandbox executor is available',
+      );
     });
   });
 

--- a/src/sandbox/__tests__/SandboxService.test.ts
+++ b/src/sandbox/__tests__/SandboxService.test.ts
@@ -1,20 +1,24 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { SandboxService, getSandboxService } from '../SandboxService.js';
+import { bashTool } from '../../tools/builtin/shell/bash.js';
+import type { SandboxCapabilities } from '../SandboxExecutor.js';
+import { getSandboxService, SandboxService } from '../SandboxService.js';
 
 const mockSandboxExecutor = {
   configure: vi.fn(() => {}),
-  canUseSandbox: vi.fn(() => false),
+  canUseSandbox: vi.fn(() => true),
   buildExecutionOptions: vi.fn(() => ({ workDir: '/test' })),
-  wrapCommand: vi.fn((cmd: string) => cmd),
-  getCapabilities: vi.fn(() => ({
-    available: false,
-    type: 'none' as const,
-    features: {
-      fileSystemIsolation: false,
-      networkIsolation: false,
-      processIsolation: false,
-    },
-  })),
+  wrapCommand: vi.fn((cmd: string) => `sandbox:${cmd}`),
+  getCapabilities: vi.fn(
+    (): SandboxCapabilities => ({
+      available: true,
+      type: 'seatbelt' as const,
+      features: {
+        fileSystemIsolation: true,
+        networkIsolation: true,
+        processIsolation: true,
+      },
+    }),
+  ),
 };
 
 vi.mock('../SandboxExecutor.js', () => ({
@@ -23,6 +27,18 @@ vi.mock('../SandboxExecutor.js', () => ({
 
 describe('SandboxService', () => {
   beforeEach(() => {
+    vi.clearAllMocks();
+    mockSandboxExecutor.canUseSandbox.mockReturnValue(true);
+    mockSandboxExecutor.getCapabilities.mockReturnValue({
+      available: true,
+      type: 'seatbelt',
+      features: {
+        fileSystemIsolation: true,
+        networkIsolation: true,
+        processIsolation: true,
+      },
+    });
+    mockSandboxExecutor.wrapCommand.mockImplementation((cmd: string) => `sandbox:${cmd}`);
     SandboxService.resetInstance();
   });
 
@@ -67,6 +83,23 @@ describe('SandboxService', () => {
       settings.enabled = false;
       expect(service.getSettings().enabled).toBe(true);
     });
+
+    it('should fail when sandbox is enabled without an available executor', () => {
+      mockSandboxExecutor.getCapabilities.mockReturnValue({
+        available: false,
+        type: 'none',
+        features: {
+          fileSystemIsolation: false,
+          networkIsolation: false,
+          processIsolation: false,
+        },
+      });
+      const service = getSandboxService();
+
+      expect(() => service.configure({ enabled: true })).toThrow(
+        'Sandbox is enabled, but no supported sandbox executor is available',
+      );
+    });
   });
 
   describe('isEnabled', () => {
@@ -105,6 +138,14 @@ describe('SandboxService', () => {
       const service = getSandboxService();
       service.configure({ enabled: true, autoAllowBashIfSandboxed: true });
       expect(service.shouldAutoAllowBash()).toBe(true);
+    });
+
+    it('should return false when the configured sandbox becomes unavailable', () => {
+      const service = getSandboxService();
+      service.configure({ enabled: true, autoAllowBashIfSandboxed: true });
+      mockSandboxExecutor.canUseSandbox.mockReturnValue(false);
+
+      expect(service.shouldAutoAllowBash()).toBe(false);
     });
   });
 
@@ -171,6 +212,19 @@ describe('SandboxService', () => {
       const result = service.checkCommand({ command: 'ls -la' });
       expect(result.outcome).toBe('sandboxed');
       expect(result.reason).toBe('Command will run in sandbox');
+    });
+
+    it('should deny a normal command when the configured sandbox becomes unavailable', () => {
+      const service = getSandboxService();
+      service.configure({ enabled: true });
+      mockSandboxExecutor.canUseSandbox.mockReturnValue(false);
+
+      const result = service.checkCommand({ command: 'ls -la' });
+
+      expect(result.outcome).toBe('unavailable');
+      expect(result.reason).toContain(
+        'Sandbox is enabled, but no supported sandbox executor is available',
+      );
     });
   });
 
@@ -302,6 +356,45 @@ describe('SandboxService', () => {
       service.configure({ enabled: false });
       const result = service.wrapCommandForSandbox('ls -la', '/tmp');
       expect(result).toBe('ls -la');
+    });
+
+    it('should use the configured executor when sandbox is enabled', () => {
+      const service = getSandboxService();
+      service.configure({ enabled: true });
+
+      expect(service.wrapCommandForSandbox('ls -la', '/tmp')).toBe('sandbox:ls -la');
+    });
+
+    it('should leave explicitly excluded commands unsandboxed', () => {
+      const service = getSandboxService();
+      service.configure({ enabled: true, excludedCommands: ['git'] });
+
+      expect(service.wrapCommandForSandbox('git status', '/tmp')).toBe('git status');
+      expect(mockSandboxExecutor.wrapCommand).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Bash integration', () => {
+    it('should deny Bash before execution when the sandbox is unavailable', async () => {
+      const service = getSandboxService();
+      service.configure({ enabled: true });
+      mockSandboxExecutor.canUseSandbox.mockReturnValue(false);
+
+      const result = await bashTool.checkPermissions?.(
+        {
+          command: 'echo unsafe',
+          timeout: 30_000,
+          run_in_background: false,
+        },
+        {},
+      );
+
+      expect(result).toEqual({
+        behavior: 'deny',
+        message: expect.stringContaining(
+          'Sandbox is enabled, but no supported sandbox executor is available',
+        ),
+      });
     });
   });
 });

--- a/src/sandbox/sandboxErrors.ts
+++ b/src/sandbox/sandboxErrors.ts
@@ -1,0 +1,8 @@
+import { ConfigError } from '../errors/ConfigError.js';
+
+export function createSandboxUnavailableError(): ConfigError {
+  return new ConfigError(
+    `Sandbox is enabled, but no supported sandbox executor is available on ${process.platform}. ` +
+      'Install Bubblewrap on Linux or disable sandbox explicitly.',
+  );
+}

--- a/src/session/__tests__/SessionRuntime.test.ts
+++ b/src/session/__tests__/SessionRuntime.test.ts
@@ -6,12 +6,14 @@ import { assertDefined } from '../../__tests__/helpers/assertDefined.js';
 import { HookManager } from '../../hooks/HookManager.js';
 import { NOOP_LOGGER } from '../../logging/Logger.js';
 import { createContextSnapshot, type RuntimeContext } from '../../runtime/index.js';
+import { getSandboxExecutor, SandboxExecutor } from '../../sandbox/SandboxExecutor.js';
+import { SandboxService } from '../../sandbox/SandboxService.js';
 import { FileAccessTracker } from '../../tools/builtin/file/FileAccessTracker.js';
 import { FileLockManager } from '../../tools/execution/FileLockManager.js';
 import {
-  collectToolExecution,
-  completeToolExecution,
-  type ToolDefinition,
+    collectToolExecution,
+    completeToolExecution,
+    type ToolDefinition,
 } from '../../tools/types/index.js';
 import { SessionId } from '../../types/branded.js';
 import type { JsonObject } from '../../types/common.js';
@@ -92,6 +94,8 @@ describe('SessionRuntime', () => {
     mockOn.mockClear();
     FileAccessTracker.resetInstance();
     FileLockManager.resetInstance();
+    SandboxExecutor.resetInstance();
+    SandboxService.resetInstance();
   });
 
   afterEach(async () => {
@@ -106,6 +110,40 @@ describe('SessionRuntime', () => {
       createFilesystemContext(workspaceRoot),
       NOOP_LOGGER,
     );
+    await runtime.close();
+    SandboxExecutor.resetInstance();
+    SandboxService.resetInstance();
+  });
+
+  it('should fail initialization when sandbox is enabled but unavailable', async () => {
+    const executor = getSandboxExecutor();
+    vi.spyOn(executor, 'getCapabilities').mockReturnValue({
+      available: false,
+      type: 'none',
+      features: {
+        fileSystemIsolation: false,
+        networkIsolation: false,
+        processIsolation: false,
+      },
+    });
+    const runtime = new SessionRuntime(
+      SessionId('session-sandbox-unavailable'),
+      createOptions({
+        sandbox: { enabled: true },
+      }),
+      {
+        models: [],
+      },
+      PermissionMode.DEFAULT,
+      createFilesystemContext(workspaceRoot),
+      NOOP_LOGGER,
+    );
+
+    await expect(runtime.initialize()).rejects.toMatchObject({
+      code: 'CONFIG_ERROR',
+      name: 'ConfigError',
+    });
+
     await runtime.close();
   });
 

--- a/src/tools/builtin/shell/bash.ts
+++ b/src/tools/builtin/shell/bash.ts
@@ -235,6 +235,7 @@ Before executing commands:
           behavior: 'ask',
           message: sandboxCheck.reason,
         } as const;
+      case 'unavailable':
       case 'denied':
         return {
           behavior: 'deny',


### PR DESCRIPTION
## Summary

- reject `sandbox.enabled: true` during Session initialization when Bubblewrap or Seatbelt is unavailable
- keep a second fail-closed guard in the low-level command wrapper
- deny Bash if a previously available sandbox becomes unavailable before execution
- make `autoAllowBashIfSandboxed` contingent on an actually usable executor
- document the fail-closed contract in both locales
- replace the stale hardcoded release-version assertion with package/CHANGELOG parity

## Behavior

Explicitly disabled Sandbox remains a no-op. `excludedCommands` remains an explicit host-execution escape hatch. All other commands are denied rather than silently running unsandboxed when the configured executor is unavailable.

## Validation

- 1154 tests passed; 62 environment-gated live/integration tests skipped
- `pnpm run type-check`
- `pnpm run lint`
- `pnpm run build`
- `pnpm run docs:build`
- `node scripts/verify-entrypoints.mjs`
- `npm pack --dry-run --json`
