### PR TITLE
feat(events): add idempotent session journal

### DIFF
--- a/.changes/durable-session-journal.json
+++ b/.changes/durable-session-journal.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "en": "Add a command-oriented durable Session journal with lifecycle preflight, bounded CAS retries, idempotent replay, and unknown-write reconciliation.",
+  "zh-CN": "新增面向 command 的 durable Session journal，提供生命周期预演、有界 CAS 重试、幂等 replay 与未知写入结果对账。"
+}

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -100,6 +100,12 @@ Node-local 能力外，这些函数都从根入口导出；实际 subpath 以“
 | 导出 | 说明 |
 |------|------|
 | `DurableEventStore` | append/read/head 的持久化接口 |
+| `DurableSessionJournal` / `DurableSessionJournalOptions` | command-oriented 串行提交、CAS 重试与对账层 |
+| `DurableSessionCommand` / `DurableCommandEventDraft` | Journal command 与不含重复 `commandId` 的事件输入 |
+| `DurableCommandCommitResult` / `DurableCommandCommitStatus` | `committed` / `replayed` / `reconciled` 提交结果 |
+| `DurableSessionJournalError` / `DurableSessionJournalErrorCode` | command、分页和 Store 返回值错误 |
+| `DurableCommandConflictError` | 同一 `commandId` 被用于不同事件 |
+| `DurableCommandOutcomeUnknownError` | 写入失败后无法确认 command 是否提交 |
 | `DurableEventEnvelope` / `DurableEventDraft` | 已提交事件与待提交事件 |
 | `DurableEventDataMap` / `DurableEventOfType` / `DurableEventError` / `DurableTokenUsage` | 事件类型到严格 payload 的映射、类型提取及公共 payload |
 | `DurableInputPriority` / `DurablePermissionDecision` | 输入优先级与权限结果 |

--- a/docs/durable-events.md
+++ b/docs/durable-events.md
@@ -20,6 +20,7 @@ import {
   CommandId,
   type DurableEventDataMap,
   DurableSessionProjector,
+  DurableSessionJournal,
   DurableEventType,
   EventSequence,
   InputId,
@@ -95,6 +96,10 @@ const result = await store.append(
   sessionId,
   [
     {
+      type: DurableEventType.SESSION_CREATED,
+      data: { source: 'create' },
+    },
+    {
       type: DurableEventType.REQUEST_ACCEPTED,
       requestId,
       commandId,
@@ -116,7 +121,7 @@ const result = await store.append(
 );
 
 console.log(result.previousSequence); // null
-console.log(result.lastSequence);     // 2
+console.log(result.lastSequence);     // 3
 ```
 
 一次 `append()` 的事件会写入同一个 batch。Store 在写入前完成 schema 校验并
@@ -140,6 +145,51 @@ await store.append(sessionId, events, {
   expectedLastSequence: EventSequence(12),
 });
 ```
+
+## Command journal
+
+生产代码应优先通过 `DurableSessionJournal` 提交生命周期事件。Journal 在 Store
+之上增加：
+
+- 每个实例内的串行提交。
+- 写入前的 lifecycle transition 预演。
+- 所有事件统一写入调用方提供的 `commandId`。
+- CAS 冲突后的有界刷新与重试。
+- 相同 command 的幂等 replay。
+- `DURABLE_EVENT_WRITE_FAILED` 后的 read-after-failure 对账。
+
+```ts
+const journal = await DurableSessionJournal.open(store, sessionId);
+
+const committed = await journal.commit({
+  commandId: CommandId('create-session-123'),
+  events: [
+    {
+      type: DurableEventType.SESSION_CREATED,
+      data: { source: 'create' },
+    },
+  ],
+});
+
+console.log(committed.status); // committed | replayed | reconciled
+console.log(journal.getProjection().status); // open
+```
+
+相同 `commandId` 和相同事件再次提交时返回 `replayed`，不会追加第二份事件。
+若 command 已存在但内容不同，抛出 `DurableCommandConflictError`。
+一个 command 的事件必须在日志中连续；同一 ID 分散在多个区间也按冲突处理。
+
+当底层写入报错后，Journal 会重新读取 canonical log：
+
+- 能找到完整且匹配的 command：返回 `reconciled`。
+- 找不到 command 或无法重新读取：抛出
+  `DurableCommandOutcomeUnknownError`，且不会自动重试。
+
+后一种情况必须由调用方或更高层 recovery coordinator 对账。自动重试可能重复
+执行已经生效但暂时不可见的写入。Journal 会在内存中记录
+`getUncertainCommandId()` 并拒绝其他 command；相同 command 只能再次触发读取
+对账。`maxConflictRetries` 只控制明确 compare-and-append 冲突的重试，不适用于
+unknown outcome。
 
 ## Cursor 读取
 
@@ -245,6 +295,9 @@ Store 不持久化 token delta、工具 progress 等高频 UI 事件。只有会
 
 | 错误 | 说明 |
 |------|------|
+| `DurableCommandConflictError` | 相同 `commandId` 对应不同内容或非连续事件区间 |
+| `DurableCommandOutcomeUnknownError` | 写入失败后无法确认 command 是否提交，Journal 已 fenced |
+| `DurableSessionJournalError` | command 输入、Store page 或 commit 返回值违反契约 |
 | `DurableEventProjectionError` | schema、事件顺序或关联关系不满足生命周期约束 |
 | `DurableEventSequenceConflictError` | compare-and-append 前置条件失败 |
 | `DurableEventStoreError` | 参数、cursor、读写或日志完整性错误 |

--- a/docs/en/api-reference.md
+++ b/docs/en/api-reference.md
@@ -60,6 +60,7 @@ These ID exports are branded identifiers, not arbitrary strings.
 Runtime:
 
 - `JsonlDurableEventStore`
+- `DurableSessionJournal`
 - `DurableEventType`
 - `DURABLE_EVENT_SCHEMA_VERSION`
 - `DURABLE_EVENT_LOG_FORMAT`
@@ -74,6 +75,15 @@ Runtime:
 Types and errors:
 
 - `DurableEventStore`
+- `DurableSessionJournalOptions`
+- `DurableSessionCommand`
+- `DurableCommandEventDraft`
+- `DurableCommandCommitResult`
+- `DurableCommandCommitStatus`
+- `DurableSessionJournalError`
+- `DurableSessionJournalErrorCode`
+- `DurableCommandConflictError`
+- `DurableCommandOutcomeUnknownError`
 - `DurableEventEnvelope`
 - `DurableEventDraft`
 - `DurableEventDataMap`

--- a/docs/en/durable-events.md
+++ b/docs/en/durable-events.md
@@ -21,6 +21,7 @@ import {
   CommandId,
   type DurableEventDataMap,
   DurableSessionProjector,
+  DurableSessionJournal,
   DurableEventType,
   EventSequence,
   InputId,
@@ -97,6 +98,10 @@ const result = await store.append(
   sessionId,
   [
     {
+      type: DurableEventType.SESSION_CREATED,
+      data: { source: 'create' },
+    },
+    {
       type: DurableEventType.REQUEST_ACCEPTED,
       requestId,
       commandId,
@@ -118,7 +123,7 @@ const result = await store.append(
 );
 
 console.log(result.previousSequence); // null
-console.log(result.lastSequence);     // 2
+console.log(result.lastSequence);     // 3
 ```
 
 One `append()` call is stored as one batch. The Store validates every draft and
@@ -142,6 +147,53 @@ await store.append(sessionId, events, {
   expectedLastSequence: EventSequence(12),
 });
 ```
+
+## Command journal
+
+Production code should commit lifecycle events through `DurableSessionJournal`.
+The Journal adds these guarantees above the Store:
+
+- serialized commits within each instance;
+- lifecycle transition preview before persistence;
+- one caller-provided `commandId` stamped onto every event;
+- bounded refresh and retry after explicit CAS conflicts;
+- idempotent replay of an identical command;
+- read-after-failure reconciliation after `DURABLE_EVENT_WRITE_FAILED`.
+
+```ts
+const journal = await DurableSessionJournal.open(store, sessionId);
+
+const committed = await journal.commit({
+  commandId: CommandId('create-session-123'),
+  events: [
+    {
+      type: DurableEventType.SESSION_CREATED,
+      data: { source: 'create' },
+    },
+  ],
+});
+
+console.log(committed.status); // committed | replayed | reconciled
+console.log(journal.getProjection().status); // open
+```
+
+Submitting the same `commandId` and identical events returns `replayed` without
+appending another copy. Reusing the command ID with different content throws
+`DurableCommandConflictError`. A command's events must be contiguous in the
+journal; the same ID appearing in separate ranges is also a conflict.
+
+After a lower-level write error, the Journal reloads the canonical log:
+
+- A complete matching command returns `reconciled`.
+- A missing command or failed reload throws
+  `DurableCommandOutcomeUnknownError` without an automatic retry.
+
+The latter case requires reconciliation by the caller or a higher-level recovery
+coordinator. An automatic retry could duplicate a write that succeeded but is
+not yet visible. The Journal records `getUncertainCommandId()` in memory and
+rejects different commands; submitting the same command can only trigger another
+read reconciliation. `maxConflictRetries` applies only to explicit
+compare-and-append conflicts, not unknown outcomes.
 
 ## Cursor reads
 
@@ -254,6 +306,9 @@ journal.
 
 | Error | Meaning |
 |-------|---------|
+| `DurableCommandConflictError` | One `commandId` maps to different content or non-contiguous ranges. |
+| `DurableCommandOutcomeUnknownError` | A failed write cannot be reconciled and the Journal is fenced. |
+| `DurableSessionJournalError` | Command input, Store page, or commit result violates its contract. |
 | `DurableEventProjectionError` | Schema, ordering, or correlation violates lifecycle invariants. |
 | `DurableEventSequenceConflictError` | Compare-and-append precondition failed. |
 | `DurableEventStoreError` | Invalid input, cursor, I/O, or log integrity failure. |

--- a/scripts/verify-entrypoints.mjs
+++ b/scripts/verify-entrypoints.mjs
@@ -96,12 +96,12 @@ const subpathOutput = run(process.execPath, [
     "const server = await import('@blade-ai/agent-sdk/server');",
     "const tools = await import('@blade-ai/agent-sdk/tools');",
     "const local = await import('@blade-ai/agent-sdk/local');",
-    "console.log(core.PermissionMode.DEFAULT, core.DurableEventType.REQUEST_ACCEPTED, core.projectDurableSession([]).status, browser.PermissionMode.DEFAULT, typeof server.createSession, typeof tools.defineTool, typeof local.getBuiltinTools, typeof local.JsonlDurableEventStore);",
+    "console.log(core.PermissionMode.DEFAULT, core.DurableEventType.REQUEST_ACCEPTED, core.projectDurableSession([]).status, typeof core.DurableSessionJournal.open, browser.PermissionMode.DEFAULT, typeof server.createSession, typeof tools.defineTool, typeof local.getBuiltinTools, typeof local.JsonlDurableEventStore);",
   ].join(' '),
 ]);
 assertIncludes(
   subpathOutput,
-  'default request_accepted empty default function function function function',
+  'default request_accepted empty function default function function function function',
   'subpath imports',
 );
 

--- a/src/__tests__/packageEntrypoints.test.ts
+++ b/src/__tests__/packageEntrypoints.test.ts
@@ -72,6 +72,7 @@ describe('package entrypoints', () => {
 
     expect(browser.PermissionMode.DEFAULT).toBe('default');
     expect(browser.DurableEventType.REQUEST_ACCEPTED).toBe('request_accepted');
+    expect(browser.DurableSessionJournal.open).toBeTypeOf('function');
     expect(browser.projectDurableSession([]).status).toBe('empty');
     expect(browser.PermissionRequestId('permission-1')).toBe('permission-1');
     expect(browser.ToolUseId('tool-call-1')).toBe('tool-call-1');

--- a/src/__tests__/rootExports.test.ts
+++ b/src/__tests__/rootExports.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, expectTypeOf, it } from 'vitest';
 import type {
+  DurableCommandEventDraft,
   DurableEventEnvelope,
   DurableEventOfType,
   DurableEventStore,
+  DurableSessionCommand,
   DurableSessionRecoveryPlan,
   InputSubmission,
   PendingSessionInput,
@@ -23,7 +25,10 @@ import {
   completeToolExecution,
   createMemoryReadTool,
   createMemoryWriteTool,
+  DurableCommandConflictError,
+  DurableCommandOutcomeUnknownError,
   DurableEventType,
+  DurableSessionJournal,
   DurableSessionProjector,
   EventId,
   EventSequence,
@@ -68,6 +73,9 @@ describe('root exports', () => {
     expect(ToolAttemptId('attempt-1')).toBe('attempt-1');
     expect(TurnId('turn-1')).toBe('turn-1');
     expect(PermissionRequestId('permission-1')).toBe('permission-1');
+    expect(DurableCommandConflictError).toBeDefined();
+    expect(DurableCommandOutcomeUnknownError).toBeDefined();
+    expect(DurableSessionJournal.open).toBeTypeOf('function');
     expect(DurableSessionProjector).toBeDefined();
     expect(projectDurableSession([]).status).toBe('empty');
   });
@@ -89,6 +97,9 @@ describe('root exports', () => {
     expectTypeOf<
       DurableEventOfType<typeof DurableEventType.REQUEST_ACCEPTED>['data']['inputId']
     >().toEqualTypeOf<InputId>();
+    expectTypeOf<
+      DurableSessionCommand['events'][number]
+    >().toEqualTypeOf<DurableCommandEventDraft>();
     expectTypeOf<DurableSessionRecoveryPlan['action']>().toEqualTypeOf<
       'none' | 'resume_request' | 'resume_turn' | 'resolve_permissions' | 'reconcile_tool_outcomes'
     >();

--- a/src/session/events/DurableSessionJournal.ts
+++ b/src/session/events/DurableSessionJournal.ts
@@ -1,0 +1,500 @@
+import { SdkError } from '../../errors/SdkError.js';
+import { type CommandId, EventSequence, type SessionId } from '../../types/branded.js';
+import { DurableEventSequenceConflictError, type DurableEventStore } from './DurableEventStore.js';
+import {
+  type DurableSessionProjection,
+  DurableSessionProjector,
+  type DurableSessionRecoveryPlan,
+} from './DurableSessionProjector.js';
+import { parseDurableEventDraft } from './schemas.js';
+import type {
+  DurableEventAppendResult,
+  DurableEventDraft,
+  DurableEventEnvelope,
+  DurableEventPage,
+  DurableEventType,
+} from './types.js';
+
+const DEFAULT_PAGE_SIZE = 500;
+const DEFAULT_MAX_CONFLICT_RETRIES = 3;
+
+type WithoutCommandId<T> = T extends unknown ? Omit<T, 'commandId'> : never;
+
+export type DurableCommandEventDraft<TType extends DurableEventType = DurableEventType> =
+  WithoutCommandId<DurableEventDraft<TType>>;
+
+export interface DurableSessionCommand {
+  readonly commandId: CommandId;
+  readonly events: readonly DurableCommandEventDraft[];
+}
+
+export type DurableCommandCommitStatus = 'committed' | 'replayed' | 'reconciled';
+
+export interface DurableCommandCommitResult extends DurableEventAppendResult {
+  readonly status: DurableCommandCommitStatus;
+  readonly commandId: CommandId;
+}
+
+export interface DurableSessionJournalOptions {
+  readonly pageSize?: number;
+  readonly maxConflictRetries?: number;
+}
+
+export type DurableSessionJournalErrorCode =
+  | 'DURABLE_COMMAND_CONFLICT'
+  | 'DURABLE_COMMAND_INVALID'
+  | 'DURABLE_COMMAND_OUTCOME_UNKNOWN'
+  | 'DURABLE_JOURNAL_INVALID_COMMIT'
+  | 'DURABLE_JOURNAL_INVALID_PAGE';
+
+export class DurableSessionJournalError extends SdkError {
+  // biome-ignore lint/complexity/noUselessConstructor: narrows the public error-code contract
+  constructor(
+    code: DurableSessionJournalErrorCode,
+    message: string,
+    options?: { cause?: unknown },
+  ) {
+    super(code, message, options);
+  }
+}
+
+export class DurableCommandConflictError extends DurableSessionJournalError {
+  readonly commandId: CommandId;
+  readonly existingEvents: readonly DurableEventEnvelope[];
+
+  constructor(commandId: CommandId, existingEvents: readonly DurableEventEnvelope[]) {
+    super(
+      'DURABLE_COMMAND_CONFLICT',
+      `Durable command ${commandId} was already committed with different events`,
+    );
+    this.commandId = commandId;
+    this.existingEvents = structuredClone(existingEvents);
+  }
+}
+
+export class DurableCommandOutcomeUnknownError extends DurableSessionJournalError {
+  readonly commandId: CommandId;
+
+  constructor(commandId: CommandId, options?: { cause?: unknown }) {
+    super(
+      'DURABLE_COMMAND_OUTCOME_UNKNOWN',
+      `The commit outcome for durable command ${commandId} is unknown`,
+      options,
+    );
+    this.commandId = commandId;
+  }
+}
+
+function isErrorCode(error: unknown, code: string): boolean {
+  return typeof error === 'object' && error !== null && 'code' in error && error.code === code;
+}
+
+function canonicalJson(value: unknown): string {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalJson).join(',')}]`;
+  }
+  const record = value as Record<string, unknown>;
+  return `{${Object.keys(record)
+    .filter((key) => record[key] !== undefined)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${canonicalJson(record[key])}`)
+    .join(',')}}`;
+}
+
+function comparableDraft(
+  draft: DurableEventDraft,
+  occurredAt: string | undefined,
+): Record<string, unknown> {
+  return {
+    type: draft.type,
+    data: draft.data,
+    commandId: draft.commandId,
+    ...('requestId' in draft ? { requestId: draft.requestId } : {}),
+    ...('turnId' in draft ? { turnId: draft.turnId } : {}),
+    ...('toolAttemptId' in draft ? { toolAttemptId: draft.toolAttemptId } : {}),
+    ...(draft.causationEventId ? { causationEventId: draft.causationEventId } : {}),
+    ...(occurredAt ? { occurredAt } : {}),
+  };
+}
+
+function commandMatches(
+  existingEvents: readonly DurableEventEnvelope[],
+  drafts: readonly DurableEventDraft[],
+): boolean {
+  if (existingEvents.length !== drafts.length) {
+    return false;
+  }
+  return drafts.every((draft, index) => {
+    const existing = existingEvents[index];
+    if (!existing) {
+      return false;
+    }
+    const existingComparable = comparableDraft(
+      existing,
+      draft.occurredAt ? existing.occurredAt : undefined,
+    );
+    return (
+      canonicalJson(existingComparable) === canonicalJson(comparableDraft(draft, draft.occurredAt))
+    );
+  });
+}
+
+function resultFromExisting(
+  status: Exclude<DurableCommandCommitStatus, 'committed'>,
+  commandId: CommandId,
+  events: readonly DurableEventEnvelope[],
+): DurableCommandCommitResult {
+  const first = events[0];
+  const last = events.at(-1);
+  if (!first || !last) {
+    throw new DurableSessionJournalError(
+      'DURABLE_COMMAND_INVALID',
+      `Durable command ${commandId} has no persisted events`,
+    );
+  }
+  return {
+    status,
+    commandId,
+    events: structuredClone(events),
+    previousSequence: first.sequence === 1 ? null : EventSequence(Number(first.sequence) - 1),
+    lastSequence: last.sequence,
+  };
+}
+
+export class DurableSessionJournal {
+  private projector = new DurableSessionProjector();
+  private commandEvents = new Map<CommandId, DurableEventEnvelope[]>();
+  private operationTail: Promise<void> = Promise.resolve();
+  private uncertainCommand: {
+    commandId: CommandId;
+    cause: unknown;
+  } | null = null;
+
+  private constructor(
+    private readonly store: DurableEventStore,
+    readonly sessionId: SessionId,
+    private readonly pageSize: number,
+    private readonly maxConflictRetries: number,
+  ) {}
+
+  static async open(
+    store: DurableEventStore,
+    sessionId: SessionId,
+    options: DurableSessionJournalOptions = {},
+  ): Promise<DurableSessionJournal> {
+    const pageSize = options.pageSize ?? DEFAULT_PAGE_SIZE;
+    const maxConflictRetries = options.maxConflictRetries ?? DEFAULT_MAX_CONFLICT_RETRIES;
+    if (!Number.isSafeInteger(pageSize) || pageSize <= 0 || pageSize > 1000) {
+      throw new DurableSessionJournalError(
+        'DURABLE_COMMAND_INVALID',
+        'Durable Session journal pageSize must be between 1 and 1000',
+      );
+    }
+    if (!Number.isSafeInteger(maxConflictRetries) || maxConflictRetries < 0) {
+      throw new DurableSessionJournalError(
+        'DURABLE_COMMAND_INVALID',
+        'Durable Session journal maxConflictRetries must be a non-negative safe integer',
+      );
+    }
+
+    const journal = new DurableSessionJournal(store, sessionId, pageSize, maxConflictRetries);
+    await journal.reload();
+    return journal;
+  }
+
+  getProjection(): DurableSessionProjection {
+    return this.projector.snapshot();
+  }
+
+  getRecoveryPlan(): DurableSessionRecoveryPlan {
+    return this.projector.recoveryPlan();
+  }
+
+  getUncertainCommandId(): CommandId | null {
+    return this.uncertainCommand?.commandId ?? null;
+  }
+
+  refresh(): Promise<DurableSessionProjection> {
+    return this.runExclusive(async () => {
+      await this.reload();
+      return this.projector.snapshot();
+    });
+  }
+
+  commit(command: DurableSessionCommand): Promise<DurableCommandCommitResult> {
+    return this.runExclusive(() => this.commitExclusive(command));
+  }
+
+  private async commitExclusive(
+    command: DurableSessionCommand,
+  ): Promise<DurableCommandCommitResult> {
+    const drafts = this.parseCommand(command);
+    if (this.uncertainCommand) {
+      if (this.uncertainCommand.commandId !== command.commandId) {
+        throw new DurableCommandOutcomeUnknownError(this.uncertainCommand.commandId, {
+          cause: this.uncertainCommand.cause,
+        });
+      }
+      await this.reloadForUnknownOutcome(
+        this.uncertainCommand.commandId,
+        this.uncertainCommand.cause,
+      );
+      const reconciled = this.commandEvents.get(command.commandId);
+      if (!reconciled) {
+        throw new DurableCommandOutcomeUnknownError(command.commandId, {
+          cause: this.uncertainCommand.cause,
+        });
+      }
+      const result = this.resolveExistingCommand(
+        'reconciled',
+        command.commandId,
+        reconciled,
+        drafts,
+      );
+      this.uncertainCommand = null;
+      return result;
+    }
+    const existing = this.commandEvents.get(command.commandId);
+    if (existing) {
+      return this.resolveExistingCommand('replayed', command.commandId, existing, drafts);
+    }
+
+    let conflicts = 0;
+    while (true) {
+      this.projector.preview(this.sessionId, drafts);
+      try {
+        const expectedLastSequence = this.projector.snapshot().headSequence;
+        const result = await this.store.append(this.sessionId, drafts, {
+          expectedLastSequence,
+        });
+        try {
+          this.validateCommitResult(result, drafts, expectedLastSequence);
+          const committedEvents = structuredClone(result.events);
+          this.projector.apply(committedEvents);
+          this.indexCommandEvents(committedEvents);
+          return {
+            ...result,
+            events: structuredClone(committedEvents),
+            status: 'committed',
+            commandId: command.commandId,
+          };
+        } catch (commitError) {
+          return this.reconcileUnknownOutcome(command.commandId, drafts, commitError);
+        }
+      } catch (error) {
+        if (
+          error instanceof DurableEventSequenceConflictError ||
+          isErrorCode(error, 'DURABLE_EVENT_SEQUENCE_CONFLICT')
+        ) {
+          await this.reload();
+          const committed = this.commandEvents.get(command.commandId);
+          if (committed) {
+            return this.resolveExistingCommand('reconciled', command.commandId, committed, drafts);
+          }
+          if (conflicts >= this.maxConflictRetries) {
+            throw error;
+          }
+          conflicts += 1;
+          continue;
+        }
+
+        if (isErrorCode(error, 'DURABLE_EVENT_WRITE_FAILED')) {
+          return this.reconcileUnknownOutcome(command.commandId, drafts, error);
+        }
+        throw error;
+      }
+    }
+  }
+
+  private parseCommand(command: DurableSessionCommand): DurableEventDraft[] {
+    if (command.commandId.trim() === '' || command.events.length === 0) {
+      throw new DurableSessionJournalError(
+        'DURABLE_COMMAND_INVALID',
+        'A durable command requires a non-empty commandId and at least one event',
+      );
+    }
+    try {
+      return command.events.map((event) =>
+        parseDurableEventDraft({
+          ...event,
+          commandId: command.commandId,
+        }),
+      );
+    } catch (cause) {
+      throw new DurableSessionJournalError(
+        'DURABLE_COMMAND_INVALID',
+        `Durable command ${command.commandId} contains an invalid event`,
+        { cause },
+      );
+    }
+  }
+
+  private resolveExistingCommand(
+    status: Exclude<DurableCommandCommitStatus, 'committed'>,
+    commandId: CommandId,
+    existing: readonly DurableEventEnvelope[],
+    drafts: readonly DurableEventDraft[],
+  ): DurableCommandCommitResult {
+    if (!commandMatches(existing, drafts)) {
+      throw new DurableCommandConflictError(commandId, existing);
+    }
+    return resultFromExisting(status, commandId, existing);
+  }
+
+  private validateCommitResult(
+    result: DurableEventAppendResult,
+    drafts: readonly DurableEventDraft[],
+    expectedLastSequence: EventSequence | null,
+  ): void {
+    const last = result.events.at(-1);
+    if (
+      result.previousSequence !== expectedLastSequence ||
+      !last ||
+      result.lastSequence !== last.sequence ||
+      !commandMatches(result.events, drafts)
+    ) {
+      throw new DurableSessionJournalError(
+        'DURABLE_JOURNAL_INVALID_COMMIT',
+        'Durable Event Store returned a commit result that does not match the command',
+      );
+    }
+  }
+
+  private async reconcileUnknownOutcome(
+    commandId: CommandId,
+    drafts: readonly DurableEventDraft[],
+    writeError: unknown,
+  ): Promise<DurableCommandCommitResult> {
+    await this.reloadForUnknownOutcome(commandId, writeError);
+    const committed = this.commandEvents.get(commandId);
+    if (committed) {
+      return this.resolveExistingCommand('reconciled', commandId, committed, drafts);
+    }
+    this.uncertainCommand = { commandId, cause: writeError };
+    throw new DurableCommandOutcomeUnknownError(commandId, { cause: writeError });
+  }
+
+  private async reloadForUnknownOutcome(commandId: CommandId, writeError: unknown): Promise<void> {
+    try {
+      await this.reload();
+    } catch (reloadError) {
+      const cause = new AggregateError(
+        [writeError, reloadError],
+        'The write failed and durable state could not be reloaded',
+      );
+      this.uncertainCommand = {
+        commandId,
+        cause,
+      };
+      throw new DurableCommandOutcomeUnknownError(commandId, { cause });
+    }
+  }
+
+  private async reload(): Promise<void> {
+    const projector = new DurableSessionProjector();
+    const commandEvents = new Map<CommandId, DurableEventEnvelope[]>();
+    const closedCommands = new Set<CommandId>();
+    let activeCommandId: CommandId | undefined;
+    let after: EventSequence | undefined;
+
+    while (true) {
+      const page = await this.store.read(this.sessionId, {
+        ...(after ? { after } : {}),
+        limit: this.pageSize,
+      });
+      this.validateReadPage(page, after);
+      projector.apply(page.events);
+
+      for (const event of page.events) {
+        if (!event.commandId) {
+          if (activeCommandId) {
+            closedCommands.add(activeCommandId);
+            activeCommandId = undefined;
+          }
+          continue;
+        }
+        if (activeCommandId !== event.commandId) {
+          if (activeCommandId) {
+            closedCommands.add(activeCommandId);
+          }
+          if (closedCommands.has(event.commandId)) {
+            throw new DurableSessionJournalError(
+              'DURABLE_COMMAND_CONFLICT',
+              `Durable command ${event.commandId} appears in non-contiguous event ranges`,
+            );
+          }
+          activeCommandId = event.commandId;
+        }
+        const events = commandEvents.get(event.commandId) ?? [];
+        events.push(event);
+        commandEvents.set(event.commandId, events);
+      }
+
+      if (!page.hasMore) {
+        break;
+      }
+      if (page.events.length === 0 || page.nextCursor === null || page.nextCursor === after) {
+        throw new DurableSessionJournalError(
+          'DURABLE_JOURNAL_INVALID_PAGE',
+          'Durable Event Store returned a non-advancing page',
+        );
+      }
+      after = page.nextCursor;
+    }
+
+    this.projector = projector;
+    this.commandEvents = commandEvents;
+  }
+
+  private validateReadPage(page: DurableEventPage, after: EventSequence | undefined): void {
+    const last = page.events.at(-1);
+    if (!last) {
+      const expectedCursor = after ?? null;
+      if (
+        page.hasMore ||
+        page.nextCursor !== expectedCursor ||
+        page.headSequence !== expectedCursor
+      ) {
+        throw new DurableSessionJournalError(
+          'DURABLE_JOURNAL_INVALID_PAGE',
+          'Durable Event Store returned inconsistent empty-page metadata',
+        );
+      }
+      return;
+    }
+    if (
+      page.nextCursor !== last.sequence ||
+      page.headSequence === null ||
+      page.headSequence < last.sequence ||
+      page.hasMore !== last.sequence < page.headSequence
+    ) {
+      throw new DurableSessionJournalError(
+        'DURABLE_JOURNAL_INVALID_PAGE',
+        'Durable Event Store returned inconsistent cursor metadata',
+      );
+    }
+  }
+
+  private indexCommandEvents(events: readonly DurableEventEnvelope[]): void {
+    for (const event of events) {
+      if (!event.commandId) {
+        continue;
+      }
+      const existing = this.commandEvents.get(event.commandId) ?? [];
+      existing.push(event);
+      this.commandEvents.set(event.commandId, existing);
+    }
+  }
+
+  private runExclusive<T>(operation: () => Promise<T>): Promise<T> {
+    const result = this.operationTail.then(operation, operation);
+    this.operationTail = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  }
+}

--- a/src/session/events/DurableSessionProjector.ts
+++ b/src/session/events/DurableSessionProjector.ts
@@ -1,20 +1,22 @@
 import { SdkError } from '../../errors/SdkError.js';
-import type {
-  CommandId,
+import {
+  type CommandId,
   EventId,
   EventSequence,
-  InputId,
-  PermissionRequestId,
-  RequestId,
-  SessionId,
-  ToolAttemptId,
-  ToolUseId,
-  TurnId,
+  type InputId,
+  type PermissionRequestId,
+  type RequestId,
+  type SessionId,
+  type ToolAttemptId,
+  type ToolUseId,
+  type TurnId,
 } from '../../types/branded.js';
 import type { JsonValue } from '../../types/common.js';
-import { parseDurableEventEnvelope } from './schemas.js';
+import { parseDurableEventDraft, parseDurableEventEnvelope } from './schemas.js';
 import {
+  DURABLE_EVENT_SCHEMA_VERSION,
   type DurableEventDataMap,
+  type DurableEventDraft,
   type DurableEventEnvelope,
   type DurableEventError,
   type DurableEventType,
@@ -618,7 +620,7 @@ function createProjectionAccumulator(): ProjectionAccumulator {
 }
 
 export class DurableSessionProjector {
-  private readonly state = createProjectionAccumulator();
+  private state = createProjectionAccumulator();
   private failure: DurableEventProjectionError | null = null;
 
   apply(events: readonly DurableEventEnvelope[]): this {
@@ -657,6 +659,43 @@ export class DurableSessionProjector {
 
   recoveryPlan(): DurableSessionRecoveryPlan {
     return planDurableSessionRecovery(this.snapshot());
+  }
+
+  fork(): DurableSessionProjector {
+    this.assertHealthy();
+    const projector = new DurableSessionProjector();
+    projector.state = structuredClone(this.state);
+    return projector;
+  }
+
+  preview(sessionId: SessionId, drafts: readonly DurableEventDraft[]): DurableSessionProjection {
+    const projector = this.fork();
+    const recordedAt = new Date(0).toISOString();
+    let nextSequence = Number(projector.state.headSequence ?? 0) + 1;
+
+    for (const candidate of drafts) {
+      let eventId = EventId(`__preview__:${nextSequence}`);
+      let collision = 0;
+      while (projector.state.seenEventIds.has(eventId)) {
+        collision += 1;
+        eventId = EventId(`__preview__:${nextSequence}:${collision}`);
+      }
+      const draft = parseDurableEventDraft(candidate);
+      projector.apply([
+        parseDurableEventEnvelope({
+          ...draft,
+          schemaVersion: DURABLE_EVENT_SCHEMA_VERSION,
+          eventId,
+          sequence: EventSequence(nextSequence),
+          sessionId,
+          recordedAt,
+          occurredAt: draft.occurredAt ?? recordedAt,
+        }),
+      ]);
+      nextSequence += 1;
+    }
+
+    return projector.snapshot();
   }
 
   private assertHealthy(): void {

--- a/src/session/events/__tests__/DurableSessionJournal.test.ts
+++ b/src/session/events/__tests__/DurableSessionJournal.test.ts
@@ -1,0 +1,672 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  CommandId,
+  EventId,
+  EventSequence,
+  InputId,
+  RequestId,
+  SessionId,
+} from '../../../types/branded.js';
+import type { JsonValue } from '../../../types/common.js';
+import {
+  DurableEventSequenceConflictError,
+  type DurableEventStore,
+  DurableEventStoreError,
+} from '../DurableEventStore.js';
+import {
+  DurableCommandConflictError,
+  DurableCommandOutcomeUnknownError,
+  DurableSessionJournal,
+  DurableSessionJournalError,
+} from '../DurableSessionJournal.js';
+import { DurableEventProjectionError } from '../DurableSessionProjector.js';
+import { JsonlDurableEventStore } from '../JsonlDurableEventStore.js';
+import type {
+  DurableEventAppendOptions,
+  DurableEventAppendResult,
+  DurableEventDraft,
+  DurableEventPage,
+  DurableEventReadOptions,
+} from '../types.js';
+import { DurableEventType } from '../types.js';
+
+const sessionId = SessionId('session-1');
+const requestId = RequestId('request-1');
+const initialInputId = InputId('input-1');
+
+function sessionCreated() {
+  return {
+    type: DurableEventType.SESSION_CREATED,
+    data: { source: 'create' as const },
+  };
+}
+
+function requestAccepted(input: JsonValue = { task: 'build' }) {
+  return {
+    type: DurableEventType.REQUEST_ACCEPTED,
+    requestId,
+    data: {
+      inputId: initialInputId,
+      input,
+      priority: 'next' as const,
+    },
+  };
+}
+
+class DelegatingStore implements DurableEventStore {
+  constructor(readonly delegate: DurableEventStore) {}
+
+  append(
+    targetSessionId: SessionId,
+    events: readonly DurableEventDraft[],
+    options?: DurableEventAppendOptions,
+  ): Promise<DurableEventAppendResult> {
+    return this.delegate.append(targetSessionId, events, options);
+  }
+
+  read(targetSessionId: SessionId, options?: DurableEventReadOptions): Promise<DurableEventPage> {
+    return this.delegate.read(targetSessionId, options);
+  }
+
+  getHeadSequence(targetSessionId: SessionId) {
+    return this.delegate.getHeadSequence(targetSessionId);
+  }
+}
+
+class FailAfterCommitStore extends DelegatingStore {
+  private shouldFail = true;
+
+  override async append(
+    targetSessionId: SessionId,
+    events: readonly DurableEventDraft[],
+    options?: DurableEventAppendOptions,
+  ): Promise<DurableEventAppendResult> {
+    const result = await super.append(targetSessionId, events, options);
+    if (this.shouldFail) {
+      this.shouldFail = false;
+      throw new DurableEventStoreError(
+        'DURABLE_EVENT_WRITE_FAILED',
+        'Injected failure after commit',
+      );
+    }
+    return result;
+  }
+}
+
+class FailBeforeCommitStore extends DelegatingStore {
+  appendCalls = 0;
+
+  override async append(): Promise<DurableEventAppendResult> {
+    this.appendCalls += 1;
+    throw new DurableEventStoreError(
+      'DURABLE_EVENT_WRITE_FAILED',
+      'Injected failure before commit',
+    );
+  }
+}
+
+class InvalidCommitResultStore extends DelegatingStore {
+  private shouldCorrupt = true;
+
+  override async append(
+    targetSessionId: SessionId,
+    events: readonly DurableEventDraft[],
+    options?: DurableEventAppendOptions,
+  ): Promise<DurableEventAppendResult> {
+    const result = await super.append(targetSessionId, events, options);
+    if (!this.shouldCorrupt) {
+      return result;
+    }
+    this.shouldCorrupt = false;
+    return {
+      ...result,
+      events: [],
+    };
+  }
+}
+
+class AlwaysConflictStore extends DelegatingStore {
+  appendCalls = 0;
+
+  override async append(
+    _targetSessionId: SessionId,
+    _events: readonly DurableEventDraft[],
+    options?: DurableEventAppendOptions,
+  ): Promise<DurableEventAppendResult> {
+    this.appendCalls += 1;
+    throw new DurableEventSequenceConflictError(
+      options?.expectedLastSequence ?? null,
+      EventSequence(999),
+    );
+  }
+}
+
+class InvalidPageStore extends DelegatingStore {
+  override async read(): Promise<DurableEventPage> {
+    return {
+      events: [],
+      headSequence: EventSequence(1),
+      nextCursor: null,
+      hasMore: true,
+    };
+  }
+}
+
+describe('DurableSessionJournal', () => {
+  let storageRoot: string;
+  let nextEventId: number;
+  let store: JsonlDurableEventStore;
+
+  beforeEach(async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'durable-session-journal-'));
+    nextEventId = 0;
+    store = new JsonlDurableEventStore(storageRoot, {
+      clock: () => new Date('2026-08-22T12:00:00.000Z'),
+      eventIdFactory: () => EventId(`event-${++nextEventId}`),
+    });
+  });
+
+  afterEach(async () => {
+    await rm(storageRoot, { recursive: true, force: true });
+  });
+
+  it('commits commands with CAS and stamps every event with the command ID', async () => {
+    const journal = await DurableSessionJournal.open(store, sessionId);
+    const created = await journal.commit({
+      commandId: CommandId('command-create'),
+      events: [sessionCreated()],
+    });
+    const accepted = await journal.commit({
+      commandId: CommandId('command-request'),
+      events: [requestAccepted()],
+    });
+
+    expect(created).toMatchObject({
+      status: 'committed',
+      previousSequence: null,
+      lastSequence: 1,
+    });
+    expect(accepted).toMatchObject({
+      status: 'committed',
+      previousSequence: 1,
+      lastSequence: 2,
+    });
+    expect((await store.read(sessionId)).events.map((event) => event.commandId)).toEqual([
+      'command-create',
+      'command-request',
+    ]);
+    expect(journal.getProjection().activeRequest).toMatchObject({
+      requestId,
+      commandId: 'command-request',
+      status: 'accepted',
+    });
+  });
+
+  it('commits a multi-event lifecycle transition as one idempotent command', async () => {
+    const journal = await DurableSessionJournal.open(store, sessionId);
+    const result = await journal.commit({
+      commandId: CommandId('command-bootstrap'),
+      events: [
+        sessionCreated(),
+        requestAccepted(),
+        {
+          type: DurableEventType.REQUEST_STARTED,
+          requestId,
+          data: {},
+        },
+      ],
+    });
+
+    expect(result.events).toHaveLength(3);
+    expect(result.events.every((event) => event.commandId === 'command-bootstrap')).toBe(true);
+    expect(journal.getProjection().activeRequest?.status).toBe('running');
+    expect(
+      (
+        await journal.commit({
+          commandId: CommandId('command-bootstrap'),
+          events: [
+            sessionCreated(),
+            requestAccepted(),
+            {
+              type: DurableEventType.REQUEST_STARTED,
+              requestId,
+              data: {},
+            },
+          ],
+        })
+      ).status,
+    ).toBe('replayed');
+  });
+
+  it('replays an identical command without appending duplicate events', async () => {
+    const journal = await DurableSessionJournal.open(store, sessionId);
+    const command = {
+      commandId: CommandId('command-create'),
+      events: [sessionCreated()],
+    } as const;
+
+    await journal.commit(command);
+    const replayed = await journal.commit(command);
+
+    expect(replayed.status).toBe('replayed');
+    expect(replayed.events).toHaveLength(1);
+    expect(await store.getHeadSequence(sessionId)).toBe(1);
+  });
+
+  it('matches semantically identical JSON regardless of object key order', async () => {
+    const journal = await DurableSessionJournal.open(store, sessionId);
+    await journal.commit({
+      commandId: CommandId('command-create'),
+      events: [sessionCreated()],
+    });
+    await journal.commit({
+      commandId: CommandId('command-request'),
+      events: [requestAccepted({ first: 1, second: 2 })],
+    });
+
+    const replayed = await journal.commit({
+      commandId: CommandId('command-request'),
+      events: [requestAccepted({ second: 2, first: 1 })],
+    });
+
+    expect(replayed.status).toBe('replayed');
+    expect(await store.getHeadSequence(sessionId)).toBe(2);
+  });
+
+  it('rejects reuse of a command ID with different events', async () => {
+    const journal = await DurableSessionJournal.open(store, sessionId);
+    await journal.commit({
+      commandId: CommandId('command-create'),
+      events: [sessionCreated()],
+    });
+
+    await expect(
+      journal.commit({
+        commandId: CommandId('command-create'),
+        events: [
+          {
+            type: DurableEventType.SESSION_CREATED,
+            data: { source: 'resume' },
+          },
+        ],
+      }),
+    ).rejects.toBeInstanceOf(DurableCommandConflictError);
+    expect(await store.getHeadSequence(sessionId)).toBe(1);
+  });
+
+  it('rejects invalid transitions before writing them', async () => {
+    const journal = await DurableSessionJournal.open(store, sessionId);
+
+    await expect(
+      journal.commit({
+        commandId: CommandId('command-request'),
+        events: [requestAccepted()],
+      }),
+    ).rejects.toBeInstanceOf(DurableEventProjectionError);
+    expect(await store.getHeadSequence(sessionId)).toBeNull();
+  });
+
+  it('retries a different command after refreshing a CAS conflict', async () => {
+    const bootstrap = await DurableSessionJournal.open(store, sessionId);
+    await bootstrap.commit({
+      commandId: CommandId('command-create'),
+      events: [sessionCreated()],
+    });
+    await bootstrap.commit({
+      commandId: CommandId('command-request'),
+      events: [requestAccepted()],
+    });
+
+    const first = await DurableSessionJournal.open(store, sessionId);
+    const second = await DurableSessionJournal.open(store, sessionId);
+    await first.commit({
+      commandId: CommandId('command-input'),
+      events: [
+        {
+          type: DurableEventType.INPUT_APPLIED,
+          requestId,
+          data: {
+            inputId: initialInputId,
+            priority: 'next',
+          },
+        },
+      ],
+    });
+    const started = await second.commit({
+      commandId: CommandId('command-start'),
+      events: [
+        {
+          type: DurableEventType.REQUEST_STARTED,
+          requestId,
+          data: {},
+        },
+      ],
+    });
+
+    expect(started).toMatchObject({
+      status: 'committed',
+      previousSequence: 3,
+      lastSequence: 4,
+    });
+    expect(second.getProjection().activeRequest?.status).toBe('running');
+  });
+
+  it('reconciles concurrent delivery of the same command', async () => {
+    const bootstrap = await DurableSessionJournal.open(store, sessionId);
+    await bootstrap.commit({
+      commandId: CommandId('command-create'),
+      events: [sessionCreated()],
+    });
+    await bootstrap.commit({
+      commandId: CommandId('command-request'),
+      events: [requestAccepted()],
+    });
+
+    const first = await DurableSessionJournal.open(store, sessionId);
+    const second = await DurableSessionJournal.open(store, sessionId);
+    const command = {
+      commandId: CommandId('command-start'),
+      events: [
+        {
+          type: DurableEventType.REQUEST_STARTED,
+          requestId,
+          data: {},
+        },
+      ],
+    } as const;
+    const results = await Promise.all([first.commit(command), second.commit(command)]);
+
+    expect(results.map((result) => result.status).sort()).toEqual(['committed', 'reconciled']);
+    expect(await store.getHeadSequence(sessionId)).toBe(3);
+  });
+
+  it('serializes concurrent commands submitted through one journal', async () => {
+    const journal = await DurableSessionJournal.open(store, sessionId);
+    await journal.commit({
+      commandId: CommandId('command-create'),
+      events: [sessionCreated()],
+    });
+    await journal.commit({
+      commandId: CommandId('command-request'),
+      events: [requestAccepted()],
+    });
+
+    const [applied, started] = await Promise.all([
+      journal.commit({
+        commandId: CommandId('command-input'),
+        events: [
+          {
+            type: DurableEventType.INPUT_APPLIED,
+            requestId,
+            data: {
+              inputId: initialInputId,
+              priority: 'next',
+            },
+          },
+        ],
+      }),
+      journal.commit({
+        commandId: CommandId('command-start'),
+        events: [
+          {
+            type: DurableEventType.REQUEST_STARTED,
+            requestId,
+            data: {},
+          },
+        ],
+      }),
+    ]);
+
+    expect(applied.status).toBe('committed');
+    expect(started.status).toBe('committed');
+    expect(await store.getHeadSequence(sessionId)).toBe(4);
+  });
+
+  it('reconciles a write failure when the command is visible after reload', async () => {
+    const journal = await DurableSessionJournal.open(new FailAfterCommitStore(store), sessionId);
+
+    const result = await journal.commit({
+      commandId: CommandId('command-create'),
+      events: [sessionCreated()],
+    });
+
+    expect(result.status).toBe('reconciled');
+    expect(result.lastSequence).toBe(1);
+    expect(journal.getProjection().status).toBe('open');
+  });
+
+  it('reports an unknown outcome instead of retrying when a failed write is absent', async () => {
+    const failingStore = new FailBeforeCommitStore(store);
+    const journal = await DurableSessionJournal.open(failingStore, sessionId);
+
+    await expect(
+      journal.commit({
+        commandId: CommandId('command-create'),
+        events: [sessionCreated()],
+      }),
+    ).rejects.toMatchObject({
+      code: 'DURABLE_COMMAND_OUTCOME_UNKNOWN',
+      commandId: 'command-create',
+    });
+    expect(journal.getUncertainCommandId()).toBe('command-create');
+    expect(await store.getHeadSequence(sessionId)).toBeNull();
+
+    await expect(
+      journal.commit({
+        commandId: CommandId('command-after-unknown'),
+        events: [sessionCreated()],
+      }),
+    ).rejects.toMatchObject({
+      code: 'DURABLE_COMMAND_OUTCOME_UNKNOWN',
+      commandId: 'command-create',
+    });
+    expect(failingStore.appendCalls).toBe(1);
+
+    await expect(
+      journal.commit({
+        commandId: CommandId('command-create'),
+        events: [sessionCreated()],
+      }),
+    ).rejects.toMatchObject({
+      code: 'DURABLE_COMMAND_OUTCOME_UNKNOWN',
+      commandId: 'command-create',
+    });
+    expect(failingStore.appendCalls).toBe(1);
+
+    await store.append(
+      sessionId,
+      [
+        {
+          ...sessionCreated(),
+          commandId: CommandId('command-create'),
+        },
+      ],
+      {
+        expectedLastSequence: null,
+      },
+    );
+    const reconciled = await journal.commit({
+      commandId: CommandId('command-create'),
+      events: [sessionCreated()],
+    });
+    expect(reconciled.status).toBe('reconciled');
+    expect(journal.getUncertainCommandId()).toBeNull();
+  });
+
+  it('reconciles an invalid append response against canonical storage', async () => {
+    const journal = await DurableSessionJournal.open(
+      new InvalidCommitResultStore(store),
+      sessionId,
+    );
+
+    const result = await journal.commit({
+      commandId: CommandId('command-create'),
+      events: [sessionCreated()],
+    });
+
+    expect(result.status).toBe('reconciled');
+    expect(result.events).toHaveLength(1);
+    expect(journal.getProjection().status).toBe('open');
+  });
+
+  it('rebuilds projection and command indexes across cursor pages', async () => {
+    const journal = await DurableSessionJournal.open(store, sessionId);
+    await journal.commit({
+      commandId: CommandId('command-create'),
+      events: [sessionCreated()],
+    });
+    await journal.commit({
+      commandId: CommandId('command-request'),
+      events: [requestAccepted()],
+    });
+    await journal.commit({
+      commandId: CommandId('command-start'),
+      events: [
+        {
+          type: DurableEventType.REQUEST_STARTED,
+          requestId,
+          data: {},
+        },
+      ],
+    });
+
+    const reopened = await DurableSessionJournal.open(store, sessionId, {
+      pageSize: 1,
+    });
+    const replayed = await reopened.commit({
+      commandId: CommandId('command-start'),
+      events: [
+        {
+          type: DurableEventType.REQUEST_STARTED,
+          requestId,
+          data: {},
+        },
+      ],
+    });
+
+    expect(reopened.getProjection().headSequence).toBe(3);
+    expect(reopened.getProjection().activeRequest?.status).toBe('running');
+    expect(replayed.status).toBe('replayed');
+  });
+
+  it('bounds CAS retries for competing commands', async () => {
+    const bootstrap = await DurableSessionJournal.open(store, sessionId);
+    await bootstrap.commit({
+      commandId: CommandId('command-create'),
+      events: [sessionCreated()],
+    });
+    const conflictingStore = new AlwaysConflictStore(store);
+    const journal = await DurableSessionJournal.open(conflictingStore, sessionId, {
+      maxConflictRetries: 2,
+    });
+
+    await expect(
+      journal.commit({
+        commandId: CommandId('command-request'),
+        events: [requestAccepted()],
+      }),
+    ).rejects.toBeInstanceOf(DurableEventSequenceConflictError);
+    expect(conflictingStore.appendCalls).toBe(3);
+  });
+
+  it('rejects non-advancing or inconsistent Store pages', async () => {
+    await expect(
+      DurableSessionJournal.open(new InvalidPageStore(store), sessionId),
+    ).rejects.toMatchObject({
+      code: 'DURABLE_JOURNAL_INVALID_PAGE',
+    });
+  });
+
+  it('rejects a command ID split across non-contiguous event ranges', async () => {
+    await store.append(sessionId, [
+      {
+        ...sessionCreated(),
+        commandId: CommandId('command-reused'),
+      },
+      {
+        ...requestAccepted(),
+        commandId: CommandId('command-request'),
+      },
+      {
+        type: DurableEventType.INPUT_APPLIED,
+        requestId,
+        commandId: CommandId('command-reused'),
+        data: {
+          inputId: initialInputId,
+          priority: 'next',
+        },
+      },
+    ]);
+
+    await expect(DurableSessionJournal.open(store, sessionId)).rejects.toMatchObject({
+      code: 'DURABLE_COMMAND_CONFLICT',
+    });
+  });
+
+  it.each([
+    { pageSize: 0, maxConflictRetries: 3 },
+    { pageSize: 1001, maxConflictRetries: 3 },
+    { pageSize: 10, maxConflictRetries: -1 },
+    { pageSize: 10, maxConflictRetries: Number.MAX_SAFE_INTEGER + 1 },
+  ])('rejects invalid journal options %#', async (options) => {
+    await expect(DurableSessionJournal.open(store, sessionId, options)).rejects.toBeInstanceOf(
+      DurableSessionJournalError,
+    );
+  });
+
+  it('rejects empty commands and blank command IDs', async () => {
+    const journal = await DurableSessionJournal.open(store, sessionId);
+
+    await expect(
+      journal.commit({
+        commandId: CommandId('command-empty'),
+        events: [],
+      }),
+    ).rejects.toMatchObject({ code: 'DURABLE_COMMAND_INVALID' });
+    await expect(
+      journal.commit({
+        commandId: CommandId('   '),
+        events: [sessionCreated()],
+      }),
+    ).rejects.toMatchObject({ code: 'DURABLE_COMMAND_INVALID' });
+  });
+
+  it('returns defensive events when replaying a command', async () => {
+    const journal = await DurableSessionJournal.open(store, sessionId);
+    const command = {
+      commandId: CommandId('command-create'),
+      events: [sessionCreated()],
+    } as const;
+    await journal.commit(command);
+    const replayed = await journal.commit(command);
+    (replayed.events[0]?.data as { source: string }).source = 'mutated';
+
+    expect((await store.read(sessionId)).events[0]?.data).toEqual({
+      source: 'create',
+    });
+  });
+
+  it('does not expose its command index through committed results', async () => {
+    const journal = await DurableSessionJournal.open(store, sessionId);
+    const command = {
+      commandId: CommandId('command-create'),
+      events: [sessionCreated()],
+    } as const;
+    const committed = await journal.commit(command);
+    (committed.events[0]?.data as { source: string }).source = 'mutated';
+
+    const replayed = await journal.commit(command);
+    expect(replayed.status).toBe('replayed');
+    expect(replayed.events[0]?.data).toEqual({ source: 'create' });
+  });
+
+  it('surfaces typed unknown-outcome errors', () => {
+    expect(new DurableCommandOutcomeUnknownError(CommandId('command-1'))).toMatchObject({
+      code: 'DURABLE_COMMAND_OUTCOME_UNKNOWN',
+      commandId: 'command-1',
+    });
+  });
+});

--- a/src/session/events/__tests__/DurableSessionProjector.test.ts
+++ b/src/session/events/__tests__/DurableSessionProjector.test.ts
@@ -234,6 +234,40 @@ describe('DurableSessionProjector', () => {
     });
   });
 
+  it('previews drafts on an isolated fork without mutating canonical state', () => {
+    const projector = new DurableSessionProjector().apply(envelopes(requestPrefix().slice(0, 2)));
+
+    const preview = projector.preview(sessionId, [
+      {
+        type: DurableEventType.REQUEST_STARTED,
+        requestId,
+        data: {},
+      },
+    ]);
+
+    expect(preview.activeRequest?.status).toBe('running');
+    expect(preview.headSequence).toBe(3);
+    expect(projector.snapshot().activeRequest?.status).toBe('accepted');
+    expect(projector.snapshot().headSequence).toBe(2);
+  });
+
+  it('rejects an invalid preview without poisoning the canonical projector', () => {
+    const projector = new DurableSessionProjector().apply(envelopes(requestPrefix().slice(0, 2)));
+
+    expect(() =>
+      projector.preview(sessionId, [
+        {
+          type: DurableEventType.TURN_STARTED,
+          requestId,
+          turnId,
+          data: { turn: 1 },
+        },
+      ]),
+    ).toThrow(/has not started/);
+
+    expect(projector.snapshot().activeRequest?.status).toBe('accepted');
+  });
+
   it('classifies accepted requests and active model turns as retryable', () => {
     const accepted = project(requestPrefix().slice(0, 2));
     expect(planDurableSessionRecovery(accepted)).toMatchObject({

--- a/src/session/events/core.ts
+++ b/src/session/events/core.ts
@@ -5,6 +5,18 @@ export {
   type DurableEventStoreErrorCode,
 } from './DurableEventStore.js';
 export {
+  type DurableCommandCommitResult,
+  type DurableCommandCommitStatus,
+  DurableCommandConflictError,
+  type DurableCommandEventDraft,
+  DurableCommandOutcomeUnknownError,
+  type DurableSessionCommand,
+  DurableSessionJournal,
+  DurableSessionJournalError,
+  type DurableSessionJournalErrorCode,
+  type DurableSessionJournalOptions,
+} from './DurableSessionJournal.js';
+export {
   DurableEventProjectionError,
   type DurablePermissionProjection,
   type DurablePermissionStatus,


### PR DESCRIPTION
## Summary

- add `DurableSessionJournal` as the command-oriented layer above `DurableEventStore`
- preview lifecycle transitions before persistence so invalid state changes never enter the canonical log
- stamp every event in a command with one caller-provided `commandId`
- serialize same-instance commits and use compare-and-append for cross-writer coordination
- retry explicit CAS conflicts after bounded refreshes
- reconcile write failures by reloading and matching canonical command content
- fence the Journal after an unresolved write outcome and reject unrelated commands

## Recovery semantics

- identical committed commands return `replayed` without another append
- concurrently committed identical commands return `reconciled`
- reused command IDs with different content fail with `DurableCommandConflictError`
- a write failure with a visible matching command returns `reconciled`
- a write failure without a provable result throws `DurableCommandOutcomeUnknownError` and is never automatically retried

This follows Claude Code message replay/deduplication behavior, Codex canonical-log-before-projection ordering, and Grok explicit reconnect/replay state handling.

## Scope

The Journal is still an opt-in sidecar and does not yet change `Session.send()` or tool execution. The next integration patch can use this API without embedding CAS or unknown-outcome logic in `Session`.

## Testing

- 123 test files passed, 3 skipped
- 1228 tests passed, 62 skipped
- `pnpm run type-check`
- `pnpm run lint`
- `pnpm run docs:build`
- `pnpm run verify:entrypoints`
- `npm pack --dry-run --json`

## Stack

Depends on #23. Merge #22, retarget and merge #23, then retarget this PR to `main` before merging.