### PR TITLE
feat(durable): add reconnectable event subscriptions

### DIFF
--- a/.changes/durable-event-subscriptions.json
+++ b/.changes/durable-event-subscriptions.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "en": "Add pull-based durable event subscriptions with validated reconnect cursors, replay barriers, bounded buffering, and live delivery.",
+  "zh-CN": "新增拉取式 durable 事件订阅，支持可验证的重连 cursor、回放边界、有界缓冲和实时交付。"
+}

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ console.log(result.usage);
 
 - Session lifecycle: `createSession()`, `resumeSession()`, `forkSession()`, and `prompt()`
 - Steerable requests: durable `now`, `next`, and `later` inputs with cancellation and pending-input inspection
-- Durable recovery: automatic pre-execution request resume plus explicit permission and tool-outcome reconciliation
+- Durable recovery: automatic pre-execution resume, explicit reconciliation, and reconnectable cursor event subscriptions
 - Streaming: 17 typed events for turns, content, reasoning, tools, usage, steering, results, and errors
 - Providers: OpenAI, Anthropic, Azure OpenAI, Gemini, DeepSeek, and OpenAI-compatible APIs
 - Tools: generator-only custom tools, capability-grouped built-ins, MCP tools, and typed progress/effects

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -61,7 +61,7 @@ console.log(result.usage);
 
 - Session 生命周期：`createSession()`、`resumeSession()`、`forkSession()`、`prompt()`
 - 可转向请求：持久化的 `now`、`next`、`later` 输入，支持取消和待处理输入查询
-- Durable 恢复：自动恢复执行前请求，并显式完成权限与工具结果对账
+- Durable 恢复：自动恢复执行前请求、显式完成权限与工具结果对账，并支持 cursor 断线续读
 - 流式事件：17 种类型化事件，覆盖轮次、内容、思维、工具、usage、转向、结果和错误
 - Provider：OpenAI、Anthropic、Azure OpenAI、Gemini、DeepSeek 和 OpenAI-compatible API
 - 工具：仅 generator 的自定义工具、按能力分组的内置工具、MCP 工具和类型化进度/副作用

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -100,6 +100,8 @@ Node-local 能力外，这些函数都从根入口导出；实际 subpath 以“
 | 导出 | 说明 |
 |------|------|
 | `DurableEventStore` | append/read/head 的持久化接口 |
+| `DurableEventSubscription` | 支持 replay/caught-up/live 阶段的可重连事件流 |
+| `durableEventCursor` / `parseDurableEventCursor` | 创建和严格解析版本化恢复 cursor |
 | `DurableSessionJournal` / `DurableSessionJournalOptions` | command-oriented 串行提交、CAS 重试与对账层 |
 | `DurableSessionRecoveryCoordinator` | accepted Request 恢复、权限消解与工具结果对账协调器 |
 | `DurableSessionCommand` / `DurableCommandEventDraft` | Journal command 与不含重复 `commandId` 的事件输入 |
@@ -118,6 +120,9 @@ Node-local 能力外，这些函数都从根入口导出；实际 subpath 以“
 | `DurableSessionCloseReason` | Session 关闭原因 |
 | `DurableEventAppendOptions` / `DurableEventAppendResult` | compare-and-append 参数与结果 |
 | `DurableEventReadOptions` / `DurableEventPage` | cursor 分页读取参数与结果 |
+| `DurableEventCursor` / `DURABLE_EVENT_CURSOR_VERSION` | 绑定 Session、sequence 和 event ID 的 cursor |
+| `DurableEventSubscriptionOptions` / `DurableEventSubscriptionMessage` | 订阅配置与 event/caught-up 消息 |
+| `DurableEventSubscriptionError` / `DurableEventSubscriptionErrorCode` | cursor、分页或订阅配置错误 |
 | `DurableEventType` / `isDurableEventType` | 生命周期事件名及运行时类型判断 |
 | `DurableSessionProjector` / `projectDurableSession` | 增量或一次性重建并校验 Session 生命周期 |
 | `planDurableSessionRecovery` / `DurableSessionRecoveryPlan` | 分类未完成 Request、Turn、Tool 与 Permission |

--- a/docs/durable-events.md
+++ b/docs/durable-events.md
@@ -19,6 +19,7 @@ adapter 从根入口或 `/local` 导入：
 ```ts
 import {
   CommandId,
+  DurableEventSubscription,
   type DurableEventDataMap,
   DurableSessionRecoveryCoordinator,
   DurableSessionProjector,
@@ -214,6 +215,48 @@ console.log(page.hasMore);
 `after` 是 exclusive cursor。单页限制为 1 到 1000 条；cursor 超过当前 head
 会被拒绝，而不是静默返回空结果。
 
+## 可重连事件订阅
+
+`DurableEventSubscription` 将 cursor 分页读取封装为 pull-based
+`AsyncIterableIterator`。订阅打开时固定一个 replay head，先回放该位置之前的
+事件，再发送一次 `caught_up` barrier，之后到达的事件标记为 `live`：
+
+```ts
+const subscription = await DurableEventSubscription.open(store, sessionId, {
+  after: savedCursor,
+  pageSize: 100,
+  pollIntervalMs: 250,
+});
+
+for await (const message of subscription) {
+  if (message.type === 'caught_up') {
+    markClientReady(message.headSequence);
+    continue;
+  }
+
+  await deliver(message.event);
+  await saveCursor(message.cursor);
+}
+```
+
+也可以从已初始化的 Session 创建相同订阅：
+
+```ts
+const subscription = await session.subscribeDurableEvents({
+  after: savedCursor,
+});
+```
+
+cursor 是严格版本化的 JSON 值，包含 `sessionId`、`sequence` 和 `eventId`。
+重连时会验证 cursor 指向的事件仍是 canonical log 中的同一事件；跨 Session、
+超前、被替换或产生 sequence gap 的 cursor 会 fail closed，而不是跳过数据。
+
+订阅只在消费者请求下一项时读取下一页，内存和读取压力由 `pageSize` 有界控制。
+收到 `session_closed` 后流自动结束；`close()` 正常结束等待中的读取，
+`AbortSignal` 则以 `AbortError` 终止。`follow: false` 只回放订阅创建时已经存在
+的快照。应用应在成功处理事件后再持久化该 delivery 的 cursor，从而在断线重连
+时获得 at-least-once 交付。
+
 ## 状态投影与恢复分类
 
 `DurableSessionProjector` 可以逐页消费事件；`projectDurableSession()` 是一次性
@@ -367,6 +410,7 @@ Store 不持久化 token delta、工具 progress 等高频 UI 事件。只有会
 | `DurableCommandConflictError` | 相同 `commandId` 对应不同内容或非连续事件区间 |
 | `DurableCommandOutcomeUnknownError` | 写入失败后无法确认 command 是否提交，Journal 已 fenced |
 | `DurableSessionJournalError` | command 输入、Store page 或 commit 返回值违反契约 |
+| `DurableEventSubscriptionError` | 订阅配置、cursor 锚点或 Store page 不满足续读契约 |
 | `DurableSessionRecoveryRequiredError` | Session 存在未完成工作，必须先执行恢复或对账 |
 | `SessionDurableRecorderError` | Session runtime 观察到非法 durable 生命周期状态 |
 | `DurableEventProjectionError` | schema、事件顺序或关联关系不满足生命周期约束 |

--- a/docs/en/api-reference.md
+++ b/docs/en/api-reference.md
@@ -60,6 +60,10 @@ These ID exports are branded identifiers, not arbitrary strings.
 Runtime:
 
 - `JsonlDurableEventStore`
+- `DurableEventSubscription`
+- `durableEventCursor`
+- `parseDurableEventCursor`
+- `DURABLE_EVENT_CURSOR_VERSION`
 - `DurableSessionJournal`
 - `DurableSessionRecoveryCoordinator`
 - `DurableEventType`
@@ -76,6 +80,11 @@ Runtime:
 Types and errors:
 
 - `DurableEventStore`
+- `DurableEventCursor`
+- `DurableEventSubscriptionOptions`
+- `DurableEventSubscriptionMessage`
+- `DurableEventSubscriptionError`
+- `DurableEventSubscriptionErrorCode`
 - `DurableSessionJournalOptions`
 - `DurableSessionCommand`
 - `DurableCommandEventDraft`

--- a/docs/en/durable-events.md
+++ b/docs/en/durable-events.md
@@ -22,6 +22,7 @@ entry. The Node.js JSONL adapter is available from root and `/local`:
 ```ts
 import {
   CommandId,
+  DurableEventSubscription,
   type DurableEventDataMap,
   DurableSessionRecoveryCoordinator,
   DurableSessionProjector,
@@ -220,6 +221,52 @@ console.log(page.hasMore);
 `after` is exclusive. Page size must be between 1 and 1000. A cursor ahead of
 the current head is rejected rather than silently returning an empty page.
 
+## Reconnectable event subscriptions
+
+`DurableEventSubscription` wraps cursor-based reads in a pull-based
+`AsyncIterableIterator`. It captures a replay head when opened, replays events
+through that position, emits one `caught_up` barrier, and then marks later
+events as `live`:
+
+```ts
+const subscription = await DurableEventSubscription.open(store, sessionId, {
+  after: savedCursor,
+  pageSize: 100,
+  pollIntervalMs: 250,
+});
+
+for await (const message of subscription) {
+  if (message.type === 'caught_up') {
+    markClientReady(message.headSequence);
+    continue;
+  }
+
+  await deliver(message.event);
+  await saveCursor(message.cursor);
+}
+```
+
+The same subscription is available from an initialized Session:
+
+```ts
+const subscription = await session.subscribeDurableEvents({
+  after: savedCursor,
+});
+```
+
+A cursor is a strictly versioned JSON value containing `sessionId`, `sequence`,
+and `eventId`. Reconnection verifies that the cursor still names the same event
+in the canonical log. A foreign, ahead-of-head, replaced, or sequence-gapped
+cursor fails closed instead of skipping data.
+
+The subscription reads another page only when the consumer asks for another
+item, bounding memory and read pressure by `pageSize`. It ends after
+`session_closed`; `close()` cleanly releases a pending wait, while an
+`AbortSignal` terminates with `AbortError`. Set `follow: false` to replay only
+the snapshot that existed when the subscription opened. Persist each delivery's
+cursor only after processing the event to obtain at-least-once delivery across
+reconnections.
+
 ## State projection and recovery classification
 
 `DurableSessionProjector` consumes events page by page.
@@ -386,6 +433,7 @@ journal.
 | `DurableCommandConflictError` | One `commandId` maps to different content or non-contiguous ranges. |
 | `DurableCommandOutcomeUnknownError` | A failed write cannot be reconciled and the Journal is fenced. |
 | `DurableSessionJournalError` | Command input, Store page, or commit result violates its contract. |
+| `DurableEventSubscriptionError` | Subscription options, cursor anchors, or Store pages violate the replay contract. |
 | `DurableSessionRecoveryRequiredError` | The Session has unfinished work that requires recovery or reconciliation. |
 | `SessionDurableRecorderError` | Session runtime observed an invalid durable lifecycle state. |
 | `DurableEventProjectionError` | Schema, ordering, or correlation violates lifecycle invariants. |

--- a/docs/en/session.md
+++ b/docs/en/session.md
@@ -276,6 +276,7 @@ until the journal has been reconciled.
 ```ts
 const projection = session.getDurableProjection();
 const recovery = session.getDurableRecoveryPlan();
+const events = await session.subscribeDurableEvents({ after: savedCursor });
 ```
 
 `resumeSession()` automatically restores a durable Request that was accepted
@@ -543,5 +544,8 @@ interface ISession extends AsyncDisposable {
   getTraces(): AgentTrace[];
   getDurableProjection(): DurableSessionProjection | null;
   getDurableRecoveryPlan(): DurableSessionRecoveryPlan | null;
+  subscribeDurableEvents(
+    options?: DurableEventSubscriptionOptions,
+  ): Promise<DurableEventSubscription>;
 }
 ```

--- a/docs/session.md
+++ b/docs/session.md
@@ -673,6 +673,7 @@ const session = await createSession({
 ```ts
 const projection = session.getDurableProjection();
 const recovery = session.getDurableRecoveryPlan();
+const events = await session.subscribeDurableEvents({ after: savedCursor });
 ```
 
 `resumeSession()` 会自动恢复已接受但尚未写入 `request_started` 的 durable
@@ -1732,6 +1733,9 @@ interface ISession extends AsyncDisposable {
   getTraces(): AgentTrace[];
   getDurableProjection(): DurableSessionProjection | null;
   getDurableRecoveryPlan(): DurableSessionRecoveryPlan | null;
+  subscribeDurableEvents(
+    options?: DurableEventSubscriptionOptions,
+  ): Promise<DurableEventSubscription>;
 }
 ```
 

--- a/scripts/verify-entrypoints.mjs
+++ b/scripts/verify-entrypoints.mjs
@@ -96,12 +96,12 @@ const subpathOutput = run(process.execPath, [
     "const server = await import('@blade-ai/agent-sdk/server');",
     "const tools = await import('@blade-ai/agent-sdk/tools');",
     "const local = await import('@blade-ai/agent-sdk/local');",
-    "console.log(core.PermissionMode.DEFAULT, core.DurableEventType.REQUEST_ACCEPTED, core.projectDurableSession([]).status, typeof core.DurableSessionJournal.open, typeof core.DurableSessionRecoveryCoordinator.open, browser.PermissionMode.DEFAULT, typeof server.createSession, typeof tools.defineTool, typeof local.getBuiltinTools, typeof local.JsonlDurableEventStore);",
+    "console.log(core.PermissionMode.DEFAULT, core.DurableEventType.REQUEST_ACCEPTED, core.projectDurableSession([]).status, typeof core.DurableSessionJournal.open, typeof core.DurableSessionRecoveryCoordinator.open, typeof core.DurableEventSubscription.open, browser.PermissionMode.DEFAULT, typeof server.createSession, typeof tools.defineTool, typeof local.getBuiltinTools, typeof local.JsonlDurableEventStore);",
   ].join(' '),
 ]);
 assertIncludes(
   subpathOutput,
-  'default request_accepted empty function function default function function function function',
+  'default request_accepted empty function function function default function function function function',
   'subpath imports',
 );
 

--- a/src/__tests__/rootExports.test.ts
+++ b/src/__tests__/rootExports.test.ts
@@ -2,9 +2,12 @@ import { describe, expect, expectTypeOf, it } from 'vitest';
 import type {
   DurableAcceptedRequestRecovery,
   DurableCommandEventDraft,
+  DurableEventCursor,
   DurableEventEnvelope,
   DurableEventOfType,
   DurableEventStore,
+  DurableEventSubscriptionMessage,
+  DurableEventSubscriptionOptions,
   DurableSessionCommand,
   DurableSessionResumeDecision,
   DurableSessionRecoveryPlan,
@@ -40,7 +43,11 @@ import {
   createMemoryWriteTool,
   DurableCommandConflictError,
   DurableCommandOutcomeUnknownError,
+  DURABLE_EVENT_CURSOR_VERSION,
   DURABLE_EVENT_SCHEMA_VERSION,
+  durableEventCursor,
+  DurableEventSubscription,
+  DurableEventSubscriptionError,
   DurableEventType,
   DurableSessionJournal,
   DurableSessionProjector,
@@ -86,7 +93,11 @@ describe('root exports', () => {
     expect(ToolErrorType.INTERRUPTED).toBe('interrupted');
     expect(ToolSideEffect.NON_IDEMPOTENT).toBe('non_idempotent');
     expect(DURABLE_EVENT_SCHEMA_VERSION).toBe(2);
+    expect(DURABLE_EVENT_CURSOR_VERSION).toBe(1);
     expect(DurableEventType.REQUEST_ACCEPTED).toBe('request_accepted');
+    expect(DurableEventSubscription.open).toBeTypeOf('function');
+    expect(DurableEventSubscriptionError).toBeDefined();
+    expect(durableEventCursor).toBeTypeOf('function');
     expect(JsonlDurableEventStore).toBeDefined();
     expect(CommandId('command-1')).toBe('command-1');
     expect(EventId('event-1')).toBe('event-1');
@@ -132,6 +143,13 @@ describe('root exports', () => {
     expectTypeOf<PendingSessionInput['priority']>().toEqualTypeOf<'now' | 'next' | 'later'>();
     expectTypeOf<ReturnType<typeof createMemoryReadTool>>().toMatchTypeOf<SessionTool>();
     expectTypeOf<DurableEventEnvelope['sequence']>().toEqualTypeOf<EventSequence>();
+    expectTypeOf<DurableEventCursor['eventId']>().toEqualTypeOf<EventId>();
+    expectTypeOf<DurableEventSubscriptionMessage['type']>().toEqualTypeOf<
+      'event' | 'caught_up'
+    >();
+    expectTypeOf<DurableEventSubscriptionOptions['follow']>().toEqualTypeOf<
+      boolean | undefined
+    >();
     expectTypeOf<
       DurableEventOfType<typeof DurableEventType.REQUEST_ACCEPTED>['data']['inputId']
     >().toEqualTypeOf<InputId>();
@@ -154,6 +172,9 @@ describe('root exports', () => {
       DurableEventStore | undefined
     >();
     expectTypeOf<ReturnType<ISession['abort']>>().toEqualTypeOf<Promise<void>>();
+    expectTypeOf<ReturnType<ISession['subscribeDurableEvents']>>().toEqualTypeOf<
+      Promise<DurableEventSubscription>
+    >();
     expectTypeOf<ToolCatalogEntry['source']['kind']>().toEqualTypeOf<
       'builtin' | 'custom' | 'mcp' | 'session'
     >();

--- a/src/session/Session.ts
+++ b/src/session/Session.ts
@@ -36,6 +36,11 @@ import {
     parseDurableUserMessageContent,
     serializeDurableRuntimeContext,
 } from './DurableRequestRecovery.js';
+import {
+    DurableEventSubscription,
+    DurableEventSubscriptionError,
+    type DurableEventSubscriptionOptions,
+} from './events/DurableEventSubscription.js';
 import { DurableSessionJournal } from './events/DurableSessionJournal.js';
 import type {
     DurableRequestProjection,
@@ -203,6 +208,21 @@ class Session implements ISession {
 
   getDurableRecoveryPlan(): DurableSessionRecoveryPlan | null {
     return this.durableJournal?.getRecoveryPlan() ?? null;
+  }
+
+  /** Replays persisted lifecycle events, then follows newly committed events. */
+  async subscribeDurableEvents(
+    options: DurableEventSubscriptionOptions = {},
+  ): Promise<DurableEventSubscription> {
+    await this.ensureInitialized();
+    const store = this.options.durableEventStore;
+    if (!store) {
+      throw new DurableEventSubscriptionError(
+        'DURABLE_EVENT_SUBSCRIPTION_NOT_CONFIGURED',
+        'Session durable event subscription requires durableEventStore',
+      );
+    }
+    return DurableEventSubscription.open(store, this.sessionId, options);
   }
 
   async initialize(): Promise<void> {

--- a/src/session/__tests__/SessionDurableEvents.test.ts
+++ b/src/session/__tests__/SessionDurableEvents.test.ts
@@ -16,6 +16,10 @@ import {
 import type { JsonValue } from '../../types/common.js';
 import { type DurableEventStore, DurableEventStoreError } from '../events/DurableEventStore.js';
 import {
+  DurableEventSubscriptionError,
+  type DurableEventSubscriptionMessage,
+} from '../events/DurableEventSubscription.js';
+import {
   DurableCommandOutcomeUnknownError,
   DurableSessionJournal,
 } from '../events/DurableSessionJournal.js';
@@ -159,6 +163,45 @@ describe('Session durable events', () => {
     expect((await store.read(session.sessionId)).events.at(-1)?.type).toBe(
       DurableEventType.SESSION_CLOSED,
     );
+  });
+
+  it('exposes the durable event subscription through Session', async () => {
+    const { store } = createStore();
+    const session = await createSession(options(store));
+    const subscription = await session.subscribeDurableEvents({
+      follow: false,
+    });
+    const messages: DurableEventSubscriptionMessage[] = [];
+
+    for await (const message of subscription) {
+      messages.push(message);
+    }
+
+    expect(messages).toMatchObject([
+      {
+        type: 'event',
+        event: { type: DurableEventType.SESSION_CREATED },
+        phase: 'replay',
+      },
+      {
+        type: 'caught_up',
+        headSequence: 1,
+      },
+    ]);
+    await session.close();
+  });
+
+  it('rejects Session event subscriptions without a durable Store', async () => {
+    const session = await createSession({
+      provider: { type: 'openai-compatible', apiKey: 'test-key' },
+      model: 'test-model',
+      persistSession: false,
+    });
+
+    await expect(session.subscribeDurableEvents()).rejects.toBeInstanceOf(
+      DurableEventSubscriptionError,
+    );
+    await session.close();
   });
 
   it('persists the accepted request execution snapshot before send returns', async () => {

--- a/src/session/events/DurableEventSubscription.ts
+++ b/src/session/events/DurableEventSubscription.ts
@@ -1,0 +1,549 @@
+import { AbortError } from '../../errors/AbortError.js';
+import { SdkError } from '../../errors/SdkError.js';
+import { EventId, EventSequence, type SessionId } from '../../types/branded.js';
+import type { DurableEventStore } from './DurableEventStore.js';
+import { parseDurableEventEnvelope } from './schemas.js';
+import { type DurableEventEnvelope, type DurableEventPage, DurableEventType } from './types.js';
+
+const DEFAULT_PAGE_SIZE = 100;
+const MAX_PAGE_SIZE = 1000;
+const DEFAULT_POLL_INTERVAL_MS = 250;
+const MAX_POLL_INTERVAL_MS = 60_000;
+
+export const DURABLE_EVENT_CURSOR_VERSION = 1 as const;
+
+export interface DurableEventCursor {
+  readonly version: typeof DURABLE_EVENT_CURSOR_VERSION;
+  readonly sessionId: SessionId;
+  readonly sequence: EventSequence;
+  readonly eventId: EventId;
+}
+
+export interface DurableEventSubscriptionOptions {
+  /** Exclusive cursor. Omit to replay from the beginning. */
+  readonly after?: DurableEventCursor | null;
+  /** Maximum number of events buffered from one Store read. */
+  readonly pageSize?: number;
+  /** Delay between empty reads while following live events. */
+  readonly pollIntervalMs?: number;
+  /** Stop after replay reaches the head captured when the subscription opens. */
+  readonly follow?: boolean;
+  readonly signal?: AbortSignal;
+}
+
+export type DurableEventSubscriptionMessage =
+  | {
+      readonly type: 'event';
+      readonly event: DurableEventEnvelope;
+      readonly cursor: DurableEventCursor;
+      readonly phase: 'replay' | 'live';
+    }
+  | {
+      readonly type: 'caught_up';
+      readonly cursor: DurableEventCursor | null;
+      readonly headSequence: EventSequence | null;
+    };
+
+export type DurableEventSubscriptionErrorCode =
+  | 'DURABLE_EVENT_SUBSCRIPTION_INVALID_CURSOR'
+  | 'DURABLE_EVENT_SUBSCRIPTION_INVALID_OPTIONS'
+  | 'DURABLE_EVENT_SUBSCRIPTION_INVALID_PAGE'
+  | 'DURABLE_EVENT_SUBSCRIPTION_NOT_CONFIGURED'
+  | 'DURABLE_EVENT_SUBSCRIPTION_STALE_CURSOR';
+
+export class DurableEventSubscriptionError extends SdkError {
+  // biome-ignore lint/complexity/noUselessConstructor: narrows the public error-code contract
+  constructor(
+    code: DurableEventSubscriptionErrorCode,
+    message: string,
+    options?: { cause?: unknown },
+  ) {
+    super(code, message, options);
+  }
+}
+
+/** Creates a reconnect cursor for an event after the consumer has processed it. */
+export function durableEventCursor(event: DurableEventEnvelope): DurableEventCursor {
+  return {
+    version: DURABLE_EVENT_CURSOR_VERSION,
+    sessionId: event.sessionId,
+    sequence: event.sequence,
+    eventId: event.eventId,
+  };
+}
+
+/** Parses an untrusted serialized cursor using the strict wire contract. */
+export function parseDurableEventCursor(value: unknown): DurableEventCursor {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new DurableEventSubscriptionError(
+      'DURABLE_EVENT_SUBSCRIPTION_INVALID_CURSOR',
+      'A durable event cursor must be an object',
+    );
+  }
+  const cursor = value as Record<string, unknown>;
+  const keys = Object.keys(cursor).sort();
+  if (
+    keys.length !== 4 ||
+    keys[0] !== 'eventId' ||
+    keys[1] !== 'sequence' ||
+    keys[2] !== 'sessionId' ||
+    keys[3] !== 'version' ||
+    cursor.version !== DURABLE_EVENT_CURSOR_VERSION ||
+    typeof cursor.sessionId !== 'string' ||
+    cursor.sessionId.length === 0 ||
+    !Number.isSafeInteger(cursor.sequence) ||
+    (cursor.sequence as number) <= 0 ||
+    typeof cursor.eventId !== 'string' ||
+    cursor.eventId.length === 0
+  ) {
+    throw new DurableEventSubscriptionError(
+      'DURABLE_EVENT_SUBSCRIPTION_INVALID_CURSOR',
+      'Durable event cursor fields are invalid',
+    );
+  }
+  return {
+    version: DURABLE_EVENT_CURSOR_VERSION,
+    sessionId: cursor.sessionId as SessionId,
+    sequence: EventSequence(cursor.sequence as number),
+    eventId: EventId(cursor.eventId),
+  };
+}
+
+function abortError(signal: AbortSignal): AbortError {
+  return new AbortError('Durable event subscription aborted', {
+    cause: signal.reason,
+  });
+}
+
+/**
+ * Pull-based durable event stream with replay and reconnect semantics.
+ *
+ * The subscription only reads another page when the consumer requests another
+ * item, so Store reads and memory use remain bounded by pageSize.
+ */
+export class DurableEventSubscription
+  implements AsyncIterableIterator<DurableEventSubscriptionMessage>, AsyncDisposable
+{
+  private readonly pageSize: number;
+  private readonly pollIntervalMs: number;
+  private readonly follow: boolean;
+  private readonly signal: AbortSignal | undefined;
+  private readonly replayHead: EventSequence | null;
+  private cursor: DurableEventCursor | null;
+  private headSequence: EventSequence | null;
+  private readonly buffer: DurableEventEnvelope[] = [];
+  private operationTail: Promise<void> = Promise.resolve();
+  private wakeWaiter: (() => void) | null = null;
+  private caughtUp = false;
+  private terminalSeen = false;
+  private closed = false;
+
+  private constructor(
+    private readonly store: DurableEventStore,
+    readonly sessionId: SessionId,
+    options: Required<
+      Pick<DurableEventSubscriptionOptions, 'pageSize' | 'pollIntervalMs' | 'follow'>
+    > &
+      Pick<DurableEventSubscriptionOptions, 'signal'>,
+    cursor: DurableEventCursor | null,
+    replayHead: EventSequence | null,
+    terminalSeen: boolean,
+  ) {
+    this.pageSize = options.pageSize;
+    this.pollIntervalMs = options.pollIntervalMs;
+    this.follow = options.follow;
+    this.signal = options.signal;
+    this.cursor = cursor;
+    this.replayHead = replayHead;
+    this.headSequence = replayHead;
+    this.terminalSeen = terminalSeen;
+  }
+
+  /** Opens a subscription and validates its reconnect cursor against canonical storage. */
+  static async open(
+    store: DurableEventStore,
+    sessionId: SessionId,
+    options: DurableEventSubscriptionOptions = {},
+  ): Promise<DurableEventSubscription> {
+    const pageSize = options.pageSize ?? DEFAULT_PAGE_SIZE;
+    const pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+    if (!Number.isSafeInteger(pageSize) || pageSize <= 0 || pageSize > MAX_PAGE_SIZE) {
+      throw new DurableEventSubscriptionError(
+        'DURABLE_EVENT_SUBSCRIPTION_INVALID_OPTIONS',
+        `Durable event subscription pageSize must be between 1 and ${MAX_PAGE_SIZE}`,
+      );
+    }
+    if (
+      !Number.isSafeInteger(pollIntervalMs) ||
+      pollIntervalMs <= 0 ||
+      pollIntervalMs > MAX_POLL_INTERVAL_MS
+    ) {
+      throw new DurableEventSubscriptionError(
+        'DURABLE_EVENT_SUBSCRIPTION_INVALID_OPTIONS',
+        `Durable event subscription pollIntervalMs must be between 1 and ${MAX_POLL_INTERVAL_MS}`,
+      );
+    }
+    if (options.signal?.aborted) {
+      throw abortError(options.signal);
+    }
+
+    const cursor = options.after ? parseDurableEventCursor(options.after) : null;
+    if (cursor && cursor.sessionId !== sessionId) {
+      throw new DurableEventSubscriptionError(
+        'DURABLE_EVENT_SUBSCRIPTION_INVALID_CURSOR',
+        `Durable event cursor belongs to Session ${cursor.sessionId}, not ${sessionId}`,
+      );
+    }
+
+    const replayHead = await store.getHeadSequence(sessionId);
+    if (replayHead !== null && (!Number.isSafeInteger(replayHead) || replayHead <= 0)) {
+      throw new DurableEventSubscriptionError(
+        'DURABLE_EVENT_SUBSCRIPTION_INVALID_PAGE',
+        `Durable Event Store returned invalid head sequence ${String(replayHead)}`,
+      );
+    }
+    let terminalSeen = false;
+    if (cursor) {
+      if (replayHead === null || cursor.sequence > replayHead) {
+        throw new DurableEventSubscriptionError(
+          'DURABLE_EVENT_SUBSCRIPTION_STALE_CURSOR',
+          `Durable event cursor ${cursor.sequence} is ahead of Session head ${String(replayHead)}`,
+        );
+      }
+      const previousSequence = Number(cursor.sequence) - 1;
+      const anchor = await store.read(sessionId, {
+        ...(previousSequence > 0
+          ? { after: EventSequence(previousSequence) }
+          : {}),
+        limit: 1,
+      });
+      if (anchor.events.length !== 1) {
+        throw new DurableEventSubscriptionError(
+          'DURABLE_EVENT_SUBSCRIPTION_STALE_CURSOR',
+          `Durable event cursor ${cursor.sequence} could not be resolved uniquely`,
+        );
+      }
+      let event: DurableEventEnvelope | undefined;
+      try {
+        event = anchor.events[0] ? parseDurableEventEnvelope(anchor.events[0]) : undefined;
+      } catch (cause) {
+        throw new DurableEventSubscriptionError(
+          'DURABLE_EVENT_SUBSCRIPTION_STALE_CURSOR',
+          `Durable event cursor ${cursor.sequence} points to an invalid event`,
+          { cause },
+        );
+      }
+      if (
+        !event ||
+        event.sessionId !== sessionId ||
+        event.sequence !== cursor.sequence ||
+        event.eventId !== cursor.eventId
+      ) {
+        throw new DurableEventSubscriptionError(
+          'DURABLE_EVENT_SUBSCRIPTION_STALE_CURSOR',
+          `Durable event cursor ${cursor.sequence} no longer matches the canonical log`,
+        );
+      }
+      terminalSeen = event.type === DurableEventType.SESSION_CLOSED;
+      if (terminalSeen && cursor.sequence !== replayHead) {
+        throw new DurableEventSubscriptionError(
+          'DURABLE_EVENT_SUBSCRIPTION_INVALID_PAGE',
+          'Durable Event Store contains events after session_closed',
+        );
+      }
+    }
+    if (options.signal?.aborted) {
+      throw abortError(options.signal);
+    }
+
+    return new DurableEventSubscription(
+      store,
+      sessionId,
+      {
+        pageSize,
+        pollIntervalMs,
+        follow: options.follow ?? true,
+        signal: options.signal,
+      },
+      cursor,
+      replayHead,
+      terminalSeen,
+    );
+  }
+
+  /** Returns the cursor for the most recently delivered event. */
+  getCursor(): DurableEventCursor | null {
+    return this.cursor ? { ...this.cursor } : null;
+  }
+
+  /** Returns the most recent Store head observed by this subscription. */
+  getHeadSequence(): EventSequence | null {
+    return this.headSequence;
+  }
+
+  /** Reports whether the subscription has reached a terminal local state. */
+  get isClosed(): boolean {
+    return this.closed;
+  }
+
+  /** Delivers the next event or replay barrier without prefetching beyond one page. */
+  next(): Promise<IteratorResult<DurableEventSubscriptionMessage, undefined>> {
+    const result = this.operationTail.then(
+      () => this.nextExclusive(),
+      () => this.nextExclusive(),
+    );
+    this.operationTail = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  }
+
+  /** Stops the subscription and releases any pending wait. */
+  async return(): Promise<IteratorResult<DurableEventSubscriptionMessage, undefined>> {
+    this.close();
+    return { done: true, value: undefined };
+  }
+
+  /** Stops the subscription and propagates the supplied consumer error. */
+  async throw(
+    error?: unknown,
+  ): Promise<IteratorResult<DurableEventSubscriptionMessage, undefined>> {
+    this.close();
+    throw error;
+  }
+
+  /** Returns this stateful subscription as its own async iterator. */
+  [Symbol.asyncIterator](): AsyncIterableIterator<DurableEventSubscriptionMessage> {
+    return this;
+  }
+
+  async [Symbol.asyncDispose](): Promise<void> {
+    this.close();
+  }
+
+  /** Stops the subscription without treating cancellation as an error. */
+  close(): void {
+    if (this.closed) {
+      return;
+    }
+    this.closed = true;
+    this.buffer.length = 0;
+    this.wakeWaiter?.();
+    this.wakeWaiter = null;
+  }
+
+  private async nextExclusive(): Promise<
+    IteratorResult<DurableEventSubscriptionMessage, undefined>
+  > {
+    try {
+      while (true) {
+        this.throwIfAborted();
+        if (this.closed) {
+          return { done: true, value: undefined };
+        }
+        const event = this.buffer.shift();
+        if (event) {
+          const cursor = durableEventCursor(event);
+          this.cursor = cursor;
+          if (event.type === DurableEventType.SESSION_CLOSED) {
+            this.terminalSeen = true;
+          }
+          return {
+            done: false,
+            value: {
+              type: 'event',
+              event,
+              cursor,
+              phase:
+                this.replayHead !== null && event.sequence <= this.replayHead ? 'replay' : 'live',
+            },
+          };
+        }
+
+        if (!this.caughtUp && this.reachedReplayHead()) {
+          this.caughtUp = true;
+          return {
+            done: false,
+            value: {
+              type: 'caught_up',
+              cursor: this.getCursor(),
+              headSequence: this.replayHead,
+            },
+          };
+        }
+        if (this.terminalSeen || (!this.follow && this.caughtUp)) {
+          this.close();
+          return { done: true, value: undefined };
+        }
+
+        const page = await this.store.read(this.sessionId, {
+          ...(this.cursor ? { after: this.cursor.sequence } : {}),
+          limit: this.pageSize,
+        });
+        this.throwIfAborted();
+        if (this.closed) {
+          return { done: true, value: undefined };
+        }
+        const events = this.validatePage(page);
+        this.headSequence = page.headSequence;
+        this.buffer.push(
+          ...events.filter(
+            (candidate) =>
+              this.caughtUp || this.replayHead === null || candidate.sequence <= this.replayHead,
+          ),
+        );
+        if (this.buffer.length > 0) {
+          continue;
+        }
+        if (!this.caughtUp && this.reachedReplayHead()) {
+          continue;
+        }
+        if (!this.follow) {
+          this.close();
+          return { done: true, value: undefined };
+        }
+        await this.waitForPoll();
+      }
+    } catch (error) {
+      this.close();
+      throw error;
+    }
+  }
+
+  private reachedReplayHead(): boolean {
+    if (this.replayHead === null) {
+      return true;
+    }
+    return Number(this.cursor?.sequence ?? 0) >= Number(this.replayHead);
+  }
+
+  private validatePage(page: DurableEventPage): DurableEventEnvelope[] {
+    const currentSequence = Number(this.cursor?.sequence ?? 0);
+    const expectedFirstSequence = currentSequence + 1;
+    if (
+      (page.headSequence !== null &&
+        (!Number.isSafeInteger(page.headSequence) || page.headSequence <= 0)) ||
+      (page.nextCursor !== null && (!Number.isSafeInteger(page.nextCursor) || page.nextCursor < 0))
+    ) {
+      throw new DurableEventSubscriptionError(
+        'DURABLE_EVENT_SUBSCRIPTION_INVALID_PAGE',
+        'Durable Event Store returned invalid subscription sequence metadata',
+      );
+    }
+    let events: DurableEventEnvelope[];
+    try {
+      events = page.events.map(parseDurableEventEnvelope);
+    } catch (cause) {
+      throw new DurableEventSubscriptionError(
+        'DURABLE_EVENT_SUBSCRIPTION_INVALID_PAGE',
+        'Durable Event Store returned an invalid subscription event',
+        { cause },
+      );
+    }
+    if (events.length > this.pageSize) {
+      throw new DurableEventSubscriptionError(
+        'DURABLE_EVENT_SUBSCRIPTION_INVALID_PAGE',
+        `Durable Event Store exceeded subscription pageSize ${this.pageSize}`,
+      );
+    }
+    const first = events[0];
+    const last = events.at(-1);
+
+    if (!first) {
+      if (Number(page.headSequence ?? 0) < currentSequence) {
+        throw new DurableEventSubscriptionError(
+          'DURABLE_EVENT_SUBSCRIPTION_STALE_CURSOR',
+          `Durable event cursor ${currentSequence} is ahead of Session head ${String(page.headSequence)}`,
+        );
+      }
+      if (
+        page.hasMore ||
+        page.nextCursor !== (this.cursor?.sequence ?? null) ||
+        Number(page.headSequence ?? 0) > currentSequence
+      ) {
+        throw new DurableEventSubscriptionError(
+          'DURABLE_EVENT_SUBSCRIPTION_INVALID_PAGE',
+          'Durable Event Store returned an inconsistent empty subscription page',
+        );
+      }
+      return events;
+    }
+
+    if (first.sequence !== expectedFirstSequence) {
+      throw new DurableEventSubscriptionError(
+        'DURABLE_EVENT_SUBSCRIPTION_STALE_CURSOR',
+        `Expected durable event sequence ${expectedFirstSequence}, received ${first.sequence}`,
+      );
+    }
+    for (const [index, event] of events.entries()) {
+      if (
+        event.sessionId !== this.sessionId ||
+        Number(event.sequence) !== expectedFirstSequence + index
+      ) {
+        throw new DurableEventSubscriptionError(
+          'DURABLE_EVENT_SUBSCRIPTION_INVALID_PAGE',
+          'Durable Event Store returned a non-contiguous subscription page',
+        );
+      }
+    }
+    if (
+      !last ||
+      page.nextCursor !== last.sequence ||
+      page.headSequence === null ||
+      page.headSequence < last.sequence ||
+      page.hasMore !== last.sequence < page.headSequence
+    ) {
+      throw new DurableEventSubscriptionError(
+        'DURABLE_EVENT_SUBSCRIPTION_INVALID_PAGE',
+        'Durable Event Store returned inconsistent subscription cursor metadata',
+      );
+    }
+    const closeIndex = events.findIndex((event) => event.type === DurableEventType.SESSION_CLOSED);
+    if (closeIndex !== -1 && (closeIndex !== events.length - 1 || page.hasMore)) {
+      throw new DurableEventSubscriptionError(
+        'DURABLE_EVENT_SUBSCRIPTION_INVALID_PAGE',
+        'Durable Event Store returned events after session_closed',
+      );
+    }
+    return events;
+  }
+
+  private throwIfAborted(): void {
+    if (this.signal?.aborted) {
+      throw abortError(this.signal);
+    }
+  }
+
+  private async waitForPoll(): Promise<void> {
+    if (this.closed) {
+      return;
+    }
+    this.throwIfAborted();
+    await new Promise<void>((resolve, reject) => {
+      let settled = false;
+      const finish = (callback: () => void): void => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimeout(timer);
+        this.signal?.removeEventListener('abort', onAbort);
+        if (this.wakeWaiter === wake) {
+          this.wakeWaiter = null;
+        }
+        callback();
+      };
+      const wake = () => finish(resolve);
+      const onAbort = () => finish(() => reject(abortError(this.signal as AbortSignal)));
+      const timer = setTimeout(wake, this.pollIntervalMs);
+      this.wakeWaiter = wake;
+      this.signal?.addEventListener('abort', onAbort, { once: true });
+      if (this.closed) {
+        wake();
+      } else if (this.signal?.aborted) {
+        onAbort();
+      }
+    });
+  }
+}

--- a/src/session/events/__tests__/DurableEventSubscription.test.ts
+++ b/src/session/events/__tests__/DurableEventSubscription.test.ts
@@ -1,0 +1,666 @@
+import { mkdtempSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AbortError } from '../../../errors/AbortError.js';
+import {
+  CommandId,
+  EventId,
+  EventSequence,
+  InputId,
+  RequestId,
+  SessionId,
+} from '../../../types/branded.js';
+import type {
+  DurableEventAppendOptions,
+  DurableEventAppendResult,
+  DurableEventDraft,
+  DurableEventPage,
+  DurableEventReadOptions,
+} from '../types.js';
+import {
+  DURABLE_EVENT_CURSOR_VERSION,
+  durableEventCursor,
+  DurableEventSubscription,
+  DurableEventSubscriptionError,
+  type DurableEventSubscriptionMessage,
+  parseDurableEventCursor,
+} from '../DurableEventSubscription.js';
+import type { DurableEventStore } from '../DurableEventStore.js';
+import { DurableSessionJournal } from '../DurableSessionJournal.js';
+import { JsonlDurableEventStore } from '../JsonlDurableEventStore.js';
+import { DurableEventType } from '../types.js';
+
+const sessionId = SessionId('subscription-session');
+const requestId = RequestId('subscription-request');
+const inputId = InputId('subscription-input');
+const roots: string[] = [];
+
+function createStore(): JsonlDurableEventStore {
+  const root = mkdtempSync(join(tmpdir(), 'durable-event-subscription-'));
+  roots.push(root);
+  let eventId = 0;
+  return new JsonlDurableEventStore(root, {
+    clock: () => new Date('2026-08-22T12:00:00.000Z'),
+    eventIdFactory: () => EventId(`subscription-event-${++eventId}`),
+  });
+}
+
+async function appendClosedSession(store: DurableEventStore): Promise<void> {
+  const journal = await DurableSessionJournal.open(store, sessionId);
+  await journal.commit({
+    commandId: CommandId('create'),
+    events: [
+      {
+        type: DurableEventType.SESSION_CREATED,
+        data: { source: 'create' },
+      },
+    ],
+  });
+  await journal.commit({
+    commandId: CommandId('close'),
+    events: [
+      {
+        type: DurableEventType.SESSION_CLOSED,
+        data: { reason: 'shutdown' },
+      },
+    ],
+  });
+}
+
+async function appendOpenRequest(store: DurableEventStore): Promise<void> {
+  const journal = await DurableSessionJournal.open(store, sessionId);
+  await journal.commit({
+    commandId: CommandId('create'),
+    events: [
+      {
+        type: DurableEventType.SESSION_CREATED,
+        data: { source: 'create' },
+      },
+    ],
+  });
+  await journal.commit({
+    commandId: CommandId('accept'),
+    events: [
+      {
+        type: DurableEventType.REQUEST_ACCEPTED,
+        requestId,
+        data: {
+          inputId,
+          input: 'run',
+          priority: 'next',
+        },
+      },
+    ],
+  });
+  await journal.commit({
+    commandId: CommandId('start'),
+    events: [
+      {
+        type: DurableEventType.INPUT_APPLIED,
+        requestId,
+        data: {
+          inputId,
+          priority: 'next',
+        },
+      },
+      {
+        type: DurableEventType.REQUEST_STARTED,
+        requestId,
+        data: {},
+      },
+    ],
+  });
+  await journal.commit({
+    commandId: CommandId('interrupt'),
+    events: [
+      {
+        type: DurableEventType.REQUEST_INTERRUPTED,
+        requestId,
+        data: { reason: 'process_restart' },
+      },
+    ],
+  });
+  await journal.commit({
+    commandId: CommandId('close'),
+    events: [
+      {
+        type: DurableEventType.SESSION_CLOSED,
+        data: { reason: 'shutdown' },
+      },
+    ],
+  });
+}
+
+async function collect(
+  subscription: DurableEventSubscription,
+): Promise<DurableEventSubscriptionMessage[]> {
+  const messages: DurableEventSubscriptionMessage[] = [];
+  for await (const message of subscription) {
+    messages.push(message);
+  }
+  return messages;
+}
+
+class CountingStore implements DurableEventStore {
+  reads = 0;
+
+  constructor(private readonly delegate: DurableEventStore) {}
+
+  append(
+    requestedSessionId: SessionId,
+    events: readonly DurableEventDraft[],
+    options?: DurableEventAppendOptions,
+  ): Promise<DurableEventAppendResult> {
+    return this.delegate.append(requestedSessionId, events, options);
+  }
+
+  read(
+    requestedSessionId: SessionId,
+    options?: DurableEventReadOptions,
+  ): Promise<DurableEventPage> {
+    this.reads += 1;
+    return this.delegate.read(requestedSessionId, options);
+  }
+
+  getHeadSequence(requestedSessionId: SessionId): Promise<EventSequence | null> {
+    return this.delegate.getHeadSequence(requestedSessionId);
+  }
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe('DurableEventSubscription', () => {
+  it('replays through a stable caught-up barrier and closes at session_closed', async () => {
+    const store = createStore();
+    await appendClosedSession(store);
+    const subscription = await DurableEventSubscription.open(store, sessionId, {
+      pageSize: 1,
+      follow: false,
+    });
+
+    const messages = await collect(subscription);
+
+    expect(messages.map((message) => message.type)).toEqual(['event', 'event', 'caught_up']);
+    expect(
+      messages
+        .filter((message) => message.type === 'event')
+        .map((message) => [message.event.type, message.phase]),
+    ).toEqual([
+      [DurableEventType.SESSION_CREATED, 'replay'],
+      [DurableEventType.SESSION_CLOSED, 'replay'],
+    ]);
+    expect(messages.at(-1)).toMatchObject({
+      type: 'caught_up',
+      headSequence: EventSequence(2),
+      cursor: {
+        version: DURABLE_EVENT_CURSOR_VERSION,
+        sequence: EventSequence(2),
+        eventId: EventId('subscription-event-2'),
+      },
+    });
+    expect(subscription.isClosed).toBe(true);
+  });
+
+  it('resumes exclusively from a validated cursor', async () => {
+    const store = createStore();
+    await appendClosedSession(store);
+    const events = (await store.read(sessionId)).events;
+    const first = events[0];
+    if (!first) {
+      throw new Error('Expected first event');
+    }
+    const subscription = await DurableEventSubscription.open(store, sessionId, {
+      after: durableEventCursor(first),
+      follow: false,
+    });
+
+    const messages = await collect(subscription);
+
+    expect(messages).toHaveLength(2);
+    expect(messages[0]).toMatchObject({
+      type: 'event',
+      event: {
+        sequence: EventSequence(2),
+        type: DurableEventType.SESSION_CLOSED,
+      },
+      phase: 'replay',
+    });
+    expect(messages[1]).toMatchObject({
+      type: 'caught_up',
+      headSequence: EventSequence(2),
+    });
+  });
+
+  it('finishes immediately when reconnecting after session_closed', async () => {
+    const store = createStore();
+    await appendClosedSession(store);
+    const closed = (await store.read(sessionId)).events.at(-1);
+    if (!closed) {
+      throw new Error('Expected session_closed event');
+    }
+    const subscription = await DurableEventSubscription.open(store, sessionId, {
+      after: durableEventCursor(closed),
+    });
+
+    await expect(subscription.next()).resolves.toMatchObject({
+      value: {
+        type: 'caught_up',
+        cursor: {
+          sequence: closed.sequence,
+          eventId: closed.eventId,
+        },
+      },
+      done: false,
+    });
+    await expect(subscription.next()).resolves.toEqual({
+      done: true,
+      value: undefined,
+    });
+  });
+
+  it('delivers events appended after caught_up as live', async () => {
+    const store = createStore();
+    const journal = await DurableSessionJournal.open(store, sessionId);
+    const created = await journal.commit({
+      commandId: CommandId('create'),
+      events: [
+        {
+          type: DurableEventType.SESSION_CREATED,
+          data: { source: 'create' },
+        },
+      ],
+    });
+    const anchor = created.events[0];
+    if (!anchor) {
+      throw new Error('Expected session_created event');
+    }
+    const subscription = await DurableEventSubscription.open(store, sessionId, {
+      after: durableEventCursor(anchor),
+      pollIntervalMs: 1,
+    });
+
+    await expect(subscription.next()).resolves.toMatchObject({
+      value: {
+        type: 'caught_up',
+        headSequence: EventSequence(1),
+      },
+      done: false,
+    });
+    const pending = subscription.next();
+    await journal.commit({
+      commandId: CommandId('close'),
+      events: [
+        {
+          type: DurableEventType.SESSION_CLOSED,
+          data: { reason: 'shutdown' },
+        },
+      ],
+    });
+
+    await expect(pending).resolves.toMatchObject({
+      value: {
+        type: 'event',
+        phase: 'live',
+        event: {
+          type: DurableEventType.SESSION_CLOSED,
+          sequence: EventSequence(2),
+        },
+      },
+      done: false,
+    });
+    await expect(subscription.next()).resolves.toEqual({
+      done: true,
+      value: undefined,
+    });
+  });
+
+  it('does not interleave live events ahead of the caught-up barrier', async () => {
+    const store = createStore();
+    const journal = await DurableSessionJournal.open(store, sessionId);
+    await journal.commit({
+      commandId: CommandId('create'),
+      events: [
+        {
+          type: DurableEventType.SESSION_CREATED,
+          data: { source: 'create' },
+        },
+      ],
+    });
+    const subscription = await DurableEventSubscription.open(store, sessionId, {
+      pollIntervalMs: 1,
+    });
+    await journal.commit({
+      commandId: CommandId('close'),
+      events: [
+        {
+          type: DurableEventType.SESSION_CLOSED,
+          data: { reason: 'shutdown' },
+        },
+      ],
+    });
+
+    await expect(subscription.next()).resolves.toMatchObject({
+      value: {
+        type: 'event',
+        phase: 'replay',
+        event: { sequence: EventSequence(1) },
+      },
+    });
+    await expect(subscription.next()).resolves.toMatchObject({
+      value: {
+        type: 'caught_up',
+        headSequence: EventSequence(1),
+      },
+    });
+    await expect(subscription.next()).resolves.toMatchObject({
+      value: {
+        type: 'event',
+        phase: 'live',
+        event: {
+          sequence: EventSequence(2),
+          type: DurableEventType.SESSION_CLOSED,
+        },
+      },
+    });
+    await expect(subscription.next()).resolves.toEqual({
+      done: true,
+      value: undefined,
+    });
+  });
+
+  it('does not read ahead beyond the configured page buffer', async () => {
+    const delegate = createStore();
+    await appendOpenRequest(delegate);
+    const store = new CountingStore(delegate);
+    const subscription = await DurableEventSubscription.open(store, sessionId, {
+      pageSize: 2,
+      follow: false,
+    });
+
+    await subscription.next();
+    expect(store.reads).toBe(1);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(store.reads).toBe(1);
+
+    await subscription.next();
+    expect(store.reads).toBe(1);
+    await subscription.next();
+    expect(store.reads).toBe(2);
+    subscription.close();
+  });
+
+  it('serializes concurrent next calls without reordering events', async () => {
+    const store = createStore();
+    await appendClosedSession(store);
+    const subscription = await DurableEventSubscription.open(store, sessionId, {
+      pageSize: 1,
+      follow: false,
+    });
+
+    const messages = await Promise.all([
+      subscription.next(),
+      subscription.next(),
+      subscription.next(),
+      subscription.next(),
+    ]);
+
+    expect(messages.slice(0, 3).map((result) => result.value?.type)).toEqual([
+      'event',
+      'event',
+      'caught_up',
+    ]);
+    expect(messages[3]).toEqual({ done: true, value: undefined });
+  });
+
+  it('rejects foreign, malformed, and stale cursors', async () => {
+    const store = createStore();
+    await appendClosedSession(store);
+    const events = (await store.read(sessionId)).events;
+    const first = events[0];
+    if (!first) {
+      throw new Error('Expected first event');
+    }
+
+    await expect(
+      DurableEventSubscription.open(store, sessionId, {
+        after: {
+          ...durableEventCursor(first),
+          sessionId: SessionId('other-session'),
+        },
+      }),
+    ).rejects.toMatchObject({
+      code: 'DURABLE_EVENT_SUBSCRIPTION_INVALID_CURSOR',
+    });
+    await expect(
+      DurableEventSubscription.open(store, sessionId, {
+        after: {
+          ...durableEventCursor(first),
+          eventId: EventId('rewritten-event'),
+        },
+      }),
+    ).rejects.toMatchObject({
+      code: 'DURABLE_EVENT_SUBSCRIPTION_STALE_CURSOR',
+    });
+    expect(() =>
+      parseDurableEventCursor({
+        version: DURABLE_EVENT_CURSOR_VERSION,
+        sessionId,
+        sequence: 0,
+        eventId: first.eventId,
+      }),
+    ).toThrow(DurableEventSubscriptionError);
+  });
+
+  it.each([
+    { pageSize: 0 },
+    { pageSize: 1001 },
+    { pollIntervalMs: 0 },
+    { pollIntervalMs: 60_001 },
+  ])('rejects invalid options %#', async (options) => {
+    await expect(
+      DurableEventSubscription.open(createStore(), sessionId, options),
+    ).rejects.toMatchObject({
+      code: 'DURABLE_EVENT_SUBSCRIPTION_INVALID_OPTIONS',
+    });
+  });
+
+  it('aborts a pending live read and removes its abort listener', async () => {
+    const store = createStore();
+    const journal = await DurableSessionJournal.open(store, sessionId);
+    const created = await journal.commit({
+      commandId: CommandId('create'),
+      events: [
+        {
+          type: DurableEventType.SESSION_CREATED,
+          data: { source: 'create' },
+        },
+      ],
+    });
+    const anchor = created.events[0];
+    if (!anchor) {
+      throw new Error('Expected session_created event');
+    }
+    const controller = new AbortController();
+    const addListener = vi.spyOn(controller.signal, 'addEventListener');
+    const removeListener = vi.spyOn(controller.signal, 'removeEventListener');
+    const subscription = await DurableEventSubscription.open(store, sessionId, {
+      after: durableEventCursor(anchor),
+      pollIntervalMs: 60_000,
+      signal: controller.signal,
+    });
+    await subscription.next();
+    const pending = subscription.next();
+    await vi.waitFor(() => {
+      expect(addListener).toHaveBeenCalled();
+    });
+
+    controller.abort('disconnect');
+
+    await expect(pending).rejects.toBeInstanceOf(AbortError);
+    expect(removeListener).toHaveBeenCalled();
+    expect(subscription.isClosed).toBe(true);
+  });
+
+  it('explicitly closes and unblocks a pending live read', async () => {
+    const store = createStore();
+    const journal = await DurableSessionJournal.open(store, sessionId);
+    const created = await journal.commit({
+      commandId: CommandId('create'),
+      events: [
+        {
+          type: DurableEventType.SESSION_CREATED,
+          data: { source: 'create' },
+        },
+      ],
+    });
+    const anchor = created.events[0];
+    if (!anchor) {
+      throw new Error('Expected session_created event');
+    }
+    const subscription = await DurableEventSubscription.open(store, sessionId, {
+      after: durableEventCursor(anchor),
+      pollIntervalMs: 60_000,
+    });
+    await subscription.next();
+    const pending = subscription.next();
+
+    subscription.close();
+
+    await expect(pending).resolves.toEqual({
+      done: true,
+      value: undefined,
+    });
+  });
+
+  it('does not deliver a page that resolves after close', async () => {
+    const delegate = createStore();
+    await appendClosedSession(delegate);
+    const page = await delegate.read(sessionId);
+    let resolveRead: ((value: DurableEventPage) => void) | undefined;
+    const read = vi.fn(
+      () =>
+        new Promise<DurableEventPage>((resolve) => {
+          resolveRead = resolve;
+        }),
+    );
+    const delayedStore: DurableEventStore = {
+      append: (...args) => delegate.append(...args),
+      read,
+      getHeadSequence: async () => page.headSequence,
+    };
+    const subscription = await DurableEventSubscription.open(delayedStore, sessionId);
+    const pending = subscription.next();
+    await vi.waitFor(() => {
+      expect(read).toHaveBeenCalled();
+    });
+
+    subscription.close();
+    resolveRead?.(page);
+
+    await expect(pending).resolves.toEqual({
+      done: true,
+      value: undefined,
+    });
+  });
+
+  it('rejects malformed events returned by a Store', async () => {
+    const delegate = createStore();
+    await appendClosedSession(delegate);
+    const page = await delegate.read(sessionId);
+    const malformedStore: DurableEventStore = {
+      append: (...args) => delegate.append(...args),
+      getHeadSequence: (requestedSessionId) => delegate.getHeadSequence(requestedSessionId),
+      async read() {
+        return {
+          ...page,
+          events: [
+            {
+              ...page.events[0],
+              schemaVersion: 999,
+            },
+          ] as unknown as DurableEventPage['events'],
+          headSequence: EventSequence(1),
+          nextCursor: EventSequence(1),
+          hasMore: false,
+        };
+      },
+    };
+    const subscription = await DurableEventSubscription.open(malformedStore, sessionId, {
+      follow: false,
+    });
+
+    await expect(subscription.next()).rejects.toMatchObject({
+      code: 'DURABLE_EVENT_SUBSCRIPTION_INVALID_PAGE',
+    });
+  });
+
+  it('rejects a Store page that exceeds the configured buffer bound', async () => {
+    const delegate = createStore();
+    await appendClosedSession(delegate);
+    const page = await delegate.read(sessionId);
+    const oversizedStore: DurableEventStore = {
+      append: (...args) => delegate.append(...args),
+      getHeadSequence: (requestedSessionId) =>
+        delegate.getHeadSequence(requestedSessionId),
+      async read() {
+        return page;
+      },
+    };
+    const subscription = await DurableEventSubscription.open(
+      oversizedStore,
+      sessionId,
+      {
+        pageSize: 1,
+        follow: false,
+      },
+    );
+
+    await expect(subscription.next()).rejects.toMatchObject({
+      code: 'DURABLE_EVENT_SUBSCRIPTION_INVALID_PAGE',
+    });
+  });
+
+  it('fails closed on a gap in a Store page', async () => {
+    const delegate = createStore();
+    await appendClosedSession(delegate);
+    const events = (await delegate.read(sessionId)).events;
+    const first = events[0];
+    if (!first) {
+      throw new Error('Expected first event');
+    }
+    const gapStore: DurableEventStore = {
+      append: (...args) => delegate.append(...args),
+      getHeadSequence: (requestedSessionId) => delegate.getHeadSequence(requestedSessionId),
+      async read(requestedSessionId, options) {
+        const page = await delegate.read(requestedSessionId, options);
+        if (options?.after === undefined && page.events[0]) {
+          return {
+            ...page,
+            events: [
+              {
+                ...page.events[0],
+                sequence: EventSequence(2),
+              },
+            ],
+            headSequence: EventSequence(2),
+            nextCursor: EventSequence(2),
+            hasMore: false,
+          };
+        }
+        return page;
+      },
+    };
+    const subscription = await DurableEventSubscription.open(gapStore, sessionId, {
+      follow: false,
+    });
+
+    await expect(subscription.next()).rejects.toMatchObject({
+      code: 'DURABLE_EVENT_SUBSCRIPTION_STALE_CURSOR',
+    });
+    expect(subscription.isClosed).toBe(true);
+  });
+});

--- a/src/session/events/core.ts
+++ b/src/session/events/core.ts
@@ -5,6 +5,17 @@ export {
   type DurableEventStoreErrorCode,
 } from './DurableEventStore.js';
 export {
+  DURABLE_EVENT_CURSOR_VERSION,
+  durableEventCursor,
+  DurableEventSubscription,
+  DurableEventSubscriptionError,
+  type DurableEventSubscriptionErrorCode,
+  type DurableEventSubscriptionMessage,
+  type DurableEventSubscriptionOptions,
+  type DurableEventCursor,
+  parseDurableEventCursor,
+} from './DurableEventSubscription.js';
+export {
   type DurableCommandCommitResult,
   type DurableCommandCommitStatus,
   DurableCommandConflictError,

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -42,6 +42,10 @@ import type { CanUseTool, PermissionHandler, PermissionUpdate } from '../types/p
 import type { Assert, IsEqual } from '../types/typeAssertions.js';
 import type { DurableEventStore } from './events/DurableEventStore.js';
 import type {
+  DurableEventSubscription,
+  DurableEventSubscriptionOptions,
+} from './events/DurableEventSubscription.js';
+import type {
   DurableSessionProjection,
   DurableSessionRecoveryPlan,
 } from './events/DurableSessionProjector.js';
@@ -377,6 +381,10 @@ export interface ISession extends AsyncDisposable {
   getTraces(): AgentTrace[];
   getDurableProjection(): DurableSessionProjection | null;
   getDurableRecoveryPlan(): DurableSessionRecoveryPlan | null;
+  /** Replays durable events from an optional cursor and then follows live commits. */
+  subscribeDurableEvents(
+    options?: DurableEventSubscriptionOptions,
+  ): Promise<DurableEventSubscription>;
 }
 
 export type { ContextSnapshot, RuntimeContext };


### PR DESCRIPTION
## Summary

- add versioned durable cursors bound to session, sequence, and event identity
- add a pull-based `DurableEventSubscription` with replay, `caught_up`, and live phases
- enforce bounded page buffering, strict page continuity, terminal-session closure, AbortSignal cancellation, and serialized concurrent reads
- expose subscriptions through `ISession.subscribeDurableEvents()` and browser-safe package entrypoints
- document the reconnect and at-least-once delivery contract in English and Chinese

## Verification

- `pnpm test` (128 files passed, 1323 tests passed, 62 live tests skipped)
- `pnpm run type-check`
- `pnpm run lint`
- `pnpm run docs:build`
- `pnpm run changelog:check`
- `pnpm run verify:entrypoints`
- `npm pack --dry-run --json`