### PR TITLE
fix(release): honor breaking changelog fragments

### DIFF
--- a/.changes/README.md
+++ b/.changes/README.md
@@ -14,12 +14,10 @@ fragments in the generated release commit.
 
 Allowed `type` values:
 
-- `breaking`
-- `feature`
-- `fix`
-- `performance`
-- `refactor`
-- `docs`
+- `breaking` → major
+- `feature` → minor
+- `fix` / `performance` / `refactor` / `docs` → patch
 
 Use a unique kebab-case filename. Both language fields are required and must
-describe user-visible behavior rather than commit mechanics.
+describe user-visible behavior rather than commit mechanics. The highest
+fragment type determines the semantic-release version.

--- a/.changes/fix-semantic-release-breaking.json
+++ b/.changes/fix-semantic-release-breaking.json
@@ -1,0 +1,5 @@
+{
+  "type": "fix",
+  "en": "Make changelog fragments drive semantic-release version selection and recognize Conventional Commit bang headers so breaking changes cannot merge without a release.",
+  "zh-CN": "让 changelog fragment 直接驱动 semantic-release 版本选择，并识别 Conventional Commit 的感叹号 header，防止 breaking change 合并后未发布版本。"
+}

--- a/release.config.cjs
+++ b/release.config.cjs
@@ -1,9 +1,14 @@
+const parserOpts = {
+  breakingHeaderPattern: /^(\w*)(?:\((.*)\))?!: (.*)$/,
+  breakingHeaderCorrespondence: ['type', 'scope', 'subject'],
+};
+
 module.exports = {
   branches: ['main'],
   tagFormat: 'v${version}',
   plugins: [
-    '@semantic-release/commit-analyzer',
-    '@semantic-release/release-notes-generator',
+    ['@semantic-release/commit-analyzer', { parserOpts }],
+    ['@semantic-release/release-notes-generator', { parserOpts }],
     './scripts/semantic-release-bilingual-changelog.cjs',
     '@semantic-release/npm',
     [

--- a/scripts/__tests__/semantic-release-bilingual-changelog.test.ts
+++ b/scripts/__tests__/semantic-release-bilingual-changelog.test.ts
@@ -14,7 +14,12 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const require = createRequire(import.meta.url);
 const plugin = require('../semantic-release-bilingual-changelog.cjs');
-const { readFragments, renderRelease, verifyRange } = plugin._internals;
+const {
+  readFragments,
+  releaseTypeFromFragments,
+  renderRelease,
+  verifyRange,
+} = plugin._internals;
 const temporaryDirectories: string[] = [];
 
 function createTemporaryDirectory(): string {
@@ -85,6 +90,30 @@ describe('bilingual changelog fragments', () => {
         '',
         '- Fix session recovery.',
       ].join('\n'),
+    );
+    expect(releaseTypeFromFragments(fragments)).toBe('minor');
+  });
+
+  it('uses the highest changelog fragment type as the release level', async () => {
+    const directory = createTemporaryDirectory();
+    writeFragment(directory, 'repair-runtime.json', {
+      type: 'fix',
+      en: 'Repair runtime behavior.',
+      'zh-CN': '修复运行时行为。',
+    });
+    writeFragment(directory, 'break-tool-contract.json', {
+      type: 'breaking',
+      en: 'Require a tool contract.',
+      'zh-CN': '要求工具契约。',
+    });
+    const logger = { log: vi.fn() };
+
+    await expect(plugin.analyzeCommits({}, {
+      cwd: directory,
+      logger,
+    })).resolves.toBe('major');
+    expect(logger.log).toHaveBeenCalledWith(
+      'Selected major release from 2 bilingual changelog fragment(s)',
     );
   });
 
@@ -194,6 +223,24 @@ describe('pull request fragment requirement', () => {
     commitAll(directory, 'docs: add changelog fragment');
 
     await expect(verifyRange(directory, base)).resolves.toBeUndefined();
+  });
+
+  it('recognizes breaking-change bang headers as releasable', async () => {
+    const directory = createTemporaryDirectory();
+    initializeRepository(directory);
+    writeFileSync(join(directory, 'README.md'), '# Test\n');
+    commitAll(directory, 'chore: initialize');
+    const base = execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd: directory,
+      encoding: 'utf8',
+    }).trim();
+
+    writeFileSync(join(directory, 'api.ts'), 'export const version = 2;\n');
+    commitAll(directory, 'feat(api)!: replace the contract');
+
+    await expect(verifyRange(directory, base)).rejects.toThrow(
+      'require a bilingual .changes/*.json fragment',
+    );
   });
 
   it('does not require a fragment for non-releasable commits', async () => {

--- a/scripts/__tests__/semantic-release-config.test.ts
+++ b/scripts/__tests__/semantic-release-config.test.ts
@@ -17,10 +17,14 @@ describe('semantic-release configuration', () => {
 
   it('updates bilingual changelogs and commits release metadata before publishing', () => {
     const config = require('../../release.config.cjs');
+    const parserOpts = {
+      breakingHeaderPattern: /^(\w*)(?:\((.*)\))?!: (.*)$/,
+      breakingHeaderCorrespondence: ['type', 'scope', 'subject'],
+    };
 
     expect(config.plugins).toEqual([
-      '@semantic-release/commit-analyzer',
-      '@semantic-release/release-notes-generator',
+      ['@semantic-release/commit-analyzer', { parserOpts }],
+      ['@semantic-release/release-notes-generator', { parserOpts }],
       './scripts/semantic-release-bilingual-changelog.cjs',
       '@semantic-release/npm',
       [

--- a/scripts/semantic-release-bilingual-changelog.cjs
+++ b/scripts/semantic-release-bilingual-changelog.cjs
@@ -41,6 +41,25 @@ const TYPE_ORDER = [
   'refactor',
   'docs',
 ];
+const RELEASE_TYPE_BY_FRAGMENT = {
+  breaking: 'major',
+  feature: 'minor',
+  fix: 'patch',
+  performance: 'patch',
+  refactor: 'patch',
+  docs: 'patch',
+};
+const RELEASE_TYPE_RANK = {
+  patch: 1,
+  minor: 2,
+  major: 3,
+};
+const COMMIT_ANALYZER_OPTIONS = {
+  parserOpts: {
+    breakingHeaderPattern: /^(\w*)(?:\((.*)\))?!: (.*)$/,
+    breakingHeaderCorrespondence: ['type', 'scope', 'subject'],
+  },
+};
 
 function getFragmentPaths(cwd) {
   const directory = path.join(cwd, FRAGMENT_DIRECTORY);
@@ -101,6 +120,20 @@ function readFragments(cwd) {
       'zh-CN': fragment['zh-CN'].trim(),
     };
   });
+}
+
+function releaseTypeFromFragments(fragments) {
+  let releaseType = null;
+  for (const fragment of fragments) {
+    const candidate = RELEASE_TYPE_BY_FRAGMENT[fragment.type];
+    if (
+      candidate
+      && (!releaseType || RELEASE_TYPE_RANK[candidate] > RELEASE_TYPE_RANK[releaseType])
+    ) {
+      releaseType = candidate;
+    }
+  }
+  return releaseType;
 }
 
 function renderRelease(version, date, locale, fragments) {
@@ -188,7 +221,7 @@ async function hasReleasableCommit(cwd, base) {
     message,
   }));
   const releaseType = await analyzeCommits(
-    {},
+    COMMIT_ANALYZER_OPTIONS,
     {
       commits,
       cwd,
@@ -196,6 +229,17 @@ async function hasReleasableCommit(cwd, base) {
     },
   );
   return releaseType !== null;
+}
+
+async function analyzeCommits(_pluginConfig, context) {
+  const fragments = readFragments(context.cwd);
+  const releaseType = releaseTypeFromFragments(fragments);
+  if (releaseType) {
+    context.logger.log(
+      `Selected ${releaseType} release from ${fragments.length} bilingual changelog fragment(s)`,
+    );
+  }
+  return releaseType;
 }
 
 async function verifyRange(cwd, base) {
@@ -259,6 +303,7 @@ if (require.main === module) {
 }
 
 module.exports = {
+  analyzeCommits,
   verifyConditions,
   prepare,
   _internals: {
@@ -268,6 +313,7 @@ module.exports = {
     hasReleasableCommit,
     prependRelease,
     readFragments,
+    releaseTypeFromFragments,
     renderRelease,
     stageFragmentDeletions,
     verifyRange,


### PR DESCRIPTION
## Summary

- parse Conventional Commit `type(scope)!:` headers as breaking changes in both version analysis and release notes
- make bilingual changelog fragments participate directly in semantic-release version selection
- choose the highest fragment level (`breaking` → major, `feature` → minor, remaining types → patch)
- add regression tests for bang headers and mixed fragment precedence

## Incident

PR #28 merged a breaking tool contract with a valid `breaking` fragment, but semantic-release 25's default Angular parser classified both the merge commit and `feat(tools)!` commit as non-releasable. The fragment therefore remained unconsumed and npm stayed on 3.3.0.

Merging this PR should consume both the retained breaking fragment and this fix fragment, producing v4.0.0.

## Verification

- `pnpm test` (125 files passed, 1271 tests passed, 62 credential-gated tests skipped)
- `pnpm run docs:build`
- `pnpm run changelog:check`
- `pnpm run type-check`
- `pnpm run lint`
- direct analyzer check confirms both bang headers and fragments select `major`