### PR TITLE
fix(session): accept complete tool instances

### DIFF
--- a/.changes/session-tool-inputs.json
+++ b/.changes/session-tool-inputs.json
@@ -1,0 +1,5 @@
+{
+  "type": "fix",
+  "en": "Allow Session custom tools to accept complete `Tool` instances from `createTool()` and the Memory tool helpers.",
+  "zh-CN": "允许 Session 自定义工具直接接收 `createTool()` 和 Memory helper 返回的完整 `Tool` 实例。"
+}

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -79,6 +79,7 @@ Node-local 能力外，这些函数都从根入口导出；实际 subpath 以“
 |------|------|
 | `ISession` | Session 实例接口 |
 | `SessionOptions` | Session 创建选项 |
+| `SessionTool` | Session 接受的 `ToolDefinition` 或完整 `Tool` 联合类型 |
 | `SendOptions` | send() 选项 |
 | `InputSubmission` | 输入被 started / steered / queued 的判别联合 |
 | `PendingSessionInput` | 尚未应用的持久化输入 |
@@ -140,8 +141,8 @@ Node-local 能力外，这些函数都从根入口导出；实际 subpath 以“
 | `MemoryStore` | Memory 后端抽象接口 |
 | `MemoryType` | Memory 类型（`user` / `feedback` / `project` / `reference`） |
 
-`createMemoryReadTool()` 和 `createMemoryWriteTool()` 返回低层 `Tool`；
-当前不能直接传给只接受 `ToolDefinition` 的 `SessionOptions.tools`。
+`createMemoryReadTool()` 和 `createMemoryWriteTool()` 返回完整 `Tool`，可直接
+传给 `SessionOptions.tools`。
 
 ### Provider
 

--- a/docs/en/api-reference.md
+++ b/docs/en/api-reference.md
@@ -33,7 +33,7 @@ Types:
 `ForkSessionResult`, `HookCallback`, `HookInput`, `HookOutput`,
 `InputSubmission`, `ISession`, `McpServerStatus`, `McpToolInfo`, `ModelInfo`,
 `PendingSessionInput`, `PromptResult`, `ProviderConfig`, `ProviderType`,
-`ResumeOptions`, `SendOptions`, `SessionOptions`, `StreamMessage`,
+`ResumeOptions`, `SendOptions`, `SessionOptions`, `SessionTool`, `StreamMessage`,
 `StreamOptions`, `SubagentInfo`, `TokenUsage`, `ToolCallRecord`,
 `ToolDefinition`, and `ToolResult`.
 
@@ -128,9 +128,8 @@ Types:
 
 Memory tools are opt-in.
 
-`createMemoryReadTool()` and `createMemoryWriteTool()` return the lower-level
-`Tool` interface and cannot currently be passed directly to
-`SessionOptions.tools`.
+`createMemoryReadTool()` and `createMemoryWriteTool()` return complete `Tool`
+instances that can be passed directly to `SessionOptions.tools`.
 
 ## Permissions
 

--- a/docs/en/recipes.md
+++ b/docs/en/recipes.md
@@ -199,13 +199,14 @@ for await (const event of session.stream({ includeThinking: true })) {
 
 ## Opt-in memory tools
 
-`getBuiltinTools()` can create a memory-enabled tool set for a custom
-lower-level runtime:
+Create the opt-in Memory tools and pass them directly to Session:
 
 ```ts
 import {
+  createMemoryReadTool,
+  createMemoryWriteTool,
+  createSession,
   FileSystemMemoryStore,
-  getBuiltinTools,
   MemoryManager,
 } from '@blade-ai/agent-sdk';
 
@@ -213,21 +214,19 @@ const manager = new MemoryManager(
   new FileSystemMemoryStore('/var/lib/my-agent/memory'),
 );
 
-const tools = await getBuiltinTools({
-  memoryManager: manager,
+const session = await createSession({
+  provider,
+  model,
+  tools: [
+    createMemoryReadTool({ manager }),
+    createMemoryWriteTool({ manager }),
+  ],
 });
 ```
 
 `FileSystemMemoryStore` writes one frontmatter-backed Markdown file per memory
 and maintains a `MEMORY.md` index. Memory types are `user`, `project`,
 `feedback`, and `reference`.
-
-::: warning Session integration
-`createMemoryReadTool()` and `createMemoryWriteTool()` return the lower-level
-`Tool` interface, while `SessionOptions.tools` currently accepts
-`ToolDefinition`. Do not pass those helper results directly to Session; there
-is no first-class `memoryManager` Session option yet.
-:::
 
 ## Tool source policy
 

--- a/docs/en/session.md
+++ b/docs/en/session.md
@@ -426,7 +426,7 @@ Payload capture is opt-in because prompts and tool data may be sensitive.
 | `providerOptions` | `JsonObject` | Provider-specific options |
 | `thinkingEnabled` / `thinkingBudget` | `boolean` / `number` | Reasoning controls |
 | `tokenBudget` | `TokenBudgetConfig` | Request and cost limits |
-| `tools` | `ToolDefinition[]` | Custom tools |
+| `tools` | `SessionTool[]` | Custom `ToolDefinition` or complete `Tool` instances |
 | `allowedTools` / `disallowedTools` | `string[]` | Tool filters |
 | `toolSourcePolicy` | `ToolCatalogSourcePolicy` | Source and trust filtering |
 | `mcpServers` | `Record<string, McpServerConfig \| SdkMcpServerHandle>` | MCP configuration |

--- a/docs/en/tools.md
+++ b/docs/en/tools.md
@@ -5,7 +5,7 @@ The SDK exposes three tool authoring APIs:
 | API | Schema | Use |
 |-----|--------|-----|
 | `defineTool()` | JSON Schema | Lightweight typed definitions accepted by Session |
-| `createTool()` | Zod | Runtime validation for lower-level tool runtimes |
+| `createTool()` | Zod | Full inference, runtime validation, and interruption policy |
 | `toolFromDefinition()` | JSON Schema | Convert a definition into the internal `Tool` interface |
 
 Every tool executes as `AsyncGenerator<ToolYield, ToolResult>`.
@@ -85,8 +85,9 @@ const deploy = createTool({
 });
 ```
 
-`createTool()` returns the lower-level `Tool` interface. It cannot currently be
-passed directly to `SessionOptions.tools`, which accepts `ToolDefinition`.
+`createTool()` returns a complete `Tool` that can be passed directly to
+`SessionOptions.tools`. Session preserves the instance instead of adapting it,
+so validation, behavior, and interruption settings remain intact.
 
 ## Streaming contract
 
@@ -198,10 +199,8 @@ const tool = createTool({
 Explicit `session.abort()` and `session.close()` are request-level cancellation and are not blocked by `interruptBehavior: 'block'`.
 
 `interruptBehavior` belongs to the `ToolConfig` accepted by `createTool()`;
-`defineTool()` / `ToolDefinition` does not expose it. Because
-`SessionOptions.tools` currently accepts only `ToolDefinition`, custom Session
-tools cannot opt into `cancel` yet. This setting is available to lower-level
-runtimes that compose `Tool` instances directly.
+`defineTool()` / `ToolDefinition` does not expose it. Use `createTool()` with
+`cancel` when a custom Session tool can safely stop for a `now` input.
 
 ## ToolDefinition
 

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -270,13 +270,14 @@ console.log(`\n总 Token: ${totalTokens}`);
 
 ## Memory 系统
 
-Memory 系统是 opt-in 的。`getBuiltinTools()` 可以为自定义低层运行时创建
-带 Memory 的工具集合：
+Memory 系统是 opt-in 的。创建 Memory 工具后直接传给 Session：
 
 ```ts
 import {
+  createMemoryReadTool,
+  createMemoryWriteTool,
+  createSession,
   FileSystemMemoryStore,
-  getBuiltinTools,
   MemoryManager,
 } from '@blade-ai/agent-sdk';
 
@@ -284,8 +285,13 @@ const memoryManager = new MemoryManager(
   new FileSystemMemoryStore('/home/user/.blade/memory'),
 );
 
-const tools = await getBuiltinTools({
-  memoryManager,
+const session = await createSession({
+  provider: { type: 'openai', apiKey: process.env.OPENAI_API_KEY! },
+  model: 'gpt-4o',
+  tools: [
+    createMemoryReadTool({ manager: memoryManager }),
+    createMemoryWriteTool({ manager: memoryManager }),
+  ],
 });
 ```
 
@@ -293,12 +299,6 @@ const tools = await getBuiltinTools({
 `FileSystemMemoryStore` 将每条 Memory 保存为带 frontmatter 的 Markdown
 文件，并维护 `MEMORY.md` 索引。Memory 类型包括 `user`、`project`、
 `feedback` 和 `reference`。
-:::
-
-::: warning Session 集成边界
-`createMemoryReadTool()` / `createMemoryWriteTool()` 返回低层 `Tool`，而
-`SessionOptions.tools` 当前只接受 `ToolDefinition`。因此不能把这些 helper
-的返回值直接放入 Session；Session 暂无一等 `memoryManager` 配置。
 :::
 
 ## 工具来源策略（ToolCatalogSourcePolicy）

--- a/docs/session.md
+++ b/docs/session.md
@@ -914,7 +914,7 @@ const currentContext = session.getDefaultContext();
 
 ```ts
 interface SessionOptions {
-  tools?: ToolDefinition[];      // 追加自定义工具
+  tools?: SessionTool[];         // ToolDefinition 或完整 Tool
   allowedTools?: string[];       // 工具白名单（仅允许列出的工具）
   disallowedTools?: string[];    // 工具黑名单（排除列出的工具）
 }
@@ -976,10 +976,10 @@ const session = await createSession({
 });
 ```
 
-### 低层 createTool + Zod Schema
+### 使用 createTool + Zod Schema
 
 ```ts
-import { createTool, ToolKind } from '@blade-ai/agent-sdk';
+import { createSession, createTool, ToolKind } from '@blade-ai/agent-sdk';
 import { z } from 'zod';
 
 const dbQueryTool = createTool({
@@ -1003,11 +1003,17 @@ const dbQueryTool = createTool({
     };
   },
 });
+
+const session = await createSession({
+  provider: { type: 'openai', apiKey: process.env.OPENAI_API_KEY },
+  model: 'gpt-4o',
+  tools: [dbQueryTool],
+});
 ```
 
-`createTool()` 返回低层 `Tool`，当前不能直接传给
-`SessionOptions.tools`。Session 自定义工具请使用上一节的
-`defineTool()`；需要直接组合 `Tool` 的自定义运行时才使用 `createTool()`。
+`SessionOptions.tools` 接受 `ToolDefinition` 和完整 `Tool`。传入
+`createTool()` 的结果时，Session 会保留其 Zod 校验、权限检查和
+`interruptBehavior`。
 
 ### 工具过滤
 
@@ -1496,7 +1502,7 @@ async function analyzeCodeManual() {
 | `allowedTools`    | `string[]`                                              | —  | —           | 工具白名单；未设置表示不限制，空数组表示禁用全部工具                    |
 | `disallowedTools` | `string[]`                                              | —  | —           | 工具黑名单                                             |
 | `toolSourcePolicy` | `ToolCatalogSourcePolicy`                              | —  | —           | 工具来源策略，按来源类型和信任级别过滤工具                            |
-| `tools`           | `ToolDefinition[]`                                      | —  | —           | 追加的自定义工具                                          |
+| `tools`           | `SessionTool[]`                                          | —  | —           | 追加的 `ToolDefinition` 或完整 `Tool`                        |
 | `mcpServers`      | `Record<string, McpServerConfig \| SdkMcpServerHandle>` | —  | —           | MCP 服务器配置映射                                       |
 | `permissionMode`  | `PermissionMode`                                        | —  | `'default'` | 权限审批模式                                            |
 | `permissionHandler` | `PermissionHandler`                                   | —  | —           | 底层权限处理器（比 `canUseTool` 更低级）                       |

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -5,7 +5,7 @@ SDK 提供三种方式创建自定义工具，从简单到完整：
 | 方式 | 函数 | Schema | 适用场景 |
 |------|------|--------|----------|
 | 简单模式 | `defineTool()` | JSON Schema | 快速定义，可直接传给 Session |
-| 工厂模式 | `createTool()` | Zod Schema | 低层运行时需要类型推断和参数验证 |
+| 工厂模式 | `createTool()` | Zod Schema | 完整类型推断、运行时验证和中断策略 |
 | 转换模式 | `toolFromDefinition()` | JSON Schema | 将 ToolDefinition 转为内部 Tool 对象 |
 
 ## defineTool
@@ -51,9 +51,9 @@ const searchTool = defineTool({
 
 ## createTool
 
-使用 Zod Schema 的工厂函数，提供完整的类型推断和运行时验证。
-它返回低层 `Tool`，当前不能直接放入只接受 `ToolDefinition` 的
-`SessionOptions.tools`。
+使用 Zod Schema 的工厂函数，提供完整的类型推断、运行时验证和工具行为配置。
+返回的 `Tool` 可以直接放入 `SessionOptions.tools`，Session 会保留原实例，
+不会再次适配或丢失行为。
 
 ```ts
 import { z } from 'zod';
@@ -349,8 +349,7 @@ const tool = createTool({
 - Session 的显式 `abort()` 和 `close()` 属于请求级终止，不受 `block` 限制。
 
 `interruptBehavior` 属于 `createTool()` 的 `ToolConfig`，轻量
-`defineTool()` / `ToolDefinition` 不暴露该字段。由于
-`SessionOptions.tools` 当前只接受 `ToolDefinition`，Session 暂不支持为
-自定义工具声明 `cancel`；该能力适用于直接组合低层 `Tool` 的运行时。
+`defineTool()` / `ToolDefinition` 不暴露该字段。需要让 Session 中的自定义
+工具响应 `now` 转向时，应使用 `createTool()` 并声明 `cancel`。
 
 内置的 `Read`、`Glob`、`Grep`、`WebFetch`、`WebSearch` 和前台 `Bash` 明确声明为 `cancel`；后台 `Bash` 及其他内置工具为 `block`。动态 MCP 工具默认 `block`。

--- a/src/__tests__/rootExports.test.ts
+++ b/src/__tests__/rootExports.test.ts
@@ -19,6 +19,7 @@ import type {
   InputSubmission,
   PendingSessionInput,
   RuntimePatch,
+  SessionTool,
   ToolCatalogEntry,
   ToolEffect,
   ToolEffectYield,
@@ -67,6 +68,7 @@ describe('root exports', () => {
     expectTypeOf<PendingSessionInput['priority']>().toEqualTypeOf<
       'now' | 'next' | 'later'
     >();
+    expectTypeOf<ReturnType<typeof createMemoryReadTool>>().toMatchTypeOf<SessionTool>();
     expectTypeOf<ToolCatalogEntry['source']['kind']>().toEqualTypeOf<
       'builtin' | 'custom' | 'mcp' | 'session'
     >();

--- a/src/index.ts
+++ b/src/index.ts
@@ -143,6 +143,7 @@ export type {
   ResumeOptions,
   SendOptions,
   SessionOptions,
+  SessionTool,
   StreamMessage,
   StreamOptions,
   SubagentInfo,

--- a/src/session/SessionRuntime.ts
+++ b/src/session/SessionRuntime.ts
@@ -39,12 +39,37 @@ import type {
   McpServerStatus,
   McpToolInfo,
   SessionOptions,
+  SessionTool,
 } from './types.js';
 
 function isSdkMcpServerHandle(
   config: McpServerConfig | SdkMcpServerHandle
 ): config is SdkMcpServerHandle {
   return 'createClientTransport' in config && 'server' in config;
+}
+
+function isRuntimeTool(tool: SessionTool): tool is Exclude<
+  SessionTool,
+  { parameters: unknown }
+> {
+  const candidate = tool as {
+    build?: unknown;
+    execute?: unknown;
+    getFunctionDeclaration?: unknown;
+  };
+  return typeof candidate.build === 'function'
+    && typeof candidate.execute === 'function'
+    && typeof candidate.getFunctionDeclaration === 'function';
+}
+
+function toRuntimeTool(tool: SessionTool): Tool {
+  // Registry dispatch validates parameters before invoking the concrete Tool.
+  // Erase its invariant parameter type only at this heterogeneous boundary.
+  return (
+    isRuntimeTool(tool)
+      ? tool
+      : toolFromDefinition(tool)
+  ) as unknown as Tool;
 }
 
 function resolveStorageRoot(storagePath?: string): string | undefined {
@@ -307,7 +332,7 @@ export class SessionRuntime {
     if (!this.options.tools || this.options.tools.length === 0) {
       return;
     }
-    const tools = this.options.tools.map((tool) => toolFromDefinition(tool));
+    const tools = this.options.tools.map(toRuntimeTool);
     this.registerTools(tools);
   }
 

--- a/src/session/__tests__/SessionRuntime.test.ts
+++ b/src/session/__tests__/SessionRuntime.test.ts
@@ -2,18 +2,23 @@ import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
 import { assertDefined } from '../../__tests__/helpers/assertDefined.js';
 import { HookManager } from '../../hooks/HookManager.js';
 import { NOOP_LOGGER } from '../../logging/Logger.js';
+import { MemoryManager } from '../../memory/MemoryManager.js';
 import { createContextSnapshot, type RuntimeContext } from '../../runtime/index.js';
 import { getSandboxExecutor, SandboxExecutor } from '../../sandbox/SandboxExecutor.js';
 import { SandboxService } from '../../sandbox/SandboxService.js';
 import { FileAccessTracker } from '../../tools/builtin/file/FileAccessTracker.js';
+import { createMemoryReadTool } from '../../tools/builtin/memory/index.js';
+import { createTool } from '../../tools/core/createTool.js';
 import { FileLockManager } from '../../tools/execution/FileLockManager.js';
 import {
-    collectToolExecution,
-    completeToolExecution,
-    type ToolDefinition,
+  collectToolExecution,
+  completeToolExecution,
+  type ToolDefinition,
+  ToolKind,
 } from '../../tools/types/index.js';
 import { SessionId } from '../../types/branded.js';
 import type { JsonObject } from '../../types/common.js';
@@ -196,6 +201,81 @@ describe('SessionRuntime', () => {
     await runtime.initialize();
 
     expect(runtime.getToolRegistry().getAll()).toEqual([]);
+
+    await runtime.close();
+  });
+
+  it('should register complete Tool instances without adapting away their behavior', async () => {
+    const execute = vi.fn(({ value }: { value: string }) =>
+      completeToolExecution({
+        status: 'success',
+        model: value,
+      }));
+    const runtimeTool = createTool({
+      name: 'RuntimeTool',
+      displayName: 'Runtime Tool',
+      kind: ToolKind.ReadOnly,
+      interruptBehavior: 'cancel',
+      strict: true,
+      schema: z.object({
+        value: z.string(),
+      }),
+      description: {
+        short: 'Runtime tool',
+      },
+      execute,
+    });
+    const memoryManager = new MemoryManager({
+      save: vi.fn(),
+      get: vi.fn(),
+      list: vi.fn(async () => []),
+      delete: vi.fn(),
+    });
+    const memoryTool = createMemoryReadTool({ manager: memoryManager });
+    const runtime = new SessionRuntime(
+      SessionId('session-complete-tools'),
+      createOptions({
+        allowedTools: ['RuntimeTool', 'MemoryRead'],
+        tools: [runtimeTool, memoryTool],
+      }),
+      {
+        models: [],
+      },
+      PermissionMode.DEFAULT,
+      createFilesystemContext(workspaceRoot),
+      NOOP_LOGGER,
+    );
+
+    await runtime.initialize();
+
+    expect(runtime.getToolRegistry().get('RuntimeTool')).toBe(runtimeTool);
+    expect(runtime.getToolRegistry().get('MemoryRead')).toBe(memoryTool);
+    expect(runtime.getToolRegistry().get('RuntimeTool')?.interruptBehavior).toBe('cancel');
+
+    const executionPipeline = runtime.getAgentRuntimeDeps().executionPipeline;
+    assertDefined(executionPipeline);
+    const invalidResult = await collectToolExecution(
+      executionPipeline.execute('RuntimeTool', {}, {}),
+    );
+    expect(invalidResult.status).toBe('error');
+    expect(execute).not.toHaveBeenCalled();
+
+    const validResult = await collectToolExecution(
+      executionPipeline.execute('RuntimeTool', { value: 'validated' }, {}),
+    );
+    expect(validResult).toMatchObject({
+      status: 'success',
+      model: 'validated',
+    });
+    expect(execute).toHaveBeenCalledOnce();
+
+    const memoryResult = await collectToolExecution(
+      executionPipeline.execute('MemoryRead', { operation: 'list' }, {}),
+    );
+    expect(memoryResult).toMatchObject({
+      status: 'success',
+      model: [],
+    });
 
     await runtime.close();
   });

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -12,8 +12,10 @@ import type { Message } from '../services/ChatServiceInterface.js';
 import type { ToolCatalogSourcePolicy } from '../tools/catalog/index.js';
 import type {
   ExecutionContext,
+  Tool,
   ToolDefinition,
   ToolDisplayContent,
+  ToolInvocation,
   ToolMessage,
   ToolModelContent,
   ToolProgress,
@@ -239,6 +241,14 @@ export interface AgentDefinition {
   model?: string;
 }
 
+// Existential Tool shape for heterogeneous arrays. The concrete parameter type
+// remains enforced where each Tool is created.
+type ErasedTool = Omit<Tool<never>, 'build'> & {
+  build(params: never): ToolInvocation<unknown>;
+};
+
+export type SessionTool = ToolDefinition<never> | ErasedTool;
+
 export interface SessionOptions {
   provider: ProviderConfig;
   model: string;
@@ -254,10 +264,8 @@ export interface SessionOptions {
   disallowedTools?: string[];
   toolSourcePolicy?: ToolCatalogSourcePolicy;
   mcpServers?: Record<string, McpServerConfig | SdkMcpServerHandle>;
-  // 使用 ToolDefinition<never> 以容纳不同 TParams 的自定义工具：execute 的参数位是逆变的，
-  // 若写成 ToolDefinition<JsonObject>[]，则 defineTool<{...}>() 得到的强类型工具无法赋值进来，
-  // 迫使调用方在 execute 内部做 cast。never 只用于数组元素的参数位，不泄漏到调用方的 execute。
-  tools?: ToolDefinition<never>[];
+  // never 用于擦除异构工具的参数类型，不会泄漏到各工具自己的 execute 实现。
+  tools?: SessionTool[];
 
   permissionMode?: PermissionMode;
   permissionHandler?: PermissionHandler;


### PR DESCRIPTION
## Summary

This reopens the Tool input fix directly against `main`. The earlier stacked PR #19 was merged into its already-merged base branch and therefore did not reach `main`.

- accept both `ToolDefinition` and complete `Tool` values in `SessionOptions.tools`
- preserve Zod validation, permission hooks, behavior metadata, and `interruptBehavior`
- allow Memory tool helpers to plug directly into Session
- update both documentation locales

## Validation

- full suite: 1154 passed; 62 environment-gated tests skipped
- type-check, lint, build, docs build, entrypoint verification, and npm pack dry-run passed
