### PR TITLE
feat(session)!: integrate durable event journaling

### DIFF
--- a/.changes/session-durable-events.json
+++ b/.changes/session-durable-events.json
@@ -1,0 +1,5 @@
+{
+  "type": "breaking",
+  "en": "Integrate fail-closed, opt-in durable event journaling into Session request, turn, tool, permission, abort, close, and stream-cancellation lifecycles; Session.abort() now returns a Promise that settles pending-request durability.",
+  "zh-CN": "将 fail-closed、opt-in durable 事件日志接入 Session 的请求、Turn、工具、权限、中止、关闭与流取消生命周期；Session.abort() 现返回 Promise，以等待 pending request 的 durable 终态。"
+}

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -106,6 +106,8 @@ Node-local 能力外，这些函数都从根入口导出；实际 subpath 以“
 | `DurableSessionJournalError` / `DurableSessionJournalErrorCode` | command、分页和 Store 返回值错误 |
 | `DurableCommandConflictError` | 同一 `commandId` 被用于不同事件 |
 | `DurableCommandOutcomeUnknownError` | 写入失败后无法确认 command 是否提交 |
+| `DurableSessionRecoveryRequiredError` | Session 恢复前需要权限或工具结果对账 |
+| `SessionDurableRecorderError` | Session runtime 观察到非法 durable 生命周期状态 |
 | `DurableEventEnvelope` / `DurableEventDraft` | 已提交事件与待提交事件 |
 | `DurableEventDataMap` / `DurableEventOfType` / `DurableEventError` / `DurableTokenUsage` | 事件类型到严格 payload 的映射、类型提取及公共 payload |
 | `DurableInputPriority` / `DurablePermissionDecision` | 输入优先级与权限结果 |

--- a/docs/durable-events.md
+++ b/docs/durable-events.md
@@ -5,10 +5,10 @@ Session 内单调序列、compare-and-append、cursor 分页读取，以及确�
 Session 生命周期投影。
 
 ::: warning 当前集成阶段
-当前不会改变 `Session.send()`、`Session.stream()` 或现有 Session JSONL。
-调用方可以独立使用 Event Store 和 recovery projector；Session 生命周期事件
-将在后续阶段接入。工具管道已经提供 awaited lifecycle hooks，以便接入时严格
-保持 persist-before-side-effect 和 persist-before-publish 顺序。
+Session 只有在显式设置 `SessionOptions.durableEventStore` 时才写入 durable
+事件；现有消息 JSONL 保持不变。活动 Request 的自动恢复尚未启用，遇到未完成
+工作时 `resumeSession()` 会抛出 `DurableSessionRecoveryRequiredError`，禁止
+自动重放已开始的工具。
 :::
 
 ## 安装与导入
@@ -278,6 +278,8 @@ Recovery plan 还分别返回 `retryableToolAttempts`、`cancelableToolAttempts`
 4. 调用文件 `fsync` 后才返回成功。
 
 事件文件使用 `0600` 权限，Session ID 经过 base64url 编码，不会成为文件路径。
+事件会保存原始请求输入、工具输入和模型侧工具结果；调用方必须将 Store 视为
+敏感数据存储，并自行配置加密、保留期限和访问控制。
 
 ## 一致性边界
 
@@ -299,6 +301,8 @@ Store 不持久化 token delta、工具 progress 等高频 UI 事件。只有会
 | `DurableCommandConflictError` | 相同 `commandId` 对应不同内容或非连续事件区间 |
 | `DurableCommandOutcomeUnknownError` | 写入失败后无法确认 command 是否提交，Journal 已 fenced |
 | `DurableSessionJournalError` | command 输入、Store page 或 commit 返回值违反契约 |
+| `DurableSessionRecoveryRequiredError` | Session 存在未完成工作，必须先执行恢复或对账 |
+| `SessionDurableRecorderError` | Session runtime 观察到非法 durable 生命周期状态 |
 | `DurableEventProjectionError` | schema、事件顺序或关联关系不满足生命周期约束 |
 | `DurableEventSequenceConflictError` | compare-and-append 前置条件失败 |
 | `DurableEventStoreError` | 参数、cursor、读写或日志完整性错误 |

--- a/docs/en/api-reference.md
+++ b/docs/en/api-reference.md
@@ -107,6 +107,8 @@ Types and errors:
 - `DurableEventStoreError`
 - `DurableEventStoreErrorCode`
 - `DurableEventProjectionError`
+- `DurableSessionRecoveryRequiredError`
+- `SessionDurableRecorderError`
 - `DurablePermissionProjection`
 - `DurablePermissionStatus`
 - `DurableRequestProjection`

--- a/docs/en/durable-events.md
+++ b/docs/en/durable-events.md
@@ -6,11 +6,11 @@ compare-and-append, cursor-based reads, and deterministic Session lifecycle
 projection.
 
 ::: warning Integration status
-The current phase does not change `Session.send()`, `Session.stream()`, or the
-existing Session JSONL format. Applications can use the Event Store and recovery
-projector directly; Session lifecycle events will be connected in a later phase.
-The tool pipeline already exposes awaited lifecycle hooks so that integration can
-preserve persist-before-side-effect and persist-before-publish ordering.
+Session writes durable events only when
+`SessionOptions.durableEventStore` is explicitly set; the existing message JSONL
+format is unchanged. Automatic recovery of an active Request is not enabled.
+`resumeSession()` throws `DurableSessionRecoveryRequiredError` for unfinished
+work instead of replaying a started tool.
 :::
 
 ## Imports
@@ -287,6 +287,9 @@ Each append:
 
 Event files use mode `0600`. Session IDs are base64url encoded and cannot
 become filesystem paths.
+Events contain raw request inputs, tool inputs, and model-facing tool results.
+Treat the Store as sensitive data and configure encryption, retention, and
+access control at the deployment boundary.
 
 ## Consistency boundary
 
@@ -311,6 +314,8 @@ journal.
 | `DurableCommandConflictError` | One `commandId` maps to different content or non-contiguous ranges. |
 | `DurableCommandOutcomeUnknownError` | A failed write cannot be reconciled and the Journal is fenced. |
 | `DurableSessionJournalError` | Command input, Store page, or commit result violates its contract. |
+| `DurableSessionRecoveryRequiredError` | The Session has unfinished work that requires recovery or reconciliation. |
+| `SessionDurableRecorderError` | Session runtime observed an invalid durable lifecycle state. |
 | `DurableEventProjectionError` | Schema, ordering, or correlation violates lifecycle invariants. |
 | `DurableEventSequenceConflictError` | Compare-and-append precondition failed. |
 | `DurableEventStoreError` | Invalid input, cursor, I/O, or log integrity failure. |

--- a/docs/en/session.md
+++ b/docs/en/session.md
@@ -102,9 +102,11 @@ for await (const event of output) {
 
 `expectedRequestId` prevents a concurrent client from steering the wrong request. If the target request is sealed or stopping, a `now` or `next` input is safely retargeted to `later`.
 
-Accepted inputs are durable only when `storagePath` enables persistence.
-Unapplied inputs are then recovered as `later` after process restart. In-memory
-Sessions do not recover inputs across processes.
+Queued and steering inputs are durable only when `storagePath` enables message
+persistence. Unapplied inputs are then recovered as `later` after process
+restart. When `durableEventStore` is configured, the initial request input is
+also captured by `request_accepted`; this does not replace pending-input
+recovery for later steering messages.
 
 ## Manage pending input
 
@@ -175,7 +177,7 @@ Partial model output produced before `turn_interrupted` can be displayed, but it
 
 ```ts
 const stream = session.stream();
-session.abort();
+await session.abort();
 
 for await (const event of stream) {
   // Drain cleanup and terminal events.
@@ -235,6 +237,53 @@ const session = await createSession({
 ```
 
 Session files are written under `{storagePath}/sessions/`. `persistSession: false` forces in-memory behavior.
+
+### Durable execution events
+
+Set `durableEventStore` to opt into the recoverable execution journal. The
+event Store is independent of message-history persistence, so it can be used
+with `persistSession: false`:
+
+```ts
+import {
+  JsonlDurableEventStore,
+  createSession,
+} from '@blade-ai/agent-sdk';
+
+const eventStore = new JsonlDurableEventStore('/var/lib/my-agent');
+const session = await createSession({
+  provider,
+  model,
+  persistSession: false,
+  durableEventStore: eventStore,
+});
+```
+
+When enabled, Session records Session, Request, Turn, Tool, Permission, and
+input-application events with these ordering guarantees:
+
+- `request_accepted` commits before `send()` returns.
+- Turn and tool scheduling events commit before `turn_start` or `tool_use` is published.
+- `tool_started` commits before the tool side effect can run.
+- Terminal events commit before `tool_result`, `result`, or `error` is published.
+- A pending request commits `request_interrupted` before
+  `await session.abort()` resolves.
+
+If a durable boundary cannot be committed, Session rejects the stream instead
+of fabricating a normal terminal event. New and queued requests remain blocked
+until the journal has been reconciled.
+
+```ts
+const projection = session.getDurableProjection();
+const recovery = session.getDurableRecoveryPlan();
+```
+
+`resumeSession()` throws `DurableSessionRecoveryRequiredError` when the
+durable log contains unfinished work, pending permission, or an unknown tool
+outcome. The current integration never replays a started tool automatically;
+reconcile it through `DurableSessionJournal` first. The JSONL adapter supports
+only one process; multi-process deployments need a `DurableEventStore` with
+transactional CAS or fencing.
 
 ### Resume
 
@@ -440,6 +489,7 @@ Payload capture is opt-in because prompts and tool data may be sensitive.
 | `logger` | `AgentLogger` | Structured logger |
 | `storagePath` | `string` | Enables JSONL persistence |
 | `persistSession` | `boolean` | Disable persistence explicitly |
+| `durableEventStore` | `DurableEventStore` | Opt-in durable execution journal |
 | `outputFormat` | `OutputFormat` | Structured output schema |
 | `sandbox` | `SandboxSettings` | Bash sandbox settings |
 | `observability` | `ObservabilityOptions` | Trace collection |
@@ -457,7 +507,7 @@ interface ISession extends AsyncDisposable {
   getPendingInputs(): readonly PendingSessionInput[];
   cancelInput(inputId: InputId): Promise<boolean>;
 
-  abort(): void;
+  abort(): Promise<void>;
   close(): Promise<void>;
   fork(options?: ForkSessionOptions): Promise<ISession>;
 
@@ -476,5 +526,7 @@ interface ISession extends AsyncDisposable {
 
   getLastTrace(): AgentTrace | undefined;
   getTraces(): AgentTrace[];
+  getDurableProjection(): DurableSessionProjection | null;
+  getDurableRecoveryPlan(): DurableSessionRecoveryPlan | null;
 }
 ```

--- a/docs/session.md
+++ b/docs/session.md
@@ -299,7 +299,8 @@ for await (const event of output) {
 已接受的输入有数量和字节双重上限。配置 `storagePath` 后，SDK 通过
 JSONL 记录 `input_enqueued`、`input_applied` 或 `input_cancelled`；
 进程重启后，尚未应用的输入会恢复为 `later`，避免绑定到已经失效的请求。
-内存模式不会跨进程恢复。
+内存模式不会跨进程恢复。配置 `durableEventStore` 时，初始请求内容还会写入
+`request_accepted`；它不会替代 `storagePath` 对后续 steering 队列的恢复。
 
 ### StreamOptions
 
@@ -635,6 +636,49 @@ const session = await createSession({
 - `forkSession()` 不可用（会抛出错误）
 - `session.fork()` 仍然可用，因为它直接复制内存中的消息
   :::
+
+### Durable 执行事件
+
+通过 `durableEventStore` 显式启用可恢复执行日志。该 Store 与消息历史存储相互
+独立，因此也可以与 `persistSession: false` 组合：
+
+```ts
+import {
+  JsonlDurableEventStore,
+  createSession,
+} from '@blade-ai/agent-sdk';
+
+const eventStore = new JsonlDurableEventStore('/var/lib/my-agent');
+const session = await createSession({
+  provider,
+  model,
+  persistSession: false,
+  durableEventStore: eventStore,
+});
+```
+
+启用后，Session 会记录 Session、Request、Turn、Tool、Permission 和输入应用
+事件，并保证：
+
+- `send()` 返回前已提交 `request_accepted`。
+- `turn_start` 和 `tool_use` 对外可见前已提交对应 durable 事件。
+- 工具副作用开始前已提交 `tool_started`。
+- `tool_result`、`result` 或 `error` 对外可见前已提交终态。
+- pending request 的 `await session.abort()` 返回前已提交
+  `request_interrupted`。
+
+如果 durable 边界提交失败，Session 会直接拒绝 stream，而不会伪造普通终态
+事件；在日志完成对账前，新请求和排队请求也不会继续执行。
+
+```ts
+const projection = session.getDurableProjection();
+const recovery = session.getDurableRecoveryPlan();
+```
+
+`resumeSession()` 遇到未完成的 durable Request、待决权限或未知工具结果时抛出
+`DurableSessionRecoveryRequiredError`。当前集成不会自动重放已开始的工具；
+调用方必须先通过 `DurableSessionJournal` 对账。JSONL adapter 只支持单进程
+writer，多进程部署需要实现带事务 CAS 或 fencing 的 `DurableEventStore`。
 
 ### 自定义存储路径
 
@@ -1296,7 +1340,7 @@ await session.close();
 
 ```ts
 const currentStream = session.stream();
-session.abort();
+await session.abort();
 
 // 先排队，当前流完成清理后再消费下一请求
 await session.send('换个思路重新试试', { priority: 'later' });
@@ -1513,7 +1557,8 @@ async function analyzeCodeManual() {
 | `defaultContext`  | `RuntimeContext`                                        | —  | `{}`        | 会话级默认运行时上下文                                       |
 | `logger`          | `AgentLogger`                                           | —  | —           | 结构化日志适配器                                          |
 | `storagePath`     | `string`                                                | —  | —           | 会话存储根路径；未设置时使用内存存储                              |
-| `persistSession`  | `boolean`                                               | —  | `true`      | 有 `storagePath` 时是否启用磁盘持久化                           |
+| `persistSession`  | `boolean`                                               | —  | `true`      | 有 `storagePath` 时是否启用消息历史持久化                         |
+| `durableEventStore` | `DurableEventStore`                                  | —  | —           | opt-in durable 执行事件 Store                                 |
 | `outputFormat`    | `OutputFormat`                                          | —  | —           | 结构化 JSON Schema 输出格式                              |
 | `sandbox`         | `SandboxSettings`                                       | —  | —           | 命令执行沙箱设置                                          |
 | `observability`   | `ObservabilityOptions`                                  | —  | —           | Trace 收集、payload 捕获与 sink 配置                         |
@@ -1632,7 +1677,7 @@ interface ISession extends AsyncDisposable {
   close(): Promise<void>;
 
   /** 中止当前正在进行的请求 */
-  abort(): void;
+  abort(): Promise<void>;
 
   /** 获取当前默认运行时上下文 */
   getDefaultContext(): RuntimeContext;
@@ -1673,6 +1718,8 @@ interface ISession extends AsyncDisposable {
   /** 获取最近一条或全部 observability trace */
   getLastTrace(): AgentTrace | undefined;
   getTraces(): AgentTrace[];
+  getDurableProjection(): DurableSessionProjection | null;
+  getDurableRecoveryPlan(): DurableSessionRecoveryPlan | null;
 }
 ```
 

--- a/src/__tests__/packageEntrypoints.test.ts
+++ b/src/__tests__/packageEntrypoints.test.ts
@@ -73,6 +73,7 @@ describe('package entrypoints', () => {
     expect(browser.PermissionMode.DEFAULT).toBe('default');
     expect(browser.DurableEventType.REQUEST_ACCEPTED).toBe('request_accepted');
     expect(browser.DurableSessionJournal.open).toBeTypeOf('function');
+    expect(browser.DurableSessionRecoveryRequiredError).toBeDefined();
     expect(browser.projectDurableSession([]).status).toBe('empty');
     expect(browser.PermissionRequestId('permission-1')).toBe('permission-1');
     expect(browser.ToolUseId('tool-call-1')).toBe('tool-call-1');

--- a/src/__tests__/rootExports.test.ts
+++ b/src/__tests__/rootExports.test.ts
@@ -7,8 +7,10 @@ import type {
   DurableSessionCommand,
   DurableSessionRecoveryPlan,
   InputSubmission,
+  ISession,
   PendingSessionInput,
   RuntimePatch,
+  SessionOptions,
   SessionTool,
   ToolCatalogEntry,
   ToolEffect,
@@ -36,6 +38,7 @@ import {
   DurableEventType,
   DurableSessionJournal,
   DurableSessionProjector,
+  DurableSessionRecoveryRequiredError,
   EventId,
   EventSequence,
   FileSystemMemoryStore,
@@ -47,6 +50,7 @@ import {
   projectDurableSession,
   RequestId,
   SessionInputError,
+  SessionDurableRecorderError,
   SubagentExecutor,
   SubagentRegistry,
   ToolAttemptId,
@@ -83,6 +87,8 @@ describe('root exports', () => {
     expect(DurableCommandOutcomeUnknownError).toBeDefined();
     expect(DurableSessionJournal.open).toBeTypeOf('function');
     expect(DurableSessionProjector).toBeDefined();
+    expect(DurableSessionRecoveryRequiredError).toBeDefined();
+    expect(SessionDurableRecorderError).toBeDefined();
     expect(projectDurableSession([]).status).toBe('empty');
   });
 
@@ -117,6 +123,10 @@ describe('root exports', () => {
       'none' | 'resume_request' | 'resume_turn' | 'resolve_permissions' | 'reconcile_tool_outcomes'
     >();
     expectTypeOf<DurableEventStore['append']>().toBeFunction();
+    expectTypeOf<SessionOptions['durableEventStore']>().toEqualTypeOf<
+      DurableEventStore | undefined
+    >();
+    expectTypeOf<ReturnType<ISession['abort']>>().toEqualTypeOf<Promise<void>>();
     expectTypeOf<ToolCatalogEntry['source']['kind']>().toEqualTypeOf<
       'builtin' | 'custom' | 'mcp' | 'session'
     >();

--- a/src/agent/LoopRunner.ts
+++ b/src/agent/LoopRunner.ts
@@ -18,13 +18,8 @@ import type { SkillActivationContext } from '../skills/index.js';
 import { injectSkillsMetadata } from '../skills/index.js';
 import { ToolCatalog } from '../tools/catalog/index.js';
 import type { ExecutionPipeline } from '../tools/execution/ExecutionPipeline.js';
-import {
-  ToolExposurePlanner,
-} from '../tools/exposure/index.js';
-import {
-  type BladeConfig,
-  PermissionMode,
-} from '../types/common.js';
+import { ToolExposurePlanner } from '../tools/exposure/index.js';
+import { type BladeConfig, PermissionMode } from '../types/common.js';
 import { getEnvironmentContext } from '../utils/environment.js';
 import type { AgentEvent } from './AgentEvent.js';
 import { agentLoop } from './AgentLoop.js';
@@ -38,13 +33,7 @@ import { LoopState } from './state/LoopState.js';
 import { isValidSystemSource } from './state/systemSource.js';
 import type { LoopSkillState } from './state/TurnState.js';
 import type { TokenBudget } from './TokenBudget.js';
-import type {
-  AgentOptions,
-  ChatContext,
-  LoopOptions,
-  LoopResult,
-  UserMessageContent,
-} from './types.js';
+import type { AgentOptions, ChatContext, LoopOptions, LoopResult, UserMessageContent } from './types.js';
 
 // ===== Module-level helpers =====
 
@@ -167,7 +156,12 @@ export class LoopRunner {
     );
 
     const permissionMode = context.permissionMode;
-    const loopState = this.createLoopState(context, conversationState, permissionMode);
+    const loopState = this.createLoopState(
+      context,
+      conversationState,
+      permissionMode,
+      options?.toolExecutionLifecycle,
+    );
 
     // 2. 保存用户消息到 JSONL
     let lastMessageUuid: string | null = null;
@@ -342,6 +336,7 @@ export class LoopRunner {
     context: ChatContext,
     conversationState: ConversationState,
     permissionMode: PermissionMode | undefined,
+    toolExecutionLifecycle: LoopOptions['toolExecutionLifecycle'],
   ): LoopState {
     const rpm = this.runtimePatchManager;
     const catalog = this.executionPipeline.getCatalog();
@@ -399,6 +394,7 @@ export class LoopRunner {
           : undefined,
         toolRegistry: registry,
         discoveredTools: Array.from(rpm.discoveredTools ?? []),
+        lifecycle: toolExecutionLifecycle,
       },
       baseContextSnapshot: context.snapshot,
       initialActiveSkill: rpm.skillContext,

--- a/src/agent/state/TurnState.ts
+++ b/src/agent/state/TurnState.ts
@@ -3,7 +3,10 @@ import type { ContextSnapshot } from '../../runtime/index.js';
 import type { IChatService, Message } from '../../services/ChatServiceInterface.js';
 import type { ToolCatalog } from '../../tools/catalog/index.js';
 import type { ToolRegistry } from '../../tools/registry/ToolRegistry.js';
-import type { ConfirmationHandler } from '../../tools/types/ExecutionTypes.js';
+import type {
+  ConfirmationHandler,
+  ToolExecutionLifecycle,
+} from '../../tools/types/ExecutionTypes.js';
 import type { SessionId } from '../../types/branded.js';
 import type { BladeConfig, PermissionMode } from '../../types/common.js';
 import type { IBackgroundAgentManager } from '../types.js';
@@ -34,6 +37,7 @@ export interface LoopExecutionContext {
   toolRegistry?: ToolRegistry;
   toolCatalog?: ToolCatalog;
   discoveredTools?: string[];
+  lifecycle?: ToolExecutionLifecycle;
 }
 
 export interface TurnState {

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -5,13 +5,8 @@
 import type { ContextSnapshot } from '../runtime/index.js';
 import type { ContentPart, Message } from '../services/ChatServiceInterface.js';
 import type { ToolCatalogSourcePolicy } from '../tools/catalog/index.js';
-import type { ConfirmationHandler } from '../tools/types/ExecutionTypes.js';
-import type {
-  AgentId,
-  InputId,
-  RequestId,
-  SessionId,
-} from '../types/branded.js';
+import type { ConfirmationHandler, ToolExecutionLifecycle } from '../tools/types/ExecutionTypes.js';
+import type { AgentId, InputId, RequestId, SessionId } from '../types/branded.js';
 import type { OutputFormat, PermissionMode, PermissionsConfig, SandboxSettings } from '../types/common.js';
 import type { CanUseTool, PermissionHandler } from '../types/permissions.js';
 import type { AgentRunControl } from './AgentRunControl.js';
@@ -142,6 +137,8 @@ export interface LoopOptions {
   prepareInput?: (input: UserMessageContent) => Promise<UserMessageContent>;
   /** @internal Session-owned input and cancellation control plane. */
   runControl?: AgentRunControl;
+  /** @internal Session-owned durable tool lifecycle recorder. */
+  toolExecutionLifecycle?: ToolExecutionLifecycle;
   onTurnLimitReached?: (data: { turnsCount: number }) => Promise<TurnLimitResponse>;
   /** 进度回调，每次 tool call 完成后触发 */
   onProgress?: (progress: AgentProgress) => void;

--- a/src/session/Session.ts
+++ b/src/session/Session.ts
@@ -7,51 +7,71 @@ import { type CleanupHandle, registerCleanup } from '../lifecycle/CleanupRegistr
 import { createRootLogger, type InternalLogger, LogCategory } from '../logging/Logger.js';
 import { type AgentTrace, TraceRecorder } from '../observability/index.js';
 import {
-  type ContextSnapshot,
-  createContextSnapshot,
-  type RuntimeContext,
+    type ContextSnapshot,
+    createContextSnapshot,
+    type RuntimeContext,
 } from '../runtime/index.js';
 import type { ContentPart, Message } from '../services/ChatServiceInterface.js';
 import { cloneMessage } from '../services/messageUtils.js';
 import {
-  InputId,
-  RequestId,
-  SessionId,
+    CommandId,
+    InputId,
+    RequestId,
+    SessionId,
 } from '../types/branded.js';
 import {
-  type BladeConfig,
-  type JsonValue,
-  type ModelConfig,
-  PermissionMode,
-  type ProviderType,
+    type BladeConfig,
+    type JsonValue,
+    type ModelConfig,
+    PermissionMode,
+    type ProviderType,
 } from '../types/common.js';
-import { ActiveRequestController } from './ActiveRequestController.js';
 import {
-  SessionInputInbox,
+    ActiveRequestController,
+    type RequestAbortReason,
+} from './ActiveRequestController.js';
+import { DurableSessionJournal } from './events/DurableSessionJournal.js';
+import type {
+    DurableSessionProjection,
+    DurableSessionRecoveryPlan,
+} from './events/DurableSessionProjector.js';
+import {
+    type DurableRequestFinish,
+    durableRequestFinishFromLoopResult,
+    DurableSessionRecoveryRequiredError,
+    SessionDurableRecorder,
+    SessionDurableRecorderError,
+} from './events/SessionDurableRecorder.js';
+import {
+    DurableEventType,
+    type DurableRequestInterruptReason,
+} from './events/types.js';
+import {
+    SessionInputInbox,
 } from './SessionInputInbox.js';
 import { SessionRuntime } from './SessionRuntime.js';
 import {
-  JsonlSessionStore,
-  NoopSessionStore,
-  type SessionSnapshot,
-  type SessionStore,
+    JsonlSessionStore,
+    NoopSessionStore,
+    type SessionSnapshot,
+    type SessionStore,
 } from './SessionStore.js';
 import type {
-  ForkSessionOptions,
-  InputSubmission,
-  ISession,
-  McpServerStatus,
-  McpToolInfo,
-  ModelInfo,
-  PendingSessionInput,
-  PromptResult,
-  ProviderConfig,
-  SendOptions,
-  SessionOptions,
-  StreamMessage,
-  StreamOptions,
-  TokenUsage,
-  ToolCallRecord,
+    ForkSessionOptions,
+    InputSubmission,
+    ISession,
+    McpServerStatus,
+    McpToolInfo,
+    ModelInfo,
+    PendingSessionInput,
+    PromptResult,
+    ProviderConfig,
+    SendOptions,
+    SessionOptions,
+    StreamMessage,
+    StreamOptions,
+    TokenUsage,
+    ToolCallRecord,
 } from './types.js';
 import { InputPriority } from './types.js';
 
@@ -69,16 +89,19 @@ type SessionExecutionState =
       message: UserMessageContent;
       options: SendOptions | null;
       snapshot: ContextSnapshot;
+      durableRecorder: SessionDurableRecorder | null;
     }
   | {
       phase: 'running';
       requestId: RequestId;
       controller: ActiveRequestController;
+      durableRecorder: SessionDurableRecorder | null;
     }
   | {
       phase: 'stopping';
       requestId: RequestId;
       controller: ActiveRequestController;
+      durableRecorder: SessionDurableRecorder | null;
     }
   | { phase: 'closed' };
 
@@ -101,6 +124,8 @@ class Session implements ISession {
   private readonly traces: AgentTrace[] = [];
   private readonly inputInbox = new SessionInputInbox();
   private readonly inputMutex = new Mutex();
+  private durableJournal: DurableSessionJournal | null = null;
+  private durableClosePromise: Promise<void> | null = null;
 
   /**
    * 请求阶段状态机：
@@ -114,7 +139,15 @@ class Session implements ISession {
    */
   private executionState: SessionExecutionState = { phase: 'idle' };
 
-  constructor(options: SessionOptions, sessionId?: SessionId, isResume = false) {
+  constructor(
+    options: SessionOptions,
+    sessionId?: SessionId,
+    isResume = false,
+    private readonly durableOrigin: {
+      source: 'create' | 'resume' | 'fork';
+      parentSessionId?: SessionId;
+    } = { source: isResume ? 'resume' : 'create' },
+  ) {
     this.sessionId = sessionId || SessionId(nanoid());
     this.options = options;
     this.maxTurns = options.maxTurns ?? 200;
@@ -154,12 +187,21 @@ class Session implements ISession {
     return [...this.traces];
   }
 
+  getDurableProjection(): DurableSessionProjection | null {
+    return this.durableJournal?.getProjection() ?? null;
+  }
+
+  getDurableRecoveryPlan(): DurableSessionRecoveryPlan | null {
+    return this.durableJournal?.getRecoveryPlan() ?? null;
+  }
+
   async initialize(): Promise<void> {
     if (this.executionState.phase === 'closed') {
       throw new Error('Session is closed');
     }
     if (this.initialized) return;
 
+    await this.initializeDurableJournal();
     const config = this.buildBladeConfig();
     this.runtime = new SessionRuntime(
       this.sessionId,
@@ -316,6 +358,7 @@ class Session implements ISession {
 
       const inputId = InputId(nanoid());
       if (this.executionState.phase === 'idle') {
+        this.assertDurableReadyForNewRequest();
         if (options?.expectedRequestId) {
           throw new SessionInputError(
             'SESSION_REQUEST_MISMATCH',
@@ -330,9 +373,23 @@ class Session implements ISession {
           targetRequestId: requestId,
           acceptedAt: Date.now(),
         };
+        const durableRecorder = this.durableJournal
+          ? new SessionDurableRecorder(this.durableJournal, requestId, this.options.model)
+          : null;
         this.inputInbox.reserve(input);
         try {
-          await this.persistInput(input);
+          await durableRecorder?.recordAccepted(inputId, message);
+          try {
+            await this.persistInput(input);
+          } catch (error) {
+            if (!durableRecorder) {
+              throw error;
+            }
+            this.logger.warn(
+              '[Session] Legacy input persistence failed after durable acceptance:',
+              error,
+            );
+          }
           this.inputInbox.markCommitted(inputId);
         } catch (error) {
           this.inputInbox.remove(inputId);
@@ -342,6 +399,7 @@ class Session implements ISession {
           requestId,
           input,
           options,
+          durableRecorder,
         );
         return {
           status: 'started',
@@ -448,6 +506,27 @@ class Session implements ISession {
         return false;
       }
 
+      const pendingState =
+        this.executionState.phase === 'pending'
+        && this.executionState.input.inputId === inputId
+          ? this.executionState
+          : null;
+      let durablyInterrupted = false;
+      if (pendingState) {
+        const durableRecorder = await this.ensureDurableRecorder(
+          pendingState.requestId,
+          pendingState.input,
+          pendingState.durableRecorder,
+        );
+        pendingState.durableRecorder = durableRecorder;
+        if (durableRecorder) {
+          await durableRecorder.finish({
+            status: 'interrupted',
+            reason: 'user_abort',
+          });
+          durablyInterrupted = true;
+        }
+      }
       try {
         await this.getRuntime().getContextManager().saveInputCancelled(
           this.sessionId,
@@ -455,16 +534,19 @@ class Session implements ISession {
           'cancelled_by_user',
         );
       } catch (error) {
-        this.inputInbox.releaseClaim(inputId);
-        throw error;
+        if (!durablyInterrupted) {
+          this.inputInbox.releaseClaim(inputId);
+          throw error;
+        }
+        this.logger.warn(
+          '[Session] Legacy input cancellation persistence failed after durable interruption:',
+          error,
+        );
       }
       this.inputInbox.remove(inputId);
 
-      if (
-        this.executionState.phase === 'pending'
-        && this.executionState.input.inputId === inputId
-      ) {
-        this.executionState.controller.dispose();
+      if (pendingState && this.executionState === pendingState) {
+        pendingState.controller.dispose();
         this.executionState = { phase: 'idle' };
         this.scheduleNextQueuedInput();
       }
@@ -479,7 +561,7 @@ class Session implements ISession {
     // 声明请求所有权必须原子：相位检查、pending→running 转换与初始输入移除
     // 需在 inputMutex 内一次完成，避免与 send()/cancelInput()/finishRequest()
     // 对 executionState 的并发读写交错。
-    const claimed = await this.inputMutex.runExclusive(() => {
+    const claimed = await this.inputMutex.runExclusive(async () => {
       if (this.executionState.phase !== 'pending') {
         return null;
       }
@@ -489,12 +571,29 @@ class Session implements ISession {
         message: initialMessage,
         options: sendOptions,
         snapshot: pendingSnapshot,
+        durableRecorder: pendingDurableRecorder,
       } = this.executionState;
       const requestController = this.executionState.controller;
+      const durableRecorder = pendingDurableRecorder
+        ?? (this.durableJournal
+          ? new SessionDurableRecorder(this.durableJournal, requestId, this.options.model)
+          : null);
+      if (durableRecorder && !pendingDurableRecorder) {
+        await durableRecorder.recordAccepted(
+          input.inputId,
+          input.content,
+          input.priority === InputPriority.LATER ? 'later' : 'next',
+        );
+      }
+      await durableRecorder?.recordStarted(
+        input.inputId,
+        input.priority === InputPriority.LATER ? 'later' : 'next',
+      );
       this.executionState = {
         phase: 'running',
         requestId,
         controller: requestController,
+        durableRecorder,
       };
       // 提交执行后立即将初始输入移出收件箱：它已被应用，不再是待处理输入，
       // 且已通过 initialInputId 从 steering 领取中排除。若延后移除，一旦流在
@@ -508,6 +607,7 @@ class Session implements ISession {
         sendOptions,
         pendingSnapshot,
         requestController,
+        durableRecorder,
       };
     });
 
@@ -522,8 +622,23 @@ class Session implements ISession {
       sendOptions,
       pendingSnapshot,
       requestController,
+      durableRecorder,
     } = claimed;
 
+    let durableFinishAttempted = false;
+    let durableFinishCommitted = !durableRecorder;
+    const finishDurableRequest = async (finish: DurableRequestFinish): Promise<void> => {
+      if (!durableRecorder || durableFinishAttempted) {
+        return;
+      }
+      durableFinishAttempted = true;
+      if (!await durableRecorder.finish(finish)) {
+        throw new SessionDurableRecorderError(
+          `Request ${requestId} has a tool outcome that requires reconciliation`,
+        );
+      }
+      durableFinishCommitted = true;
+    };
     let message = initialMessage;
     const traceRecorder = this.createTraceRecorder(message);
     let traceFinished = false;
@@ -542,13 +657,26 @@ class Session implements ISession {
     try {
       message = await runtime.getHookRuntime().applyUserPromptSubmit(message);
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
+      let terminalError = error;
+      try {
+        await finishDurableRequest({ status: 'failed', error });
+      } catch (durableError) {
+        terminalError = new AggregateError(
+          [error, durableError],
+          'Request setup and durable finalization both failed',
+        );
+      }
+      const errorMessage =
+        terminalError instanceof Error ? terminalError.message : String(terminalError);
       await finishTrace('error', { error: errorMessage });
       runtime.getHookRuntime().setTraceCollector(undefined);
       // 初始输入已在进入 running 时移出收件箱；hook 失败时仍需与正常路径一样
       // 释放请求资源，否则会话会永久停留在 running 且外部 AbortSignal 监听器泄漏。
       requestController.dispose();
       await this.finishRequest(requestId);
+      if (durableRecorder && !durableFinishCommitted) {
+        throw terminalError;
+      }
       yield { type: 'error', message: errorMessage, sessionId: this.sessionId };
       return;
     }
@@ -586,7 +714,9 @@ class Session implements ISession {
         requestId,
       },
       runControl: requestController,
+      toolExecutionLifecycle: durableRecorder ?? undefined,
     });
+    let agentStreamCompleted = false;
 
     try {
       let loopResult: LoopResult | undefined;
@@ -597,8 +727,10 @@ class Session implements ISession {
         const { value, done } = await stream.next();
         if (done) {
           loopResult = value;
+          agentStreamCompleted = true;
           break;
         }
+        await durableRecorder?.recordAgentEvent(value);
         switch (value.type) {
           case 'turn_start': {
             const spanId = traceRecorder?.recordTurnStart(value.turn, value.maxTurns);
@@ -850,12 +982,15 @@ class Session implements ISession {
 
       if (!loopResult.success && !isAborted && !shouldExit) {
         const messageText = loopResult.error?.message || 'Unknown error';
+        await finishDurableRequest({
+          status: 'failed',
+          error: messageText,
+        });
         await finishTrace('error', { error: messageText });
         yield { type: 'error', message: messageText, sessionId: this.sessionId };
         return;
       }
 
-      yield { type: 'usage', usage: totalUsage, sessionId: this.sessionId };
       this._messages = context.messages;
       const imageCount = this.getImageCount(message);
       await runtime.getHookRuntime().runTaskCompleted({
@@ -873,6 +1008,14 @@ class Session implements ISession {
         toolCallsCount: loopResult.metadata?.toolCallsCount,
         duration: loopResult.metadata?.duration,
       });
+      await finishDurableRequest(
+        durableRequestFinishFromLoopResult(
+          loopResult,
+          totalUsage,
+          this.getDurableInterruptReason(requestController),
+        ),
+      );
+      yield { type: 'usage', usage: totalUsage, sessionId: this.sessionId };
       yield {
         type: 'result',
         subtype: 'success',
@@ -880,26 +1023,93 @@ class Session implements ISession {
         sessionId: this.sessionId,
       };
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
+      let terminalError = error;
+      if (!durableFinishAttempted) {
+        try {
+          await finishDurableRequest({ status: 'failed', error });
+        } catch (durableError) {
+          terminalError = new AggregateError(
+            [error, durableError],
+            'Request execution and durable finalization both failed',
+          );
+        }
+      }
+      const errorMessage =
+        terminalError instanceof Error ? terminalError.message : String(terminalError);
       await finishTrace('error', { error: errorMessage });
+      if (durableRecorder && !durableFinishCommitted) {
+        throw terminalError;
+      }
       yield { type: 'error', message: errorMessage, sessionId: this.sessionId };
     } finally {
+      let cleanupError: unknown;
+      if (!agentStreamCompleted) {
+        requestController.abortRequest({ kind: 'user_abort' });
+        try {
+          await stream.return(undefined as never);
+        } catch (error) {
+          cleanupError = error;
+        }
+        try {
+          if (!durableFinishAttempted) {
+            await finishDurableRequest({
+              status: 'interrupted',
+              reason: 'user_abort',
+            });
+          }
+        } catch (error) {
+          cleanupError = cleanupError
+            ? new AggregateError(
+                [cleanupError, error],
+                'Agent stream cleanup and durable finalization both failed',
+              )
+            : error;
+        }
+      }
       runtime.getHookRuntime().setTraceCollector(undefined);
       requestController.dispose();
       await this.finishRequest(requestId);
+      if (this.executionState.phase === 'closed') {
+        await this.closeDurableSession();
+      }
+      if (cleanupError) {
+        await Promise.reject(cleanupError);
+      }
     }
   }
 
   async close(): Promise<void> {
+    await this.closeInternal(true);
+  }
+
+  async disposeAfterFork(): Promise<void> {
+    await this.closeInternal(false);
+  }
+
+  private async closeInternal(recordDurableClose: boolean): Promise<void> {
     // 关闭时对 executionState 的读写走 inputMutex，避免与并发 send()/stream()
     // 交错（例如 send() 在 await 处让出后用 pending 覆盖 closed）。
-    const alreadyClosed = await this.inputMutex.runExclusive(() => {
+    const alreadyClosed = await this.inputMutex.runExclusive(async () => {
       if (this.executionState.phase === 'closed') {
         return true;
       }
       if (this.executionState.phase === 'pending') {
-        this.executionState.controller.abortRequest({ kind: 'session_close' });
-        this.executionState.controller.dispose();
+        const { controller, input, requestId } = this.executionState;
+        controller.abortRequest({ kind: 'session_close' });
+        if (recordDurableClose) {
+          const durableRecorder = await this.ensureDurableRecorder(
+            requestId,
+            input,
+            this.executionState.durableRecorder,
+          );
+          this.executionState.durableRecorder = durableRecorder;
+          await durableRecorder?.finish({
+            status: 'interrupted',
+            reason: 'session_close',
+          });
+        }
+        controller.dispose();
+        this.inputInbox.remove(input.inputId);
       } else if (
         this.executionState.phase === 'running'
         || this.executionState.phase === 'stopping'
@@ -910,6 +1120,9 @@ class Session implements ISession {
       return false;
     });
     if (alreadyClosed) {
+      if (recordDurableClose) {
+        await this.closeDurableSession();
+      }
       return;
     }
     this.cleanupHandle?.unregister();
@@ -925,29 +1138,48 @@ class Session implements ISession {
         await runtime.close();
       }
     }
+    if (recordDurableClose) {
+      await this.closeDurableSession();
+    }
     this.logger.debug(`[Session] Closed session ${this.sessionId}`);
   }
 
-  abort(): void {
-    // abort() 是同步 API，无法 await inputMutex；但它在单个微任务内原子执行
-    // （无 await 让出点），因此对 executionState 的读改本身不会与其他转换交错。
+  async abort(): Promise<void> {
     if (this.executionState.phase === 'running') {
-      const { requestId, controller } = this.executionState;
+      const { requestId, controller, durableRecorder } = this.executionState;
       controller.abortRequest({ kind: 'user_abort' });
       this.executionState = {
         phase: 'stopping',
         requestId,
         controller,
+        durableRecorder,
       };
     } else if (this.executionState.phase === 'pending') {
-      // send() 已返回但 stream() 尚未启动：此时没有运行中的流去驱动 finishRequest，
-      // 必须在此直接完成收尾，否则该请求会永久停留在 pending。
-      const { controller, input } = this.executionState;
-      controller.abortRequest({ kind: 'user_abort' });
-      controller.dispose();
-      this.inputInbox.remove(input.inputId);
-      this.executionState = { phase: 'idle' };
-      this.scheduleNextQueuedInput();
+      const pendingState = this.executionState;
+      pendingState.controller.abortRequest({ kind: 'user_abort' });
+      await this.inputMutex.runExclusive(async () => {
+        if (
+          this.executionState.phase !== 'pending'
+          || this.executionState.requestId !== pendingState.requestId
+        ) {
+          return;
+        }
+        const durableRecorder = await this.ensureDurableRecorder(
+          pendingState.requestId,
+          pendingState.input,
+          pendingState.durableRecorder,
+        );
+        pendingState.durableRecorder = durableRecorder;
+        await durableRecorder?.finish({
+          status: 'interrupted',
+          reason: 'user_abort',
+        });
+        const { controller, input } = pendingState;
+        controller.dispose();
+        this.inputInbox.remove(input.inputId);
+        this.executionState = { phase: 'idle' };
+        this.scheduleNextQueuedInput();
+      });
     }
   }
 
@@ -1031,6 +1263,119 @@ class Session implements ISession {
     return this.runtime;
   }
 
+  private async initializeDurableJournal(): Promise<void> {
+    if (this.durableJournal) {
+      return;
+    }
+    const eventStore = this.options.durableEventStore;
+    if (!eventStore) {
+      return;
+    }
+
+    const journal = await DurableSessionJournal.open(eventStore, this.sessionId);
+    const projection = journal.getProjection();
+    if (projection.status === 'empty') {
+      await journal.commit({
+        commandId: CommandId(nanoid()),
+        events: [
+          {
+            type: DurableEventType.SESSION_CREATED,
+            data: {
+              source: this.durableOrigin.source,
+              ...(this.durableOrigin.parentSessionId
+                ? { parentSessionId: this.durableOrigin.parentSessionId }
+                : {}),
+            },
+          },
+        ],
+      });
+      this.durableJournal = journal;
+      return;
+    }
+    if (!this.isResumeSession) {
+      throw new SessionDurableRecorderError(
+        `Durable Session ${this.sessionId} already exists`,
+      );
+    }
+    if (projection.status === 'closed') {
+      throw new SessionDurableRecorderError(
+        `Durable Session ${this.sessionId} is closed`,
+      );
+    }
+    const recoveryPlan = journal.getRecoveryPlan();
+    if (recoveryPlan.action !== 'none') {
+      throw new DurableSessionRecoveryRequiredError(recoveryPlan);
+    }
+    this.durableJournal = journal;
+  }
+
+  private async ensureDurableRecorder(
+    requestId: RequestId,
+    input: PendingSessionInput,
+    existing: SessionDurableRecorder | null,
+  ): Promise<SessionDurableRecorder | null> {
+    if (existing || !this.durableJournal) {
+      return existing;
+    }
+    const recorder = new SessionDurableRecorder(
+      this.durableJournal,
+      requestId,
+      this.options.model,
+    );
+    await recorder.recordAccepted(
+      input.inputId,
+      input.content,
+      input.priority === InputPriority.LATER ? 'later' : 'next',
+    );
+    return recorder;
+  }
+
+  private async closeDurableSession(): Promise<void> {
+    if (this.durableClosePromise) {
+      return this.durableClosePromise;
+    }
+    const journal = this.durableJournal;
+    if (!journal) {
+      return;
+    }
+    const projection = journal.getProjection();
+    if (projection.status !== 'open' || projection.activeRequest) {
+      return;
+    }
+    const closePromise = journal.commit({
+      commandId: CommandId(nanoid()),
+      events: [
+        {
+          type: DurableEventType.SESSION_CLOSED,
+          data: { reason: 'shutdown' },
+        },
+      ],
+    }).then(() => undefined);
+    this.durableClosePromise = closePromise;
+    try {
+      await closePromise;
+    } catch (error) {
+      if (this.durableClosePromise === closePromise) {
+        this.durableClosePromise = null;
+      }
+      throw error;
+    }
+  }
+
+  private assertDurableReadyForNewRequest(): void {
+    const recoveryPlan = this.durableJournal?.getRecoveryPlan();
+    if (recoveryPlan && recoveryPlan.action !== 'none') {
+      throw new DurableSessionRecoveryRequiredError(recoveryPlan);
+    }
+  }
+
+  private getDurableInterruptReason(
+    controller: ActiveRequestController,
+  ): DurableRequestInterruptReason {
+    const reason = controller.requestSignal.reason as RequestAbortReason | undefined;
+    return reason?.kind === 'session_close' ? 'session_close' : 'user_abort';
+  }
+
   private async finishRequest(requestId: RequestId): Promise<void> {
     await this.inputMutex.runExclusive(() => {
       if (
@@ -1051,6 +1396,7 @@ class Session implements ISession {
     requestId: RequestId,
     input: PendingSessionInput,
     options?: SendOptions,
+    durableRecorder: SessionDurableRecorder | null = null,
   ): Extract<SessionExecutionState, { phase: 'pending' }> {
     return {
       phase: 'pending',
@@ -1064,6 +1410,7 @@ class Session implements ISession {
       ),
       message: input.content,
       options: options || null,
+      durableRecorder,
       snapshot: createContextSnapshot(
         this.sessionId,
         nanoid(),
@@ -1075,6 +1422,12 @@ class Session implements ISession {
 
   private scheduleNextQueuedInput(): void {
     if (this.executionState.phase !== 'idle') {
+      return;
+    }
+    if (
+      this.durableJournal
+      && this.durableJournal.getRecoveryPlan().action !== 'none'
+    ) {
       return;
     }
     const requestId = RequestId(nanoid());
@@ -1146,10 +1499,18 @@ class Session implements ISession {
         })
       : this.createSnapshotFromMessages(options?.messageId);
 
-    const forkedSession = new Session({
-      ...this.options,
-      defaultContext: this.defaultContext,
-    });
+    const forkedSession = new Session(
+      {
+        ...this.options,
+        defaultContext: this.defaultContext,
+      },
+      undefined,
+      false,
+      {
+        source: 'fork',
+        parentSessionId: this.sessionId,
+      },
+    );
     await forkedSession.initialize();
     forkedSession._messages = this.cloneSnapshotMessages(snapshot);
 
@@ -1244,11 +1605,11 @@ export async function forkSession(options: ForkOptions): Promise<ISession> {
   await sourceSession.initialize();
   await sourceSession.loadHistory();
 
-  const forkedSession = await sourceSession.fork({ messageId });
-
-  await sourceSession.close();
-
-  return forkedSession;
+  try {
+    return await sourceSession.fork({ messageId });
+  } finally {
+    await sourceSession.disposeAfterFork();
+  }
 }
 
 export async function prompt(

--- a/src/session/__tests__/SessionContext.test.ts
+++ b/src/session/__tests__/SessionContext.test.ts
@@ -469,7 +469,7 @@ describe('Session runtime context', () => {
       done: false,
     });
 
-    session.abort();
+    await session.abort();
     await expect(session.send('second')).resolves.toMatchObject({
       status: 'queued',
       priority: 'later',

--- a/src/session/__tests__/SessionDurableEvents.test.ts
+++ b/src/session/__tests__/SessionDurableEvents.test.ts
@@ -1,0 +1,554 @@
+import { mkdtempSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { AgentEvent } from '../../agent/AgentEvent.js';
+import type { LoopOptions, LoopResult, UserMessageContent } from '../../agent/types.js';
+import {
+  CommandId,
+  EventId,
+  InputId,
+  RequestId,
+  SessionId,
+  ToolUseId,
+} from '../../types/branded.js';
+import { type DurableEventStore, DurableEventStoreError } from '../events/DurableEventStore.js';
+import {
+  DurableCommandOutcomeUnknownError,
+  DurableSessionJournal,
+} from '../events/DurableSessionJournal.js';
+import { JsonlDurableEventStore } from '../events/JsonlDurableEventStore.js';
+import { DurableSessionRecoveryRequiredError } from '../events/SessionDurableRecorder.js';
+import type {
+  DurableEventAppendOptions,
+  DurableEventAppendResult,
+  DurableEventDraft,
+  DurableEventPage,
+  DurableEventReadOptions,
+} from '../events/types.js';
+import { DurableEventType } from '../events/types.js';
+
+type StreamChat = (
+  message: UserMessageContent,
+  context: unknown,
+  options?: LoopOptions,
+) => AsyncGenerator<AgentEvent, LoopResult>;
+
+let streamChat: StreamChat = async function* defaultStream() {
+  yield { type: 'turn_start', turn: 1, maxTurns: 10 };
+  yield { type: 'turn_end', turn: 1, hasToolCalls: false };
+  return {
+    success: true,
+    finalMessage: 'done',
+    metadata: { turnsCount: 1, toolCallsCount: 0, duration: 1 },
+  };
+};
+
+const createAgent = vi.fn(async () => ({
+  streamChat: (message: UserMessageContent, context: unknown, options?: LoopOptions) =>
+    streamChat(message, context, options),
+  async setModel() {},
+}));
+
+vi.mock('../../agent/Agent.js', () => ({
+  Agent: { create: createAgent },
+}));
+
+const { createSession, forkSession, resumeSession } = await import('../Session.js');
+
+class FailOnEventTypeStore implements DurableEventStore {
+  constructor(
+    private readonly delegate: DurableEventStore,
+    private readonly failedType: string,
+  ) {}
+
+  async append(
+    sessionId: SessionId,
+    events: readonly DurableEventDraft[],
+    options?: DurableEventAppendOptions,
+  ): Promise<DurableEventAppendResult> {
+    if (events.some((event) => event.type === this.failedType)) {
+      throw new DurableEventStoreError(
+        'DURABLE_EVENT_WRITE_FAILED',
+        `Injected ${this.failedType} failure`,
+      );
+    }
+    return this.delegate.append(sessionId, events, options);
+  }
+
+  read(sessionId: SessionId, options?: DurableEventReadOptions): Promise<DurableEventPage> {
+    return this.delegate.read(sessionId, options);
+  }
+
+  getHeadSequence(sessionId: SessionId) {
+    return this.delegate.getHeadSequence(sessionId);
+  }
+}
+
+const tempRoots: string[] = [];
+
+function createStore() {
+  const root = mkdtempSync(join(tmpdir(), 'session-durable-events-'));
+  tempRoots.push(root);
+  let eventId = 0;
+  return {
+    root,
+    store: new JsonlDurableEventStore(root, {
+      clock: () => new Date('2026-08-22T12:00:00.000Z'),
+      eventIdFactory: () => EventId(`event-${++eventId}`),
+    }),
+  };
+}
+
+function options(store: DurableEventStore) {
+  return {
+    provider: { type: 'openai-compatible' as const, apiKey: 'test-key' },
+    model: 'test-model',
+    persistSession: false,
+    durableEventStore: store,
+  };
+}
+
+afterEach(async () => {
+  streamChat = async function* defaultStream() {
+    yield { type: 'turn_start', turn: 1, maxTurns: 10 };
+    yield { type: 'turn_end', turn: 1, hasToolCalls: false };
+    return {
+      success: true,
+      finalMessage: 'done',
+      metadata: { turnsCount: 1, toolCallsCount: 0, duration: 1 },
+    };
+  };
+  await Promise.all(tempRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe('Session durable events', () => {
+  it('persists request and turn boundaries before exposing stream events', async () => {
+    const { store } = createStore();
+    const session = await createSession(options(store));
+    const submission = await session.send('hello');
+
+    expect((await store.read(session.sessionId)).events.map((event) => event.type)).toEqual([
+      DurableEventType.SESSION_CREATED,
+      DurableEventType.REQUEST_ACCEPTED,
+    ]);
+
+    for await (const event of session.stream()) {
+      const durableTypes = (await store.read(session.sessionId)).events.map((entry) => entry.type);
+      if (event.type === 'turn_start') {
+        expect(durableTypes.at(-1)).toBe(DurableEventType.TURN_STARTED);
+      }
+      if (event.type === 'result') {
+        expect(durableTypes.at(-1)).toBe(DurableEventType.REQUEST_COMPLETED);
+      }
+    }
+
+    expect(session.getDurableProjection()).toMatchObject({
+      status: 'open',
+      activeRequest: null,
+    });
+    expect(session.getDurableRecoveryPlan()?.action).toBe('none');
+    expect(submission.status).toBe('started');
+
+    await session.close();
+    expect((await store.read(session.sessionId)).events.at(-1)?.type).toBe(
+      DurableEventType.SESSION_CLOSED,
+    );
+  });
+
+  it('persists tool and permission boundaries around the real side effect', async () => {
+    const { store } = createStore();
+    let sideEffectSawToolStarted = false;
+    streamChat = async function* toolStream(_message, _context, loopOptions) {
+      yield { type: 'turn_start', turn: 1, maxTurns: 10 };
+      const lifecycle = loopOptions?.toolExecutionLifecycle;
+      const invocation = await lifecycle?.onToolScheduled?.({
+        toolCallId: ToolUseId('tool-call-1'),
+        toolName: 'Write',
+        input: { file_path: '/tmp/file' },
+        interruptBehavior: 'block',
+      });
+      if (!invocation) {
+        throw new Error('Missing tool invocation lifecycle');
+      }
+      yield {
+        type: 'tool_start',
+        toolCall: {
+          id: 'tool-call-1',
+          type: 'function',
+          function: { name: 'Write', arguments: '{"file_path":"/tmp/file"}' },
+        },
+      };
+      const permissionRequestId = await invocation.onPermissionRequested?.(
+        { message: 'Allow write?' },
+        { file_path: '/tmp/file' },
+      );
+      if (!permissionRequestId) {
+        throw new Error('Missing permission request ID');
+      }
+      await invocation.onPermissionResolved?.({
+        permissionRequestId,
+        decision: 'allow',
+      });
+      await invocation.onExecutionStarted?.();
+      sideEffectSawToolStarted = (await store.read(sessionIdForTest)).events.some(
+        (event) => event.type === DurableEventType.TOOL_STARTED,
+      );
+      await lifecycle?.onToolSettled?.({
+        toolCallId: ToolUseId('tool-call-1'),
+        toolName: 'Write',
+        result: { status: 'success', model: 'written' },
+      });
+      yield {
+        type: 'tool_result',
+        toolCall: {
+          id: 'tool-call-1',
+          type: 'function',
+          function: { name: 'Write', arguments: '{"file_path":"/tmp/file"}' },
+        },
+        result: { status: 'success', model: 'written' },
+      };
+      yield { type: 'turn_end', turn: 1, hasToolCalls: true };
+      return {
+        success: true,
+        finalMessage: 'done',
+        metadata: { turnsCount: 1, toolCallsCount: 1, duration: 1 },
+      };
+    };
+
+    const session = await createSession(options(store));
+    const sessionIdForTest = session.sessionId;
+    await session.send('write');
+    for await (const _event of session.stream()) {
+      // Drain.
+    }
+
+    expect(sideEffectSawToolStarted).toBe(true);
+    expect((await store.read(session.sessionId)).events.map((event) => event.type)).toEqual([
+      DurableEventType.SESSION_CREATED,
+      DurableEventType.REQUEST_ACCEPTED,
+      DurableEventType.INPUT_APPLIED,
+      DurableEventType.REQUEST_STARTED,
+      DurableEventType.TURN_STARTED,
+      DurableEventType.TOOL_SCHEDULED,
+      DurableEventType.PERMISSION_REQUESTED,
+      DurableEventType.PERMISSION_RESOLVED,
+      DurableEventType.TOOL_STARTED,
+      DurableEventType.TOOL_COMPLETED,
+      DurableEventType.TURN_COMPLETED,
+      DurableEventType.REQUEST_COMPLETED,
+    ]);
+    await session.close();
+  });
+
+  it('does not cross the side-effect boundary when tool-start persistence fails', async () => {
+    const { store } = createStore();
+    const failingStore = new FailOnEventTypeStore(store, DurableEventType.TOOL_STARTED);
+    let sideEffectRan = false;
+    streamChat = async function* failedToolStart(_message, _context, loopOptions) {
+      yield { type: 'turn_start', turn: 1, maxTurns: 10 };
+      const lifecycle = loopOptions?.toolExecutionLifecycle;
+      const invocation = await lifecycle?.onToolScheduled?.({
+        toolCallId: ToolUseId('tool-call-1'),
+        toolName: 'Write',
+        input: {},
+        interruptBehavior: 'block',
+      });
+      if (!invocation) {
+        throw new Error('Missing tool invocation lifecycle');
+      }
+      await invocation.onExecutionStarted?.();
+      sideEffectRan = true;
+      return {
+        success: true,
+        finalMessage: 'unexpected',
+        metadata: { turnsCount: 1, toolCallsCount: 1, duration: 1 },
+      };
+    };
+
+    const session = await createSession(options(failingStore));
+    await session.send('write');
+    const messages: AgentEvent[] = [];
+    await expect((async () => {
+      for await (const event of session.stream()) {
+        messages.push(event as AgentEvent);
+      }
+    })()).rejects.toThrow('Request execution and durable finalization both failed');
+
+    expect(sideEffectRan).toBe(false);
+    expect(messages.some((event) => event.type === 'error')).toBe(false);
+    const durableTypes = (await store.read(session.sessionId)).events.map((event) => event.type);
+    expect(durableTypes).toContain(DurableEventType.TOOL_SCHEDULED);
+    expect(durableTypes).not.toContain(DurableEventType.TOOL_STARTED);
+    expect(session.getDurableRecoveryPlan()?.action).toBe('resume_turn');
+  });
+
+  it('does not publish a terminal event or start another request when terminal persistence fails', async () => {
+    const { store } = createStore();
+    const failingStore = new FailOnEventTypeStore(store, DurableEventType.REQUEST_COMPLETED);
+    const session = await createSession(options(failingStore));
+    await session.send('complete durably');
+    const output = session.stream();
+
+    await expect(output.next()).resolves.toMatchObject({
+      value: { type: 'turn_start' },
+      done: false,
+    });
+    await expect(output.next()).resolves.toMatchObject({
+      value: { type: 'turn_end' },
+      done: false,
+    });
+    await expect(output.next()).rejects.toBeInstanceOf(DurableCommandOutcomeUnknownError);
+
+    const durableTypes = (await store.read(session.sessionId)).events.map((event) => event.type);
+    expect(durableTypes).not.toContain(DurableEventType.REQUEST_COMPLETED);
+    expect(session.getDurableRecoveryPlan()?.action).toBe('resume_request');
+    await expect(session.send('must wait for recovery')).rejects.toBeInstanceOf(
+      DurableSessionRecoveryRequiredError,
+    );
+    await session.close();
+  });
+
+  it('fails closed when resuming a session with unfinished durable work', async () => {
+    const { root, store } = createStore();
+    const sessionId = SessionId('unfinished-session');
+    const journal = await DurableSessionJournal.open(store, sessionId);
+    await journal.commit({
+      commandId: CommandId('command-create'),
+      events: [
+        {
+          type: DurableEventType.SESSION_CREATED,
+          data: { source: 'create' },
+        },
+      ],
+    });
+    await journal.commit({
+      commandId: CommandId('command-request'),
+      events: [
+        {
+          type: DurableEventType.REQUEST_ACCEPTED,
+          requestId: RequestId('unfinished-request'),
+          data: {
+            inputId: InputId('unfinished-input'),
+            input: 'resume me',
+            priority: 'next',
+          },
+        },
+      ],
+    });
+
+    await expect(
+      resumeSession({
+        ...options(store),
+        persistSession: true,
+        storagePath: root,
+        sessionId,
+      }),
+    ).rejects.toBeInstanceOf(DurableSessionRecoveryRequiredError);
+  });
+
+  it('durably interrupts a pending request before abort resolves', async () => {
+    const { store } = createStore();
+    const session = await createSession(options(store));
+    await session.send('pending');
+
+    await session.abort();
+
+    expect(session.getDurableRecoveryPlan()?.action).toBe('none');
+    expect((await store.read(session.sessionId)).events.map((event) => event.type)).toEqual([
+      DurableEventType.SESSION_CREATED,
+      DurableEventType.REQUEST_ACCEPTED,
+      DurableEventType.REQUEST_INTERRUPTED,
+    ]);
+
+    await session.send('next');
+    for await (const _event of session.stream()) {
+      // Drain.
+    }
+    await session.close();
+  });
+
+  it('durably interrupts a pending request before cancelling its input', async () => {
+    const { store } = createStore();
+    const session = await createSession(options(store));
+    const submission = await session.send('pending');
+    if (submission.status !== 'started') {
+      throw new Error('Expected started submission');
+    }
+
+    await expect(session.cancelInput(submission.inputId)).resolves.toBe(true);
+
+    expect(session.getDurableRecoveryPlan()?.action).toBe('none');
+    expect((await store.read(session.sessionId)).events.at(-1)?.type).toBe(
+      DurableEventType.REQUEST_INTERRUPTED,
+    );
+    await session.close();
+  });
+
+  it('closes the inner stream and durably interrupts when a consumer stops early', async () => {
+    const { store } = createStore();
+    let innerClosed = false;
+    streamChat = async function* interruptedByConsumer() {
+      try {
+        yield { type: 'turn_start', turn: 1, maxTurns: 10 };
+        yield { type: 'content_delta', delta: 'partial' };
+        return {
+          success: true,
+          finalMessage: 'unexpected',
+          metadata: { turnsCount: 1, toolCallsCount: 0, duration: 1 },
+        };
+      } finally {
+        innerClosed = true;
+      }
+    };
+    const session = await createSession(options(store));
+    await session.send('stop early');
+
+    for await (const event of session.stream()) {
+      expect(event.type).toBe('turn_start');
+      break;
+    }
+
+    expect(innerClosed).toBe(true);
+    expect(session.getDurableRecoveryPlan()?.action).toBe('none');
+    expect((await store.read(session.sessionId)).events.map((event) => event.type).slice(-2)).toEqual([
+      DurableEventType.TURN_ABORTED,
+      DurableEventType.REQUEST_INTERRUPTED,
+    ]);
+    await session.close();
+  });
+
+  it('closes a pending durable request before closing the session', async () => {
+    const { store } = createStore();
+    const session = await createSession(options(store));
+    await session.send('pending close');
+
+    await session.close();
+
+    expect((await store.read(session.sessionId)).events.map((event) => event.type).slice(-2)).toEqual([
+      DurableEventType.REQUEST_INTERRUPTED,
+      DurableEventType.SESSION_CLOSED,
+    ]);
+  });
+
+  it('commits session closure once across concurrent close calls', async () => {
+    const { store } = createStore();
+    const session = await createSession(options(store));
+
+    await Promise.all([session.close(), session.close()]);
+
+    expect(
+      (await store.read(session.sessionId)).events.filter(
+        (event) => event.type === DurableEventType.SESSION_CLOSED,
+      ),
+    ).toHaveLength(1);
+  });
+
+  it('preserves the session-close reason when closing a running request', async () => {
+    const { store } = createStore();
+    streamChat = async function* interruptedByClose(_message, context) {
+      yield { type: 'turn_start', turn: 1, maxTurns: 10 };
+      const signal = (context as { signal?: AbortSignal }).signal;
+      if (!signal) {
+        throw new Error('Missing request signal');
+      }
+      await new Promise<void>((resolve) => {
+        if (signal.aborted) {
+          resolve();
+          return;
+        }
+        signal.addEventListener('abort', () => resolve(), { once: true });
+      });
+      return {
+        success: false,
+        error: { type: 'aborted', message: 'closed' },
+        metadata: { turnsCount: 1, toolCallsCount: 0, duration: 1 },
+      };
+    };
+    const session = await createSession(options(store));
+    await session.send('close while running');
+    const output = session.stream();
+    await expect(output.next()).resolves.toMatchObject({
+      value: { type: 'turn_start' },
+      done: false,
+    });
+
+    await session.close();
+    for await (const _event of output) {
+      // Drain cleanup after close.
+    }
+
+    const events = (await store.read(session.sessionId)).events;
+    expect(events.find((event) => event.type === DurableEventType.REQUEST_INTERRUPTED)?.data)
+      .toMatchObject({ reason: 'session_close' });
+    expect(events.at(-1)?.type).toBe(DurableEventType.SESSION_CLOSED);
+  });
+
+  it('accepts a queued later input durably when it becomes the next request', async () => {
+    const { store } = createStore();
+    const session = await createSession(options(store));
+    await session.send('first');
+    const queued = await session.send('second', { priority: 'later' });
+    expect(queued.status).toBe('queued');
+
+    for await (const _event of session.stream()) {
+      // Drain first request.
+    }
+    for await (const _event of session.stream()) {
+      // Drain promoted request.
+    }
+
+    const accepted = (await store.read(session.sessionId)).events.filter(
+      (event) => event.type === DurableEventType.REQUEST_ACCEPTED,
+    );
+    expect(accepted).toHaveLength(2);
+    expect(accepted[1]?.data).toMatchObject({
+      input: 'second',
+      priority: 'later',
+    });
+    await session.close();
+  });
+
+  it('does not close the source durable session after forkSession releases its local runtime', async () => {
+    const { root, store } = createStore();
+    const source = await createSession({
+      ...options(store),
+      persistSession: true,
+      storagePath: root,
+    });
+    await source.send('source');
+    for await (const _event of source.stream()) {
+      // Drain.
+    }
+
+    const forked = await forkSession({
+      ...options(store),
+      persistSession: true,
+      storagePath: root,
+      sessionId: source.sessionId,
+    });
+
+    const sourceJournal = await DurableSessionJournal.open(store, source.sessionId);
+    expect(sourceJournal.getProjection().status).toBe('open');
+    expect(forked.getDurableProjection()?.created).toMatchObject({
+      source: 'fork',
+      parentSessionId: source.sessionId,
+    });
+
+    await forked.close();
+    await source.close();
+  });
+
+  it('preserves the existing Session behavior when no durable Store is configured', async () => {
+    const session = await createSession({
+      provider: { type: 'openai-compatible', apiKey: 'test-key' },
+      model: 'test-model',
+      persistSession: false,
+    });
+
+    expect(session.getDurableProjection()).toBeNull();
+    expect(session.getDurableRecoveryPlan()).toBeNull();
+    await session.close();
+  });
+});

--- a/src/session/__tests__/SessionSteeringResilience.test.ts
+++ b/src/session/__tests__/SessionSteeringResilience.test.ts
@@ -155,7 +155,7 @@ describe('Session steering resilience', () => {
     expect(submission.status).toBe('started');
 
     // send() 已返回、stream() 尚未调用时中止：不应被静默忽略。
-    session.abort();
+    await session.abort();
 
     // 中止后会话回到 idle，可以启动全新请求。
     const next = await session.send('after abort');

--- a/src/session/events/SessionDurableRecorder.ts
+++ b/src/session/events/SessionDurableRecorder.ts
@@ -1,0 +1,594 @@
+import { nanoid } from 'nanoid';
+import type { AgentEvent, TokenUsageInfo } from '../../agent/AgentEvent.js';
+import type { LoopResult, UserMessageContent } from '../../agent/types.js';
+import { SdkError } from '../../errors/SdkError.js';
+import type {
+  ToolExecutionLifecycle,
+  ToolInvocationLifecycle,
+  ToolPermissionResolution,
+  ToolScheduledLifecycle,
+  ToolSettledLifecycle,
+} from '../../tools/types/ExecutionTypes.js';
+import { ToolErrorType } from '../../tools/types/ToolResult.js';
+import {
+  CommandId,
+  type InputId,
+  PermissionRequestId,
+  type RequestId,
+  ToolAttemptId,
+  type ToolUseId,
+  TurnId,
+} from '../../types/branded.js';
+import type { JsonValue } from '../../types/common.js';
+import { toJsonValue } from '../../utils/jsonValue.js';
+import type { DurableSessionJournal } from './DurableSessionJournal.js';
+import type { DurableSessionRecoveryPlan } from './DurableSessionProjector.js';
+import {
+  DurableEventType,
+  type DurableRequestInterruptReason,
+  type DurableToolCancelReason,
+} from './types.js';
+
+type ActiveToolStatus = 'scheduled' | 'started' | 'settled';
+
+interface ActiveTool {
+  toolAttemptId: ToolAttemptId;
+  toolCallId: ToolUseId;
+  toolName: string;
+  status: ActiveToolStatus;
+  permissionRequestId?: PermissionRequestId;
+  permissionDecision?: ToolPermissionResolution['decision'];
+}
+
+interface ActiveTurn {
+  turnId: TurnId;
+  turn: number;
+  tools: Map<ToolUseId, ActiveTool>;
+}
+
+export type DurableRequestFinish =
+  | {
+      status: 'completed';
+      output?: JsonValue;
+      usage?: TokenUsageInfo;
+    }
+  | {
+      status: 'failed';
+      error: unknown;
+    }
+  | {
+      status: 'interrupted';
+      reason: DurableRequestInterruptReason;
+      byInputId?: InputId;
+    };
+
+export class SessionDurableRecorderError extends SdkError {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super('DURABLE_SESSION_RECORDER_INVALID_STATE', message, options);
+  }
+}
+
+export class DurableSessionRecoveryRequiredError extends SdkError {
+  readonly recoveryPlan: DurableSessionRecoveryPlan;
+
+  constructor(recoveryPlan: DurableSessionRecoveryPlan) {
+    super(
+      'DURABLE_SESSION_RECOVERY_REQUIRED',
+      `Session recovery requires action: ${recoveryPlan.action}`,
+    );
+    this.recoveryPlan = structuredClone(recoveryPlan);
+  }
+}
+
+export class SessionDurableRecorder implements ToolExecutionLifecycle {
+  private activeTurn: ActiveTurn | null = null;
+  private ignoredTurnEnd: number | null = null;
+  private requestStarted = false;
+  private requestFinished = false;
+
+  constructor(
+    private readonly journal: DurableSessionJournal,
+    readonly requestId: RequestId,
+    private readonly model: string,
+  ) {}
+
+  async recordAccepted(
+    inputId: InputId,
+    input: UserMessageContent,
+    priority: 'next' | 'later' = 'next',
+  ): Promise<void> {
+    await this.commit([
+      {
+        type: DurableEventType.REQUEST_ACCEPTED,
+        requestId: this.requestId,
+        data: {
+          inputId,
+          input: toJsonValue(input),
+          priority,
+        },
+      },
+    ]);
+  }
+
+  async recordStarted(inputId: InputId, priority: 'next' | 'later' = 'next'): Promise<void> {
+    this.assertRequestOpen();
+    if (this.requestStarted) {
+      throw new SessionDurableRecorderError(`Request ${this.requestId} was already started`);
+    }
+    await this.commit([
+      {
+        type: DurableEventType.INPUT_APPLIED,
+        requestId: this.requestId,
+        data: {
+          inputId,
+          priority: priority === 'later' ? 'next' : priority,
+        },
+      },
+      {
+        type: DurableEventType.REQUEST_STARTED,
+        requestId: this.requestId,
+        data: {},
+      },
+    ]);
+    this.requestStarted = true;
+  }
+
+  async recordAgentEvent(event: AgentEvent): Promise<void> {
+    this.assertRequestOpen();
+    switch (event.type) {
+      case 'turn_start':
+        await this.startTurn(event.turn);
+        return;
+      case 'turn_end':
+        if (this.ignoredTurnEnd === event.turn) {
+          this.ignoredTurnEnd = null;
+          return;
+        }
+        await this.completeTurn(event.turn, event.hasToolCalls);
+        return;
+      case 'turn_interrupted':
+        if (!await this.abortTurn(event.turn, 'request_interrupted')) {
+          throw new SessionDurableRecorderError(
+            `Turn ${this.activeTurn?.turnId ?? event.turn} has a tool outcome that requires reconciliation`,
+          );
+        }
+        this.ignoredTurnEnd = event.turn;
+        return;
+      case 'input_applied':
+        await this.commit([
+          {
+            type: DurableEventType.INPUT_APPLIED,
+            requestId: this.requestId,
+            ...(this.activeTurn ? { turnId: this.activeTurn.turnId } : {}),
+            data: {
+              inputId: event.inputId,
+              priority: event.priority,
+            },
+          },
+        ]);
+        return;
+      default:
+        return;
+    }
+  }
+
+  async finish(finish: DurableRequestFinish): Promise<boolean> {
+    this.assertRequestOpen();
+    if (this.activeTurn) {
+      if (finish.status === 'completed') {
+        throw new SessionDurableRecorderError(
+          `Request ${this.requestId} completed while turn ${this.activeTurn.turnId} was still active`,
+        );
+      }
+      const reason = finish.status === 'interrupted' ? 'request_interrupted' : 'error';
+      if (!(await this.abortTurn(this.activeTurn.turn, reason))) {
+        return false;
+      }
+    }
+
+    switch (finish.status) {
+      case 'completed':
+        await this.commit([
+          {
+            type: DurableEventType.REQUEST_COMPLETED,
+            requestId: this.requestId,
+            data: {
+              ...(finish.output !== undefined ? { output: finish.output } : {}),
+              ...(finish.usage
+                ? {
+                    usage: {
+                      inputTokens: finish.usage.inputTokens,
+                      outputTokens: finish.usage.outputTokens,
+                      totalTokens: finish.usage.totalTokens,
+                    },
+                  }
+                : {}),
+            },
+          },
+        ]);
+        break;
+      case 'failed':
+        await this.commit([
+          {
+            type: DurableEventType.REQUEST_FAILED,
+            requestId: this.requestId,
+            data: {
+              error: {
+                message:
+                  finish.error instanceof Error ? finish.error.message : String(finish.error),
+              },
+            },
+          },
+        ]);
+        break;
+      case 'interrupted':
+        await this.commit([
+          {
+            type: DurableEventType.REQUEST_INTERRUPTED,
+            requestId: this.requestId,
+            data: {
+              reason: finish.reason,
+              ...(finish.byInputId ? { byInputId: finish.byInputId } : {}),
+            },
+          },
+        ]);
+        break;
+    }
+    this.requestFinished = true;
+    return true;
+  }
+
+  async onToolScheduled(event: ToolScheduledLifecycle): Promise<ToolInvocationLifecycle> {
+    const turn = this.requireActiveTurn();
+    if (turn.tools.has(event.toolCallId)) {
+      throw new SessionDurableRecorderError(
+        `Tool call ${event.toolCallId} was already scheduled in turn ${turn.turnId}`,
+      );
+    }
+    const tool: ActiveTool = {
+      toolAttemptId: ToolAttemptId(nanoid()),
+      toolCallId: event.toolCallId,
+      toolName: event.toolName,
+      status: 'scheduled',
+    };
+    turn.tools.set(tool.toolCallId, tool);
+    try {
+      await this.commit([
+        {
+          type: DurableEventType.TOOL_SCHEDULED,
+          requestId: this.requestId,
+          turnId: turn.turnId,
+          toolAttemptId: tool.toolAttemptId,
+          data: {
+            toolCallId: tool.toolCallId,
+            toolName: tool.toolName,
+            input: event.input,
+            interruptBehavior: event.interruptBehavior,
+          },
+        },
+      ]);
+    } catch (error) {
+      if (turn.tools.get(tool.toolCallId) === tool) {
+        turn.tools.delete(tool.toolCallId);
+      }
+      throw error;
+    }
+
+    return {
+      onPermissionRequested: (details, input) =>
+        this.recordPermissionRequested(tool, details.message, input),
+      onPermissionResolved: (resolution) => this.recordPermissionResolved(tool, resolution),
+      onExecutionStarted: () => this.recordToolStarted(tool),
+    };
+  }
+
+  async onToolSettled(event: ToolSettledLifecycle): Promise<void> {
+    const turn = this.requireActiveTurn();
+    const tool = turn.tools.get(event.toolCallId);
+    if (!tool || tool.toolName !== event.toolName) {
+      throw new SessionDurableRecorderError(
+        `No scheduled tool matches ${event.toolName} (${event.toolCallId})`,
+      );
+    }
+    if (tool.status === 'settled') {
+      throw new SessionDurableRecorderError(`Tool call ${event.toolCallId} was already settled`);
+    }
+
+    if (event.result.status === 'success') {
+      if (tool.status !== 'started') {
+        throw new SessionDurableRecorderError(
+          `Successful tool ${event.toolCallId} never crossed the execution boundary`,
+        );
+      }
+      await this.commit([
+        {
+          type: DurableEventType.TOOL_COMPLETED,
+          requestId: this.requestId,
+          turnId: turn.turnId,
+          toolAttemptId: tool.toolAttemptId,
+          data: {
+            toolCallId: tool.toolCallId,
+            toolName: tool.toolName,
+            result: event.result.model,
+          },
+        },
+      ]);
+    } else if (tool.permissionDecision === 'deny' || tool.permissionDecision === 'cancel') {
+      await this.recordToolCancelled(
+        tool,
+        tool.permissionDecision === 'deny' ? 'permission_denied' : 'permission_cancelled',
+      );
+    } else if (event.result.error.type === ToolErrorType.INTERRUPTED) {
+      await this.recordToolCancelled(tool, 'request_interrupted');
+    } else {
+      await this.commit([
+        {
+          type: DurableEventType.TOOL_FAILED,
+          requestId: this.requestId,
+          turnId: turn.turnId,
+          toolAttemptId: tool.toolAttemptId,
+          data: {
+            toolCallId: tool.toolCallId,
+            toolName: tool.toolName,
+            error: {
+              message: event.result.error.message,
+              ...(event.result.error.code ? { code: event.result.error.code } : {}),
+            },
+          },
+        },
+      ]);
+    }
+    tool.status = 'settled';
+  }
+
+  private async startTurn(turn: number): Promise<void> {
+    if (this.activeTurn) {
+      throw new SessionDurableRecorderError(`Turn ${this.activeTurn.turnId} is still active`);
+    }
+    const activeTurn: ActiveTurn = {
+      turnId: TurnId(nanoid()),
+      turn,
+      tools: new Map(),
+    };
+    await this.commit([
+      {
+        type: DurableEventType.TURN_STARTED,
+        requestId: this.requestId,
+        turnId: activeTurn.turnId,
+        data: {
+          turn,
+          model: this.model,
+        },
+      },
+    ]);
+    this.activeTurn = activeTurn;
+  }
+
+  private async completeTurn(turn: number, hasToolCalls: boolean): Promise<void> {
+    const activeTurn = this.requireTurnNumber(turn);
+    await this.commit([
+      {
+        type: DurableEventType.TURN_COMPLETED,
+        requestId: this.requestId,
+        turnId: activeTurn.turnId,
+        data: {
+          turn,
+          hasToolCalls,
+        },
+      },
+    ]);
+    this.activeTurn = null;
+  }
+
+  private async abortTurn(turn: number, reason: 'request_interrupted' | 'error'): Promise<boolean> {
+    const activeTurn = this.requireTurnNumber(turn);
+    const drafts = [];
+    const cancelledPermissions: ActiveTool[] = [];
+    const settledTools: ActiveTool[] = [];
+    let hasUnknownOutcome = false;
+
+    for (const tool of activeTurn.tools.values()) {
+      if (tool.status === 'settled') {
+        continue;
+      }
+      if (tool.status === 'started') {
+        hasUnknownOutcome = true;
+        continue;
+      }
+      if (tool.permissionRequestId && !tool.permissionDecision) {
+        drafts.push({
+          type: DurableEventType.PERMISSION_RESOLVED,
+          requestId: this.requestId,
+          turnId: activeTurn.turnId,
+          toolAttemptId: tool.toolAttemptId,
+          data: {
+            permissionRequestId: tool.permissionRequestId,
+            decision: 'cancel',
+            message: 'Request ended before permission resolution',
+          },
+        } as const);
+        cancelledPermissions.push(tool);
+      }
+      drafts.push({
+        type: DurableEventType.TOOL_CANCELLED,
+        requestId: this.requestId,
+        turnId: activeTurn.turnId,
+        toolAttemptId: tool.toolAttemptId,
+        data: {
+          toolCallId: tool.toolCallId,
+          toolName: tool.toolName,
+          reason: reason === 'request_interrupted' ? 'request_interrupted' : 'cascade_abort',
+        },
+      } as const);
+      settledTools.push(tool);
+    }
+
+    if (drafts.length > 0) {
+      await this.commit(drafts);
+      for (const tool of cancelledPermissions) {
+        tool.permissionDecision = 'cancel';
+      }
+      for (const tool of settledTools) {
+        tool.status = 'settled';
+      }
+    }
+    if (hasUnknownOutcome) {
+      return false;
+    }
+    await this.commit([
+      {
+        type: DurableEventType.TURN_ABORTED,
+        requestId: this.requestId,
+        turnId: activeTurn.turnId,
+        data: {
+          turn,
+          reason,
+        },
+      },
+    ]);
+    this.activeTurn = null;
+    return true;
+  }
+
+  private async recordPermissionRequested(
+    tool: ActiveTool,
+    message: string,
+    input: JsonValue,
+  ): Promise<PermissionRequestId> {
+    const turn = this.requireActiveTurn();
+    const permissionRequestId = PermissionRequestId(nanoid());
+    await this.commit([
+      {
+        type: DurableEventType.PERMISSION_REQUESTED,
+        requestId: this.requestId,
+        turnId: turn.turnId,
+        toolAttemptId: tool.toolAttemptId,
+        data: {
+          permissionRequestId,
+          toolCallId: tool.toolCallId,
+          toolName: tool.toolName,
+          input,
+          message,
+        },
+      },
+    ]);
+    tool.permissionRequestId = permissionRequestId;
+    return permissionRequestId;
+  }
+
+  private async recordPermissionResolved(
+    tool: ActiveTool,
+    resolution: ToolPermissionResolution,
+  ): Promise<void> {
+    const turn = this.requireActiveTurn();
+    if (tool.permissionRequestId !== resolution.permissionRequestId) {
+      throw new SessionDurableRecorderError(
+        `Permission ${resolution.permissionRequestId} does not match tool ${tool.toolCallId}`,
+      );
+    }
+    await this.commit([
+      {
+        type: DurableEventType.PERMISSION_RESOLVED,
+        requestId: this.requestId,
+        turnId: turn.turnId,
+        toolAttemptId: tool.toolAttemptId,
+        data: resolution,
+      },
+    ]);
+    tool.permissionDecision = resolution.decision;
+  }
+
+  private async recordToolStarted(tool: ActiveTool): Promise<void> {
+    const turn = this.requireActiveTurn();
+    await this.commit([
+      {
+        type: DurableEventType.TOOL_STARTED,
+        requestId: this.requestId,
+        turnId: turn.turnId,
+        toolAttemptId: tool.toolAttemptId,
+        data: {
+          toolCallId: tool.toolCallId,
+          toolName: tool.toolName,
+        },
+      },
+    ]);
+    tool.status = 'started';
+  }
+
+  private async recordToolCancelled(
+    tool: ActiveTool,
+    reason: DurableToolCancelReason,
+  ): Promise<void> {
+    const turn = this.requireActiveTurn();
+    await this.commit([
+      {
+        type: DurableEventType.TOOL_CANCELLED,
+        requestId: this.requestId,
+        turnId: turn.turnId,
+        toolAttemptId: tool.toolAttemptId,
+        data: {
+          toolCallId: tool.toolCallId,
+          toolName: tool.toolName,
+          reason,
+        },
+      },
+    ]);
+  }
+
+  private assertRequestOpen(): void {
+    if (this.requestFinished) {
+      throw new SessionDurableRecorderError(`Request ${this.requestId} is already terminal`);
+    }
+  }
+
+  private requireActiveTurn(): ActiveTurn {
+    this.assertRequestOpen();
+    if (!this.activeTurn) {
+      throw new SessionDurableRecorderError(`Request ${this.requestId} has no active turn`);
+    }
+    return this.activeTurn;
+  }
+
+  private requireTurnNumber(turn: number): ActiveTurn {
+    const activeTurn = this.requireActiveTurn();
+    if (activeTurn.turn !== turn) {
+      throw new SessionDurableRecorderError(
+        `Expected active turn ${activeTurn.turn}, received ${turn}`,
+      );
+    }
+    return activeTurn;
+  }
+
+  private async commit(
+    events: Parameters<DurableSessionJournal['commit']>[0]['events'],
+  ): Promise<void> {
+    await this.journal.commit({
+      commandId: CommandId(nanoid()),
+      events,
+    });
+  }
+}
+
+export function durableRequestFinishFromLoopResult(
+  result: LoopResult,
+  usage: TokenUsageInfo,
+  interruptionReason: DurableRequestInterruptReason = 'user_abort',
+): DurableRequestFinish {
+  if (result.error?.type === 'aborted') {
+    return {
+      status: 'interrupted',
+      reason: interruptionReason,
+    };
+  }
+  if (!result.success && !result.metadata?.shouldExitLoop) {
+    return {
+      status: 'failed',
+      error: result.error?.message ?? 'Agent request failed',
+    };
+  }
+  return {
+    status: 'completed',
+    output: result.finalMessage ?? '',
+    usage,
+  };
+}

--- a/src/session/events/__tests__/SessionDurableRecorder.test.ts
+++ b/src/session/events/__tests__/SessionDurableRecorder.test.ts
@@ -1,0 +1,424 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { ToolErrorType } from '../../../tools/types/ToolResult.js';
+import {
+  CommandId,
+  EventId,
+  InputId,
+  RequestId,
+  SessionId,
+  ToolUseId,
+} from '../../../types/branded.js';
+import { DurableSessionJournal } from '../DurableSessionJournal.js';
+import { JsonlDurableEventStore } from '../JsonlDurableEventStore.js';
+import {
+  durableRequestFinishFromLoopResult,
+  SessionDurableRecorder,
+  SessionDurableRecorderError,
+} from '../SessionDurableRecorder.js';
+import { DurableEventType } from '../types.js';
+
+describe('SessionDurableRecorder', () => {
+  let storageRoot: string;
+  let store: JsonlDurableEventStore;
+  let journal: DurableSessionJournal;
+  let recorder: SessionDurableRecorder;
+  const sessionId = SessionId('session-recorder');
+  const requestId = RequestId('request-1');
+  const inputId = InputId('input-1');
+
+  beforeEach(async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'session-durable-recorder-'));
+    let nextEventId = 0;
+    store = new JsonlDurableEventStore(storageRoot, {
+      clock: () => new Date('2026-08-22T12:00:00.000Z'),
+      eventIdFactory: () => EventId(`event-${++nextEventId}`),
+    });
+    journal = await DurableSessionJournal.open(store, sessionId);
+    await journal.commit({
+      commandId: CommandId('command-create'),
+      events: [
+        {
+          type: DurableEventType.SESSION_CREATED,
+          data: { source: 'create' },
+        },
+      ],
+    });
+    recorder = new SessionDurableRecorder(journal, requestId, 'test-model');
+  });
+
+  afterEach(async () => {
+    await rm(storageRoot, { recursive: true, force: true });
+  });
+
+  it('records a complete request, turn, permission, and tool lifecycle', async () => {
+    await recorder.recordAccepted(inputId, 'run write');
+    await recorder.recordStarted(inputId);
+    await recorder.recordAgentEvent({
+      type: 'turn_start',
+      turn: 1,
+      maxTurns: 10,
+    });
+
+    const lifecycle = await recorder.onToolScheduled({
+      toolCallId: ToolUseId('tool-call-1'),
+      toolName: 'Write',
+      input: { file_path: '/tmp/file' },
+      interruptBehavior: 'block',
+    });
+    const permissionRequestId = await lifecycle.onPermissionRequested?.(
+      { message: 'Allow write?' },
+      { file_path: '/tmp/file' },
+    );
+    if (!permissionRequestId) {
+      throw new Error('Expected permission request ID');
+    }
+    await lifecycle.onPermissionResolved?.({
+      permissionRequestId,
+      decision: 'allow',
+    });
+    await lifecycle.onExecutionStarted?.();
+    await recorder.onToolSettled({
+      toolCallId: ToolUseId('tool-call-1'),
+      toolName: 'Write',
+      result: {
+        status: 'success',
+        model: { changed: true },
+      },
+    });
+    await recorder.recordAgentEvent({
+      type: 'turn_end',
+      turn: 1,
+      hasToolCalls: true,
+    });
+    await recorder.finish({
+      status: 'completed',
+      output: 'done',
+      usage: {
+        inputTokens: 10,
+        outputTokens: 2,
+        totalTokens: 12,
+        maxContextTokens: 100,
+      },
+    });
+
+    expect((await store.read(sessionId)).events.map((event) => event.type)).toEqual([
+      'session_created',
+      'request_accepted',
+      'input_applied',
+      'request_started',
+      'turn_started',
+      'tool_scheduled',
+      'permission_requested',
+      'permission_resolved',
+      'tool_started',
+      'tool_completed',
+      'turn_completed',
+      'request_completed',
+    ]);
+    expect(journal.getProjection().activeRequest).toBeNull();
+  });
+
+  it('records a denied permission as a cancelled tool without starting it', async () => {
+    await recorder.recordAccepted(inputId, 'run write');
+    await recorder.recordStarted(inputId);
+    await recorder.recordAgentEvent({
+      type: 'turn_start',
+      turn: 1,
+      maxTurns: 10,
+    });
+    const lifecycle = await recorder.onToolScheduled({
+      toolCallId: ToolUseId('tool-call-1'),
+      toolName: 'Write',
+      input: {},
+      interruptBehavior: 'block',
+    });
+    const permissionRequestId = await lifecycle.onPermissionRequested?.({ message: 'Allow?' }, {});
+    if (!permissionRequestId) {
+      throw new Error('Expected permission request ID');
+    }
+    await lifecycle.onPermissionResolved?.({
+      permissionRequestId,
+      decision: 'deny',
+      message: 'No',
+    });
+    await recorder.onToolSettled({
+      toolCallId: ToolUseId('tool-call-1'),
+      toolName: 'Write',
+      result: {
+        status: 'error',
+        model: 'denied',
+        error: {
+          type: ToolErrorType.PERMISSION_DENIED,
+          message: 'No',
+        },
+      },
+    });
+
+    const types = (await store.read(sessionId)).events.map((event) => event.type);
+    expect(types).toContain(DurableEventType.PERMISSION_RESOLVED);
+    expect(types).toContain(DurableEventType.TOOL_CANCELLED);
+    expect(types).not.toContain(DurableEventType.TOOL_STARTED);
+  });
+
+  it('records pre-execution validation failures as failed tools', async () => {
+    await recorder.recordAccepted(inputId, 'run invalid tool');
+    await recorder.recordStarted(inputId);
+    await recorder.recordAgentEvent({
+      type: 'turn_start',
+      turn: 1,
+      maxTurns: 10,
+    });
+    await recorder.onToolScheduled({
+      toolCallId: ToolUseId('tool-call-1'),
+      toolName: 'Write',
+      input: {},
+      interruptBehavior: 'block',
+    });
+    await recorder.onToolSettled({
+      toolCallId: ToolUseId('tool-call-1'),
+      toolName: 'Write',
+      result: {
+        status: 'error',
+        model: 'invalid',
+        error: {
+          type: ToolErrorType.VALIDATION_ERROR,
+          message: 'Invalid input',
+        },
+      },
+    });
+
+    expect((await store.read(sessionId)).events.map((event) => event.type)).toEqual(
+      expect.arrayContaining([DurableEventType.TOOL_SCHEDULED, DurableEventType.TOOL_FAILED]),
+    );
+  });
+
+  it('closes scheduled work before aborting a turn and request', async () => {
+    await recorder.recordAccepted(inputId, 'run tool');
+    await recorder.recordStarted(inputId);
+    await recorder.recordAgentEvent({
+      type: 'turn_start',
+      turn: 1,
+      maxTurns: 10,
+    });
+    await recorder.onToolScheduled({
+      toolCallId: ToolUseId('tool-call-1'),
+      toolName: 'Write',
+      input: {},
+      interruptBehavior: 'block',
+    });
+
+    await expect(
+      recorder.finish({
+        status: 'interrupted',
+        reason: 'user_abort',
+      }),
+    ).resolves.toBe(true);
+
+    expect((await store.read(sessionId)).events.map((event) => event.type).slice(-3)).toEqual([
+      DurableEventType.TOOL_CANCELLED,
+      DurableEventType.TURN_ABORTED,
+      DurableEventType.REQUEST_INTERRUPTED,
+    ]);
+  });
+
+  it('rejects successful request completion while a turn is still active', async () => {
+    await recorder.recordAccepted(inputId, 'run');
+    await recorder.recordStarted(inputId);
+    await recorder.recordAgentEvent({
+      type: 'turn_start',
+      turn: 1,
+      maxTurns: 10,
+    });
+
+    await expect(recorder.finish({
+      status: 'completed',
+      output: 'invalid',
+    })).rejects.toBeInstanceOf(SessionDurableRecorderError);
+    expect(journal.getRecoveryPlan().action).toBe('resume_turn');
+  });
+
+  it('leaves a started tool recoverable instead of inventing a terminal outcome', async () => {
+    await recorder.recordAccepted(inputId, 'run tool');
+    await recorder.recordStarted(inputId);
+    await recorder.recordAgentEvent({
+      type: 'turn_start',
+      turn: 1,
+      maxTurns: 10,
+    });
+    const lifecycle = await recorder.onToolScheduled({
+      toolCallId: ToolUseId('tool-call-1'),
+      toolName: 'Write',
+      input: {},
+      interruptBehavior: 'block',
+    });
+    await lifecycle.onExecutionStarted?.();
+
+    await expect(
+      recorder.finish({
+        status: 'failed',
+        error: new Error('worker disappeared'),
+      }),
+    ).resolves.toBe(false);
+    expect(journal.getRecoveryPlan()).toMatchObject({
+      action: 'reconcile_tool_outcomes',
+      requestId,
+      unknownToolAttempts: [
+        expect.objectContaining({
+          toolCallId: 'tool-call-1',
+          status: 'started',
+        }),
+      ],
+    });
+    expect((await store.read(sessionId)).events.at(-1)?.type).toBe(DurableEventType.TOOL_STARTED);
+  });
+
+  it('blocks steering past a started tool with an unknown outcome', async () => {
+    await recorder.recordAccepted(inputId, 'run tool');
+    await recorder.recordStarted(inputId);
+    await recorder.recordAgentEvent({
+      type: 'turn_start',
+      turn: 1,
+      maxTurns: 10,
+    });
+    const lifecycle = await recorder.onToolScheduled({
+      toolCallId: ToolUseId('tool-call-1'),
+      toolName: 'Write',
+      input: {},
+      interruptBehavior: 'block',
+    });
+    await lifecycle.onExecutionStarted?.();
+
+    await expect(
+      recorder.recordAgentEvent({
+        type: 'turn_interrupted',
+        inputId: InputId('steering-input'),
+        requestId,
+        turn: 1,
+      }),
+    ).rejects.toBeInstanceOf(SessionDurableRecorderError);
+    expect(journal.getRecoveryPlan().action).toBe('reconcile_tool_outcomes');
+  });
+
+  it('rejects duplicate tool settlement', async () => {
+    await recorder.recordAccepted(inputId, 'run tool');
+    await recorder.recordStarted(inputId);
+    await recorder.recordAgentEvent({
+      type: 'turn_start',
+      turn: 1,
+      maxTurns: 10,
+    });
+    const toolCallId = ToolUseId('tool-call-1');
+    const lifecycle = await recorder.onToolScheduled({
+      toolCallId,
+      toolName: 'Read',
+      input: {},
+      interruptBehavior: 'cancel',
+    });
+    await lifecycle.onExecutionStarted?.();
+    const settled = {
+      toolCallId,
+      toolName: 'Read',
+      result: {
+        status: 'success' as const,
+        model: 'done',
+      },
+    };
+    await recorder.onToolSettled(settled);
+
+    await expect(recorder.onToolSettled(settled)).rejects.toBeInstanceOf(
+      SessionDurableRecorderError,
+    );
+  });
+
+  it('reserves a tool call ID before its durable schedule commit completes', async () => {
+    await recorder.recordAccepted(inputId, 'run tool');
+    await recorder.recordStarted(inputId);
+    await recorder.recordAgentEvent({
+      type: 'turn_start',
+      turn: 1,
+      maxTurns: 10,
+    });
+    const toolCallId = ToolUseId('tool-call-1');
+
+    const first = recorder.onToolScheduled({
+      toolCallId,
+      toolName: 'Read',
+      input: {},
+      interruptBehavior: 'cancel',
+    });
+    const duplicate = recorder.onToolScheduled({
+      toolCallId,
+      toolName: 'Read',
+      input: {},
+      interruptBehavior: 'cancel',
+    });
+
+    await Promise.all([
+      expect(first).resolves.toBeDefined(),
+      expect(duplicate).rejects.toBeInstanceOf(SessionDurableRecorderError),
+    ]);
+    expect(
+      (await store.read(sessionId)).events.filter(
+        (event) => event.type === DurableEventType.TOOL_SCHEDULED,
+      ),
+    ).toHaveLength(1);
+  });
+
+  it('maps loop results to durable terminal outcomes', () => {
+    expect(
+      durableRequestFinishFromLoopResult(
+        {
+          success: true,
+          finalMessage: 'done',
+        },
+        {
+          inputTokens: 1,
+          outputTokens: 2,
+          totalTokens: 3,
+          maxContextTokens: 100,
+        },
+      ),
+    ).toMatchObject({
+      status: 'completed',
+      output: 'done',
+    });
+    expect(
+      durableRequestFinishFromLoopResult(
+        {
+          success: false,
+          error: { type: 'aborted', message: 'aborted' },
+        },
+        {
+          inputTokens: 0,
+          outputTokens: 0,
+          totalTokens: 0,
+          maxContextTokens: 100,
+        },
+      ),
+    ).toEqual({
+      status: 'interrupted',
+      reason: 'user_abort',
+    });
+    expect(
+      durableRequestFinishFromLoopResult(
+        {
+          success: false,
+          error: { type: 'aborted', message: 'closed' },
+        },
+        {
+          inputTokens: 0,
+          outputTokens: 0,
+          totalTokens: 0,
+          maxContextTokens: 100,
+        },
+        'session_close',
+      ),
+    ).toEqual({
+      status: 'interrupted',
+      reason: 'session_close',
+    });
+  });
+});

--- a/src/session/events/core.ts
+++ b/src/session/events/core.ts
@@ -36,6 +36,10 @@ export {
   projectDurableSession,
 } from './DurableSessionProjector.js';
 export {
+  DurableSessionRecoveryRequiredError,
+  SessionDurableRecorderError,
+} from './SessionDurableRecorder.js';
+export {
   DURABLE_EVENT_LOG_FORMAT,
   type PersistedDurableEventBatch,
   parseDurableEventDraft,

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -40,6 +40,12 @@ import type { HookEvent, StreamMessageType } from '../types/constants.js';
 import type { AgentLogger } from '../types/logging.js';
 import type { CanUseTool, PermissionHandler, PermissionUpdate } from '../types/permissions.js';
 import type { Assert, IsEqual } from '../types/typeAssertions.js';
+import type { DurableEventStore } from './events/DurableEventStore.js';
+import type {
+  DurableSessionProjection,
+  DurableSessionRecoveryPlan,
+} from './events/DurableSessionProjector.js';
+
 export type {
   ExecutionContext,
   ProviderType,
@@ -282,6 +288,7 @@ export interface SessionOptions {
   logger?: AgentLogger;
   storagePath?: string;
   persistSession?: boolean;
+  durableEventStore?: DurableEventStore;
 
   outputFormat?: OutputFormat;
 
@@ -347,7 +354,7 @@ export interface ISession extends AsyncDisposable {
   stream(options?: StreamOptions): AsyncGenerator<StreamMessage>;
 
   close(): Promise<void>;
-  abort(): void;
+  abort(): Promise<void>;
 
   getDefaultContext(): RuntimeContext;
   setDefaultContext(context: RuntimeContext): void;
@@ -368,6 +375,8 @@ export interface ISession extends AsyncDisposable {
 
   getLastTrace(): AgentTrace | undefined;
   getTraces(): AgentTrace[];
+  getDurableProjection(): DurableSessionProjection | null;
+  getDurableRecoveryPlan(): DurableSessionRecoveryPlan | null;
 }
 
 export type { ContextSnapshot, RuntimeContext };


### PR DESCRIPTION
## Summary

- add opt-in `SessionOptions.durableEventStore` integration for Session, Request, Turn, Tool, Permission, and input-application lifecycle events
- enforce persist-before-side-effect and persist-before-publish boundaries through `SessionDurableRecorder`
- fail closed on unfinished recovery state, unknown tool outcomes, and terminal write failures
- make `Session.abort()` asynchronous so pending-request interruption is durable before it resolves
- preserve durable parent state during `forkSession()` cleanup and make concurrent Session closure idempotent
- expose durable projection/recovery inspection and document payload security and current recovery limits in Chinese and English

## Ordering guarantees

- `request_accepted` commits before `send()` returns
- `turn_started` and `tool_scheduled` commit before corresponding public stream events
- permission request/resolution commits surround the real permission decision
- `tool_started` commits before generator execution or side effects
- tool and request terminal events commit before public terminal events

## Breaking change

`ISession.abort()` now returns `Promise<void>`.

## Stack

Depends on #25. Retarget this PR to `main` after #25 merges.

## Verification

- `pnpm test` (125 files passed, 1261 tests passed, 62 credential-gated tests skipped)
- `pnpm run lint`
- `pnpm run type-check`
- `pnpm run docs:build`
- `pnpm run changelog:check`
- `pnpm run verify:entrypoints`
- `npm pack --dry-run`