### PR TITLE
feat(durable): coordinate safe session recovery

### DIFF
--- a/.changes/durable-recovery-coordinator.json
+++ b/.changes/durable-recovery-coordinator.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "en": "Add a durable recovery coordinator with idempotent tool-outcome and permission reconciliation, and automatically resume requests that were accepted before execution started.",
+  "zh-CN": "新增 Durable Recovery Coordinator，支持幂等的工具结果与权限对账，并自动恢复已接受但尚未开始执行的请求。"
+}

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ console.log(result.usage);
 
 - Session lifecycle: `createSession()`, `resumeSession()`, `forkSession()`, and `prompt()`
 - Steerable requests: durable `now`, `next`, and `later` inputs with cancellation and pending-input inspection
+- Durable recovery: automatic pre-execution request resume plus explicit permission and tool-outcome reconciliation
 - Streaming: 17 typed events for turns, content, reasoning, tools, usage, steering, results, and errors
 - Providers: OpenAI, Anthropic, Azure OpenAI, Gemini, DeepSeek, and OpenAI-compatible APIs
 - Tools: generator-only custom tools, capability-grouped built-ins, MCP tools, and typed progress/effects

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -61,6 +61,7 @@ console.log(result.usage);
 
 - Session 生命周期：`createSession()`、`resumeSession()`、`forkSession()`、`prompt()`
 - 可转向请求：持久化的 `now`、`next`、`later` 输入，支持取消和待处理输入查询
+- Durable 恢复：自动恢复执行前请求，并显式完成权限与工具结果对账
 - 流式事件：17 种类型化事件，覆盖轮次、内容、思维、工具、usage、转向、结果和错误
 - Provider：OpenAI、Anthropic、Azure OpenAI、Gemini、DeepSeek 和 OpenAI-compatible API
 - 工具：仅 generator 的自定义工具、按能力分组的内置工具、MCP 工具和类型化进度/副作用

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -101,11 +101,13 @@ Node-local 能力外，这些函数都从根入口导出；实际 subpath 以“
 |------|------|
 | `DurableEventStore` | append/read/head 的持久化接口 |
 | `DurableSessionJournal` / `DurableSessionJournalOptions` | command-oriented 串行提交、CAS 重试与对账层 |
+| `DurableSessionRecoveryCoordinator` | accepted Request 恢复、权限消解与工具结果对账协调器 |
 | `DurableSessionCommand` / `DurableCommandEventDraft` | Journal command 与不含重复 `commandId` 的事件输入 |
 | `DurableCommandCommitResult` / `DurableCommandCommitStatus` | `committed` / `replayed` / `reconciled` 提交结果 |
 | `DurableSessionJournalError` / `DurableSessionJournalErrorCode` | command、分页和 Store 返回值错误 |
 | `DurableCommandConflictError` | 同一 `commandId` 被用于不同事件 |
 | `DurableCommandOutcomeUnknownError` | 写入失败后无法确认 command 是否提交 |
+| `DurableSessionRecoveryError` / `DurableSessionRecoveryErrorCode` | 恢复目标缺失或状态不满足恢复契约 |
 | `DurableSessionRecoveryRequiredError` | Session 恢复前需要权限或工具结果对账 |
 | `SessionDurableRecorderError` | Session runtime 观察到非法 durable 生命周期状态 |
 | `DurableEventEnvelope` / `DurableEventDraft` | 已提交事件与待提交事件 |
@@ -125,6 +127,12 @@ Node-local 能力外，这些函数都从根入口导出；实际 subpath 以“
 | `DurableToolAttemptProjection` / `DurableToolAttemptStatus` | 当前 Turn 的工具尝试状态 |
 | `DurablePermissionProjection` / `DurablePermissionStatus` | 工具权限状态 |
 | `DurableSessionRecoveryAction` | 恢复动作判别值 |
+| `DurableAcceptedRequestRecovery` | 可自动恢复且带完整执行快照的 accepted Request |
+| `DurableSessionResumeDecision` | `ready` / `resume_accepted_request` / `recovery_required` 决策 |
+| `DurableToolOutcomeReconciliation` / `DurableToolOutcomeReconciliationCommand` | 显式工具结果对账输入 |
+| `DurableToolStartCommand` | 恢复执行前持久化 `tool_started` 的幂等命令 |
+| `DurablePermissionResolutionCommand` | 幂等权限消解输入 |
+| `DurableRecoveryCommitResult` | 对账提交结果及更新后的 projection/recovery plan |
 | `DURABLE_EVENT_SCHEMA_VERSION` / `DURABLE_EVENT_LOG_FORMAT` | wire schema 与日志格式版本 |
 | `DurableEventProjectionError` | 生命周期事件顺序或关联关系非法 |
 | `DurableEventSequenceConflictError` | CAS 序列冲突错误 |

--- a/docs/durable-events.md
+++ b/docs/durable-events.md
@@ -6,9 +6,9 @@ Session 生命周期投影。
 
 ::: warning 当前集成阶段
 Session 只有在显式设置 `SessionOptions.durableEventStore` 时才写入 durable
-事件；现有消息 JSONL 保持不变。活动 Request 的自动恢复尚未启用，遇到未完成
-工作时 `resumeSession()` 会抛出 `DurableSessionRecoveryRequiredError`，禁止
-自动重放已开始的工具。
+事件；现有消息 JSONL 保持不变。`resumeSession()` 会自动恢复已接受但尚未跨过
+`request_started` 边界的 Request。活动 Turn、待决权限和已开始的工具仍需要
+显式恢复或对账；`non_idempotent` 工具绝不会被自动重放。
 :::
 
 ## 安装与导入
@@ -20,6 +20,7 @@ adapter 从根入口或 `/local` 导入：
 import {
   CommandId,
   type DurableEventDataMap,
+  DurableSessionRecoveryCoordinator,
   DurableSessionProjector,
   DurableSessionJournal,
   DurableEventType,
@@ -29,6 +30,7 @@ import {
   PermissionRequestId,
   RequestId,
   SessionId,
+  ToolAttemptId,
 } from '@blade-ai/agent-sdk';
 ```
 
@@ -66,7 +68,7 @@ interface DurableEventEnvelope<TType extends DurableEventType> {
 |------|-----------|--------------|
 | `session_created` | Session | `source?`、`parentSessionId?` |
 | `session_closed` | Session | `reason` |
-| `request_accepted` | `requestId`、`commandId` | `inputId`、`input`、`priority` |
+| `request_accepted` | `requestId`、`commandId` | `inputId`、`input`、`priority`、`maxTurns?`、`model?`、`context?` |
 | `request_started` | `requestId` | 空对象 |
 | `request_completed` | `requestId` | `output?`、`usage?` |
 | `request_failed` | `requestId` | `error` |
@@ -260,6 +262,64 @@ Recovery plan 还分别返回 `retryableToolAttempts`、`cancelableToolAttempts`
 `non_idempotent` 工具进入 unknown 集合，必须在外部对账后由
 `tool_completed`、`tool_failed` 或 `tool_cancelled` 解析。在此之前投影器不会
 允许 Turn 结束。
+
+## Recovery Coordinator
+
+`DurableSessionRecoveryCoordinator` 在 projector 的恢复分类之上提供受约束的
+状态变更 API：
+
+```ts
+const coordinator = await DurableSessionRecoveryCoordinator.open(
+  store,
+  sessionId,
+);
+
+const decision = coordinator.planResume();
+if (decision.action === 'resume_accepted_request') {
+  console.log(decision.request.input);
+}
+
+await coordinator.reconcileToolOutcome({
+  commandId: CommandId('reconcile-deploy-42'),
+  toolAttemptId: ToolAttemptId('attempt-42'),
+  outcome: {
+    status: 'completed',
+    result: { deploymentId: 'dep-42' },
+  },
+});
+```
+
+`reconcileToolOutcome()` 只允许 projector 当前仍可解析的 Tool Attempt，并复用
+Journal 的 command 幂等和 CAS 语义。`completed`、`failed` 与 `cancelled`
+三种结果都可显式提交；调用方重试时必须复用同一个 `commandId`。
+
+待决权限通过 `resolvePermission()` 处理。`deny` 或 `cancel` 会把
+`permission_resolved` 和对应的 `tool_cancelled` 放在同一 command/batch 中，
+不会暴露“权限已拒绝但工具仍处于 scheduled”的中间状态：
+
+```ts
+await coordinator.resolvePermission({
+  commandId: CommandId('deny-deploy-42'),
+  permissionRequestId: PermissionRequestId('permission-42'),
+  decision: 'deny',
+  message: 'Deployment window closed',
+});
+```
+
+权限恢复为 `allow` 后，应用必须先调用并等待
+`startToolAttempt({ commandId, toolAttemptId, input, sideEffect })`，再使用完全
+相同的最终输入执行工具。该方法把 `tool_started` 作为独立幂等 command 提交，
+从而保持 persist-before-side-effect。已经处于 `started` 的 `pure` /
+`idempotent` 工具可直接安全重放，再通过 `reconcileToolOutcome()` 写入终态；
+已经处于 `started` 的 `non_idempotent` 工具只能查询外部系统后对账，禁止再次
+执行。
+
+`planResume()` 仅将没有 `input_applied` / `request_started` 且具备完整执行快照的
+accepted Request 标记为 `resume_accepted_request`。
+Session 会使用 durable 输入以及持久化的 `maxTurns`、模型和 Runtime Context
+恢复同一个 `requestId`。旧日志中缺少执行快照的 Request，以及已经开始的
+Request，即使暂时没有活动 Turn，也返回 `recovery_required`；这是为了避免
+使用不同配置执行或重复提交一次可能已完成的模型调用。
 
 Schema v2 为 `tool_scheduled` 增加必填 `sideEffect`。v1 日志不会被静默推断，
 需要显式迁移后才能由当前 runtime 恢复。

--- a/docs/durable-events.md
+++ b/docs/durable-events.md
@@ -307,12 +307,13 @@ await coordinator.resolvePermission({
 ```
 
 权限恢复为 `allow` 后，应用必须先调用并等待
-`startToolAttempt({ commandId, toolAttemptId, input, sideEffect })`，再使用完全
-相同的最终输入执行工具。该方法把 `tool_started` 作为独立幂等 command 提交，
-从而保持 persist-before-side-effect。已经处于 `started` 的 `pure` /
-`idempotent` 工具可直接安全重放，再通过 `reconcileToolOutcome()` 写入终态；
-已经处于 `started` 的 `non_idempotent` 工具只能查询外部系统后对账，禁止再次
-执行。
+`startToolAttempt({ commandId, toolAttemptId })`，再使用返回 projection 中完全
+相同的输入执行工具。该方法只使用已持久化的操作事实并把 `tool_started` 作为
+独立幂等 command 提交，从而保持 persist-before-side-effect。经过权限恢复的
+工具会保守标记为 `non_idempotent`，调用方不能在恢复时降低副作用等级。已经处于
+`started` 的 `pure` / `idempotent` 工具可直接安全重放，再通过
+`reconcileToolOutcome()` 写入终态；已经处于 `started` 的 `non_idempotent`
+工具只能查询外部系统后对账，禁止再次执行。
 
 `planResume()` 仅将没有 `input_applied` / `request_started` 且具备完整执行快照的
 accepted Request 标记为 `resume_accepted_request`。

--- a/docs/en/api-reference.md
+++ b/docs/en/api-reference.md
@@ -61,6 +61,7 @@ Runtime:
 
 - `JsonlDurableEventStore`
 - `DurableSessionJournal`
+- `DurableSessionRecoveryCoordinator`
 - `DurableEventType`
 - `DURABLE_EVENT_SCHEMA_VERSION`
 - `DURABLE_EVENT_LOG_FORMAT`
@@ -82,6 +83,8 @@ Types and errors:
 - `DurableCommandCommitStatus`
 - `DurableSessionJournalError`
 - `DurableSessionJournalErrorCode`
+- `DurableSessionRecoveryError`
+- `DurableSessionRecoveryErrorCode`
 - `DurableCommandConflictError`
 - `DurableCommandOutcomeUnknownError`
 - `DurableEventEnvelope`
@@ -117,6 +120,13 @@ Types and errors:
 - `DurableSessionProjectionStatus`
 - `DurableSessionRecoveryAction`
 - `DurableSessionRecoveryPlan`
+- `DurableAcceptedRequestRecovery`
+- `DurableSessionResumeDecision`
+- `DurableToolOutcomeReconciliation`
+- `DurableToolOutcomeReconciliationCommand`
+- `DurableToolStartCommand`
+- `DurablePermissionResolutionCommand`
+- `DurableRecoveryCommitResult`
 - `DurableToolAttemptProjection`
 - `DurableToolAttemptStatus`
 - `DurableTurnProjection`

--- a/docs/en/durable-events.md
+++ b/docs/en/durable-events.md
@@ -8,9 +8,10 @@ projection.
 ::: warning Integration status
 Session writes durable events only when
 `SessionOptions.durableEventStore` is explicitly set; the existing message JSONL
-format is unchanged. Automatic recovery of an active Request is not enabled.
-`resumeSession()` throws `DurableSessionRecoveryRequiredError` for unfinished
-work instead of replaying a started tool.
+format is unchanged. `resumeSession()` automatically restores a Request that
+was accepted but did not cross the `request_started` boundary. Active Turns,
+pending permissions, and started tools still require explicit recovery or
+reconciliation. A `non_idempotent` tool is never replayed automatically.
 :::
 
 ## Imports
@@ -22,6 +23,7 @@ entry. The Node.js JSONL adapter is available from root and `/local`:
 import {
   CommandId,
   type DurableEventDataMap,
+  DurableSessionRecoveryCoordinator,
   DurableSessionProjector,
   DurableSessionJournal,
   DurableEventType,
@@ -31,6 +33,7 @@ import {
   PermissionRequestId,
   RequestId,
   SessionId,
+  ToolAttemptId,
 } from '@blade-ai/agent-sdk';
 ```
 
@@ -69,7 +72,7 @@ are rejected before append.
 |-------|----------------|-------------|
 | `session_created` | Session | `source?`, `parentSessionId?` |
 | `session_closed` | Session | `reason` |
-| `request_accepted` | `requestId`, `commandId` | `inputId`, `input`, `priority` |
+| `request_accepted` | `requestId`, `commandId` | `inputId`, `input`, `priority`, `maxTurns?`, `model?`, `context?` |
 | `request_started` | `requestId` | Empty object |
 | `request_completed` | `requestId` | `output?`, `usage?` |
 | `request_failed` | `requestId` | `error` |
@@ -267,6 +270,67 @@ The plan also separates `retryableToolAttempts`, `cancelableToolAttempts`,
 `non_idempotent` tools remain unknown and require external reconciliation with
 `tool_completed`, `tool_failed`, or `tool_cancelled`; the projector does not
 allow the Turn to end before then.
+
+## Recovery Coordinator
+
+`DurableSessionRecoveryCoordinator` adds constrained state mutations above the
+projector's recovery classification:
+
+```ts
+const coordinator = await DurableSessionRecoveryCoordinator.open(
+  store,
+  sessionId,
+);
+
+const decision = coordinator.planResume();
+if (decision.action === 'resume_accepted_request') {
+  console.log(decision.request.input);
+}
+
+await coordinator.reconcileToolOutcome({
+  commandId: CommandId('reconcile-deploy-42'),
+  toolAttemptId: ToolAttemptId('attempt-42'),
+  outcome: {
+    status: 'completed',
+    result: { deploymentId: 'dep-42' },
+  },
+});
+```
+
+`reconcileToolOutcome()` accepts only a Tool Attempt still addressable by the
+current projection and inherits the Journal's command idempotency and CAS
+semantics. Callers can explicitly record `completed`, `failed`, or `cancelled`
+and must reuse the same `commandId` when retrying an operation.
+
+Resolve a pending permission with `resolvePermission()`. A `deny` or `cancel`
+decision commits `permission_resolved` and the matching `tool_cancelled` in one
+command/batch, so observers never see a denied permission with a scheduled tool:
+
+```ts
+await coordinator.resolvePermission({
+  commandId: CommandId('deny-deploy-42'),
+  permissionRequestId: PermissionRequestId('permission-42'),
+  decision: 'deny',
+  message: 'Deployment window closed',
+});
+```
+
+After resolving a permission as `allow`, the application must call and await
+`startToolAttempt({ commandId, toolAttemptId, input, sideEffect })` before
+running the tool with exactly that final input. This method commits
+`tool_started` as a separate idempotent command and preserves the
+persist-before-side-effect boundary. A `pure` or `idempotent` tool already in
+`started` state may be replayed and then settled with
+`reconcileToolOutcome()`. A started `non_idempotent` tool must only be
+reconciled after querying the external system and must not be executed again.
+
+`planResume()` returns `resume_accepted_request` only when the accepted Request
+has no `input_applied` or `request_started` boundary and carries a complete
+execution snapshot. Session resumes the same `requestId` using the durable
+input and persisted `maxTurns`, model, and Runtime Context. A legacy Request
+without that snapshot, or a started Request even without an active Turn, returns
+`recovery_required`. This avoids executing under different settings or
+duplicating a model call that may already have completed.
 
 Schema v2 adds the required `sideEffect` field to `tool_scheduled`. Version 1
 logs are not inferred silently and must be migrated before this runtime can

--- a/docs/en/durable-events.md
+++ b/docs/en/durable-events.md
@@ -316,11 +316,13 @@ await coordinator.resolvePermission({
 ```
 
 After resolving a permission as `allow`, the application must call and await
-`startToolAttempt({ commandId, toolAttemptId, input, sideEffect })` before
-running the tool with exactly that final input. This method commits
-`tool_started` as a separate idempotent command and preserves the
-persist-before-side-effect boundary. A `pure` or `idempotent` tool already in
-`started` state may be replayed and then settled with
+`startToolAttempt({ commandId, toolAttemptId })` before running the exact input
+returned in the updated projection. The method only uses persisted operation
+facts and commits `tool_started` as a separate idempotent command, preserving
+the persist-before-side-effect boundary. A tool resumed after a permission
+round-trip is conservatively classified as `non_idempotent`; callers cannot
+downgrade its side-effect class during recovery. A `pure` or `idempotent` tool
+already in `started` state may be replayed and then settled with
 `reconcileToolOutcome()`. A started `non_idempotent` tool must only be
 reconciled after querying the external system and must not be executed again.
 

--- a/docs/en/session.md
+++ b/docs/en/session.md
@@ -278,12 +278,18 @@ const projection = session.getDurableProjection();
 const recovery = session.getDurableRecoveryPlan();
 ```
 
-`resumeSession()` throws `DurableSessionRecoveryRequiredError` when the
-durable log contains unfinished work, pending permission, or an unknown tool
-outcome. The current integration never replays a started tool automatically;
-reconcile it through `DurableSessionJournal` first. The JSONL adapter supports
-only one process; multi-process deployments need a `DurableEventStore` with
-transactional CAS or fencing.
+`resumeSession()` automatically restores a durable Request that was accepted
+but has no `request_started` event. It preserves the `requestId`, input,
+`maxTurns`, model, and Runtime Context, so the caller can continue it by
+calling `stream()` directly. Legacy durable Requests without a complete
+execution snapshot are not resumed automatically.
+
+A started Request, active Turn, pending permission, or unknown tool outcome is
+never replayed speculatively and raises `DurableSessionRecoveryRequiredError`.
+Use `DurableSessionRecoveryCoordinator` to resolve permissions or reconcile
+tool outcomes explicitly. `non_idempotent` tools always remain fail-closed. The
+JSONL adapter supports only one process; multi-process deployments need a
+`DurableEventStore` with transactional CAS or fencing.
 
 ### Resume
 
@@ -296,6 +302,15 @@ const session = await resumeSession({
   model,
   storagePath: '/var/lib/my-agent',
 });
+
+// A process that stopped after send() but before stream() leaves the original
+// Request pending. Do not submit the same input twice.
+if (session.getPendingInputs().length === 0) {
+  await session.send('Continue the analysis');
+}
+for await (const event of session.stream()) {
+  // Consume the resumed or newly submitted Request.
+}
 ```
 
 `resumeSession()` requires persistent storage.

--- a/docs/session.md
+++ b/docs/session.md
@@ -675,9 +675,15 @@ const projection = session.getDurableProjection();
 const recovery = session.getDurableRecoveryPlan();
 ```
 
-`resumeSession()` 遇到未完成的 durable Request、待决权限或未知工具结果时抛出
-`DurableSessionRecoveryRequiredError`。当前集成不会自动重放已开始的工具；
-调用方必须先通过 `DurableSessionJournal` 对账。JSONL adapter 只支持单进程
+`resumeSession()` 会自动恢复已接受但尚未写入 `request_started` 的 durable
+Request，并保留其 `requestId`、输入、`maxTurns` 和 Runtime Context。调用方可
+直接调用 `stream()` 继续这个 pending Request；执行时也会恢复接受请求时的
+模型。缺少完整执行快照的旧 durable Request 不会自动恢复。
+
+已经开始的 Request、活动 Turn、待决权限或未知工具结果不会被推测性重放，而是
+抛出 `DurableSessionRecoveryRequiredError`。使用
+`DurableSessionRecoveryCoordinator` 显式消解权限或对账工具结果；
+`non_idempotent` 工具始终保持 fail-closed。JSONL adapter 只支持单进程
 writer，多进程部署需要实现带事务 CAS 或 fencing 的 `DurableEventStore`。
 
 ### 自定义存储路径
@@ -720,7 +726,10 @@ const session = await resumeSession({
 
 console.log('已恢复消息数:', session.messages.length);
 
-await session.send('继续之前的分析');
+// 如果进程在 send() 之后、stream() 之前退出，原请求已经恢复为 pending。
+if (session.getPendingInputs().length === 0) {
+  await session.send('继续之前的分析');
+}
 for await (const msg of session.stream()) {
   if (msg.type === 'content') process.stdout.write(msg.delta);
 }

--- a/scripts/verify-entrypoints.mjs
+++ b/scripts/verify-entrypoints.mjs
@@ -96,12 +96,12 @@ const subpathOutput = run(process.execPath, [
     "const server = await import('@blade-ai/agent-sdk/server');",
     "const tools = await import('@blade-ai/agent-sdk/tools');",
     "const local = await import('@blade-ai/agent-sdk/local');",
-    "console.log(core.PermissionMode.DEFAULT, core.DurableEventType.REQUEST_ACCEPTED, core.projectDurableSession([]).status, typeof core.DurableSessionJournal.open, browser.PermissionMode.DEFAULT, typeof server.createSession, typeof tools.defineTool, typeof local.getBuiltinTools, typeof local.JsonlDurableEventStore);",
+    "console.log(core.PermissionMode.DEFAULT, core.DurableEventType.REQUEST_ACCEPTED, core.projectDurableSession([]).status, typeof core.DurableSessionJournal.open, typeof core.DurableSessionRecoveryCoordinator.open, browser.PermissionMode.DEFAULT, typeof server.createSession, typeof tools.defineTool, typeof local.getBuiltinTools, typeof local.JsonlDurableEventStore);",
   ].join(' '),
 ]);
 assertIncludes(
   subpathOutput,
-  'default request_accepted empty function default function function function function',
+  'default request_accepted empty function function default function function function function',
   'subpath imports',
 );
 

--- a/src/__tests__/rootExports.test.ts
+++ b/src/__tests__/rootExports.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, expectTypeOf, it } from 'vitest';
 import type {
+  DurableAcceptedRequestRecovery,
   DurableCommandEventDraft,
   DurableEventEnvelope,
   DurableEventOfType,
   DurableEventStore,
   DurableSessionCommand,
+  DurableSessionResumeDecision,
   DurableSessionRecoveryPlan,
+  DurableToolOutcomeReconciliationCommand,
+  DurableToolStartCommand,
   InputSubmission,
   ISession,
   PendingSessionInput,
@@ -40,6 +44,8 @@ import {
   DurableEventType,
   DurableSessionJournal,
   DurableSessionProjector,
+  DurableSessionRecoveryCoordinator,
+  DurableSessionRecoveryError,
   DurableSessionRecoveryRequiredError,
   EventId,
   EventSequence,
@@ -92,6 +98,8 @@ describe('root exports', () => {
     expect(DurableCommandOutcomeUnknownError).toBeDefined();
     expect(DurableSessionJournal.open).toBeTypeOf('function');
     expect(DurableSessionProjector).toBeDefined();
+    expect(DurableSessionRecoveryCoordinator.open).toBeTypeOf('function');
+    expect(DurableSessionRecoveryError).toBeDefined();
     expect(DurableSessionRecoveryRequiredError).toBeDefined();
     expect(SessionDurableRecorderError).toBeDefined();
     expect(projectDurableSession([]).status).toBe('empty');
@@ -133,6 +141,14 @@ describe('root exports', () => {
     expectTypeOf<DurableSessionRecoveryPlan['action']>().toEqualTypeOf<
       'none' | 'resume_request' | 'resume_turn' | 'resolve_permissions' | 'reconcile_tool_outcomes'
     >();
+    expectTypeOf<DurableSessionResumeDecision['action']>().toEqualTypeOf<
+      'ready' | 'resume_accepted_request' | 'recovery_required'
+    >();
+    expectTypeOf<DurableAcceptedRequestRecovery['model']>().toEqualTypeOf<string>();
+    expectTypeOf<
+      DurableToolOutcomeReconciliationCommand['toolAttemptId']
+    >().toEqualTypeOf<ToolAttemptId>();
+    expectTypeOf<DurableToolStartCommand['commandId']>().toEqualTypeOf<CommandId>();
     expectTypeOf<DurableEventStore['append']>().toBeFunction();
     expectTypeOf<SessionOptions['durableEventStore']>().toEqualTypeOf<
       DurableEventStore | undefined

--- a/src/agent/LoopRunner.ts
+++ b/src/agent/LoopRunner.ts
@@ -195,7 +195,7 @@ export class LoopRunner {
     // 3. 计算 maxTurns
     const isYoloMode = context.permissionMode === PermissionMode.YOLO;
     const configuredMaxTurns =
-      this.runtimeOptions.maxTurns ?? options?.maxTurns ?? this.config.maxTurns ?? -1;
+      options?.maxTurns ?? this.runtimeOptions.maxTurns ?? this.config.maxTurns ?? -1;
 
     if (configuredMaxTurns === 0) {
       return {

--- a/src/agent/__tests__/LoopRunner.test.ts
+++ b/src/agent/__tests__/LoopRunner.test.ts
@@ -17,15 +17,15 @@ import { createTool } from '../../tools/core/createTool.js';
 import type { ExecutionPipeline } from '../../tools/execution/ExecutionPipeline.js';
 import { ToolRegistry } from '../../tools/registry/ToolRegistry.js';
 import {
-  completeToolExecution,
-  type ToolEffect,
-  type ToolResult,
+    completeToolExecution,
+    type ToolEffect,
+    type ToolResult,
 } from '../../tools/types/index.js';
 import { ToolKind } from '../../tools/types/ToolKind.js';
 import {
-  InputId,
-  RequestId,
-  SessionId,
+    InputId,
+    RequestId,
+    SessionId,
 } from '../../types/branded.js';
 import type { BladeConfig } from '../../types/common.js';
 import { PermissionMode } from '../../types/common.js';
@@ -307,6 +307,25 @@ describe('LoopRunner', () => {
 
       expect(result.success).toBe(false);
       expect(result.error?.type).toBe('chat_disabled');
+    });
+
+    it('should let request maxTurns override the Session default', async () => {
+      const mm = createMockModelManager();
+      const pipeline = createMockPipeline();
+      const runner = new LoopRunner(
+        baseConfig,
+        { ...baseOptions, maxTurns: 10 },
+        mm,
+        pipeline,
+      );
+
+      const result = await runner.runLoop('Hello', createContext(), {
+        maxTurns: 0,
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error?.type).toBe('chat_disabled');
+      expect(mm._chat).not.toHaveBeenCalled();
     });
 
     it('should handle abort signal', async () => {

--- a/src/session/DurableRequestRecovery.ts
+++ b/src/session/DurableRequestRecovery.ts
@@ -1,0 +1,132 @@
+import type { UserMessageContent } from '../agent/types.js';
+import type { ContentPart } from '../services/ChatServiceInterface.js';
+import type { RuntimeContext } from '../runtime/index.js';
+import type { JsonObject, JsonValue } from '../types/common.js';
+import { toJsonValue } from '../utils/jsonValue.js';
+import { SessionDurableRecorderError } from './events/SessionDurableRecorder.js';
+
+function isJsonObject(value: JsonValue | undefined): value is JsonObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function serializeDurableRuntimeContext(context: RuntimeContext): JsonObject {
+  const serialized = toJsonValue(context);
+  if (typeof serialized !== 'object' || serialized === null || Array.isArray(serialized)) {
+    throw new SessionDurableRecorderError('Request runtime context is not a JSON object');
+  }
+  return serialized;
+}
+
+export function parseDurableUserMessageContent(input: JsonValue): UserMessageContent {
+  if (typeof input === 'string') {
+    return input;
+  }
+  if (!Array.isArray(input)) {
+    throw new SessionDurableRecorderError(
+      'A recoverable request input must be text or an array of content parts',
+    );
+  }
+
+  return input.map((value, index): ContentPart => {
+    if (!isJsonObject(value)) {
+      throw new SessionDurableRecorderError(
+        `Recoverable request content part ${index} is not an object`,
+      );
+    }
+    if (value.type === 'text' && typeof value.text === 'string') {
+      if (value.providerOptions !== undefined && !isJsonObject(value.providerOptions)) {
+        throw new SessionDurableRecorderError(
+          `Recoverable request text part ${index} has invalid providerOptions`,
+        );
+      }
+      return {
+        type: 'text',
+        text: value.text,
+        ...(value.providerOptions
+          ? {
+              providerOptions: structuredClone(value.providerOptions) as Extract<
+                ContentPart,
+                { type: 'text' }
+              >['providerOptions'],
+            }
+          : {}),
+      };
+    }
+    if (
+      value.type === 'image_url' &&
+      isJsonObject(value.image_url) &&
+      typeof value.image_url.url === 'string'
+    ) {
+      return {
+        type: 'image_url',
+        image_url: {
+          url: value.image_url.url,
+        },
+      };
+    }
+    throw new SessionDurableRecorderError(`Recoverable request content part ${index} is invalid`);
+  });
+}
+
+export function parseDurableRuntimeContext(
+  context: JsonObject | undefined,
+): RuntimeContext | undefined {
+  if (!context) {
+    return undefined;
+  }
+  if (context.id !== undefined && typeof context.id !== 'string') {
+    throw new SessionDurableRecorderError('Recoverable request context.id must be a string');
+  }
+  if (
+    context.environment !== undefined &&
+    (!isJsonObject(context.environment) ||
+      Object.values(context.environment).some((value) => typeof value !== 'string'))
+  ) {
+    throw new SessionDurableRecorderError(
+      'Recoverable request context.environment must contain string values',
+    );
+  }
+  if (context.metadata !== undefined && !isJsonObject(context.metadata)) {
+    throw new SessionDurableRecorderError('Recoverable request context.metadata must be an object');
+  }
+
+  const capabilities = context.capabilities;
+  if (capabilities !== undefined && !isJsonObject(capabilities)) {
+    throw new SessionDurableRecorderError(
+      'Recoverable request context.capabilities must be an object',
+    );
+  }
+  if (isJsonObject(capabilities)) {
+    const filesystem = capabilities.filesystem;
+    if (
+      filesystem !== undefined &&
+      (!isJsonObject(filesystem) ||
+        !Array.isArray(filesystem.roots) ||
+        filesystem.roots.some((root) => typeof root !== 'string') ||
+        (filesystem.cwd !== undefined && typeof filesystem.cwd !== 'string'))
+    ) {
+      throw new SessionDurableRecorderError('Recoverable request filesystem capability is invalid');
+    }
+    const browser = capabilities.browser;
+    if (
+      browser !== undefined &&
+      (!isJsonObject(browser) ||
+        (browser.pageId !== undefined && typeof browser.pageId !== 'string') ||
+        (browser.tabId !== undefined && typeof browser.tabId !== 'string'))
+    ) {
+      throw new SessionDurableRecorderError('Recoverable request browser capability is invalid');
+    }
+    const network = capabilities.network;
+    if (
+      network !== undefined &&
+      (!isJsonObject(network) ||
+        (network.allowDomains !== undefined &&
+          (!Array.isArray(network.allowDomains) ||
+            network.allowDomains.some((domain) => typeof domain !== 'string'))))
+    ) {
+      throw new SessionDurableRecorderError('Recoverable request network capability is invalid');
+    }
+  }
+
+  return structuredClone(context) as RuntimeContext;
+}

--- a/src/session/Session.ts
+++ b/src/session/Session.ts
@@ -21,6 +21,7 @@ import {
 } from '../types/branded.js';
 import {
     type BladeConfig,
+    type JsonObject,
     type JsonValue,
     type ModelConfig,
     PermissionMode,
@@ -30,11 +31,18 @@ import {
     ActiveRequestController,
     type RequestAbortReason,
 } from './ActiveRequestController.js';
+import {
+    parseDurableRuntimeContext,
+    parseDurableUserMessageContent,
+    serializeDurableRuntimeContext,
+} from './DurableRequestRecovery.js';
 import { DurableSessionJournal } from './events/DurableSessionJournal.js';
 import type {
+    DurableRequestProjection,
     DurableSessionProjection,
     DurableSessionRecoveryPlan,
 } from './events/DurableSessionProjector.js';
+import { DurableSessionRecoveryCoordinator } from './events/DurableSessionRecoveryCoordinator.js';
 import {
     type DurableRequestFinish,
     durableRequestFinishFromLoopResult,
@@ -54,6 +62,7 @@ import {
     JsonlSessionStore,
     NoopSessionStore,
     type SessionSnapshot,
+    type SessionState,
     type SessionStore,
 } from './SessionStore.js';
 import type {
@@ -125,6 +134,7 @@ class Session implements ISession {
   private readonly inputInbox = new SessionInputInbox();
   private readonly inputMutex = new Mutex();
   private durableJournal: DurableSessionJournal | null = null;
+  private durableAcceptedRequest: DurableRequestProjection | null = null;
   private durableClosePromise: Promise<void> | null = null;
 
   /**
@@ -245,35 +255,48 @@ class Session implements ISession {
   }
 
   async loadHistory(): Promise<void> {
+    let state: SessionState | null = null;
     try {
-      const state = await this.store.loadState(this.sessionId);
-      this._messages = state?.messages ?? [];
-      // 恢复待处理输入并调度下一个排队输入的过程会读写 executionState 与
-      // inputInbox，与其他状态转换保持一致地在 inputMutex 内完成。
-      await this.inputMutex.runExclusive(() => {
-        const dropped = this.inputInbox.restore(
-          (state?.pendingInputs ?? []).map((input) => ({
+      state = await this.store.loadState(this.sessionId);
+    } catch (error) {
+      if (this.durableAcceptedRequest) {
+        throw new SessionDurableRecorderError(
+          `Failed to load history before resuming request ${this.durableAcceptedRequest.requestId}`,
+          { cause: error },
+        );
+      }
+      this.logger.warn(`[Session] Failed to load history for session ${this.sessionId}:`, error);
+    }
+    this._messages = state?.messages ?? [];
+    // Durable acceptance is authoritative. The legacy queue remains a
+    // best-effort message/history projection and may be missing after a crash.
+    await this.inputMutex.runExclusive(() => {
+      const durableAcceptedRequest = this.durableAcceptedRequest;
+      if (durableAcceptedRequest) {
+        this.restoreDurableAcceptedRequest(durableAcceptedRequest);
+      }
+      const dropped = this.inputInbox.restore(
+        (state?.pendingInputs ?? [])
+          .filter((input) => input.inputId !== durableAcceptedRequest?.inputId)
+          .map((input) => ({
             ...input,
             content: input.content as UserMessageContent,
           })),
+      );
+      if (dropped > 0) {
+        this.logger.warn(
+          `[Session] Dropped ${dropped} pending input(s) exceeding queue capacity while restoring session ${this.sessionId}`,
         );
-        if (dropped > 0) {
-          this.logger.warn(
-            `[Session] Dropped ${dropped} pending input(s) exceeding queue capacity while restoring session ${this.sessionId}`,
-          );
-        }
-        if (this.executionState.phase === 'idle') {
-          this.scheduleNextQueuedInput();
-        }
-      });
-      if (this._messages.length === 0) {
-        this.logger.debug(`[Session] No history found for session ${this.sessionId}`);
-        return;
       }
-      this.logger.debug(`[Session] Loaded ${this._messages.length} messages from history`);
-    } catch (error) {
-      this.logger.warn(`[Session] Failed to load history for session ${this.sessionId}:`, error);
+      if (this.executionState.phase === 'idle') {
+        this.scheduleNextQueuedInput();
+      }
+    });
+    if (this._messages.length === 0) {
+      this.logger.debug(`[Session] No history found for session ${this.sessionId}`);
+      return;
     }
+    this.logger.debug(`[Session] Loaded ${this._messages.length} messages from history`);
   }
 
   private buildBladeConfig(): BladeConfig {
@@ -376,9 +399,15 @@ class Session implements ISession {
         const durableRecorder = this.durableJournal
           ? new SessionDurableRecorder(this.durableJournal, requestId, this.options.model)
           : null;
+        const pendingState = this.createPendingState(requestId, input, options, durableRecorder);
         this.inputInbox.reserve(input);
         try {
-          await durableRecorder?.recordAccepted(inputId, message);
+          await durableRecorder?.recordAccepted(
+            inputId,
+            message,
+            'next',
+            this.durableExecutionSnapshot(pendingState),
+          );
           try {
             await this.persistInput(input);
           } catch (error) {
@@ -395,12 +424,7 @@ class Session implements ISession {
           this.inputInbox.remove(inputId);
           throw error;
         }
-        this.executionState = this.createPendingState(
-          requestId,
-          input,
-          options,
-          durableRecorder,
-        );
+        this.executionState = pendingState;
         return {
           status: 'started',
           inputId,
@@ -513,11 +537,7 @@ class Session implements ISession {
           : null;
       let durablyInterrupted = false;
       if (pendingState) {
-        const durableRecorder = await this.ensureDurableRecorder(
-          pendingState.requestId,
-          pendingState.input,
-          pendingState.durableRecorder,
-        );
+        const durableRecorder = await this.ensureDurableRecorder(pendingState);
         pendingState.durableRecorder = durableRecorder;
         if (durableRecorder) {
           await durableRecorder.finish({
@@ -565,6 +585,7 @@ class Session implements ISession {
       if (this.executionState.phase !== 'pending') {
         return null;
       }
+      const pendingState = this.executionState;
       const {
         requestId,
         input,
@@ -578,17 +599,25 @@ class Session implements ISession {
         ?? (this.durableJournal
           ? new SessionDurableRecorder(this.durableJournal, requestId, this.options.model)
           : null);
-      if (durableRecorder && !pendingDurableRecorder) {
-        await durableRecorder.recordAccepted(
+      try {
+        if (durableRecorder && !pendingDurableRecorder) {
+          await durableRecorder.recordAccepted(
+            input.inputId,
+            input.content,
+            input.priority === InputPriority.LATER ? 'later' : 'next',
+            this.durableExecutionSnapshot(pendingState),
+          );
+        }
+        await durableRecorder?.recordStarted(
           input.inputId,
-          input.content,
           input.priority === InputPriority.LATER ? 'later' : 'next',
         );
+      } catch (error) {
+        requestController.dispose();
+        this.inputInbox.remove(input.inputId);
+        this.executionState = { phase: 'idle' };
+        throw error;
       }
-      await durableRecorder?.recordStarted(
-        input.inputId,
-        input.priority === InputPriority.LATER ? 'later' : 'next',
-      );
       this.executionState = {
         phase: 'running',
         requestId,
@@ -1094,14 +1123,10 @@ class Session implements ISession {
         return true;
       }
       if (this.executionState.phase === 'pending') {
-        const { controller, input, requestId } = this.executionState;
+        const { controller, input } = this.executionState;
         controller.abortRequest({ kind: 'session_close' });
         if (recordDurableClose) {
-          const durableRecorder = await this.ensureDurableRecorder(
-            requestId,
-            input,
-            this.executionState.durableRecorder,
-          );
+          const durableRecorder = await this.ensureDurableRecorder(this.executionState);
           this.executionState.durableRecorder = durableRecorder;
           await durableRecorder?.finish({
             status: 'interrupted',
@@ -1164,11 +1189,7 @@ class Session implements ISession {
         ) {
           return;
         }
-        const durableRecorder = await this.ensureDurableRecorder(
-          pendingState.requestId,
-          pendingState.input,
-          pendingState.durableRecorder,
-        );
+        const durableRecorder = await this.ensureDurableRecorder(pendingState);
         pendingState.durableRecorder = durableRecorder;
         await durableRecorder?.finish({
           status: 'interrupted',
@@ -1302,30 +1323,33 @@ class Session implements ISession {
         `Durable Session ${this.sessionId} is closed`,
       );
     }
-    const recoveryPlan = journal.getRecoveryPlan();
-    if (recoveryPlan.action !== 'none') {
-      throw new DurableSessionRecoveryRequiredError(recoveryPlan);
+    const resumeDecision = new DurableSessionRecoveryCoordinator(journal).planResume();
+    if (resumeDecision.action === 'recovery_required') {
+      throw new DurableSessionRecoveryRequiredError(resumeDecision.recoveryPlan);
+    }
+    if (resumeDecision.action === 'resume_accepted_request') {
+      this.durableAcceptedRequest = resumeDecision.request;
+      this.options.model = resumeDecision.request.model;
     }
     this.durableJournal = journal;
   }
 
   private async ensureDurableRecorder(
-    requestId: RequestId,
-    input: PendingSessionInput,
-    existing: SessionDurableRecorder | null,
+    pendingState: Extract<SessionExecutionState, { phase: 'pending' }>,
   ): Promise<SessionDurableRecorder | null> {
-    if (existing || !this.durableJournal) {
-      return existing;
+    if (pendingState.durableRecorder || !this.durableJournal) {
+      return pendingState.durableRecorder;
     }
     const recorder = new SessionDurableRecorder(
       this.durableJournal,
-      requestId,
+      pendingState.requestId,
       this.options.model,
     );
     await recorder.recordAccepted(
-      input.inputId,
-      input.content,
-      input.priority === InputPriority.LATER ? 'later' : 'next',
+      pendingState.input.inputId,
+      pendingState.input.content,
+      pendingState.input.priority === InputPriority.LATER ? 'later' : 'next',
+      this.durableExecutionSnapshot(pendingState),
     );
     return recorder;
   }
@@ -1397,6 +1421,7 @@ class Session implements ISession {
     input: PendingSessionInput,
     options?: SendOptions,
     durableRecorder: SessionDurableRecorder | null = null,
+    snapshot?: ContextSnapshot,
   ): Extract<SessionExecutionState, { phase: 'pending' }> {
     return {
       phase: 'pending',
@@ -1411,13 +1436,59 @@ class Session implements ISession {
       message: input.content,
       options: options || null,
       durableRecorder,
-      snapshot: createContextSnapshot(
+      snapshot: snapshot ?? createContextSnapshot(
         this.sessionId,
         nanoid(),
         this.defaultContext,
         options?.context,
       ),
     };
+  }
+
+  private durableExecutionSnapshot(state: Extract<SessionExecutionState, { phase: 'pending' }>): {
+    maxTurns: number;
+    context: JsonObject;
+  } {
+    return {
+      maxTurns: state.options?.maxTurns ?? this.maxTurns,
+      context: serializeDurableRuntimeContext(state.snapshot.context),
+    };
+  }
+
+  private restoreDurableAcceptedRequest(request: DurableRequestProjection): void {
+    if (this.executionState.phase !== 'idle') {
+      throw new SessionDurableRecorderError(
+        `Cannot restore request ${request.requestId} while Session is ${this.executionState.phase}`,
+      );
+    }
+    const content = parseDurableUserMessageContent(request.input);
+    const acceptedAt = Date.parse(request.acceptedAt);
+    const input: PendingSessionInput = {
+      inputId: request.inputId,
+      content,
+      priority: request.priority === InputPriority.LATER ? InputPriority.LATER : InputPriority.NEXT,
+      targetRequestId: request.requestId,
+      acceptedAt: Number.isFinite(acceptedAt) ? acceptedAt : Date.now(),
+    };
+    this.inputInbox.remove(input.inputId);
+    this.inputInbox.enqueue(input);
+
+    const recoveredContext = parseDurableRuntimeContext(request.context) ?? this.defaultContext;
+    const snapshot = createContextSnapshot(this.sessionId, nanoid(), recoveredContext);
+    const sendOptions: SendOptions = {
+      ...(request.maxTurns !== undefined ? { maxTurns: request.maxTurns } : {}),
+    };
+    const recorder = this.durableJournal
+      ? new SessionDurableRecorder(this.durableJournal, request.requestId, this.options.model)
+      : null;
+    this.executionState = this.createPendingState(
+      request.requestId,
+      input,
+      sendOptions,
+      recorder,
+      snapshot,
+    );
+    this.durableAcceptedRequest = null;
   }
 
   private scheduleNextQueuedInput(): void {
@@ -1584,9 +1655,14 @@ export async function resumeSession(options: ResumeOptions): Promise<ISession> {
   }
   const { sessionId, ...sessionOptions } = options;
   const session = new Session(sessionOptions, sessionId, true);
-  await session.initialize();
-  await session.loadHistory();
-  return session;
+  try {
+    await session.initialize();
+    await session.loadHistory();
+    return session;
+  } catch (error) {
+    await session.disposeAfterFork();
+    throw error;
+  }
 }
 
 export interface ForkOptions extends ResumeOptions {

--- a/src/session/Session.ts
+++ b/src/session/Session.ts
@@ -421,6 +421,7 @@ class Session implements ISession {
           }
           this.inputInbox.markCommitted(inputId);
         } catch (error) {
+          pendingState.controller.dispose();
           this.inputInbox.remove(inputId);
           throw error;
         }

--- a/src/session/__tests__/DurableRequestRecovery.test.ts
+++ b/src/session/__tests__/DurableRequestRecovery.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import type { JsonObject, JsonValue } from '../../types/common.js';
+import {
+  parseDurableRuntimeContext,
+  parseDurableUserMessageContent,
+  serializeDurableRuntimeContext,
+} from '../DurableRequestRecovery.js';
+import { SessionDurableRecorderError } from '../events/SessionDurableRecorder.js';
+
+describe('DurableRequestRecovery', () => {
+  it('round-trips every supported request content variant', () => {
+    expect(parseDurableUserMessageContent('continue')).toBe('continue');
+    expect(
+      parseDurableUserMessageContent([
+        {
+          type: 'text',
+          text: 'inspect',
+          providerOptions: {
+            anthropic: {
+              cacheControl: { type: 'ephemeral' },
+            },
+          },
+        },
+        {
+          type: 'image_url',
+          image_url: { url: 'data:image/png;base64,recovery' },
+        },
+      ]),
+    ).toEqual([
+      {
+        type: 'text',
+        text: 'inspect',
+        providerOptions: {
+          anthropic: {
+            cacheControl: { type: 'ephemeral' },
+          },
+        },
+      },
+      {
+        type: 'image_url',
+        image_url: { url: 'data:image/png;base64,recovery' },
+      },
+    ]);
+  });
+
+  it.each([
+    42,
+    [null],
+    [{ type: 'text' }],
+    [{ type: 'text', text: 'invalid', providerOptions: [] }],
+    [{ type: 'image_url', image_url: {} }],
+    [{ type: 'unknown' }],
+  ] satisfies JsonValue[])('rejects invalid request content %#', (input) => {
+    expect(() => parseDurableUserMessageContent(input)).toThrow(
+      SessionDurableRecorderError,
+    );
+  });
+
+  it('round-trips a complete runtime context', () => {
+    const context = {
+      id: 'runtime-context',
+      capabilities: {
+        filesystem: {
+          roots: ['/workspace'],
+          cwd: '/workspace',
+        },
+        browser: {
+          pageId: 'page-1',
+          tabId: 'tab-1',
+        },
+        network: {
+          allowDomains: ['example.com'],
+        },
+      },
+      environment: {
+        REGION: 'test',
+      },
+      metadata: {
+        tenant: 'tenant-1',
+      },
+    };
+
+    expect(parseDurableRuntimeContext(serializeDurableRuntimeContext(context))).toEqual(context);
+  });
+
+  it.each([
+    { id: 1 },
+    { environment: { REGION: 1 } },
+    { metadata: [] },
+    { capabilities: [] },
+    { capabilities: { filesystem: { roots: [1] } } },
+    { capabilities: { browser: { pageId: 1 } } },
+    { capabilities: { network: { allowDomains: [1] } } },
+  ] as JsonObject[])('rejects invalid runtime context %#', (context) => {
+    expect(() => parseDurableRuntimeContext(context)).toThrow(
+      SessionDurableRecorderError,
+    );
+  });
+
+  it('rejects non-JSON runtime context values before persistence', () => {
+    expect(() =>
+      serializeDurableRuntimeContext({
+        metadata: {
+          value: BigInt(1) as never,
+        },
+      }),
+    ).toThrow(/not JSON serializable/);
+  });
+});

--- a/src/session/__tests__/DurableRequestRecovery.test.ts
+++ b/src/session/__tests__/DurableRequestRecovery.test.ts
@@ -44,13 +44,13 @@ describe('DurableRequestRecovery', () => {
   });
 
   it.each([
-    42,
-    [null],
-    [{ type: 'text' }],
-    [{ type: 'text', text: 'invalid', providerOptions: [] }],
-    [{ type: 'image_url', image_url: {} }],
-    [{ type: 'unknown' }],
-  ] satisfies JsonValue[])('rejects invalid request content %#', (input) => {
+    { input: 42 },
+    { input: [null] },
+    { input: [{ type: 'text' }] },
+    { input: [{ type: 'text', text: 'invalid', providerOptions: [] }] },
+    { input: [{ type: 'image_url', image_url: {} }] },
+    { input: [{ type: 'unknown' }] },
+  ] satisfies Array<{ input: JsonValue }>)('rejects invalid request content %#', ({ input }) => {
     expect(() => parseDurableUserMessageContent(input)).toThrow(
       SessionDurableRecorderError,
     );

--- a/src/session/__tests__/SessionDurableEvents.test.ts
+++ b/src/session/__tests__/SessionDurableEvents.test.ts
@@ -200,6 +200,25 @@ describe('Session durable events', () => {
     await session.close();
   });
 
+  it('releases the external abort listener when durable acceptance fails', async () => {
+    const { store } = createStore();
+    const failingStore = new FailOnEventTypeStore(store, DurableEventType.REQUEST_ACCEPTED);
+    const session = await createSession(options(failingStore));
+    const controller = new AbortController();
+    const addListener = vi.spyOn(controller.signal, 'addEventListener');
+    const removeListener = vi.spyOn(controller.signal, 'removeEventListener');
+
+    await expect(
+      session.send('must not leak', { signal: controller.signal }),
+    ).rejects.toBeInstanceOf(DurableCommandOutcomeUnknownError);
+
+    const abortListener = addListener.mock.calls.find(([type]) => type === 'abort')?.[1];
+    expect(abortListener).toBeDefined();
+    expect(removeListener).toHaveBeenCalledWith('abort', abortListener);
+    expect(session.getPendingInputs()).toEqual([]);
+    await expect(session.close()).rejects.toBeInstanceOf(DurableCommandOutcomeUnknownError);
+  });
+
   it('persists tool and permission boundaries around the real side effect', async () => {
     const { store } = createStore();
     let sideEffectSawToolStarted = false;

--- a/src/session/__tests__/SessionDurableEvents.test.ts
+++ b/src/session/__tests__/SessionDurableEvents.test.ts
@@ -13,13 +13,17 @@ import {
   SessionId,
   ToolUseId,
 } from '../../types/branded.js';
+import type { JsonValue } from '../../types/common.js';
 import { type DurableEventStore, DurableEventStoreError } from '../events/DurableEventStore.js';
 import {
   DurableCommandOutcomeUnknownError,
   DurableSessionJournal,
 } from '../events/DurableSessionJournal.js';
 import { JsonlDurableEventStore } from '../events/JsonlDurableEventStore.js';
-import { DurableSessionRecoveryRequiredError } from '../events/SessionDurableRecorder.js';
+import {
+  DurableSessionRecoveryRequiredError,
+  SessionDurableRecorderError,
+} from '../events/SessionDurableRecorder.js';
 import type {
   DurableEventAppendOptions,
   DurableEventAppendResult,
@@ -45,7 +49,7 @@ let streamChat: StreamChat = async function* defaultStream() {
   };
 };
 
-const createAgent = vi.fn(async () => ({
+const createAgent = vi.fn(async (_config?: unknown, _options?: unknown, _deps?: unknown) => ({
   streamChat: (message: UserMessageContent, context: unknown, options?: LoopOptions) =>
     streamChat(message, context, options),
   async setModel() {},
@@ -155,6 +159,45 @@ describe('Session durable events', () => {
     expect((await store.read(session.sessionId)).events.at(-1)?.type).toBe(
       DurableEventType.SESSION_CLOSED,
     );
+  });
+
+  it('persists the accepted request execution snapshot before send returns', async () => {
+    const { store } = createStore();
+    const session = await createSession({
+      ...options(store),
+      maxTurns: 50,
+      defaultContext: {
+        id: 'default-context',
+        environment: { DEFAULT: 'yes', OVERRIDE: 'before' },
+      },
+    });
+
+    await session.send('snapshot me', {
+      maxTurns: 9,
+      context: {
+        id: 'request-context',
+        environment: { OVERRIDE: 'after' },
+      },
+    });
+
+    expect(
+      (await store.read(session.sessionId)).events.find(
+        (event) => event.type === DurableEventType.REQUEST_ACCEPTED,
+      )?.data,
+    ).toMatchObject({
+      input: 'snapshot me',
+      maxTurns: 9,
+      model: 'test-model',
+      context: {
+        id: 'request-context',
+        environment: {
+          DEFAULT: 'yes',
+          OVERRIDE: 'after',
+        },
+      },
+    });
+    await session.abort();
+    await session.close();
   });
 
   it('persists tool and permission boundaries around the real side effect', async () => {
@@ -278,11 +321,13 @@ describe('Session durable events', () => {
     const session = await createSession(options(failingStore));
     await session.send('write');
     const messages: AgentEvent[] = [];
-    await expect((async () => {
-      for await (const event of session.stream()) {
-        messages.push(event as AgentEvent);
-      }
-    })()).rejects.toThrow('Request execution and durable finalization both failed');
+    await expect(
+      (async () => {
+        for await (const event of session.stream()) {
+          messages.push(event as AgentEvent);
+        }
+      })(),
+    ).rejects.toThrow('Request execution and durable finalization both failed');
 
     expect(sideEffectRan).toBe(false);
     expect(messages.some((event) => event.type === 'error')).toBe(false);
@@ -318,9 +363,11 @@ describe('Session durable events', () => {
     await session.close();
   });
 
-  it('fails closed when resuming a session with unfinished durable work', async () => {
+  it('resumes a durably accepted request without accepting it twice', async () => {
     const { root, store } = createStore();
     const sessionId = SessionId('unfinished-session');
+    const requestId = RequestId('unfinished-request');
+    const inputId = InputId('unfinished-input');
     const journal = await DurableSessionJournal.open(store, sessionId);
     await journal.commit({
       commandId: CommandId('command-create'),
@@ -336,12 +383,279 @@ describe('Session durable events', () => {
       events: [
         {
           type: DurableEventType.REQUEST_ACCEPTED,
-          requestId: RequestId('unfinished-request'),
+          requestId,
           data: {
-            inputId: InputId('unfinished-input'),
+            inputId,
             input: 'resume me',
             priority: 'next',
+            maxTurns: 17,
+            model: 'durable-model',
+            context: {
+              id: 'durable-context',
+              environment: { RECOVERED: 'yes' },
+            },
           },
+        },
+      ],
+    });
+    let observedMessage: UserMessageContent | undefined;
+    let observedContext: unknown;
+    let observedOptions: LoopOptions | undefined;
+    streamChat = async function* recoveredStream(message, context, loopOptions) {
+      observedMessage = message;
+      observedContext = context;
+      observedOptions = loopOptions;
+      yield { type: 'turn_start', turn: 1, maxTurns: 17 };
+      yield { type: 'turn_end', turn: 1, hasToolCalls: false };
+      return {
+        success: true,
+        finalMessage: 'recovered',
+        metadata: { turnsCount: 1, toolCallsCount: 0, duration: 1 },
+      };
+    };
+
+    const session = await resumeSession({
+      ...options(store),
+      persistSession: true,
+      storagePath: root,
+      sessionId,
+      defaultContext: {
+        id: 'replacement-context',
+        environment: { RECOVERED: 'no' },
+      },
+    });
+
+    const createdConfig = createAgent.mock.calls.at(-1)?.[0] as
+      | { models?: Array<{ model?: string }> }
+      | undefined;
+    expect(createdConfig?.models?.[0]?.model).toBe('durable-model');
+    expect(session.getPendingInputs()).toEqual([
+      expect.objectContaining({
+        inputId,
+        content: 'resume me',
+        targetRequestId: requestId,
+      }),
+    ]);
+    for await (const _event of session.stream()) {
+      // Drain the recovered request.
+    }
+
+    expect(observedMessage).toBe('resume me');
+    expect(observedOptions?.maxTurns).toBe(17);
+    expect(observedContext).toMatchObject({
+      snapshot: {
+        context: {
+          id: 'durable-context',
+          environment: { RECOVERED: 'yes' },
+        },
+      },
+    });
+    const events = (await store.read(sessionId)).events;
+    expect(events.filter((event) => event.type === DurableEventType.REQUEST_ACCEPTED)).toHaveLength(
+      1,
+    );
+    expect(events.find((event) => event.type === DurableEventType.REQUEST_STARTED)?.requestId).toBe(
+      requestId,
+    );
+    expect(session.getDurableRecoveryPlan()?.action).toBe('none');
+    await session.close();
+  });
+
+  it('allows only one concurrent resume to cross request_started', async () => {
+    const { root, store } = createStore();
+    const sessionId = SessionId('concurrent-recovery-session');
+    const requestId = RequestId('concurrent-recovery-request');
+    const inputId = InputId('concurrent-recovery-input');
+    const journal = await DurableSessionJournal.open(store, sessionId);
+    await journal.commit({
+      commandId: CommandId('concurrent-bootstrap'),
+      events: [
+        {
+          type: DurableEventType.SESSION_CREATED,
+          data: { source: 'create' },
+        },
+        {
+          type: DurableEventType.REQUEST_ACCEPTED,
+          requestId,
+          data: {
+            inputId,
+            input: 'execute once',
+            priority: 'next',
+            maxTurns: 20,
+            model: 'test-model',
+            context: {},
+          },
+        },
+      ],
+    });
+    let modelCalls = 0;
+    streamChat = async function* concurrentRecoveryStream() {
+      modelCalls += 1;
+      yield { type: 'turn_start', turn: 1, maxTurns: 20 };
+      yield { type: 'turn_end', turn: 1, hasToolCalls: false };
+      return {
+        success: true,
+        finalMessage: 'done',
+        metadata: { turnsCount: 1, toolCallsCount: 0, duration: 1 },
+      };
+    };
+
+    const [winner, loser] = await Promise.all([
+      resumeSession({
+        ...options(store),
+        persistSession: true,
+        storagePath: root,
+        sessionId,
+      }),
+      resumeSession({
+        ...options(store),
+        persistSession: true,
+        storagePath: root,
+        sessionId,
+      }),
+    ]);
+    const winnerStream = winner.stream();
+    await expect(winnerStream.next()).resolves.toMatchObject({
+      value: { type: 'turn_start' },
+      done: false,
+    });
+    await expect(loser.stream().next()).rejects.toThrow(
+      /already applied|already started|has not started/,
+    );
+    expect(loser.getPendingInputs()).toEqual([]);
+
+    while (!(await winnerStream.next()).done) {
+      // Drain the winning execution.
+    }
+    expect(modelCalls).toBe(1);
+    expect(
+      (await store.read(sessionId)).events.filter(
+        (event) => event.type === DurableEventType.REQUEST_STARTED,
+      ),
+    ).toHaveLength(1);
+    await winner.close();
+    await loser.close();
+  });
+
+  it('restores multimodal content from an accepted durable request', async () => {
+    const { root, store } = createStore();
+    const sessionId = SessionId('multimodal-recovery-session');
+    const requestId = RequestId('multimodal-recovery-request');
+    const inputId = InputId('multimodal-recovery-input');
+    const input: JsonValue = [
+      { type: 'text', text: 'Inspect this image' },
+      {
+        type: 'image_url',
+        image_url: { url: 'data:image/png;base64,recovery' },
+      },
+    ];
+    const journal = await DurableSessionJournal.open(store, sessionId);
+    await journal.commit({
+      commandId: CommandId('multimodal-bootstrap'),
+      events: [
+        {
+          type: DurableEventType.SESSION_CREATED,
+          data: { source: 'create' },
+        },
+        {
+          type: DurableEventType.REQUEST_ACCEPTED,
+          requestId,
+          data: {
+            inputId,
+            input,
+            priority: 'next',
+            maxTurns: 20,
+            model: 'test-model',
+            context: {},
+          },
+        },
+      ],
+    });
+
+    const session = await resumeSession({
+      ...options(store),
+      persistSession: true,
+      storagePath: root,
+      sessionId,
+    });
+
+    expect(session.getPendingInputs()[0]?.content).toEqual(input);
+    await session.abort();
+    await session.close();
+  });
+
+  it('fails closed when an accepted request payload cannot be restored', async () => {
+    const { root, store } = createStore();
+    const sessionId = SessionId('invalid-recovery-session');
+    const requestId = RequestId('invalid-recovery-request');
+    const inputId = InputId('invalid-recovery-input');
+    const journal = await DurableSessionJournal.open(store, sessionId);
+    await journal.commit({
+      commandId: CommandId('invalid-bootstrap'),
+      events: [
+        {
+          type: DurableEventType.SESSION_CREATED,
+          data: { source: 'create' },
+        },
+        {
+          type: DurableEventType.REQUEST_ACCEPTED,
+          requestId,
+          data: {
+            inputId,
+            input: { unsupported: true },
+            priority: 'next',
+            maxTurns: 20,
+            model: 'test-model',
+            context: {},
+          },
+        },
+      ],
+    });
+
+    await expect(
+      resumeSession({
+        ...options(store),
+        persistSession: true,
+        storagePath: root,
+        sessionId,
+      }),
+    ).rejects.toBeInstanceOf(SessionDurableRecorderError);
+  });
+
+  it('fails closed when resuming a request that crossed the execution boundary', async () => {
+    const { root, store } = createStore();
+    const sessionId = SessionId('running-session');
+    const requestId = RequestId('running-request');
+    const inputId = InputId('running-input');
+    const journal = await DurableSessionJournal.open(store, sessionId);
+    await journal.commit({
+      commandId: CommandId('command-bootstrap'),
+      events: [
+        {
+          type: DurableEventType.SESSION_CREATED,
+          data: { source: 'create' },
+        },
+        {
+          type: DurableEventType.REQUEST_ACCEPTED,
+          requestId,
+          data: {
+            inputId,
+            input: 'do not replay me',
+            priority: 'next',
+          },
+        },
+        {
+          type: DurableEventType.INPUT_APPLIED,
+          requestId,
+          data: {
+            inputId,
+            priority: 'next',
+          },
+        },
+        {
+          type: DurableEventType.REQUEST_STARTED,
+          requestId,
+          data: {},
         },
       ],
     });
@@ -420,10 +734,9 @@ describe('Session durable events', () => {
 
     expect(innerClosed).toBe(true);
     expect(session.getDurableRecoveryPlan()?.action).toBe('none');
-    expect((await store.read(session.sessionId)).events.map((event) => event.type).slice(-2)).toEqual([
-      DurableEventType.TURN_ABORTED,
-      DurableEventType.REQUEST_INTERRUPTED,
-    ]);
+    expect(
+      (await store.read(session.sessionId)).events.map((event) => event.type).slice(-2),
+    ).toEqual([DurableEventType.TURN_ABORTED, DurableEventType.REQUEST_INTERRUPTED]);
     await session.close();
   });
 
@@ -434,10 +747,9 @@ describe('Session durable events', () => {
 
     await session.close();
 
-    expect((await store.read(session.sessionId)).events.map((event) => event.type).slice(-2)).toEqual([
-      DurableEventType.REQUEST_INTERRUPTED,
-      DurableEventType.SESSION_CLOSED,
-    ]);
+    expect(
+      (await store.read(session.sessionId)).events.map((event) => event.type).slice(-2),
+    ).toEqual([DurableEventType.REQUEST_INTERRUPTED, DurableEventType.SESSION_CLOSED]);
   });
 
   it('commits session closure once across concurrent close calls', async () => {
@@ -488,8 +800,9 @@ describe('Session durable events', () => {
     }
 
     const events = (await store.read(session.sessionId)).events;
-    expect(events.find((event) => event.type === DurableEventType.REQUEST_INTERRUPTED)?.data)
-      .toMatchObject({ reason: 'session_close' });
+    expect(
+      events.find((event) => event.type === DurableEventType.REQUEST_INTERRUPTED)?.data,
+    ).toMatchObject({ reason: 'session_close' });
     expect(events.at(-1)?.type).toBe(DurableEventType.SESSION_CLOSED);
   });
 

--- a/src/session/events/DurableSessionProjector.ts
+++ b/src/session/events/DurableSessionProjector.ts
@@ -12,7 +12,7 @@ import {
   type ToolUseId,
   type TurnId,
 } from '../../types/branded.js';
-import type { JsonValue } from '../../types/common.js';
+import type { JsonObject, JsonValue } from '../../types/common.js';
 import { parseDurableEventDraft, parseDurableEventEnvelope } from './schemas.js';
 import {
   DURABLE_EVENT_SCHEMA_VERSION,
@@ -85,6 +85,10 @@ export interface DurableRequestProjection {
   readonly inputId: InputId;
   readonly input: JsonValue;
   readonly priority: DurableInputPriority;
+  readonly acceptedAt: string;
+  readonly maxTurns?: number;
+  readonly model?: string;
+  readonly context?: JsonObject;
   readonly status: DurableRequestStatus;
   readonly lastTurn: number;
   readonly activeTurn: DurableTurnProjection | null;
@@ -164,6 +168,10 @@ interface MutableRequestProjection {
   inputId: InputId;
   input: JsonValue;
   priority: DurableInputPriority;
+  acceptedAt: string;
+  maxTurns?: number;
+  model?: string;
+  context?: JsonObject;
   status: DurableRequestStatus;
   lastTurn: number;
   activeTurn: MutableTurnProjection | null;
@@ -321,6 +329,10 @@ function cloneRequest(request: MutableRequestProjection | null): DurableRequestP
     inputId: request.inputId,
     input: request.input,
     priority: request.priority,
+    acceptedAt: request.acceptedAt,
+    ...(request.maxTurns !== undefined ? { maxTurns: request.maxTurns } : {}),
+    ...(request.model ? { model: request.model } : {}),
+    ...(request.context ? { context: request.context } : {}),
     status: request.status,
     lastTurn: request.lastTurn,
     activeTurn: cloneTurn(request.activeTurn),
@@ -371,6 +383,10 @@ function applyEvent(state: ProjectionAccumulator, event: DurableEventEnvelope): 
         inputId: event.data.inputId,
         input: event.data.input,
         priority: event.data.priority,
+        acceptedAt: event.occurredAt,
+        ...(event.data.maxTurns !== undefined ? { maxTurns: event.data.maxTurns } : {}),
+        ...(event.data.model ? { model: event.data.model } : {}),
+        ...(event.data.context ? { context: event.data.context } : {}),
         status: 'accepted',
         lastTurn: 0,
         activeTurn: null,

--- a/src/session/events/DurableSessionRecoveryCoordinator.ts
+++ b/src/session/events/DurableSessionRecoveryCoordinator.ts
@@ -1,0 +1,367 @@
+import { SdkError } from '../../errors/SdkError.js';
+import type {
+  CommandId,
+  PermissionRequestId,
+  SessionId,
+  ToolAttemptId,
+} from '../../types/branded.js';
+import type { ToolSideEffect } from '../../tools/types/ToolKind.js';
+import type { JsonObject, JsonValue } from '../../types/common.js';
+import type { DurableEventStore } from './DurableEventStore.js';
+import {
+  type DurableCommandCommitResult,
+  type DurableSessionCommand,
+  DurableSessionJournal,
+  type DurableSessionJournalOptions,
+} from './DurableSessionJournal.js';
+import {
+  DurableEventProjectionError,
+  type DurablePermissionProjection,
+  type DurableRequestProjection,
+  type DurableSessionProjection,
+  type DurableSessionRecoveryPlan,
+  type DurableToolAttemptProjection,
+} from './DurableSessionProjector.js';
+import {
+  type DurableEventError,
+  DurableEventType,
+  type DurablePermissionDecision,
+} from './types.js';
+
+export type DurableAcceptedRequestRecovery = DurableRequestProjection & {
+  readonly maxTurns: number;
+  readonly model: string;
+  readonly context: JsonObject;
+};
+
+export type DurableSessionResumeDecision =
+  | {
+      readonly action: 'ready';
+      readonly projection: DurableSessionProjection;
+      readonly recoveryPlan: DurableSessionRecoveryPlan;
+    }
+  | {
+      readonly action: 'resume_accepted_request';
+      readonly projection: DurableSessionProjection;
+      readonly recoveryPlan: DurableSessionRecoveryPlan;
+      readonly request: DurableAcceptedRequestRecovery;
+    }
+  | {
+      readonly action: 'recovery_required';
+      readonly projection: DurableSessionProjection;
+      readonly recoveryPlan: DurableSessionRecoveryPlan;
+    };
+
+export type DurableToolOutcomeReconciliation =
+  | {
+      readonly status: 'completed';
+      readonly result: JsonValue;
+    }
+  | {
+      readonly status: 'failed';
+      readonly error: DurableEventError;
+    }
+  | {
+      readonly status: 'cancelled';
+    };
+
+export interface DurableToolOutcomeReconciliationCommand {
+  readonly commandId: CommandId;
+  readonly toolAttemptId: ToolAttemptId;
+  readonly outcome: DurableToolOutcomeReconciliation;
+}
+
+export interface DurableToolStartCommand {
+  readonly commandId: CommandId;
+  readonly toolAttemptId: ToolAttemptId;
+  readonly input: JsonObject;
+  readonly sideEffect: ToolSideEffect;
+}
+
+export interface DurablePermissionResolutionCommand {
+  readonly commandId: CommandId;
+  readonly permissionRequestId: PermissionRequestId;
+  readonly decision: DurablePermissionDecision;
+  readonly message?: string;
+}
+
+export interface DurableRecoveryCommitResult {
+  readonly commit: DurableCommandCommitResult;
+  readonly projection: DurableSessionProjection;
+  readonly recoveryPlan: DurableSessionRecoveryPlan;
+}
+
+export type DurableSessionRecoveryErrorCode =
+  | 'DURABLE_RECOVERY_INVALID_STATE'
+  | 'DURABLE_RECOVERY_TARGET_NOT_FOUND';
+
+export class DurableSessionRecoveryError extends SdkError {
+  // biome-ignore lint/complexity/noUselessConstructor: narrows the public error-code contract
+  constructor(
+    code: DurableSessionRecoveryErrorCode,
+    message: string,
+    options?: { cause?: unknown },
+  ) {
+    super(code, message, options);
+  }
+}
+
+function isAcceptedRequestRecovery(
+  request: DurableRequestProjection | null,
+  projection: DurableSessionProjection,
+  recoveryPlan: DurableSessionRecoveryPlan,
+): request is DurableAcceptedRequestRecovery {
+  return (
+    recoveryPlan.action === 'resume_request' &&
+    request?.status === 'accepted' &&
+    request.activeTurn === null &&
+    !projection.appliedInputIds.includes(request.inputId) &&
+    request.maxTurns !== undefined &&
+    request.model !== undefined &&
+    request.context !== undefined
+  );
+}
+
+/**
+ * Coordinates explicit recovery mutations against one durable Session journal.
+ *
+ * Recovery never guesses the outcome of a started tool. Callers must supply a
+ * stable command ID so retries remain idempotent across process restarts.
+ */
+export class DurableSessionRecoveryCoordinator {
+  constructor(private readonly journal: DurableSessionJournal) {}
+
+  static async open(
+    store: DurableEventStore,
+    sessionId: SessionId,
+    options: DurableSessionJournalOptions = {},
+  ): Promise<DurableSessionRecoveryCoordinator> {
+    return new DurableSessionRecoveryCoordinator(
+      await DurableSessionJournal.open(store, sessionId, options),
+    );
+  }
+
+  getProjection(): DurableSessionProjection {
+    return this.journal.getProjection();
+  }
+
+  getRecoveryPlan(): DurableSessionRecoveryPlan {
+    return this.journal.getRecoveryPlan();
+  }
+
+  async refresh(): Promise<DurableSessionRecoveryPlan> {
+    await this.journal.refresh();
+    return this.getRecoveryPlan();
+  }
+
+  planResume(): DurableSessionResumeDecision {
+    const projection = this.getProjection();
+    const recoveryPlan = this.getRecoveryPlan();
+    if (recoveryPlan.action === 'none') {
+      return {
+        action: 'ready',
+        projection,
+        recoveryPlan,
+      };
+    }
+
+    const request = projection.activeRequest;
+    if (isAcceptedRequestRecovery(request, projection, recoveryPlan)) {
+      return {
+        action: 'resume_accepted_request',
+        projection,
+        recoveryPlan,
+        request,
+      };
+    }
+
+    return {
+      action: 'recovery_required',
+      projection,
+      recoveryPlan,
+    };
+  }
+
+  async reconcileToolOutcome(
+    command: DurableToolOutcomeReconciliationCommand,
+  ): Promise<DurableRecoveryCommitResult> {
+    await this.journal.refresh();
+    const { request, turn, tool } = this.findToolAttempt(command.toolAttemptId);
+    const event = (() => {
+      const correlation = {
+        requestId: request.requestId,
+        turnId: turn.turnId,
+        toolAttemptId: tool.toolAttemptId,
+      };
+      const identity = {
+        toolCallId: tool.toolCallId,
+        toolName: tool.toolName,
+      };
+      switch (command.outcome.status) {
+        case 'completed':
+          return {
+            type: DurableEventType.TOOL_COMPLETED,
+            ...correlation,
+            data: {
+              ...identity,
+              result: command.outcome.result,
+            },
+          } as const;
+        case 'failed':
+          return {
+            type: DurableEventType.TOOL_FAILED,
+            ...correlation,
+            data: {
+              ...identity,
+              error: command.outcome.error,
+            },
+          } as const;
+        case 'cancelled':
+          return {
+            type: DurableEventType.TOOL_CANCELLED,
+            ...correlation,
+            data: {
+              ...identity,
+              reason: 'process_restart',
+            },
+          } as const;
+      }
+    })();
+
+    const commit = await this.commitRecovery({
+      commandId: command.commandId,
+      events: [event],
+    });
+    return this.result(commit);
+  }
+
+  async startToolAttempt(command: DurableToolStartCommand): Promise<DurableRecoveryCommitResult> {
+    await this.journal.refresh();
+    const { request, turn, tool } = this.findToolAttempt(command.toolAttemptId);
+    const commit = await this.commitRecovery({
+      commandId: command.commandId,
+      events: [
+        {
+          type: DurableEventType.TOOL_STARTED,
+          requestId: request.requestId,
+          turnId: turn.turnId,
+          toolAttemptId: tool.toolAttemptId,
+          data: {
+            toolCallId: tool.toolCallId,
+            toolName: tool.toolName,
+            input: command.input,
+            sideEffect: command.sideEffect,
+          },
+        },
+      ],
+    });
+    return this.result(commit);
+  }
+
+  async resolvePermission(
+    command: DurablePermissionResolutionCommand,
+  ): Promise<DurableRecoveryCommitResult> {
+    await this.journal.refresh();
+    const { request, turn, tool, permission } = this.findPermission(command.permissionRequestId);
+    const events = [
+      {
+        type: DurableEventType.PERMISSION_RESOLVED,
+        requestId: request.requestId,
+        turnId: turn.turnId,
+        toolAttemptId: tool.toolAttemptId,
+        data: {
+          permissionRequestId: permission.permissionRequestId,
+          decision: command.decision,
+          ...(command.message !== undefined ? { message: command.message } : {}),
+        },
+      },
+      ...(command.decision === 'allow'
+        ? []
+        : [
+            {
+              type: DurableEventType.TOOL_CANCELLED,
+              requestId: request.requestId,
+              turnId: turn.turnId,
+              toolAttemptId: tool.toolAttemptId,
+              data: {
+                toolCallId: tool.toolCallId,
+                toolName: tool.toolName,
+                reason:
+                  command.decision === 'deny'
+                    ? ('permission_denied' as const)
+                    : ('permission_cancelled' as const),
+              },
+            } as const,
+          ]),
+    ];
+
+    const commit = await this.commitRecovery({
+      commandId: command.commandId,
+      events,
+    });
+    return this.result(commit);
+  }
+
+  private findToolAttempt(toolAttemptId: ToolAttemptId): {
+    request: DurableRequestProjection;
+    turn: NonNullable<DurableRequestProjection['activeTurn']>;
+    tool: DurableToolAttemptProjection;
+  } {
+    const request = this.getProjection().activeRequest;
+    const turn = request?.activeTurn;
+    const tool = turn?.toolAttempts.find((candidate) => candidate.toolAttemptId === toolAttemptId);
+    if (!request || !turn || !tool) {
+      throw new DurableSessionRecoveryError(
+        'DURABLE_RECOVERY_TARGET_NOT_FOUND',
+        `No active tool attempt matches ${toolAttemptId}`,
+      );
+    }
+    return { request, turn, tool };
+  }
+
+  private findPermission(permissionRequestId: PermissionRequestId): {
+    request: DurableRequestProjection;
+    turn: NonNullable<DurableRequestProjection['activeTurn']>;
+    tool: DurableToolAttemptProjection;
+    permission: DurablePermissionProjection;
+  } {
+    const request = this.getProjection().activeRequest;
+    const turn = request?.activeTurn;
+    const tool = turn?.toolAttempts.find(
+      (candidate) => candidate.permission?.permissionRequestId === permissionRequestId,
+    );
+    const permission = tool?.permission;
+    if (!request || !turn || !tool || !permission) {
+      throw new DurableSessionRecoveryError(
+        'DURABLE_RECOVERY_TARGET_NOT_FOUND',
+        `No active permission request matches ${permissionRequestId}`,
+      );
+    }
+    return { request, turn, tool, permission };
+  }
+
+  private result(commit: DurableCommandCommitResult): DurableRecoveryCommitResult {
+    return {
+      commit,
+      projection: this.getProjection(),
+      recoveryPlan: this.getRecoveryPlan(),
+    };
+  }
+
+  private async commitRecovery(
+    command: DurableSessionCommand,
+  ): Promise<DurableCommandCommitResult> {
+    try {
+      return await this.journal.commit(command);
+    } catch (cause) {
+      if (cause instanceof DurableEventProjectionError) {
+        throw new DurableSessionRecoveryError(
+          'DURABLE_RECOVERY_INVALID_STATE',
+          `Durable recovery command ${command.commandId} is invalid: ${cause.message}`,
+          { cause },
+        );
+      }
+      throw cause;
+    }
+  }
+}

--- a/src/session/events/DurableSessionRecoveryCoordinator.ts
+++ b/src/session/events/DurableSessionRecoveryCoordinator.ts
@@ -5,7 +5,6 @@ import type {
   SessionId,
   ToolAttemptId,
 } from '../../types/branded.js';
-import type { ToolSideEffect } from '../../tools/types/ToolKind.js';
 import type { JsonObject, JsonValue } from '../../types/common.js';
 import type { DurableEventStore } from './DurableEventStore.js';
 import {
@@ -74,8 +73,6 @@ export interface DurableToolOutcomeReconciliationCommand {
 export interface DurableToolStartCommand {
   readonly commandId: CommandId;
   readonly toolAttemptId: ToolAttemptId;
-  readonly input: JsonObject;
-  readonly sideEffect: ToolSideEffect;
 }
 
 export interface DurablePermissionResolutionCommand {
@@ -238,6 +235,8 @@ export class DurableSessionRecoveryCoordinator {
   async startToolAttempt(command: DurableToolStartCommand): Promise<DurableRecoveryCommitResult> {
     await this.journal.refresh();
     const { request, turn, tool } = this.findToolAttempt(command.toolAttemptId);
+    const recoveredFromPermission = tool.permission?.status === 'resolved'
+      && tool.permission.decision === 'allow';
     const commit = await this.commitRecovery({
       commandId: command.commandId,
       events: [
@@ -249,8 +248,11 @@ export class DurableSessionRecoveryCoordinator {
           data: {
             toolCallId: tool.toolCallId,
             toolName: tool.toolName,
-            input: command.input,
-            sideEffect: command.sideEffect,
+            input: recoveredFromPermission ? tool.permission?.input ?? tool.input : tool.input,
+            // A permission round-trip may have changed input after scheduling.
+            // Without the live Tool resolver, only the most conservative
+            // classification is safe across the restart boundary.
+            sideEffect: recoveredFromPermission ? 'non_idempotent' : tool.sideEffect,
           },
         },
       ],

--- a/src/session/events/SessionDurableRecorder.ts
+++ b/src/session/events/SessionDurableRecorder.ts
@@ -20,7 +20,7 @@ import {
   type ToolUseId,
   TurnId,
 } from '../../types/branded.js';
-import type { JsonValue } from '../../types/common.js';
+import type { JsonObject, JsonValue } from '../../types/common.js';
 import { toJsonValue } from '../../utils/jsonValue.js';
 import type { DurableSessionJournal } from './DurableSessionJournal.js';
 import type { DurableSessionRecoveryPlan } from './DurableSessionProjector.js';
@@ -97,6 +97,10 @@ export class SessionDurableRecorder implements ToolExecutionLifecycle {
     inputId: InputId,
     input: UserMessageContent,
     priority: 'next' | 'later' = 'next',
+    execution: {
+      readonly maxTurns?: number;
+      readonly context?: JsonObject;
+    } = {},
   ): Promise<void> {
     await this.commit([
       {
@@ -106,6 +110,9 @@ export class SessionDurableRecorder implements ToolExecutionLifecycle {
           inputId,
           input: toJsonValue(input),
           priority,
+          ...(execution.maxTurns !== undefined ? { maxTurns: execution.maxTurns } : {}),
+          model: this.model,
+          ...(execution.context ? { context: execution.context } : {}),
         },
       },
     ]);

--- a/src/session/events/__tests__/DurableSessionProjector.test.ts
+++ b/src/session/events/__tests__/DurableSessionProjector.test.ts
@@ -277,7 +277,28 @@ describe('DurableSessionProjector', () => {
   });
 
   it('classifies accepted requests and active model turns as retryable', () => {
-    const accepted = project(requestPrefix().slice(0, 2));
+    const accepted = project([
+      requestPrefix()[0] as DurableEventDraft,
+      {
+        type: DurableEventType.REQUEST_ACCEPTED,
+        requestId,
+        commandId,
+        data: {
+          inputId: initialInputId,
+          input: 'Build the feature',
+          priority: 'next',
+          maxTurns: 12,
+          model: 'request-model',
+          context: { id: 'request-context' },
+        },
+      },
+    ]);
+    expect(accepted.activeRequest).toMatchObject({
+      acceptedAt: timestamp,
+      maxTurns: 12,
+      model: 'request-model',
+      context: { id: 'request-context' },
+    });
     expect(planDurableSessionRecovery(accepted)).toMatchObject({
       action: 'resume_request',
       requestId,

--- a/src/session/events/__tests__/DurableSessionRecoveryCoordinator.test.ts
+++ b/src/session/events/__tests__/DurableSessionRecoveryCoordinator.test.ts
@@ -1,0 +1,414 @@
+import { mkdtempSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  CommandId,
+  EventId,
+  InputId,
+  PermissionRequestId,
+  RequestId,
+  SessionId,
+  ToolAttemptId,
+  ToolUseId,
+  TurnId,
+} from '../../../types/branded.js';
+import { DurableSessionJournal } from '../DurableSessionJournal.js';
+import {
+  DurableSessionRecoveryCoordinator,
+  DurableSessionRecoveryError,
+} from '../DurableSessionRecoveryCoordinator.js';
+import { JsonlDurableEventStore } from '../JsonlDurableEventStore.js';
+import { DurableEventType } from '../types.js';
+
+const sessionId = SessionId('recovery-session');
+const requestId = RequestId('recovery-request');
+const inputId = InputId('recovery-input');
+const turnId = TurnId('recovery-turn');
+const toolAttemptId = ToolAttemptId('recovery-attempt');
+const toolCallId = ToolUseId('recovery-call');
+const permissionRequestId = PermissionRequestId('recovery-permission');
+
+const roots: string[] = [];
+
+function createStore(): JsonlDurableEventStore {
+  const root = mkdtempSync(join(tmpdir(), 'durable-recovery-coordinator-'));
+  roots.push(root);
+  let eventId = 0;
+  return new JsonlDurableEventStore(root, {
+    clock: () => new Date('2026-08-22T12:00:00.000Z'),
+    eventIdFactory: () => EventId(`recovery-event-${++eventId}`),
+  });
+}
+
+async function createJournal(
+  store: JsonlDurableEventStore,
+  options: {
+    requestStarted?: boolean;
+    tool?: 'none' | 'pending_permission' | 'started';
+  } = {},
+): Promise<DurableSessionJournal> {
+  const journal = await DurableSessionJournal.open(store, sessionId);
+  await journal.commit({
+    commandId: CommandId('bootstrap'),
+    events: [
+      {
+        type: DurableEventType.SESSION_CREATED,
+        data: { source: 'create' },
+      },
+      {
+        type: DurableEventType.REQUEST_ACCEPTED,
+        requestId,
+        data: {
+          inputId,
+          input: 'recover this request',
+          priority: 'next',
+          maxTurns: 17,
+          model: 'accepted-model',
+          context: {
+            id: 'accepted-context',
+            environment: { RECOVERED: 'yes' },
+          },
+        },
+      },
+      ...(options.requestStarted
+        ? ([
+            {
+              type: DurableEventType.INPUT_APPLIED,
+              requestId,
+              data: { inputId, priority: 'next' as const },
+            },
+            {
+              type: DurableEventType.REQUEST_STARTED,
+              requestId,
+              data: {},
+            },
+          ] as const)
+        : []),
+      ...(options.tool && options.tool !== 'none'
+        ? ([
+            {
+              type: DurableEventType.TURN_STARTED,
+              requestId,
+              turnId,
+              data: { turn: 1, model: 'test-model' },
+            },
+            {
+              type: DurableEventType.TOOL_SCHEDULED,
+              requestId,
+              turnId,
+              toolAttemptId,
+              data: {
+                toolCallId,
+                toolName: 'Deploy',
+                input: { environment: 'production' },
+                sideEffect: 'non_idempotent' as const,
+                interruptBehavior: 'block' as const,
+              },
+            },
+            ...(options.tool === 'pending_permission'
+              ? ([
+                  {
+                    type: DurableEventType.PERMISSION_REQUESTED,
+                    requestId,
+                    turnId,
+                    toolAttemptId,
+                    data: {
+                      permissionRequestId,
+                      toolCallId,
+                      toolName: 'Deploy',
+                      input: { environment: 'production' },
+                      message: 'Allow deployment?',
+                    },
+                  },
+                ] as const)
+              : ([
+                  {
+                    type: DurableEventType.TOOL_STARTED,
+                    requestId,
+                    turnId,
+                    toolAttemptId,
+                    data: {
+                      toolCallId,
+                      toolName: 'Deploy',
+                      input: { environment: 'production' },
+                      sideEffect: 'non_idempotent' as const,
+                    },
+                  },
+                ] as const)),
+          ] as const)
+        : []),
+    ],
+  });
+  return journal;
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe('DurableSessionRecoveryCoordinator', () => {
+  it('only auto-resumes an accepted request that never crossed the start boundary', async () => {
+    const store = createStore();
+    const accepted = new DurableSessionRecoveryCoordinator(await createJournal(store)).planResume();
+
+    expect(accepted).toMatchObject({
+      action: 'resume_accepted_request',
+      request: {
+        requestId,
+        inputId,
+        input: 'recover this request',
+        maxTurns: 17,
+        model: 'accepted-model',
+        context: {
+          id: 'accepted-context',
+          environment: { RECOVERED: 'yes' },
+        },
+      },
+    });
+
+    const legacyStore = createStore();
+    const legacyJournal = await DurableSessionJournal.open(legacyStore, sessionId);
+    await legacyJournal.commit({
+      commandId: CommandId('legacy-bootstrap'),
+      events: [
+        {
+          type: DurableEventType.SESSION_CREATED,
+          data: { source: 'create' },
+        },
+        {
+          type: DurableEventType.REQUEST_ACCEPTED,
+          requestId,
+          data: {
+            inputId,
+            input: 'missing execution snapshot',
+            priority: 'next',
+          },
+        },
+      ],
+    });
+    expect(new DurableSessionRecoveryCoordinator(legacyJournal).planResume()).toMatchObject({
+      action: 'recovery_required',
+      recoveryPlan: {
+        action: 'resume_request',
+      },
+    });
+
+    const runningStore = createStore();
+    const running = new DurableSessionRecoveryCoordinator(
+      await createJournal(runningStore, { requestStarted: true }),
+    ).planResume();
+    expect(running).toMatchObject({
+      action: 'recovery_required',
+      recoveryPlan: {
+        action: 'resume_request',
+        requestId,
+      },
+    });
+
+    const unknownStore = createStore();
+    const unknown = new DurableSessionRecoveryCoordinator(
+      await createJournal(unknownStore, { requestStarted: true, tool: 'started' }),
+    ).planResume();
+    expect(unknown).toMatchObject({
+      action: 'recovery_required',
+      recoveryPlan: {
+        action: 'reconcile_tool_outcomes',
+        unknownToolAttempts: [
+          {
+            toolAttemptId,
+            sideEffect: 'non_idempotent',
+            status: 'started',
+          },
+        ],
+      },
+    });
+  });
+
+  it('reconciles an unknown tool outcome idempotently across coordinator instances', async () => {
+    const store = createStore();
+    await createJournal(store, { requestStarted: true, tool: 'started' });
+    const first = await DurableSessionRecoveryCoordinator.open(store, sessionId);
+    const second = await DurableSessionRecoveryCoordinator.open(store, sessionId);
+    const command = {
+      commandId: CommandId('reconcile-deployment'),
+      toolAttemptId,
+      outcome: {
+        status: 'completed' as const,
+        result: { deploymentId: 'dep-123' },
+      },
+    };
+
+    const results = await Promise.all([
+      first.reconcileToolOutcome(command),
+      second.reconcileToolOutcome(command),
+    ]);
+
+    expect(results.map((result) => result.commit.status).sort()).toEqual([
+      'committed',
+      'reconciled',
+    ]);
+    expect(results.every((result) => result.recoveryPlan.action === 'resume_turn')).toBe(true);
+    expect(
+      (await store.read(sessionId)).events.filter(
+        (event) => event.type === DurableEventType.TOOL_COMPLETED,
+      ),
+    ).toHaveLength(1);
+    await expect(
+      first.reconcileToolOutcome({
+        ...command,
+        outcome: {
+          status: 'completed',
+          result: { deploymentId: 'different-deployment' },
+        },
+      }),
+    ).rejects.toThrow(/different events/);
+  });
+
+  it.each([
+    {
+      outcome: {
+        status: 'failed' as const,
+        error: { message: 'Deployment status is unknown', code: 'REMOTE_UNAVAILABLE' },
+      },
+      eventType: DurableEventType.TOOL_FAILED,
+      status: 'failed',
+    },
+    {
+      outcome: { status: 'cancelled' as const },
+      eventType: DurableEventType.TOOL_CANCELLED,
+      status: 'cancelled',
+    },
+  ])('reconciles a started tool as $status', async ({ outcome, eventType, status }) => {
+    const store = createStore();
+    await createJournal(store, { requestStarted: true, tool: 'started' });
+    const coordinator = await DurableSessionRecoveryCoordinator.open(store, sessionId);
+
+    const result = await coordinator.reconcileToolOutcome({
+      commandId: CommandId(`reconcile-${status}`),
+      toolAttemptId,
+      outcome,
+    });
+
+    expect(result.commit.events).toEqual([
+      expect.objectContaining({
+        type: eventType,
+        toolAttemptId,
+      }),
+    ]);
+    expect(result.projection.activeRequest?.activeTurn?.toolAttempts[0]?.status).toBe(status);
+  });
+
+  it.each([
+    {
+      decision: 'allow' as const,
+      eventTypes: [DurableEventType.PERMISSION_RESOLVED],
+      toolStatus: 'scheduled',
+    },
+    {
+      decision: 'deny' as const,
+      eventTypes: [DurableEventType.PERMISSION_RESOLVED, DurableEventType.TOOL_CANCELLED],
+      toolStatus: 'cancelled',
+    },
+    {
+      decision: 'cancel' as const,
+      eventTypes: [DurableEventType.PERMISSION_RESOLVED, DurableEventType.TOOL_CANCELLED],
+      toolStatus: 'cancelled',
+    },
+  ])('resolves a pending permission with $decision in one command', async ({
+    decision,
+    eventTypes,
+    toolStatus,
+  }) => {
+    const store = createStore();
+    await createJournal(store, { requestStarted: true, tool: 'pending_permission' });
+    const coordinator = await DurableSessionRecoveryCoordinator.open(store, sessionId);
+    const command = {
+      commandId: CommandId(`permission-${decision}`),
+      permissionRequestId,
+      decision,
+      message: `Permission ${decision}`,
+    };
+
+    const first = await coordinator.resolvePermission(command);
+    const replayed = await coordinator.resolvePermission(command);
+
+    expect(first.commit.status).toBe('committed');
+    expect(first.commit.events.map((event) => event.type)).toEqual(eventTypes);
+    expect(replayed.commit.status).toBe('replayed');
+    expect(first.projection.activeRequest?.activeTurn?.toolAttempts[0]).toMatchObject({
+      status: toolStatus,
+      permission: {
+        status: 'resolved',
+        decision,
+        message: `Permission ${decision}`,
+      },
+    });
+  });
+
+  it('persists a recovered tool start before the caller may run its side effect', async () => {
+    const store = createStore();
+    await createJournal(store, { requestStarted: true, tool: 'pending_permission' });
+    const coordinator = await DurableSessionRecoveryCoordinator.open(store, sessionId);
+
+    await expect(
+      coordinator.startToolAttempt({
+        commandId: CommandId('start-before-permission'),
+        toolAttemptId,
+        input: { environment: 'approved-production' },
+        sideEffect: 'idempotent',
+      }),
+    ).rejects.toMatchObject({
+      code: 'DURABLE_RECOVERY_INVALID_STATE',
+      message: expect.stringContaining('unresolved permission'),
+    });
+
+    await coordinator.resolvePermission({
+      commandId: CommandId('allow-deployment'),
+      permissionRequestId,
+      decision: 'allow',
+    });
+    const command = {
+      commandId: CommandId('start-deployment'),
+      toolAttemptId,
+      input: { environment: 'approved-production' },
+      sideEffect: 'idempotent' as const,
+    };
+    const started = await coordinator.startToolAttempt(command);
+    const replayed = await coordinator.startToolAttempt(command);
+
+    expect(started.commit.status).toBe('committed');
+    expect(replayed.commit.status).toBe('replayed');
+    expect(started.recoveryPlan).toMatchObject({
+      action: 'resume_turn',
+      retryableToolAttempts: [
+        {
+          toolAttemptId,
+          input: { environment: 'approved-production' },
+          sideEffect: 'idempotent',
+          status: 'started',
+        },
+      ],
+    });
+    expect(
+      (await store.read(sessionId)).events.filter(
+        (event) => event.type === DurableEventType.TOOL_STARTED,
+      ),
+    ).toHaveLength(1);
+  });
+
+  it('fails closed when a reconciliation target is not active', async () => {
+    const store = createStore();
+    await createJournal(store);
+    const coordinator = await DurableSessionRecoveryCoordinator.open(store, sessionId);
+
+    await expect(
+      coordinator.reconcileToolOutcome({
+        commandId: CommandId('missing-tool'),
+        toolAttemptId,
+        outcome: { status: 'cancelled' },
+      }),
+    ).rejects.toBeInstanceOf(DurableSessionRecoveryError);
+  });
+});

--- a/src/session/events/__tests__/DurableSessionRecoveryCoordinator.test.ts
+++ b/src/session/events/__tests__/DurableSessionRecoveryCoordinator.test.ts
@@ -118,7 +118,7 @@ async function createJournal(
                       permissionRequestId,
                       toolCallId,
                       toolName: 'Deploy',
-                      input: { environment: 'production' },
+                      input: { environment: 'approved-production' },
                       message: 'Allow deployment?',
                     },
                   },
@@ -356,8 +356,6 @@ describe('DurableSessionRecoveryCoordinator', () => {
       coordinator.startToolAttempt({
         commandId: CommandId('start-before-permission'),
         toolAttemptId,
-        input: { environment: 'approved-production' },
-        sideEffect: 'idempotent',
       }),
     ).rejects.toMatchObject({
       code: 'DURABLE_RECOVERY_INVALID_STATE',
@@ -372,8 +370,6 @@ describe('DurableSessionRecoveryCoordinator', () => {
     const command = {
       commandId: CommandId('start-deployment'),
       toolAttemptId,
-      input: { environment: 'approved-production' },
-      sideEffect: 'idempotent' as const,
     };
     const started = await coordinator.startToolAttempt(command);
     const replayed = await coordinator.startToolAttempt(command);
@@ -381,12 +377,12 @@ describe('DurableSessionRecoveryCoordinator', () => {
     expect(started.commit.status).toBe('committed');
     expect(replayed.commit.status).toBe('replayed');
     expect(started.recoveryPlan).toMatchObject({
-      action: 'resume_turn',
-      retryableToolAttempts: [
+      action: 'reconcile_tool_outcomes',
+      unknownToolAttempts: [
         {
           toolAttemptId,
           input: { environment: 'approved-production' },
-          sideEffect: 'idempotent',
+          sideEffect: 'non_idempotent',
           status: 'started',
         },
       ],

--- a/src/session/events/__tests__/SessionDurableRecorder.test.ts
+++ b/src/session/events/__tests__/SessionDurableRecorder.test.ts
@@ -54,7 +54,13 @@ describe('SessionDurableRecorder', () => {
   });
 
   it('records a complete request, turn, permission, and tool lifecycle', async () => {
-    await recorder.recordAccepted(inputId, 'run write');
+    await recorder.recordAccepted(inputId, 'run write', 'next', {
+      maxTurns: 17,
+      context: {
+        id: 'request-context',
+        environment: { REGION: 'test' },
+      },
+    });
     await recorder.recordStarted(inputId);
     await recorder.recordAgentEvent({
       type: 'turn_start',
@@ -122,6 +128,18 @@ describe('SessionDurableRecorder', () => {
       'turn_completed',
       'request_completed',
     ]);
+    expect(
+      (await store.read(sessionId)).events.find(
+        (event) => event.type === DurableEventType.REQUEST_ACCEPTED,
+      )?.data,
+    ).toMatchObject({
+      maxTurns: 17,
+      model: 'test-model',
+      context: {
+        id: 'request-context',
+        environment: { REGION: 'test' },
+      },
+    });
     expect(
       (await store.read(sessionId)).events.find(
         (event) => event.type === DurableEventType.TOOL_SCHEDULED,

--- a/src/session/events/__tests__/schemas.test.ts
+++ b/src/session/events/__tests__/schemas.test.ts
@@ -40,6 +40,12 @@ const validDrafts: readonly DurableEventDraft[] = [
       inputId: InputId('input-1'),
       input: [{ type: 'text', text: 'hello' }],
       priority: 'next',
+      maxTurns: 12,
+      model: 'test-model',
+      context: {
+        id: 'request-context',
+        environment: { REGION: 'test' },
+      },
     },
   },
   {
@@ -237,6 +243,20 @@ describe('durable event schemas', () => {
         type: DurableEventType.REQUEST_STARTED,
         requestId,
         data: { unexpected: true },
+      }),
+    ).toThrow();
+
+    expect(() =>
+      parseDurableEventDraft({
+        type: DurableEventType.REQUEST_ACCEPTED,
+        requestId,
+        commandId,
+        data: {
+          inputId: InputId('input-1'),
+          input: 'hello',
+          priority: 'next',
+          maxTurns: Number.POSITIVE_INFINITY,
+        },
       }),
     ).toThrow();
 

--- a/src/session/events/core.ts
+++ b/src/session/events/core.ts
@@ -17,6 +17,18 @@ export {
   type DurableSessionJournalOptions,
 } from './DurableSessionJournal.js';
 export {
+  type DurableAcceptedRequestRecovery,
+  type DurablePermissionResolutionCommand,
+  type DurableRecoveryCommitResult,
+  DurableSessionRecoveryCoordinator,
+  DurableSessionRecoveryError,
+  type DurableSessionRecoveryErrorCode,
+  type DurableSessionResumeDecision,
+  type DurableToolOutcomeReconciliation,
+  type DurableToolOutcomeReconciliationCommand,
+  type DurableToolStartCommand,
+} from './DurableSessionRecoveryCoordinator.js';
+export {
   DurableEventProjectionError,
   type DurablePermissionProjection,
   type DurablePermissionStatus,

--- a/src/session/events/schemas.ts
+++ b/src/session/events/schemas.ts
@@ -76,6 +76,9 @@ const DurableEventDataSchemas = {
       inputId: NonEmptyStringSchema,
       input: JsonValueSchema,
       priority: z.enum(['now', 'next', 'later']),
+      maxTurns: z.number().int().min(-1).max(Number.MAX_SAFE_INTEGER).optional(),
+      model: NonEmptyStringSchema.optional(),
+      context: JsonObjectSchema.optional(),
     })
     .strict(),
   [DurableEventTypeValue.REQUEST_STARTED]: z.object({}).strict(),

--- a/src/session/events/types.ts
+++ b/src/session/events/types.ts
@@ -11,7 +11,7 @@ import type {
   ToolUseId,
   TurnId,
 } from '../../types/branded.js';
-import type { JsonValue } from '../../types/common.js';
+import type { JsonObject, JsonValue } from '../../types/common.js';
 
 export const DURABLE_EVENT_SCHEMA_VERSION = 2 as const;
 
@@ -85,6 +85,9 @@ export interface DurableEventDataMap {
     inputId: InputId;
     input: JsonValue;
     priority: DurableInputPriority;
+    maxTurns?: number;
+    model?: string;
+    context?: JsonObject;
   };
   [DurableEventType.REQUEST_STARTED]: Record<string, never>;
   [DurableEventType.REQUEST_COMPLETED]: {


### PR DESCRIPTION
## Summary

- add a browser-safe `DurableSessionRecoveryCoordinator` for resume decisions, permission resolution, persist-before-side-effect tool starts, and explicit tool outcome reconciliation
- persist accepted-request execution snapshots and automatically restore only requests that never crossed `request_started`
- preserve fail-closed behavior for active turns and non-idempotent unknown outcomes, including CAS protection against concurrent resume
- document the recovery protocol in English and Chinese

## Verification

- `pnpm test` (127 files passed, 1302 tests passed, 62 live tests skipped)
- `pnpm run type-check`
- `pnpm run lint`
- `pnpm run docs:build`
- `pnpm run changelog:check`
- `pnpm run verify:entrypoints`
- `npm pack --dry-run --json`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added durable session recovery for automatically resuming accepted requests that have not started execution.
  * Added recovery coordination for permissions, tool outcomes, and tool attempts with idempotent processing.
  * Preserved execution settings, including model, turn limits, context, and multimodal request content.
  * Added safeguards to avoid speculative replay of active work and non-idempotent tools.

* **Bug Fixes**
  * Request-level turn limits now correctly override session defaults, including a limit of zero.

* **Documentation**
  * Updated English and Chinese documentation with durable recovery behavior, recovery decisions, and API guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->