### PR TITLE
feat(tools): add awaited durable lifecycle boundaries

### DIFF
--- a/.changes/durable-tool-lifecycle.json
+++ b/.changes/durable-tool-lifecycle.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "en": "Add awaited tool lifecycle hooks that enforce durable ordering around scheduling, permission prompts, side-effect start, and terminal result publication.",
+  "zh-CN": "新增可等待的工具生命周期钩子，在调度、权限交互、副作用开始和终态结果发布之间强制 durable 顺序。"
+}

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -143,6 +143,10 @@ Node-local 能力外，这些函数都从根入口导出；实际 subpath 以“
 | `ToolDescription` | 工具描述（短描述/长描述/使用提示/示例） |
 | `ToolDescriptionResolver` | 动态工具描述解析器 |
 | `ToolExecution` | 工具的异步生成器执行契约 |
+| `ToolExecutionLifecycle` | Request 级工具 scheduled / settled 持久化边界 |
+| `ToolInvocationLifecycle` | 单次工具权限与副作用开始边界 |
+| `ToolScheduledLifecycle` / `ToolSettledLifecycle` | 工具调度与终态 payload |
+| `ToolPermissionResolution` | 权限请求的 durable 决策 payload |
 | `ToolYield` | 工具产生的结构化进度、展示消息或 effect |
 | `ToolProgress` | 可选包含计数、结构化数据和恢复令牌的进度事件 |
 | `ToolMessage` | 面向用户界面的执行消息 |

--- a/docs/durable-events.md
+++ b/docs/durable-events.md
@@ -7,7 +7,8 @@ Session 生命周期投影。
 ::: warning 当前集成阶段
 当前不会改变 `Session.send()`、`Session.stream()` 或现有 Session JSONL。
 调用方可以独立使用 Event Store 和 recovery projector；Session 生命周期事件
-将在后续阶段接入。
+将在后续阶段接入。工具管道已经提供 awaited lifecycle hooks，以便接入时严格
+保持 persist-before-side-effect 和 persist-before-publish 顺序。
 :::
 
 ## 安装与导入

--- a/docs/en/api-reference.md
+++ b/docs/en/api-reference.md
@@ -142,9 +142,11 @@ Types:
 
 `FunctionDeclaration`, `Tool`, `ToolBehavior`, `ToolConfig`, `ToolDescription`,
 `ToolDescriptionResolver`, `ToolDisplayContent`, `ToolEffect`,
-`ToolEffectYield`, `ToolError`, `ToolExecution`, `ToolExposureConfig`,
-`ToolExposureMode`, `ToolMessage`, `ToolModelContent`, `ToolProgress`,
-`ToolSchema`, `ToolExecutionUpdate`, and `ToolYield`.
+`ToolEffectYield`, `ToolError`, `ToolExecution`, `ToolExecutionLifecycle`,
+`ToolInvocationLifecycle`, `ToolScheduledLifecycle`, `ToolSettledLifecycle`,
+`ToolPermissionResolution`, `ToolExposureConfig`, `ToolExposureMode`,
+`ToolMessage`, `ToolModelContent`, `ToolProgress`, `ToolSchema`,
+`ToolExecutionUpdate`, and `ToolYield`.
 
 Constants:
 

--- a/docs/en/durable-events.md
+++ b/docs/en/durable-events.md
@@ -9,6 +9,8 @@ projection.
 The current phase does not change `Session.send()`, `Session.stream()`, or the
 existing Session JSONL format. Applications can use the Event Store and recovery
 projector directly; Session lifecycle events will be connected in a later phase.
+The tool pipeline already exposes awaited lifecycle hooks so that integration can
+preserve persist-before-side-effect and persist-before-publish ordering.
 :::
 
 ## Imports

--- a/docs/en/tools.md
+++ b/docs/en/tools.md
@@ -242,8 +242,47 @@ interface ExecutionContext {
   toolRegistry?: ToolRegistry;
   toolCatalog?: ToolCatalog;
   discoveredTools?: string[];
+  toolInvocationLifecycle?: ToolInvocationLifecycle; // injected by the runtime
 }
 ```
+
+## Durable lifecycle boundaries
+
+A runtime can use `ToolExecutionLifecycle` to observe and block critical tool
+persistence boundaries:
+
+```ts
+interface ToolExecutionLifecycle {
+  onToolScheduled?(
+    event: ToolScheduledLifecycle,
+  ): Promise<ToolInvocationLifecycle | undefined>;
+  onToolSettled?(event: ToolSettledLifecycle): Promise<void>;
+}
+
+interface ToolInvocationLifecycle {
+  onPermissionRequested?(
+    details: ConfirmationDetails,
+    input: JsonObject,
+  ): Promise<PermissionRequestId>;
+  onPermissionResolved?(
+    resolution: ToolPermissionResolution,
+  ): Promise<void>;
+  onExecutionStarted?(): Promise<void>;
+}
+```
+
+These callbacks are not best-effort telemetry. Their ordering is fixed:
+
+1. `onToolScheduled` completes before `tool_start` is published.
+2. `onPermissionRequested` completes before the interactive confirmation handler runs.
+3. `onPermissionResolved` completes before the permission decision is accepted.
+4. `onExecutionStarted` completes before the tool generator is invoked, so a durable write failure blocks the side effect.
+5. `onToolSettled` completes before `tool_result` is published.
+
+Invalid JSON arguments and synthetic interruption results for calls that were
+never dispatched do not enter the durable lifecycle because they never form an
+executable invocation. Without a lifecycle observer, normal tool execution
+behavior is unchanged.
 
 ## Built-in tools
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -326,8 +326,45 @@ interface ExecutionContext {
   toolRegistry?: ToolRegistry;
   toolCatalog?: ToolCatalog;
   discoveredTools?: string[];
+  toolInvocationLifecycle?: ToolInvocationLifecycle; // runtime 内部注入
 }
 ```
+
+### Durable lifecycle 边界
+
+Runtime 可以通过 `ToolExecutionLifecycle` 观察并阻塞工具的关键持久化边界：
+
+```ts
+interface ToolExecutionLifecycle {
+  onToolScheduled?(
+    event: ToolScheduledLifecycle,
+  ): Promise<ToolInvocationLifecycle | undefined>;
+  onToolSettled?(event: ToolSettledLifecycle): Promise<void>;
+}
+
+interface ToolInvocationLifecycle {
+  onPermissionRequested?(
+    details: ConfirmationDetails,
+    input: JsonObject,
+  ): Promise<PermissionRequestId>;
+  onPermissionResolved?(
+    resolution: ToolPermissionResolution,
+  ): Promise<void>;
+  onExecutionStarted?(): Promise<void>;
+}
+```
+
+这些回调不是 best-effort telemetry。执行顺序固定为：
+
+1. `onToolScheduled` 完成后才发布 `tool_start`。
+2. `onPermissionRequested` 完成后才调用交互式确认处理器。
+3. `onPermissionResolved` 完成后才接受权限决定。
+4. `onExecutionStarted` 完成后才调用工具 generator，因此 durable 写失败不会放行副作用。
+5. `onToolSettled` 完成后才发布 `tool_result`。
+
+无效 JSON 参数和从未派发的 synthetic interruption result 不会进入 durable
+lifecycle，因为它们尚未形成可执行调用。未配置 lifecycle observer 时行为与
+普通工具执行一致。
 
 ### 工具中断策略
 

--- a/src/__tests__/rootExports.test.ts
+++ b/src/__tests__/rootExports.test.ts
@@ -14,9 +14,15 @@ import type {
   ToolEffect,
   ToolEffectYield,
   ToolExecution,
+  ToolExecutionLifecycle,
   ToolExecutionUpdate,
+  ToolInvocationLifecycle,
   ToolMessage,
+  ToolPermissionResolution,
   ToolProgress,
+  ToolResult,
+  ToolScheduledLifecycle,
+  ToolSettledLifecycle,
   ToolYield,
 } from '../index.js';
 import {
@@ -90,6 +96,13 @@ describe('root exports', () => {
     expectTypeOf<ToolMessage['kind']>().toEqualTypeOf<'message'>();
     expectTypeOf<ToolEffectYield['kind']>().toEqualTypeOf<'effect'>();
     expectTypeOf<ToolExecution>().toMatchTypeOf<AsyncGenerator<ToolYield, unknown, void>>();
+    expectTypeOf<NonNullable<ToolExecutionLifecycle['onToolScheduled']>>().toBeFunction();
+    expectTypeOf<NonNullable<ToolInvocationLifecycle['onExecutionStarted']>>().toBeFunction();
+    expectTypeOf<ToolPermissionResolution['decision']>().toEqualTypeOf<
+      'allow' | 'deny' | 'cancel'
+    >();
+    expectTypeOf<ToolScheduledLifecycle['interruptBehavior']>().toEqualTypeOf<'block' | 'cancel'>();
+    expectTypeOf<ToolSettledLifecycle['result']>().toEqualTypeOf<ToolResult>();
     expectTypeOf<InputSubmission['status']>().toEqualTypeOf<'started' | 'steered' | 'queued'>();
     expectTypeOf<PendingSessionInput['priority']>().toEqualTypeOf<'now' | 'next' | 'later'>();
     expectTypeOf<ReturnType<typeof createMemoryReadTool>>().toMatchTypeOf<SessionTool>();

--- a/src/agent/StreamingToolExecutor.ts
+++ b/src/agent/StreamingToolExecutor.ts
@@ -1,10 +1,10 @@
 import type { JSONSchema7 } from 'json-schema';
 import { type InternalLogger, LogCategory, NOOP_LOGGER } from '../logging/Logger.js';
 import type {
-  ChatResponse,
-  IChatService,
-  Message,
-  StreamToolCall,
+    ChatResponse,
+    IChatService,
+    Message,
+    StreamToolCall,
 } from '../services/ChatServiceInterface.js';
 import type { ExecutionPipeline } from '../tools/execution/ExecutionPipeline.js';
 import type { ToolEffect, ToolResult } from '../tools/types/index.js';
@@ -15,10 +15,10 @@ import type { ExecutionEpoch } from './ExecutionEpoch.js';
 import type { ToolExecutionOutcome } from './loop/executeToolCalls.js';
 import { planToolExecution } from './loop/planToolExecution.js';
 import {
-  emitToolExecutionUpdate,
-  runToolCall,
-  type ToolExecutionContext,
-  type ToolExecutionUpdate,
+    emitToolExecutionUpdate,
+    runToolCall,
+    type ToolExecutionContext,
+    type ToolExecutionUpdate,
 } from './loop/runToolCall.js';
 import { streamChatResponse } from './loop/streamChatResponse.js';
 import type { FunctionToolCall } from './loop/types.js';
@@ -493,45 +493,22 @@ export class StreamingToolExecutor {
       return;
     }
 
-    await this.emitToolExecutionUpdate(input.executionConfig, {
-      type: 'tool_ready',
+    const outcome = await runToolCall({
       toolCall: input.toolCall,
-    }, input.epoch);
-
-    let result: ToolResult;
-    let effects = [] as ToolExecutionOutcome['effects'];
-    let toolUseUuid: string | null = null;
-
-    try {
-      const outcome = await runToolCall({
-        toolCall: input.toolCall,
-        executionPipeline: input.executionConfig.executionPipeline,
-        executionContext: input.executionConfig.executionContext,
-        logger: this.logger,
-        permissionMode: input.executionConfig.permissionMode,
-        signal: input.executionConfig.requestSignal ?? input.signal,
-        steeringSignal: input.executionConfig.steeringSignal,
-        batchSignal: input.batchController.signal,
-        hooks: {
-          onBeforeToolExec: input.executionConfig.hooks?.onBeforeToolExec,
-          onUpdate: (update) => this.emitToolExecutionUpdate(input.executionConfig, update, input.epoch),
-        },
-      });
-      result = outcome.result;
-      effects = outcome.effects;
-      toolUseUuid = outcome.toolUseUuid;
-    } catch (error) {
-      this.logger.error(`Tool execution failed for ${input.toolCall.function.name}:`, error);
-      const message = error instanceof Error ? error.message : 'Unknown error';
-      result = {
-        status: 'error',
-        model: `Tool execution failed: ${message}`,
-        error: {
-          type: ToolErrorType.EXECUTION_ERROR,
-          message,
-        },
-      };
-    }
+      executionPipeline: input.executionConfig.executionPipeline,
+      executionContext: input.executionConfig.executionContext,
+      logger: this.logger,
+      permissionMode: input.executionConfig.permissionMode,
+      signal: input.executionConfig.requestSignal ?? input.signal,
+      steeringSignal: input.executionConfig.steeringSignal,
+      batchSignal: input.batchController.signal,
+      hooks: {
+        onBeforeToolExec: input.executionConfig.hooks?.onBeforeToolExec,
+        onUpdate: (update) =>
+          this.emitToolExecutionUpdate(input.executionConfig, update, input.epoch),
+      },
+    });
+    const { result, effects, toolUseUuid } = outcome;
 
     // Epoch guard: 工具执行完后检查 epoch 是否仍有效
     if (!this.isEpochActive(input.epoch)) {

--- a/src/agent/__tests__/StreamingToolExecutor.test.ts
+++ b/src/agent/__tests__/StreamingToolExecutor.test.ts
@@ -3,9 +3,9 @@ import type { ChatResponse, StreamChunk } from '../../services/ChatServiceInterf
 import { ActiveRequestController } from '../../session/ActiveRequestController.js';
 import type { ToolExecution, ToolResult } from '../../tools/types/index.js';
 import {
-  InputId,
-  RequestId,
-  SessionId,
+    InputId,
+    RequestId,
+    SessionId,
 } from '../../types/branded.js';
 import { PermissionMode } from '../../types/common.js';
 import { StreamingToolExecutor } from '../StreamingToolExecutor.js';
@@ -74,6 +74,131 @@ function createExecutor(options: {
 }
 
 describe('StreamingToolExecutor', () => {
+  it('awaits durable scheduling before publishing or dispatching a streaming tool', async () => {
+    const scheduleGate = deferred<void>();
+    const order: string[] = [];
+    const { executor, execute } = createExecutor({
+      streamChat: async function* () {
+        yield {
+          toolCalls: [
+            {
+              index: 0,
+              id: 'tool-durable',
+              function: {
+                name: 'Write',
+                arguments: '{}',
+              },
+            },
+          ],
+        };
+        yield { finishReason: 'tool_calls' };
+      },
+      execute: async () => {
+        order.push('execute');
+        return { status: 'success', model: 'done' };
+      },
+      toolInterruptBehaviors: {
+        Write: 'block',
+      },
+    });
+
+    const promise = executor.collectAndExecute(
+      [{ role: 'user', content: 'write' }],
+      [{ name: 'Write', description: 'writes', parameters: {} }],
+      undefined,
+      {
+        executionPipeline: executionPipelineFromMock(execute, {
+          Write: { interruptBehavior: 'block' },
+        }),
+        executionContext: {
+          sessionId: SessionId('session-1'),
+          userId: 'user-1',
+          lifecycle: {
+            onToolScheduled: async () => {
+              order.push('schedule-start');
+              await scheduleGate.promise;
+              order.push('schedule-end');
+              return undefined;
+            },
+            onToolSettled: async () => {
+              order.push('settled');
+            },
+          },
+        },
+        onToolReady: () => {
+          order.push('ready');
+        },
+      },
+    );
+
+    await tick();
+    expect(order).toEqual(['schedule-start']);
+    expect(execute).not.toHaveBeenCalled();
+
+    scheduleGate.resolve();
+    await promise;
+    expect(order).toEqual([
+      'schedule-start',
+      'schedule-end',
+      'ready',
+      'execute',
+      'settled',
+    ]);
+  });
+
+  it('fails the streaming turn before publishing a terminal result when durable settlement fails', async () => {
+    const published: string[] = [];
+    const { executor, execute } = createExecutor({
+      streamChat: async function* () {
+        yield {
+          toolCalls: [
+            {
+              index: 0,
+              id: 'tool-settlement',
+              function: {
+                name: 'Write',
+                arguments: '{}',
+              },
+            },
+          ],
+        };
+        yield { finishReason: 'tool_calls' };
+      },
+      execute: async () => ({
+        status: 'success',
+        model: 'done',
+      }),
+    });
+
+    await expect(
+      executor.collectAndExecute(
+        [{ role: 'user', content: 'write' }],
+        [{ name: 'Write', description: 'writes', parameters: {} }],
+        undefined,
+        {
+          executionPipeline: executionPipelineFromMock(execute),
+          executionContext: {
+            sessionId: SessionId('session-1'),
+            userId: 'user-1',
+            lifecycle: {
+              onToolScheduled: async () => undefined,
+              onToolSettled: async () => {
+                throw new Error('terminal write failed');
+              },
+            },
+          },
+          onAfterToolExec: () => {
+            published.push('result');
+          },
+          onToolComplete: () => {
+            published.push('completed');
+          },
+        },
+      ),
+    ).rejects.toThrow('terminal write failed');
+    expect(published).toEqual([]);
+  });
+
   it('dispatches a tool as soon as arguments become parseable, forwards deltas, and emits stream_end before tool completion', async () => {
     const finishGate = deferred<void>();
     const toolGate = deferred<ToolResult>();

--- a/src/agent/loop/__tests__/executeToolCalls.test.ts
+++ b/src/agent/loop/__tests__/executeToolCalls.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
 import { createContextSnapshot } from '../../../runtime/index.js';
-import { completeToolExecution } from '../../../tools/types/index.js';
+import { completeToolExecution, type ExecutionContext } from '../../../tools/types/index.js';
 import { SessionId } from '../../../types/branded.js';
+import type { JsonObject } from '../../../types/common.js';
 import { executeToolCalls } from '../executeToolCalls.js';
 
 describe('executeToolCalls', () => {
@@ -56,10 +57,12 @@ describe('executeToolCalls', () => {
   });
 
   it('should forward the turn-scoped context snapshot into tool execution', async () => {
-    const execute = vi.fn(() => completeToolExecution({
-      status: 'success',
-      model: 'ok',
-    }));
+    const execute = vi.fn(() =>
+      completeToolExecution({
+        status: 'success',
+        model: 'ok',
+      }),
+    );
 
     await executeToolCalls({
       plan: {
@@ -111,10 +114,12 @@ describe('executeToolCalls', () => {
     const controller = new AbortController();
     controller.abort();
 
-    const execute = vi.fn(() => completeToolExecution({
-      status: 'success',
-      model: 'ok',
-    }));
+    const execute = vi.fn(() =>
+      completeToolExecution({
+        status: 'success',
+        model: 'ok',
+      }),
+    );
 
     await executeToolCalls({
       plan: {
@@ -155,10 +160,13 @@ describe('executeToolCalls', () => {
   });
 
   it('returns model-facing content when tool arguments are invalid JSON', async () => {
-    const execute = vi.fn(() => completeToolExecution({
-      status: 'success',
-      model: 'unexpected',
-    }));
+    const execute = vi.fn(() =>
+      completeToolExecution({
+        status: 'success',
+        model: 'unexpected',
+      }),
+    );
+    const onToolScheduled = vi.fn(async () => undefined);
 
     const [outcome] = await executeToolCalls({
       plan: {
@@ -183,10 +191,14 @@ describe('executeToolCalls', () => {
       executionContext: {
         sessionId: SessionId('session-invalid-json'),
         userId: 'user-1',
+        lifecycle: {
+          onToolScheduled,
+        },
       },
     });
 
     expect(execute).not.toHaveBeenCalled();
+    expect(onToolScheduled).not.toHaveBeenCalled();
     expect(outcome.result.status).toBe('error');
     expect(outcome.result.model).toContain('Tool execution failed:');
     expect(outcome.result.model).toContain('JSON');
@@ -329,5 +341,177 @@ describe('executeToolCalls', () => {
       'result:Read',
       'completed:Read',
     ]);
+  });
+
+  it('awaits durable schedule and settlement around tool execution', async () => {
+    const lifecycle: string[] = [];
+
+    const [outcome] = await executeToolCalls({
+      plan: {
+        mode: 'serial',
+        calls: [
+          {
+            id: 'tool-lifecycle',
+            type: 'function',
+            function: {
+              name: 'Write',
+              arguments: '{"value":"ok"}',
+            },
+          },
+        ],
+      },
+      executionPipeline: {
+        // biome-ignore lint/correctness/useYield: test double returns a terminal generator result
+        execute: vi.fn(async function* (
+          _toolName: string,
+          _params: JsonObject,
+          context: ExecutionContext,
+        ) {
+          lifecycle.push(`pipeline:${String(_params.value)}`);
+          await context.toolInvocationLifecycle?.onExecutionStarted?.();
+          lifecycle.push('side-effect');
+          return {
+            status: 'success',
+            model: 'ok',
+          };
+        }),
+        getRegistry: () => ({
+          get: () => ({ kind: 'write', interruptBehavior: 'block' }),
+        }),
+      } as never,
+      executionContext: {
+        sessionId: SessionId('session-lifecycle'),
+        userId: 'user-1',
+        lifecycle: {
+          onToolScheduled: async ({ toolCallId, input, interruptBehavior }) => {
+            lifecycle.push(`scheduled:${toolCallId}:${String(input.value)}:${interruptBehavior}`);
+            input.value = 'mutated';
+            return {
+              onExecutionStarted: async () => {
+                lifecycle.push('execution-started');
+              },
+            };
+          },
+          onToolSettled: async ({ result }) => {
+            lifecycle.push(`settled:${result.status}`);
+          },
+        },
+      },
+      hooks: {
+        onUpdate: (update) => {
+          lifecycle.push(`update:${update.type}`);
+        },
+      },
+    });
+
+    expect(outcome.result.status).toBe('success');
+    expect(lifecycle).toEqual([
+      'scheduled:tool-lifecycle:ok:block',
+      'update:tool_ready',
+      'update:tool_started',
+      'pipeline:ok',
+      'execution-started',
+      'side-effect',
+      'settled:success',
+      'update:tool_result',
+      'update:tool_completed',
+    ]);
+  });
+
+  it('does not enter the execution pipeline when durable scheduling fails', async () => {
+    const execute = vi.fn(() =>
+      completeToolExecution({
+        status: 'success',
+        model: 'unexpected',
+      }),
+    );
+    const onToolSettled = vi.fn(async () => {});
+
+    await expect(
+      executeToolCalls({
+        plan: {
+          mode: 'serial',
+          calls: [
+            {
+              id: 'tool-schedule-failure',
+              type: 'function',
+              function: {
+                name: 'Write',
+                arguments: '{}',
+              },
+            },
+          ],
+        },
+        executionPipeline: {
+          execute,
+          getRegistry: () => ({
+            get: () => ({ kind: 'write', interruptBehavior: 'block' }),
+          }),
+        } as never,
+        executionContext: {
+          sessionId: SessionId('session-lifecycle'),
+          userId: 'user-1',
+          lifecycle: {
+            onToolScheduled: async () => {
+              throw new Error('schedule write failed');
+            },
+            onToolSettled,
+          },
+        },
+      }),
+    ).rejects.toThrow('schedule write failed');
+
+    expect(execute).not.toHaveBeenCalled();
+    expect(onToolSettled).not.toHaveBeenCalled();
+  });
+
+  it('does not publish a tool result when durable settlement fails', async () => {
+    const updates: string[] = [];
+
+    await expect(
+      executeToolCalls({
+        plan: {
+          mode: 'serial',
+          calls: [
+            {
+              id: 'tool-settle-failure',
+              type: 'function',
+              function: {
+                name: 'Write',
+                arguments: '{}',
+              },
+            },
+          ],
+        },
+        executionPipeline: {
+          execute: vi.fn(() =>
+            completeToolExecution({
+              status: 'success',
+              model: 'done',
+            }),
+          ),
+          getRegistry: () => ({
+            get: () => ({ kind: 'write', interruptBehavior: 'block' }),
+          }),
+        } as never,
+        executionContext: {
+          sessionId: SessionId('session-lifecycle'),
+          userId: 'user-1',
+          lifecycle: {
+            onToolScheduled: async () => undefined,
+            onToolSettled: async () => {
+              throw new Error('settlement write failed');
+            },
+          },
+        },
+        hooks: {
+          onUpdate: (update) => {
+            updates.push(update.type);
+          },
+        },
+      }),
+    ).rejects.toThrow('settlement write failed');
+
+    expect(updates).toEqual(['tool_ready', 'tool_started']);
   });
 });

--- a/src/agent/loop/executeToolCalls.ts
+++ b/src/agent/loop/executeToolCalls.ts
@@ -7,7 +7,7 @@ import type {
   ToolExecutionHooks,
   ToolExecutionOutcome,
 } from './runToolCall.js';
-import { emitToolExecutionUpdate, runToolCall } from './runToolCall.js';
+import { runToolCall } from './runToolCall.js';
 import type { FunctionToolCall } from './types.js';
 
 export type {
@@ -39,19 +39,13 @@ export async function executeToolCalls(
     return results;
   }
 
-  return Promise.all(
-    plan.calls.map((toolCall) => executeToolCall(toolCall, input)),
-  );
+  return Promise.all(plan.calls.map((toolCall) => executeToolCall(toolCall, input)));
 }
 
 async function executeToolCall(
   toolCall: FunctionToolCall,
   input: ExecuteToolCallsInput,
 ): Promise<ToolExecutionOutcome> {
-  await emitToolExecutionUpdate(input.hooks, {
-    type: 'tool_ready',
-    toolCall,
-  });
   return runToolCall({
     toolCall,
     executionPipeline: input.executionPipeline,

--- a/src/agent/loop/runToolCall.ts
+++ b/src/agent/loop/runToolCall.ts
@@ -3,7 +3,10 @@ import type { ContextSnapshot } from '../../runtime/index.js';
 import type { ToolCatalog } from '../../tools/catalog/index.js';
 import type { ExecutionPipeline } from '../../tools/execution/ExecutionPipeline.js';
 import type { ToolRegistry } from '../../tools/registry/ToolRegistry.js';
-import type { ConfirmationHandler } from '../../tools/types/ExecutionTypes.js';
+import type {
+  ConfirmationHandler,
+  ToolExecutionLifecycle,
+} from '../../tools/types/ExecutionTypes.js';
 import {
   type ToolEffect,
   ToolErrorType,
@@ -11,7 +14,7 @@ import {
   type ToolYield,
 } from '../../tools/types/index.js';
 import { isSteeringInterruptSignal } from '../../types/abort.js';
-import type { SessionId } from '../../types/branded.js';
+import { type SessionId, ToolUseId } from '../../types/branded.js';
 import type { BladeConfig, JsonObject, PermissionMode } from '../../types/common.js';
 import type { IBackgroundAgentManager } from '../types.js';
 import { repairToolCallParams } from './repairToolCallParams.js';
@@ -89,6 +92,7 @@ export interface ToolExecutionContext {
   toolCatalog?: ToolCatalog;
   toolRegistry?: ToolRegistry;
   discoveredTools?: string[];
+  lifecycle?: ToolExecutionLifecycle;
 }
 
 export interface ToolExecutionHooks {
@@ -114,21 +118,58 @@ export interface RunToolCallInput {
   batchSignal?: AbortSignal;
 }
 
-export async function runToolCall(
-  input: RunToolCallInput,
-): Promise<ToolExecutionOutcome> {
+export async function runToolCall(input: RunToolCallInput): Promise<ToolExecutionOutcome> {
   const logger = input.logger ?? NOOP_LOGGER.child(LogCategory.AGENT);
-  let outcome: ToolExecutionOutcome;
   let interruptBehavior: 'cancel' | 'block' = 'block';
+  let params: JsonObject;
 
   try {
-    const params = JSON.parse(input.toolCall.function.arguments) as JsonObject;
+    const parsed: unknown = JSON.parse(input.toolCall.function.arguments);
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      throw new Error('Tool arguments must be a JSON object');
+    }
+    params = parsed as JsonObject;
     await repairToolCallParams(input.toolCall, params);
     interruptBehavior = resolveToolInterruptBehavior(
       input.executionPipeline.getRegistry(),
       input.toolCall.function.name,
       params,
     );
+  } catch (error) {
+    const outcome = buildFailedOutcome(
+      input.toolCall,
+      error,
+      interruptBehavior,
+      input.steeringSignal,
+    );
+    await emitToolExecutionUpdate(input.hooks, {
+      type: 'tool_ready',
+      toolCall: input.toolCall,
+    });
+    await emitToolExecutionUpdate(input.hooks, {
+      type: 'tool_result',
+      outcome,
+    });
+    await emitToolExecutionUpdate(input.hooks, {
+      type: 'tool_completed',
+      outcome,
+    });
+    return outcome;
+  }
+
+  const invocationLifecycle = await input.executionContext.lifecycle?.onToolScheduled?.({
+    toolCallId: ToolUseId(input.toolCall.id),
+    toolName: input.toolCall.function.name,
+    input: structuredClone(params),
+    interruptBehavior,
+  });
+  await emitToolExecutionUpdate(input.hooks, {
+    type: 'tool_ready',
+    toolCall: input.toolCall,
+  });
+
+  let outcome: ToolExecutionOutcome;
+  try {
     const interruptSignal = createInterruptAwareAbortSignal({
       requestSignal: input.signal,
       steeringSignal: input.steeringSignal,
@@ -136,10 +177,11 @@ export async function runToolCall(
       interruptBehavior,
     });
 
-    const toolUseUuid = await input.hooks?.onBeforeToolExec?.({
-      toolCall: input.toolCall,
-      params,
-    }) ?? null;
+    const toolUseUuid =
+      (await input.hooks?.onBeforeToolExec?.({
+        toolCall: input.toolCall,
+        params,
+      })) ?? null;
     await emitToolExecutionUpdate(input.hooks, {
       type: 'tool_started',
       toolCall: input.toolCall,
@@ -152,24 +194,21 @@ export async function runToolCall(
     let execution: ReturnType<ExecutionPipeline['execute']> | undefined;
     let executionCompleted = false;
     try {
-      execution = input.executionPipeline.execute(
-        input.toolCall.function.name,
-        params,
-        {
-          sessionId: input.executionContext.sessionId,
-          userId: input.executionContext.userId,
-          contextSnapshot: input.executionContext.contextSnapshot,
-          skillActivationPaths: input.executionContext.skillActivationPaths,
-          signal: interruptSignal.signal,
-          confirmationHandler: input.executionContext.confirmationHandler,
-          bladeConfig: input.executionContext.bladeConfig,
-          backgroundAgentManager: input.executionContext.backgroundAgentManager,
-          toolCatalog: input.executionContext.toolCatalog,
-          toolRegistry: input.executionContext.toolRegistry,
-          discoveredTools: input.executionContext.discoveredTools,
-          permissionMode: input.permissionMode,
-        },
-      );
+      execution = input.executionPipeline.execute(input.toolCall.function.name, params, {
+        sessionId: input.executionContext.sessionId,
+        userId: input.executionContext.userId,
+        contextSnapshot: input.executionContext.contextSnapshot,
+        skillActivationPaths: input.executionContext.skillActivationPaths,
+        signal: interruptSignal.signal,
+        confirmationHandler: input.executionContext.confirmationHandler,
+        bladeConfig: input.executionContext.bladeConfig,
+        backgroundAgentManager: input.executionContext.backgroundAgentManager,
+        toolCatalog: input.executionContext.toolCatalog,
+        toolRegistry: input.executionContext.toolRegistry,
+        discoveredTools: input.executionContext.discoveredTools,
+        permissionMode: input.permissionMode,
+        toolInvocationLifecycle: invocationLifecycle,
+      });
       while (true) {
         const step = await execution.next();
         if (step.done) {
@@ -186,9 +225,9 @@ export async function runToolCall(
         );
       }
       if (
-        result.status === 'error'
-        && interruptBehavior === 'cancel'
-        && isSteeringInterruptSignal(input.steeringSignal)
+        result.status === 'error' &&
+        interruptBehavior === 'cancel' &&
+        isSteeringInterruptSignal(input.steeringSignal)
       ) {
         result = {
           ...result,
@@ -212,27 +251,14 @@ export async function runToolCall(
     outcome = { toolCall: input.toolCall, result, effects, toolUseUuid };
   } catch (error) {
     logger.error(`Tool execution failed for ${input.toolCall.function.name}:`, error);
-    const message = error instanceof Error ? error.message : 'Unknown error';
-    const interrupted =
-      interruptBehavior === 'cancel'
-      && isSteeringInterruptSignal(input.steeringSignal);
-    outcome = {
-      toolCall: input.toolCall,
-      result: {
-        status: 'error',
-        model: `Tool execution failed: ${message}`,
-        error: {
-          type: interrupted
-            ? ToolErrorType.INTERRUPTED
-            : ToolErrorType.EXECUTION_ERROR,
-          message,
-        },
-      },
-      effects: [],
-      toolUseUuid: null,
-    };
+    outcome = buildFailedOutcome(input.toolCall, error, interruptBehavior, input.steeringSignal);
   }
 
+  await input.executionContext.lifecycle?.onToolSettled?.({
+    toolCallId: ToolUseId(input.toolCall.id),
+    toolName: input.toolCall.function.name,
+    result: outcome.result,
+  });
   await emitToolExecutionUpdate(input.hooks, {
     type: 'tool_result',
     outcome,
@@ -242,6 +268,29 @@ export async function runToolCall(
     outcome,
   });
   return outcome;
+}
+
+function buildFailedOutcome(
+  toolCall: FunctionToolCall,
+  error: unknown,
+  interruptBehavior: 'cancel' | 'block',
+  steeringSignal: AbortSignal | undefined,
+): ToolExecutionOutcome {
+  const message = error instanceof Error ? error.message : 'Unknown error';
+  const interrupted = interruptBehavior === 'cancel' && isSteeringInterruptSignal(steeringSignal);
+  return {
+    toolCall,
+    result: {
+      status: 'error',
+      model: `Tool execution failed: ${message}`,
+      error: {
+        type: interrupted ? ToolErrorType.INTERRUPTED : ToolErrorType.EXECUTION_ERROR,
+        message,
+      },
+    },
+    effects: [],
+    toolUseUuid: null,
+  };
 }
 
 export async function emitToolExecutionUpdate(

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -21,10 +21,15 @@ export type {
   ToolEffect,
   ToolEffectYield,
   ToolExecution,
+  ToolExecutionLifecycle,
+  ToolInvocationLifecycle,
   ToolMessage,
   ToolModelContent,
+  ToolPermissionResolution,
   ToolProgress,
   ToolResult,
+  ToolScheduledLifecycle,
+  ToolSettledLifecycle,
   ToolYield,
 } from '../core/index.js';
 export {

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -46,13 +46,18 @@ export type {
   ToolEffectYield,
   ToolError,
   ToolExecution,
+  ToolExecutionLifecycle,
   ToolExposureConfig,
   ToolExposureMode,
+  ToolInvocationLifecycle,
   ToolMessage,
   ToolModelContent,
+  ToolPermissionResolution,
   ToolProgress,
   ToolResult,
+  ToolScheduledLifecycle,
   ToolSchema,
+  ToolSettledLifecycle,
   ToolYield,
 } from '../tools/types/index.js';
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -186,12 +186,17 @@ export type {
   ToolEffectYield,
   ToolError,
   ToolExecution,
+  ToolExecutionLifecycle,
   ToolExposureConfig,
   ToolExposureMode,
+  ToolInvocationLifecycle,
   ToolMessage,
   ToolModelContent,
+  ToolPermissionResolution,
   ToolProgress,
+  ToolScheduledLifecycle,
   ToolSchema,
+  ToolSettledLifecycle,
   ToolYield,
 } from './tools/types/index.js';
 export {

--- a/src/tools/execution/ExecutionPipeline.ts
+++ b/src/tools/execution/ExecutionPipeline.ts
@@ -1,7 +1,11 @@
 import type { HookRuntime } from '../../hooks/HookRuntime.js';
 import { type InternalLogger, LogCategory, NOOP_LOGGER } from '../../logging/Logger.js';
 import { isSteeringInterruptSignal } from '../../types/abort.js';
-import { SessionId, ToolUseId } from '../../types/branded.js';
+import {
+    type PermissionRequestId,
+    SessionId,
+    ToolUseId,
+} from '../../types/branded.js';
 import { type JsonObject, PermissionMode, type PermissionsConfig } from '../../types/common.js';
 import {
     type CanUseTool,
@@ -546,6 +550,7 @@ export class ExecutionPipeline {
       return;
     }
 
+    await state.context.toolInvocationLifecycle?.onExecutionStarted?.();
     const timeoutController = this.toolTimeoutMs ? new AbortController() : undefined;
     const executionSignal = timeoutController
       ? state.context.signal
@@ -881,6 +886,8 @@ export class ExecutionPipeline {
       return;
     }
 
+    let permissionRequestId: PermissionRequestId | undefined;
+    let resolutionAttempted = false;
     try {
       const description = state.invocation.getDescription();
       const confirmationTitle =
@@ -905,9 +912,22 @@ export class ExecutionPipeline {
 
       const confirmationHandler = state.context.confirmationHandler;
       if (confirmationHandler) {
+        permissionRequestId =
+          await state.context.toolInvocationLifecycle?.onPermissionRequested?.(
+            confirmationDetails,
+            structuredClone(state.params),
+          );
         this.logger.info(`[ExecutionPipeline] Requesting confirmation for ${state.tool.name}`);
         const response = await confirmationHandler.requestConfirmation(confirmationDetails);
         this.logger.info(`[ExecutionPipeline] Confirmation response: approved=${response.approved}`);
+        if (permissionRequestId) {
+          resolutionAttempted = true;
+          await state.context.toolInvocationLifecycle?.onPermissionResolved?.({
+            permissionRequestId,
+            decision: response.approved ? 'allow' : 'deny',
+            ...(response.reason ? { message: response.reason } : {}),
+          });
+        }
 
         if (!response.approved) {
           const reason = response.reason || 'User rejected';
@@ -933,8 +953,24 @@ export class ExecutionPipeline {
         state.needsConfirmation = false;
       }
     } catch (error) {
+      let failure = error;
+      if (permissionRequestId && !resolutionAttempted) {
+        try {
+          resolutionAttempted = true;
+          await state.context.toolInvocationLifecycle?.onPermissionResolved?.({
+            permissionRequestId,
+            decision: 'cancel',
+            message: getErrorMessage(error),
+          });
+        } catch (resolutionError) {
+          failure = new AggregateError(
+            [error, resolutionError],
+            'Permission handling and durable resolution both failed',
+          );
+        }
+      }
       state.result = this.createAbortedResult(
-        `User confirmation failed: ${getErrorMessage(error)}`,
+        `User confirmation failed: ${getErrorMessage(failure)}`,
       );
     }
   }

--- a/src/tools/execution/__tests__/ExecutionPipeline.test.ts
+++ b/src/tools/execution/__tests__/ExecutionPipeline.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
 import { createTool } from '../../core/createTool.js';
 import { ToolRegistry } from '../../registry/ToolRegistry.js';
-import { SessionId } from '../../../types/branded.js';
+import { PermissionRequestId, SessionId } from '../../../types/branded.js';
 import { type JsonObject, PermissionMode } from '../../../types/common.js';
 import {
   collectToolExecution,
@@ -985,6 +985,247 @@ describe('ExecutionPipeline', () => {
     expect(result.status).toBe('error');
     expect(result.error?.message).toContain('User rejected sensitive file access');
     expect(confirmationHandler.requestConfirmation).toHaveBeenCalledTimes(1);
+    expect(executeSpy).not.toHaveBeenCalled();
+  });
+
+  it('awaits permission and execution lifecycle boundaries before invoking a tool', async () => {
+    const registry = new ToolRegistry();
+    const events: string[] = [];
+
+    registerTool(
+      registry,
+      createTool({
+        name: 'LifecycleTool',
+        displayName: 'Lifecycle Tool',
+        kind: ToolKind.Execute,
+        description: { short: 'Lifecycle tool' },
+        schema: z.object({ value: z.string() }),
+        checkPermissions: () => ({
+          behavior: 'ask',
+          message: 'Confirm lifecycle tool',
+        }),
+        execute: ({ value }) => {
+          events.push(`execute:${value}`);
+          return completeToolExecution({
+            status: 'success',
+            model: value,
+          });
+        },
+      }),
+    );
+
+    const pipeline = new ExecutionPipeline(registry, {
+      permissionMode: PermissionMode.YOLO,
+      permissionHandler: async () => ({ behavior: 'allow' }),
+    });
+    const result = await executePipeline(
+      pipeline,
+      'LifecycleTool',
+      { value: 'ok' },
+      {
+        permissionMode: PermissionMode.YOLO,
+        confirmationHandler: {
+          requestConfirmation: async () => {
+            events.push('permission-handler');
+            return { approved: true };
+          },
+        },
+        toolInvocationLifecycle: {
+          onPermissionRequested: async (_details, input) => {
+            events.push('permission-requested');
+            input.value = 'mutated';
+            return PermissionRequestId('permission-1');
+          },
+          onPermissionResolved: async ({ decision }) => {
+            events.push(`permission-resolved:${decision}`);
+          },
+          onExecutionStarted: async () => {
+            events.push('execution-started');
+          },
+        },
+      },
+    );
+
+    expect(result.status).toBe('success');
+    expect(events).toEqual([
+      'permission-requested',
+      'permission-handler',
+      'permission-resolved:allow',
+      'execution-started',
+      'execute:ok',
+    ]);
+  });
+
+  it('records denied and cancelled permission decisions without starting execution', async () => {
+    const registry = new ToolRegistry();
+    const executeSpy = vi.fn(() => completeToolExecution({
+      status: 'success',
+      model: 'unexpected',
+    }));
+    registerTool(
+      registry,
+      createTool({
+        name: 'PermissionLifecycleTool',
+        displayName: 'Permission Lifecycle Tool',
+        kind: ToolKind.Execute,
+        description: { short: 'Permission lifecycle tool' },
+        schema: z.object({}),
+        checkPermissions: () => ({ behavior: 'ask', message: 'Confirm' }),
+        execute: executeSpy,
+      }),
+    );
+    const pipeline = new ExecutionPipeline(registry, {
+      permissionMode: PermissionMode.YOLO,
+      permissionHandler: async () => ({ behavior: 'allow' }),
+    });
+
+    const denied: string[] = [];
+    const deniedResult = await executePipeline(
+      pipeline,
+      'PermissionLifecycleTool',
+      {},
+      {
+        permissionMode: PermissionMode.YOLO,
+        confirmationHandler: {
+          requestConfirmation: async () => ({ approved: false, reason: 'no' }),
+        },
+        toolInvocationLifecycle: {
+          onPermissionRequested: async () => PermissionRequestId('permission-denied'),
+          onPermissionResolved: async ({ decision }) => {
+            denied.push(decision);
+          },
+          onExecutionStarted: async () => {
+            denied.push('started');
+          },
+        },
+      },
+    );
+
+    const cancelled: string[] = [];
+    const cancelledResult = await executePipeline(
+      pipeline,
+      'PermissionLifecycleTool',
+      {},
+      {
+        permissionMode: PermissionMode.YOLO,
+        confirmationHandler: {
+          requestConfirmation: async () => {
+            throw new Error('prompt closed');
+          },
+        },
+        toolInvocationLifecycle: {
+          onPermissionRequested: async () => PermissionRequestId('permission-cancelled'),
+          onPermissionResolved: async ({ decision }) => {
+            cancelled.push(decision);
+          },
+          onExecutionStarted: async () => {
+            cancelled.push('started');
+          },
+        },
+      },
+    );
+
+    expect(deniedResult.status).toBe('error');
+    expect(cancelledResult.status).toBe('error');
+    expect(denied).toEqual(['deny']);
+    expect(cancelled).toEqual(['cancel']);
+    expect(executeSpy).not.toHaveBeenCalled();
+  });
+
+  it('blocks the side effect when an execution-start lifecycle boundary fails', async () => {
+    const registry = new ToolRegistry();
+    const executeSpy = vi.fn(() => completeToolExecution({
+      status: 'success',
+      model: 'unexpected',
+    }));
+    registerTool(
+      registry,
+      createTool({
+        name: 'BlockedLifecycleTool',
+        displayName: 'Blocked Lifecycle Tool',
+        kind: ToolKind.Execute,
+        description: { short: 'Blocked lifecycle tool' },
+        schema: z.object({}),
+        execute: executeSpy,
+      }),
+    );
+    const pipeline = new ExecutionPipeline(registry, {
+      permissionMode: PermissionMode.YOLO,
+    });
+
+    const result = await executePipeline(
+      pipeline,
+      'BlockedLifecycleTool',
+      {},
+      {
+        permissionMode: PermissionMode.YOLO,
+        toolInvocationLifecycle: {
+          onExecutionStarted: async () => {
+            throw new Error('durable write failed');
+          },
+        },
+      },
+    );
+
+    expect(result).toMatchObject({
+      status: 'error',
+      error: {
+        message: 'durable write failed',
+      },
+    });
+    expect(executeSpy).not.toHaveBeenCalled();
+  });
+
+  it('blocks the side effect when permission resolution cannot be persisted', async () => {
+    const registry = new ToolRegistry();
+    const executeSpy = vi.fn(() => completeToolExecution({
+      status: 'success',
+      model: 'unexpected',
+    }));
+    registerTool(
+      registry,
+      createTool({
+        name: 'PermissionResolutionTool',
+        displayName: 'Permission Resolution Tool',
+        kind: ToolKind.Execute,
+        description: { short: 'Permission resolution tool' },
+        schema: z.object({}),
+        checkPermissions: () => ({ behavior: 'ask', message: 'Confirm' }),
+        execute: executeSpy,
+      }),
+    );
+    const pipeline = new ExecutionPipeline(registry, {
+      permissionMode: PermissionMode.YOLO,
+      permissionHandler: async () => ({ behavior: 'allow' }),
+    });
+
+    const result = await executePipeline(
+      pipeline,
+      'PermissionResolutionTool',
+      {},
+      {
+        permissionMode: PermissionMode.YOLO,
+        confirmationHandler: {
+          requestConfirmation: async () => ({ approved: true }),
+        },
+        toolInvocationLifecycle: {
+          onPermissionRequested: async () => PermissionRequestId('permission-1'),
+          onPermissionResolved: async () => {
+            throw new Error('resolution write failed');
+          },
+          onExecutionStarted: async () => {
+            throw new Error('must not start');
+          },
+        },
+      },
+    );
+
+    expect(result).toMatchObject({
+      status: 'error',
+      error: {
+        message: expect.stringContaining('resolution write failed'),
+      },
+    });
     expect(executeSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/tools/types/ExecutionTypes.ts
+++ b/src/tools/types/ExecutionTypes.ts
@@ -1,4 +1,4 @@
-import type { MessageId, SessionId } from '@/types/branded.js';
+import type { MessageId, PermissionRequestId, SessionId, ToolUseId } from '@/types/branded.js';
 import type { IBackgroundAgentManager } from '../../agent/types.js';
 import type { ContextSnapshot } from '../../runtime/index.js';
 import type { BladeConfig, JsonObject, PermissionMode } from '../../types/common.js';
@@ -57,6 +57,39 @@ export interface ConfirmationHandler {
   requestConfirmation(details: ConfirmationDetails): Promise<ConfirmationResponse>;
 }
 
+export interface ToolPermissionResolution {
+  permissionRequestId: PermissionRequestId;
+  decision: 'allow' | 'deny' | 'cancel';
+  message?: string;
+}
+
+export interface ToolInvocationLifecycle {
+  onPermissionRequested?(
+    details: ConfirmationDetails,
+    input: JsonObject,
+  ): Promise<PermissionRequestId>;
+  onPermissionResolved?(resolution: ToolPermissionResolution): Promise<void>;
+  onExecutionStarted?(): Promise<void>;
+}
+
+export interface ToolScheduledLifecycle {
+  toolCallId: ToolUseId;
+  toolName: string;
+  input: JsonObject;
+  interruptBehavior: 'block' | 'cancel';
+}
+
+export interface ToolSettledLifecycle {
+  toolCallId: ToolUseId;
+  toolName: string;
+  result: ToolResult;
+}
+
+export interface ToolExecutionLifecycle {
+  onToolScheduled?(event: ToolScheduledLifecycle): Promise<ToolInvocationLifecycle | undefined>;
+  onToolSettled?(event: ToolSettledLifecycle): Promise<void>;
+}
+
 /**
  * 执行上下文
  */
@@ -74,6 +107,8 @@ export interface ExecutionContext {
   toolRegistry?: ToolRegistry;
   toolCatalog?: ToolCatalog;
   discoveredTools?: string[];
+  /** @internal Awaited lifecycle boundary immediately before the tool side effect. */
+  toolInvocationLifecycle?: ToolInvocationLifecycle;
 }
 
 export function getEffectiveProjectDir(context: ExecutionContext): string | undefined {


### PR DESCRIPTION
## Summary

- add transport-agnostic `ToolExecutionLifecycle` and per-invocation lifecycle contracts
- await durable scheduling before publishing `tool_start` for executable calls
- record permission request/resolution around the real confirmation boundary
- await `onExecutionStarted` immediately before invoking the tool generator
- await terminal settlement before publishing `tool_result`
- propagate lifecycle failures through both streaming and non-streaming paths instead of degrading them to best-effort telemetry

## Ordering guarantees

1. scheduled persistence completes before an executable tool is exposed as ready
2. permission-request persistence completes before prompting
3. permission-resolution persistence completes before accepting the decision
4. execution-start persistence completes before the side effect can run
5. terminal persistence completes before the result reaches AgentLoop consumers

Invalid JSON calls and synthetic results for calls that were never dispatched remain outside the durable lifecycle because they never cross an execution boundary.

## Testing

- 123 test files passed, 3 skipped
- 1237 tests passed, 62 skipped
- explicit streaming and non-streaming ordering coverage
- lifecycle failure blocks side effects and terminal publication
- type-check, lint, docs build, entrypoint verification, and npm pack dry-run passed

## Stack

Depends on #24. Merge #22, #23, and #24 in order; retarget this PR to `main` before merging.