### PR TITLE
feat(durable): add active turn recovery rollover

### DIFF
--- a/.changes/durable-turn-rollover.json
+++ b/.changes/durable-turn-rollover.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "en": "Add atomic active-turn rollover into provenance-linked continuation requests with stale-CAS protection and fail-closed non-idempotent boundaries.",
+  "zh-CN": "新增 active Turn 到 provenance continuation Request 的原子 rollover，并提供 stale-CAS 防护与非幂等边界的 fail-closed 保证。"
+}

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ console.log(result.usage);
 
 - Session lifecycle: `createSession()`, `resumeSession()`, `forkSession()`, and `prompt()`
 - Steerable requests: durable `now`, `next`, and `later` inputs with cancellation and pending-input inspection
-- Durable recovery: automatic pre-execution resume, explicit reconciliation, and reconnectable cursor event subscriptions
+- Durable recovery: pre-execution resume, safe active-turn rollover, explicit reconciliation, and reconnectable cursors
 - Streaming: 17 typed events for turns, content, reasoning, tools, usage, steering, results, and errors
 - Providers: OpenAI, Anthropic, Azure OpenAI, Gemini, DeepSeek, and OpenAI-compatible APIs
 - Tools: generator-only custom tools, capability-grouped built-ins, MCP tools, and typed progress/effects

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -61,7 +61,7 @@ console.log(result.usage);
 
 - Session 生命周期：`createSession()`、`resumeSession()`、`forkSession()`、`prompt()`
 - 可转向请求：持久化的 `now`、`next`、`later` 输入，支持取消和待处理输入查询
-- Durable 恢复：自动恢复执行前请求、显式完成权限与工具结果对账，并支持 cursor 断线续读
+- Durable 恢复：执行前恢复、安全的 active-turn rollover、显式对账与 cursor 断线续读
 - 流式事件：17 种类型化事件，覆盖轮次、内容、思维、工具、usage、转向、结果和错误
 - Provider：OpenAI、Anthropic、Azure OpenAI、Gemini、DeepSeek 和 OpenAI-compatible API
 - 工具：仅 generator 的自定义工具、按能力分组的内置工具、MCP 工具和类型化进度/副作用

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -105,6 +105,7 @@ Node-local 能力外，这些函数都从根入口导出；实际 subpath 以“
 | `DurableSessionJournal` / `DurableSessionJournalOptions` | command-oriented 串行提交、CAS 重试与对账层 |
 | `DurableSessionRecoveryCoordinator` | accepted Request 恢复、权限消解与工具结果对账协调器 |
 | `DurableSessionCommand` / `DurableCommandEventDraft` | Journal command 与不含重复 `commandId` 的事件输入 |
+| `DurableCommandCommitOptions` | 通过 `expectedHeadSequence` 固定状态派生 command 的前置 head |
 | `DurableCommandCommitResult` / `DurableCommandCommitStatus` | `committed` / `replayed` / `reconciled` 提交结果 |
 | `DurableSessionJournalError` / `DurableSessionJournalErrorCode` | command、分页和 Store 返回值错误 |
 | `DurableCommandConflictError` | 同一 `commandId` 被用于不同事件 |
@@ -128,6 +129,7 @@ Node-local 能力外，这些函数都从根入口导出；实际 subpath 以“
 | `planDurableSessionRecovery` / `DurableSessionRecoveryPlan` | 分类未完成 Request、Turn、Tool 与 Permission |
 | `DurableSessionProjection` / `DurableSessionProjectionStatus` | Session 当前 durable 状态 |
 | `DurableRequestProjection` / `DurableRequestStatus` | 活动 Request 状态 |
+| `DurableRequestRecoveryOrigin` | continuation Request 的 source Request/Turn provenance |
 | `DurableTurnProjection` / `DurableTurnStatus` | 活动 Turn 状态 |
 | `DurableToolAttemptProjection` / `DurableToolAttemptStatus` | 当前 Turn 的工具尝试状态 |
 | `DurablePermissionProjection` / `DurablePermissionStatus` | 工具权限状态 |
@@ -136,6 +138,7 @@ Node-local 能力外，这些函数都从根入口导出；实际 subpath 以“
 | `DurableSessionResumeDecision` | `ready` / `resume_accepted_request` / `recovery_required` 决策 |
 | `DurableToolOutcomeReconciliation` / `DurableToolOutcomeReconciliationCommand` | 显式工具结果对账输入 |
 | `DurableToolStartCommand` | 恢复执行前持久化 `tool_started` 的幂等命令 |
+| `DurableTurnRecoveryCommand` / `DurableTurnRecoveryResult` | 原子 Turn rollover 命令及结果 |
 | `DurablePermissionResolutionCommand` | 幂等权限消解输入 |
 | `DurableRecoveryCommitResult` | 对账提交结果及更新后的 projection/recovery plan |
 | `DURABLE_EVENT_SCHEMA_VERSION` / `DURABLE_EVENT_LOG_FORMAT` | wire schema 与日志格式版本 |

--- a/docs/durable-events.md
+++ b/docs/durable-events.md
@@ -7,8 +7,9 @@ Session 生命周期投影。
 ::: warning 当前集成阶段
 Session 只有在显式设置 `SessionOptions.durableEventStore` 时才写入 durable
 事件；现有消息 JSONL 保持不变。`resumeSession()` 会自动恢复已接受但尚未跨过
-`request_started` 边界的 Request。活动 Turn、待决权限和已开始的工具仍需要
-显式恢复或对账；`non_idempotent` 工具绝不会被自动重放。
+`request_started` 边界的 Request。活动 Turn 必须先通过 Recovery Coordinator
+原子 rollover；待决权限和未知工具结果仍需显式消解。`non_idempotent` 工具
+绝不会被自动重放。
 :::
 
 ## 安装与导入
@@ -69,7 +70,7 @@ interface DurableEventEnvelope<TType extends DurableEventType> {
 |------|-----------|--------------|
 | `session_created` | Session | `source?`、`parentSessionId?` |
 | `session_closed` | Session | `reason` |
-| `request_accepted` | `requestId`、`commandId` | `inputId`、`input`、`priority`、`maxTurns?`、`model?`、`context?` |
+| `request_accepted` | `requestId`、`commandId` | `inputId`、`input`、`priority`、`maxTurns?`、`model?`、`context?`、`recovery?` |
 | `request_started` | `requestId` | 空对象 |
 | `request_completed` | `requestId` | `output?`、`usage?` |
 | `request_failed` | `requestId` | `error` |
@@ -182,6 +183,10 @@ console.log(journal.getProjection().status); // open
 相同 `commandId` 和相同事件再次提交时返回 `replayed`，不会追加第二份事件。
 若 command 已存在但内容不同，抛出 `DurableCommandConflictError`。
 一个 command 的事件必须在日志中连续；同一 ID 分散在多个区间也按冲突处理。
+依赖当前 projection 生成的 command 应通过 `expectedHeadSequence` 固定其观察
+到的 head，避免同进程或其他 writer 更新状态后仍提交旧决策。Recovery
+Coordinator 对所有恢复 command 强制设置该前置条件；相同 command 已由竞争者
+提交时仍返回 `reconciled`。
 
 当底层写入报错后，Journal 会重新读取 canonical log：
 
@@ -364,6 +369,47 @@ Session 会使用 durable 输入以及持久化的 `maxTurns`、模型和 Runtim
 恢复同一个 `requestId`。旧日志中缺少执行快照的 Request，以及已经开始的
 Request，即使暂时没有活动 Turn，也返回 `recovery_required`；这是为了避免
 使用不同配置执行或重复提交一次可能已完成的模型调用。
+
+对于 `resume_turn`，调用 `prepareTurnRecovery()` 可在同一个 CAS command 中：
+
+1. 取消尚未获得可信终态的 `pure` / `idempotent` 或未开始工具；
+2. 以 `process_restart` 终止旧 Turn 和 Request；
+3. 接受一个包含原始输入、工具终态和 source Request/Turn provenance 的新
+   continuation Request。
+
+continuation 会把从未执行的工具标记为 `not_started`，把已开始但可安全重试的
+工具标记为 `interrupted_before_trusted_completion`。恢复后的消息历史会丢弃
+没有配对结果的旧 tool call；上述 durable 状态随新的 user continuation 一起
+送入模型，因此不会构造跨 Store 的伪造 tool result，也不会留下 provider
+不接受的悬空 tool call。多模态原始输入仍以原始 content parts 传递，不会降级
+成 JSON 文本。权限恢复为 `allow` 但尚未执行的工具使用权限阶段更新后的输入，
+并按 `non_idempotent` 保守分类。
+
+```ts
+await coordinator.prepareTurnRecovery({
+  commandId: CommandId('recover-turn-42'),
+  requestId: RequestId('request-source-42'),
+  turnId: TurnId('turn-source-42'),
+  recoveryRequestId: RequestId('request-recovery-42'),
+  recoveryInputId: InputId('input-recovery-42'),
+});
+
+const session = await resumeSession({
+  ...options,
+  sessionId,
+});
+for await (const event of session.stream()) {
+  // 新 accepted Request 通过现有恢复路径执行。
+}
+```
+
+整个 rollover 可按相同 `commandId` 重试，竞争进程只能提交一次。provenance
+只有在同一 command 中紧邻 `turn_aborted → request_interrupted →
+request_accepted` 时才有效。`requestId` 和 `turnId` 是调用方已观察状态的
+前置条件，不能隐式切换到更新后的 active Turn。任何已 `completed` / `failed`，或在开始执行后
+变为 `cancelled` 的 `non_idempotent` 工具都会触发
+`DURABLE_RECOVERY_UNSAFE_ROLLOVER`，必须保持 fail-closed；该 API 不使用提示词
+绕过未知副作用。
 
 Schema v2 为 `tool_scheduled` 增加必填 `sideEffect`。v1 日志不会被静默推断，
 需要显式迁移后才能由当前 runtime 恢复。

--- a/docs/durable-events.md
+++ b/docs/durable-events.md
@@ -383,7 +383,10 @@ continuation 会把从未执行的工具标记为 `not_started`，把已开始�
 送入模型，因此不会构造跨 Store 的伪造 tool result，也不会留下 provider
 不接受的悬空 tool call。多模态原始输入仍以原始 content parts 传递，不会降级
 成 JSON 文本。权限恢复为 `allow` 但尚未执行的工具使用权限阶段更新后的输入，
-并按 `non_idempotent` 保守分类。
+并按 `non_idempotent` 保守分类。每个工具的 input、result、error 和 permission
+最多保留 4,000 个序列化字符；超限值会携带
+`kind: "truncated_recovery_value"`、原始长度和 JSON 前后缀，模型不会把预览误认
+为完整结果。
 
 ```ts
 await coordinator.prepareTurnRecovery({

--- a/docs/en/api-reference.md
+++ b/docs/en/api-reference.md
@@ -88,6 +88,7 @@ Types and errors:
 - `DurableSessionJournalOptions`
 - `DurableSessionCommand`
 - `DurableCommandEventDraft`
+- `DurableCommandCommitOptions`
 - `DurableCommandCommitResult`
 - `DurableCommandCommitStatus`
 - `DurableSessionJournalError`
@@ -105,6 +106,7 @@ Types and errors:
 - `DurableInputPriority`
 - `DurablePermissionDecision`
 - `DurableRequestInterruptReason`
+- `DurableRequestRecoveryOrigin`
 - `DurableTurnAbortReason`
 - `DurableToolInterruptBehavior`
 - `DurableToolCancelReason`
@@ -120,6 +122,8 @@ Types and errors:
 - `DurableEventStoreErrorCode`
 - `DurableEventProjectionError`
 - `DurableSessionRecoveryRequiredError`
+- `DurableTurnRecoveryCommand`
+- `DurableTurnRecoveryResult`
 - `SessionDurableRecorderError`
 - `DurablePermissionProjection`
 - `DurablePermissionStatus`

--- a/docs/en/durable-events.md
+++ b/docs/en/durable-events.md
@@ -404,7 +404,10 @@ durable recovery facts instead, avoiding both cross-store synthetic results
 and provider-invalid dangling tool calls. Multimodal original inputs retain
 their content parts instead of being flattened into JSON text. A permitted but
 not-yet-started tool uses the permission-updated input and is conservatively
-classified as `non_idempotent`.
+classified as `non_idempotent`. Each tool input, result, error, and permission
+value is limited to 4,000 serialized characters. Oversized values carry
+`kind: "truncated_recovery_value"`, the original size, and JSON prefix/suffix
+metadata so the model cannot mistake the preview for a complete result.
 
 ```ts
 await coordinator.prepareTurnRecovery({

--- a/docs/en/durable-events.md
+++ b/docs/en/durable-events.md
@@ -9,9 +9,10 @@ projection.
 Session writes durable events only when
 `SessionOptions.durableEventStore` is explicitly set; the existing message JSONL
 format is unchanged. `resumeSession()` automatically restores a Request that
-was accepted but did not cross the `request_started` boundary. Active Turns,
-pending permissions, and started tools still require explicit recovery or
-reconciliation. A `non_idempotent` tool is never replayed automatically.
+was accepted but did not cross the `request_started` boundary. An active Turn
+must first be atomically rolled over through the Recovery Coordinator; pending
+permissions and unknown tool outcomes still require explicit resolution. A
+`non_idempotent` tool is never replayed automatically.
 :::
 
 ## Imports
@@ -73,7 +74,7 @@ are rejected before append.
 |-------|----------------|-------------|
 | `session_created` | Session | `source?`, `parentSessionId?` |
 | `session_closed` | Session | `reason` |
-| `request_accepted` | `requestId`, `commandId` | `inputId`, `input`, `priority`, `maxTurns?`, `model?`, `context?` |
+| `request_accepted` | `requestId`, `commandId` | `inputId`, `input`, `priority`, `maxTurns?`, `model?`, `context?`, `recovery?` |
 | `request_started` | `requestId` | Empty object |
 | `request_completed` | `requestId` | `output?`, `usage?` |
 | `request_failed` | `requestId` | `error` |
@@ -187,6 +188,11 @@ Submitting the same `commandId` and identical events returns `replayed` without
 appending another copy. Reusing the command ID with different content throws
 `DurableCommandConflictError`. A command's events must be contiguous in the
 journal; the same ID appearing in separate ranges is also a conflict.
+Commands derived from the current projection should pin the observed head with
+`expectedHeadSequence` so stale decisions cannot commit after either local or
+external writers advance the state. The Recovery Coordinator enforces this for
+all recovery commands; the same command committed by a competitor still
+returns `reconciled`.
 
 After a lower-level write error, the Journal reloads the canonical log:
 
@@ -380,6 +386,53 @@ input and persisted `maxTurns`, model, and Runtime Context. A legacy Request
 without that snapshot, or a started Request even without an active Turn, returns
 `recovery_required`. This avoids executing under different settings or
 duplicating a model call that may already have completed.
+
+For `resume_turn`, `prepareTurnRecovery()` performs these transitions in one
+CAS command:
+
+1. cancel `pure` / `idempotent` or not-yet-started tools without a trusted
+   terminal outcome;
+2. terminate the old Turn and Request with `process_restart`;
+3. accept a new continuation Request containing the original input, durable
+   tool outcomes, and source Request/Turn provenance.
+
+The continuation marks tools that never executed as `not_started` and
+retry-safe tools that crossed the execution boundary as
+`interrupted_before_trusted_completion`. Restored message history omits old
+tool calls without paired results; the new user continuation carries the
+durable recovery facts instead, avoiding both cross-store synthetic results
+and provider-invalid dangling tool calls. Multimodal original inputs retain
+their content parts instead of being flattened into JSON text. A permitted but
+not-yet-started tool uses the permission-updated input and is conservatively
+classified as `non_idempotent`.
+
+```ts
+await coordinator.prepareTurnRecovery({
+  commandId: CommandId('recover-turn-42'),
+  requestId: RequestId('request-source-42'),
+  turnId: TurnId('turn-source-42'),
+  recoveryRequestId: RequestId('request-recovery-42'),
+  recoveryInputId: InputId('input-recovery-42'),
+});
+
+const session = await resumeSession({
+  ...options,
+  sessionId,
+});
+for await (const event of session.stream()) {
+  // The new accepted Request uses the existing resume path.
+}
+```
+
+The entire rollover can be retried with the same `commandId`, and competing
+processes can commit it only once. Provenance is valid only when the same
+command contains the adjacent `turn_aborted -> request_interrupted ->
+request_accepted` transition. `requestId` and `turnId` are preconditions for
+the state observed by the caller, so the command cannot silently target a
+newer active Turn. A `non_idempotent` tool that is `completed`, `failed`, or
+`cancelled` after execution started raises
+`DURABLE_RECOVERY_UNSAFE_ROLLOVER` and remains fail-closed; the API does not use
+prompting to bypass an unknown side effect.
 
 Schema v2 adds the required `sideEffect` field to `tool_scheduled`. Version 1
 logs are not inferred silently and must be migrated before this runtime can

--- a/docs/en/session.md
+++ b/docs/en/session.md
@@ -288,9 +288,14 @@ execution snapshot are not resumed automatically.
 A started Request, active Turn, pending permission, or unknown tool outcome is
 never replayed speculatively and raises `DurableSessionRecoveryRequiredError`.
 Use `DurableSessionRecoveryCoordinator` to resolve permissions or reconcile
-tool outcomes explicitly. `non_idempotent` tools always remain fail-closed. The
-JSONL adapter supports only one process; multi-process deployments need a
-`DurableEventStore` with transactional CAS or fencing.
+tool outcomes explicitly. For a safe `resume_turn`, call
+`prepareTurnRecovery()` first to atomically terminate the old execution and
+accept a provenance-linked continuation Request. `resumeSession()` then uses
+the normal accepted-Request path. A `non_idempotent` tool that completed,
+failed, or was cancelled after execution started always remains fail-closed.
+The JSONL adapter supports only one process;
+multi-process deployments need a `DurableEventStore` with transactional CAS or
+fencing.
 
 ### Resume
 

--- a/docs/session.md
+++ b/docs/session.md
@@ -683,9 +683,13 @@ Request，并保留其 `requestId`、输入、`maxTurns` 和 Runtime Context。�
 
 已经开始的 Request、活动 Turn、待决权限或未知工具结果不会被推测性重放，而是
 抛出 `DurableSessionRecoveryRequiredError`。使用
-`DurableSessionRecoveryCoordinator` 显式消解权限或对账工具结果；
-`non_idempotent` 工具始终保持 fail-closed。JSONL adapter 只支持单进程
-writer，多进程部署需要实现带事务 CAS 或 fencing 的 `DurableEventStore`。
+`DurableSessionRecoveryCoordinator` 显式消解权限或对账工具结果；对于安全的
+`resume_turn`，先调用 `prepareTurnRecovery()` 原子终止旧执行并接受一个带
+provenance 的 continuation Request，随后 `resumeSession()` 会按普通 accepted
+Request 恢复。已完成、失败，或在开始执行后被取消的 `non_idempotent` 工具
+始终保持 fail-closed。
+JSONL adapter 只支持单进程 writer，多进程部署需要实现带事务 CAS 或 fencing
+的 `DurableEventStore`。
 
 ### 自定义存储路径
 

--- a/src/__tests__/rootExports.test.ts
+++ b/src/__tests__/rootExports.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, expectTypeOf, it } from 'vitest';
 import type {
   DurableAcceptedRequestRecovery,
+  DurableCommandCommitOptions,
   DurableCommandEventDraft,
   DurableEventCursor,
   DurableEventEnvelope,
@@ -8,11 +9,14 @@ import type {
   DurableEventStore,
   DurableEventSubscriptionMessage,
   DurableEventSubscriptionOptions,
+  DurableRequestRecoveryOrigin,
   DurableSessionCommand,
-  DurableSessionResumeDecision,
   DurableSessionRecoveryPlan,
+  DurableSessionResumeDecision,
   DurableToolOutcomeReconciliationCommand,
   DurableToolStartCommand,
+  DurableTurnRecoveryCommand,
+  DurableTurnRecoveryResult,
   InputSubmission,
   ISession,
   PendingSessionInput,
@@ -23,8 +27,8 @@ import type {
   ToolEffect,
   ToolEffectYield,
   ToolExecution,
-  ToolExecutionStartedLifecycle,
   ToolExecutionLifecycle,
+  ToolExecutionStartedLifecycle,
   ToolExecutionUpdate,
   ToolInvocationLifecycle,
   ToolMessage,
@@ -41,11 +45,10 @@ import {
   completeToolExecution,
   createMemoryReadTool,
   createMemoryWriteTool,
-  DurableCommandConflictError,
-  DurableCommandOutcomeUnknownError,
   DURABLE_EVENT_CURSOR_VERSION,
   DURABLE_EVENT_SCHEMA_VERSION,
-  durableEventCursor,
+  DurableCommandConflictError,
+  DurableCommandOutcomeUnknownError,
   DurableEventSubscription,
   DurableEventSubscriptionError,
   DurableEventType,
@@ -54,6 +57,7 @@ import {
   DurableSessionRecoveryCoordinator,
   DurableSessionRecoveryError,
   DurableSessionRecoveryRequiredError,
+  durableEventCursor,
   EventId,
   EventSequence,
   FileSystemMemoryStore,
@@ -64,8 +68,8 @@ import {
   PermissionRequestId,
   projectDurableSession,
   RequestId,
-  SessionInputError,
   SessionDurableRecorderError,
+  SessionInputError,
   SubagentExecutor,
   SubagentRegistry,
   ToolAttemptId,
@@ -144,12 +148,8 @@ describe('root exports', () => {
     expectTypeOf<ReturnType<typeof createMemoryReadTool>>().toMatchTypeOf<SessionTool>();
     expectTypeOf<DurableEventEnvelope['sequence']>().toEqualTypeOf<EventSequence>();
     expectTypeOf<DurableEventCursor['eventId']>().toEqualTypeOf<EventId>();
-    expectTypeOf<DurableEventSubscriptionMessage['type']>().toEqualTypeOf<
-      'event' | 'caught_up'
-    >();
-    expectTypeOf<DurableEventSubscriptionOptions['follow']>().toEqualTypeOf<
-      boolean | undefined
-    >();
+    expectTypeOf<DurableEventSubscriptionMessage['type']>().toEqualTypeOf<'event' | 'caught_up'>();
+    expectTypeOf<DurableEventSubscriptionOptions['follow']>().toEqualTypeOf<boolean | undefined>();
     expectTypeOf<
       DurableEventOfType<typeof DurableEventType.REQUEST_ACCEPTED>['data']['inputId']
     >().toEqualTypeOf<InputId>();
@@ -163,10 +163,17 @@ describe('root exports', () => {
       'ready' | 'resume_accepted_request' | 'recovery_required'
     >();
     expectTypeOf<DurableAcceptedRequestRecovery['model']>().toEqualTypeOf<string>();
+    expectTypeOf<DurableRequestRecoveryOrigin['turnId']>().toEqualTypeOf<TurnId>();
     expectTypeOf<
       DurableToolOutcomeReconciliationCommand['toolAttemptId']
     >().toEqualTypeOf<ToolAttemptId>();
     expectTypeOf<DurableToolStartCommand['commandId']>().toEqualTypeOf<CommandId>();
+    expectTypeOf<DurableTurnRecoveryCommand['recoveryInputId']>().toEqualTypeOf<InputId>();
+    expectTypeOf<DurableTurnRecoveryCommand['turnId']>().toEqualTypeOf<TurnId>();
+    expectTypeOf<DurableTurnRecoveryResult['recoveryRequestId']>().toEqualTypeOf<RequestId>();
+    expectTypeOf<DurableCommandCommitOptions['expectedHeadSequence']>().toEqualTypeOf<
+      EventSequence | null | undefined
+    >();
     expectTypeOf<DurableEventStore['append']>().toBeFunction();
     expectTypeOf<SessionOptions['durableEventStore']>().toEqualTypeOf<
       DurableEventStore | undefined

--- a/src/session/__tests__/SessionDurableEvents.test.ts
+++ b/src/session/__tests__/SessionDurableEvents.test.ts
@@ -5,13 +5,17 @@ import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { AgentEvent } from '../../agent/AgentEvent.js';
 import type { LoopOptions, LoopResult, UserMessageContent } from '../../agent/types.js';
+import { PersistentStore } from '../../context/storage/PersistentStore.js';
+import type { Message } from '../../services/ChatServiceInterface.js';
 import {
   CommandId,
   EventId,
   InputId,
   RequestId,
   SessionId,
+  ToolAttemptId,
   ToolUseId,
+  TurnId,
 } from '../../types/branded.js';
 import type { JsonValue } from '../../types/common.js';
 import { type DurableEventStore, DurableEventStoreError } from '../events/DurableEventStore.js';
@@ -23,6 +27,7 @@ import {
   DurableCommandOutcomeUnknownError,
   DurableSessionJournal,
 } from '../events/DurableSessionJournal.js';
+import { DurableSessionRecoveryCoordinator } from '../events/DurableSessionRecoveryCoordinator.js';
 import { JsonlDurableEventStore } from '../events/JsonlDurableEventStore.js';
 import {
   DurableSessionRecoveryRequiredError,
@@ -519,6 +524,158 @@ describe('Session durable events', () => {
     expect(events.find((event) => event.type === DurableEventType.REQUEST_STARTED)?.requestId).toBe(
       requestId,
     );
+    expect(session.getDurableRecoveryPlan()?.action).toBe('none');
+    await session.close();
+  });
+
+  it('resumes a safely rolled-over active turn as a new durable request', async () => {
+    const { root, store } = createStore();
+    const sessionId = SessionId('turn-rollover-session');
+    const requestId = RequestId('turn-rollover-source');
+    const inputId = InputId('turn-rollover-source-input');
+    const recoveryRequestId = RequestId('turn-rollover-recovery');
+    const recoveryInputId = InputId('turn-rollover-recovery-input');
+    const journal = await DurableSessionJournal.open(store, sessionId);
+    await journal.commit({
+      commandId: CommandId('turn-rollover-bootstrap'),
+      events: [
+        {
+          type: DurableEventType.SESSION_CREATED,
+          data: { source: 'create' },
+        },
+        {
+          type: DurableEventType.REQUEST_ACCEPTED,
+          requestId,
+          data: {
+            inputId,
+            input: 'finish the original task',
+            priority: 'next',
+            maxTurns: 9,
+            model: 'rollover-model',
+            context: {
+              id: 'rollover-context',
+            },
+          },
+        },
+        {
+          type: DurableEventType.INPUT_APPLIED,
+          requestId,
+          data: { inputId, priority: 'next' },
+        },
+        {
+          type: DurableEventType.REQUEST_STARTED,
+          requestId,
+          data: {},
+        },
+        {
+          type: DurableEventType.TURN_STARTED,
+          requestId,
+          turnId: TurnId('turn-rollover-active-turn'),
+          data: { turn: 1, model: 'rollover-model' },
+        },
+        {
+          type: DurableEventType.TOOL_SCHEDULED,
+          requestId,
+          turnId: TurnId('turn-rollover-active-turn'),
+          toolAttemptId: ToolAttemptId('turn-rollover-tool-attempt'),
+          data: {
+            toolCallId: ToolUseId('turn-rollover-tool-call'),
+            toolName: 'Read',
+            input: { file_path: '/tmp/recovery-input' },
+            sideEffect: 'pure',
+            interruptBehavior: 'cancel',
+          },
+        },
+        {
+          type: DurableEventType.TOOL_STARTED,
+          requestId,
+          turnId: TurnId('turn-rollover-active-turn'),
+          toolAttemptId: ToolAttemptId('turn-rollover-tool-attempt'),
+          data: {
+            toolCallId: ToolUseId('turn-rollover-tool-call'),
+            toolName: 'Read',
+            input: { file_path: '/tmp/recovery-input' },
+            sideEffect: 'pure',
+          },
+        },
+      ],
+    });
+    const persistentStore = new PersistentStore(root);
+    const sourceMessageId = await persistentStore.saveAppliedInputMessage(
+      sessionId,
+      inputId,
+      requestId,
+      'finish the original task',
+    );
+    await persistentStore.saveMessage(sessionId, 'assistant', '', sourceMessageId, {
+      toolCalls: [
+        {
+          id: 'turn-rollover-tool-call',
+          type: 'function',
+          function: {
+            name: 'Read',
+            arguments: '{"file_path":"/tmp/recovery-input"}',
+          },
+        },
+      ],
+    });
+    await new DurableSessionRecoveryCoordinator(journal).prepareTurnRecovery({
+      commandId: CommandId('prepare-turn-rollover'),
+      requestId,
+      turnId: TurnId('turn-rollover-active-turn'),
+      recoveryRequestId,
+      recoveryInputId,
+    });
+    let observedMessage: UserMessageContent | undefined;
+    let observedHistory: readonly Message[] | undefined;
+    streamChat = async function* rolloverStream(message, context) {
+      observedMessage = message;
+      observedHistory = (context as { messages: Message[] }).messages;
+      yield { type: 'turn_start', turn: 1, maxTurns: 9 };
+      yield { type: 'turn_end', turn: 1, hasToolCalls: false };
+      return {
+        success: true,
+        finalMessage: 'recovered',
+        metadata: { turnsCount: 1, toolCallsCount: 0, duration: 1 },
+      };
+    };
+
+    const session = await resumeSession({
+      ...options(store),
+      persistSession: true,
+      storagePath: root,
+      sessionId,
+    });
+
+    expect(session.getPendingInputs()).toEqual([
+      expect.objectContaining({
+        inputId: recoveryInputId,
+        targetRequestId: recoveryRequestId,
+      }),
+    ]);
+    for await (const _event of session.stream()) {
+      // Drain the recovery request.
+    }
+
+    expect(observedMessage).toContain('finish the original task');
+    expect(observedMessage).toContain('interrupted_before_trusted_completion');
+    expect(observedHistory).toEqual([
+      expect.objectContaining({
+        role: 'user',
+        content: 'finish the original task',
+      }),
+    ]);
+    expect(observedHistory?.some((message) => message.tool_calls?.length)).toBe(false);
+    const events = (await store.read(sessionId)).events;
+    expect(events.filter((event) => event.type === DurableEventType.REQUEST_ACCEPTED)).toHaveLength(
+      2,
+    );
+    expect(
+      events.find(
+        (event) =>
+          event.type === DurableEventType.REQUEST_STARTED && event.requestId === recoveryRequestId,
+      ),
+    ).toBeDefined();
     expect(session.getDurableRecoveryPlan()?.action).toBe('none');
     await session.close();
   });

--- a/src/session/events/DurableSessionJournal.ts
+++ b/src/session/events/DurableSessionJournal.ts
@@ -28,6 +28,14 @@ export interface DurableSessionCommand {
   readonly events: readonly DurableCommandEventDraft[];
 }
 
+export interface DurableCommandCommitOptions {
+  /**
+   * Requires the Journal to still be at this exact head before committing.
+   * Commands derived from a state snapshot should always set this precondition.
+   */
+  readonly expectedHeadSequence?: EventSequence | null;
+}
+
 export type DurableCommandCommitStatus = 'committed' | 'replayed' | 'reconciled';
 
 export interface DurableCommandCommitResult extends DurableEventAppendResult {
@@ -217,6 +225,12 @@ export class DurableSessionJournal {
     return this.uncertainCommand?.commandId ?? null;
   }
 
+  /** Returns a defensive snapshot of one already-indexed command. */
+  getCommandEvents(commandId: CommandId): readonly DurableEventEnvelope[] | null {
+    const events = this.commandEvents.get(commandId);
+    return events ? structuredClone(events) : null;
+  }
+
   refresh(): Promise<DurableSessionProjection> {
     return this.runExclusive(async () => {
       await this.reload();
@@ -224,12 +238,16 @@ export class DurableSessionJournal {
     });
   }
 
-  commit(command: DurableSessionCommand): Promise<DurableCommandCommitResult> {
-    return this.runExclusive(() => this.commitExclusive(command));
+  commit(
+    command: DurableSessionCommand,
+    options: DurableCommandCommitOptions = {},
+  ): Promise<DurableCommandCommitResult> {
+    return this.runExclusive(() => this.commitExclusive(command, options));
   }
 
   private async commitExclusive(
     command: DurableSessionCommand,
+    options: DurableCommandCommitOptions,
   ): Promise<DurableCommandCommitResult> {
     const drafts = this.parseCommand(command);
     if (this.uncertainCommand) {
@@ -260,6 +278,16 @@ export class DurableSessionJournal {
     const existing = this.commandEvents.get(command.commandId);
     if (existing) {
       return this.resolveExistingCommand('replayed', command.commandId, existing, drafts);
+    }
+    const currentHeadSequence = this.projector.snapshot().headSequence;
+    if (
+      options.expectedHeadSequence !== undefined
+      && currentHeadSequence !== options.expectedHeadSequence
+    ) {
+      throw new DurableEventSequenceConflictError(
+        options.expectedHeadSequence,
+        currentHeadSequence,
+      );
     }
 
     let conflicts = 0;
@@ -294,7 +322,10 @@ export class DurableSessionJournal {
           if (committed) {
             return this.resolveExistingCommand('reconciled', command.commandId, committed, drafts);
           }
-          if (conflicts >= this.maxConflictRetries) {
+          if (
+            options.expectedHeadSequence !== undefined
+            || conflicts >= this.maxConflictRetries
+          ) {
             throw error;
           }
           conflicts += 1;

--- a/src/session/events/DurableSessionProjector.ts
+++ b/src/session/events/DurableSessionProjector.ts
@@ -24,10 +24,13 @@ import {
   DurableEventType as DurableEventTypeValue,
   type DurableInputPriority,
   type DurablePermissionDecision,
+  type DurableRequestInterruptReason,
+  type DurableRequestRecoveryOrigin,
   type DurableSessionCloseReason,
   type DurableToolCancelReason,
   type DurableToolInterruptBehavior,
   type DurableToolOutcomeUnknownReason,
+  type DurableTurnAbortReason,
 } from './types.js';
 
 export type DurableSessionProjectionStatus = 'empty' | 'open' | 'closed';
@@ -63,6 +66,7 @@ export interface DurableToolAttemptProjection {
   readonly input: JsonValue;
   readonly sideEffect: ToolSideEffect;
   readonly interruptBehavior: DurableToolInterruptBehavior;
+  readonly executionStarted: boolean;
   readonly status: DurableToolAttemptStatus;
   readonly permission: DurablePermissionProjection | null;
   readonly result?: JsonValue;
@@ -89,6 +93,7 @@ export interface DurableRequestProjection {
   readonly maxTurns?: number;
   readonly model?: string;
   readonly context?: JsonObject;
+  readonly recovery?: DurableRequestRecoveryOrigin;
   readonly status: DurableRequestStatus;
   readonly lastTurn: number;
   readonly activeTurn: DurableTurnProjection | null;
@@ -146,6 +151,7 @@ interface MutableToolAttemptProjection {
   input: JsonValue;
   sideEffect: ToolSideEffect;
   interruptBehavior: DurableToolInterruptBehavior;
+  executionStarted: boolean;
   status: DurableToolAttemptStatus;
   permission: MutablePermissionProjection | null;
   result?: JsonValue;
@@ -172,6 +178,7 @@ interface MutableRequestProjection {
   maxTurns?: number;
   model?: string;
   context?: JsonObject;
+  recovery?: DurableRequestRecoveryOrigin;
   status: DurableRequestStatus;
   lastTurn: number;
   activeTurn: MutableTurnProjection | null;
@@ -190,6 +197,22 @@ interface ProjectionAccumulator {
   seenEventIds: Set<EventId>;
   seenRequestIds: Set<RequestId>;
   seenTurnIds: Set<TurnId>;
+  turnOrigins: Map<TurnId, { requestId: RequestId; turn: number }>;
+  lastTurnAbort: {
+    requestId: RequestId;
+    turnId: TurnId;
+    turn: number;
+    commandId?: CommandId;
+    sequence: EventSequence;
+    reason: DurableTurnAbortReason;
+    unsafeNonIdempotentToolAttemptId: ToolAttemptId | null;
+  } | null;
+  lastRequestInterruption: {
+    requestId: RequestId;
+    commandId?: CommandId;
+    sequence: EventSequence;
+    reason: DurableRequestInterruptReason;
+  } | null;
   seenToolAttemptIds: Set<ToolAttemptId>;
   seenPermissionRequestIds: Set<PermissionRequestId>;
   seenInputIds: Set<InputId>;
@@ -293,6 +316,17 @@ function assertTurnCanEnd(event: DurableEventEnvelope, turn: MutableTurnProjecti
   }
 }
 
+export function hasCrossedNonIdempotentBoundary(
+  tool: DurableToolAttemptProjection,
+): boolean {
+  return tool.sideEffect === 'non_idempotent'
+    && (
+      tool.status === 'completed'
+      || tool.status === 'failed'
+      || (tool.status === 'cancelled' && tool.executionStarted)
+    );
+}
+
 function clonePermission(
   permission: MutablePermissionProjection | null,
 ): DurablePermissionProjection | null {
@@ -333,6 +367,7 @@ function cloneRequest(request: MutableRequestProjection | null): DurableRequestP
     ...(request.maxTurns !== undefined ? { maxTurns: request.maxTurns } : {}),
     ...(request.model ? { model: request.model } : {}),
     ...(request.context ? { context: request.context } : {}),
+    ...(request.recovery ? { recovery: request.recovery } : {}),
     status: request.status,
     lastTurn: request.lastTurn,
     activeTurn: cloneTurn(request.activeTurn),
@@ -373,6 +408,39 @@ function applyEvent(state: ProjectionAccumulator, event: DurableEventEnvelope): 
       if (state.seenInputIds.has(event.data.inputId)) {
         invalid(event, `Input ID ${event.data.inputId} was already accepted`);
       }
+      if (event.data.recovery) {
+        const origin = state.turnOrigins.get(event.data.recovery.turnId);
+        const turnAbort = state.lastTurnAbort;
+        const requestInterruption = state.lastRequestInterruption;
+        if (
+          !origin ||
+          origin.requestId !== event.data.recovery.requestId ||
+          origin.turn !== event.data.recovery.turn ||
+          !turnAbort ||
+          turnAbort.requestId !== event.data.recovery.requestId ||
+          turnAbort.turnId !== event.data.recovery.turnId ||
+          turnAbort.turn !== event.data.recovery.turn ||
+          turnAbort.reason !== 'process_restart' ||
+          turnAbort.commandId !== event.commandId ||
+          !requestInterruption ||
+          requestInterruption.requestId !== event.data.recovery.requestId ||
+          requestInterruption.reason !== 'process_restart' ||
+          requestInterruption.commandId !== event.commandId ||
+          Number(turnAbort.sequence) + 1 !== Number(requestInterruption.sequence) ||
+          Number(requestInterruption.sequence) + 1 !== Number(event.sequence)
+        ) {
+          invalid(
+            event,
+            `Recovery origin ${event.data.recovery.turnId} is not an atomic canonical rollover`,
+          );
+        }
+        if (turnAbort.unsafeNonIdempotentToolAttemptId) {
+          invalid(
+            event,
+            `Recovery origin ${event.data.recovery.turnId} crossed non-idempotent tool attempt ${turnAbort.unsafeNonIdempotentToolAttemptId}`,
+          );
+        }
+      }
       state.seenRequestIds.add(event.requestId);
       state.seenCommandIds.add(event.commandId);
       state.seenInputIds.add(event.data.inputId);
@@ -387,6 +455,7 @@ function applyEvent(state: ProjectionAccumulator, event: DurableEventEnvelope): 
         ...(event.data.maxTurns !== undefined ? { maxTurns: event.data.maxTurns } : {}),
         ...(event.data.model ? { model: event.data.model } : {}),
         ...(event.data.context ? { context: event.data.context } : {}),
+        ...(event.data.recovery ? { recovery: event.data.recovery } : {}),
         status: 'accepted',
         lastTurn: 0,
         activeTurn: null,
@@ -411,13 +480,27 @@ function applyEvent(state: ProjectionAccumulator, event: DurableEventEnvelope): 
       return;
     }
 
-    case DurableEventTypeValue.REQUEST_FAILED:
+    case DurableEventTypeValue.REQUEST_FAILED: {
+      const request = requireActiveRequest(state, event);
+      if (request.activeTurn) {
+        invalid(event, `Turn ${request.activeTurn.turnId} is still active`);
+      }
+      state.activeRequest = null;
+      return;
+    }
+
     case DurableEventTypeValue.REQUEST_INTERRUPTED: {
       const request = requireActiveRequest(state, event);
       if (request.activeTurn) {
         invalid(event, `Turn ${request.activeTurn.turnId} is still active`);
       }
       state.activeRequest = null;
+      state.lastRequestInterruption = {
+        requestId: event.requestId,
+        ...(event.commandId ? { commandId: event.commandId } : {}),
+        sequence: event.sequence,
+        reason: event.data.reason,
+      };
       return;
     }
 
@@ -433,6 +516,10 @@ function applyEvent(state: ProjectionAccumulator, event: DurableEventEnvelope): 
         invalid(event, `Expected turn number ${request.lastTurn + 1}, received ${event.data.turn}`);
       }
       state.seenTurnIds.add(event.turnId);
+      state.turnOrigins.set(event.turnId, {
+        requestId: request.requestId,
+        turn: event.data.turn,
+      });
       request.lastTurn = event.data.turn;
       request.activeTurn = {
         turnId: event.turnId,
@@ -444,8 +531,7 @@ function applyEvent(state: ProjectionAccumulator, event: DurableEventEnvelope): 
       return;
     }
 
-    case DurableEventTypeValue.TURN_COMPLETED:
-    case DurableEventTypeValue.TURN_ABORTED: {
+    case DurableEventTypeValue.TURN_COMPLETED: {
       const request = requireRunningRequest(state, event);
       const turn = requireActiveTurn(state, event);
       if (event.data.turn !== turn.turn) {
@@ -453,6 +539,29 @@ function applyEvent(state: ProjectionAccumulator, event: DurableEventEnvelope): 
       }
       assertTurnCanEnd(event, turn);
       request.activeTurn = null;
+      return;
+    }
+
+    case DurableEventTypeValue.TURN_ABORTED: {
+      const request = requireRunningRequest(state, event);
+      const turn = requireActiveTurn(state, event);
+      if (event.data.turn !== turn.turn) {
+        invalid(event, `Turn number ${event.data.turn} does not match active turn ${turn.turn}`);
+      }
+      assertTurnCanEnd(event, turn);
+      const unsafeNonIdempotentTool = Array.from(turn.toolAttempts.values()).find(
+        hasCrossedNonIdempotentBoundary,
+      );
+      request.activeTurn = null;
+      state.lastTurnAbort = {
+        requestId: event.requestId,
+        turnId: event.turnId,
+        turn: event.data.turn,
+        ...(event.commandId ? { commandId: event.commandId } : {}),
+        sequence: event.sequence,
+        reason: event.data.reason,
+        unsafeNonIdempotentToolAttemptId: unsafeNonIdempotentTool?.toolAttemptId ?? null,
+      };
       return;
     }
 
@@ -469,6 +578,7 @@ function applyEvent(state: ProjectionAccumulator, event: DurableEventEnvelope): 
         input: event.data.input,
         sideEffect: event.data.sideEffect,
         interruptBehavior: event.data.interruptBehavior,
+        executionStarted: false,
         status: 'scheduled',
         permission: null,
       });
@@ -527,6 +637,7 @@ function applyEvent(state: ProjectionAccumulator, event: DurableEventEnvelope): 
       }
       tool.input = event.data.input;
       tool.sideEffect = event.data.sideEffect;
+      tool.executionStarted = true;
       tool.status = 'started';
       return;
     }
@@ -636,6 +747,9 @@ function createProjectionAccumulator(): ProjectionAccumulator {
     seenEventIds: new Set(),
     seenRequestIds: new Set(),
     seenTurnIds: new Set(),
+    turnOrigins: new Map(),
+    lastTurnAbort: null,
+    lastRequestInterruption: null,
     seenToolAttemptIds: new Set(),
     seenPermissionRequestIds: new Set(),
     seenInputIds: new Set(),

--- a/src/session/events/DurableSessionRecoveryCoordinator.ts
+++ b/src/session/events/DurableSessionRecoveryCoordinator.ts
@@ -38,6 +38,8 @@ import {
   type DurablePermissionDecision,
 } from './types.js';
 
+const MAX_RECOVERY_TOOL_VALUE_CHARS = 4_000;
+
 export type DurableAcceptedRequestRecovery = DurableRequestProjection & {
   readonly maxTurns: number;
   readonly model: string;
@@ -230,6 +232,24 @@ function jsonText(value: unknown): string {
   return JSON.stringify(value, null, 2);
 }
 
+function boundedRecoveryValue(value: unknown): JsonValue {
+  const normalized = toJsonValue(value);
+  const serialized = JSON.stringify(normalized);
+  if (serialized.length <= MAX_RECOVERY_TOOL_VALUE_CHARS) {
+    return normalized;
+  }
+
+  const retainedPerEdge = Math.floor(MAX_RECOVERY_TOOL_VALUE_CHARS / 2);
+  return {
+    kind: 'truncated_recovery_value',
+    complete: false,
+    encoding: 'json',
+    originalJsonCharacters: serialized.length,
+    jsonPrefix: serialized.slice(0, retainedPerEdge),
+    jsonSuffix: serialized.slice(-retainedPerEdge),
+  };
+}
+
 function buildTurnRecoveryContinuation(
   request: DurableRequestProjection,
   turn: NonNullable<DurableRequestProjection['activeTurn']>,
@@ -251,10 +271,12 @@ function buildTurnRecoveryContinuation(
       tool.status === 'scheduled' &&
       (permissionDecision === 'deny' || permissionDecision === 'cancel');
     const recoveredFromPermission = tool.status === 'scheduled' && permissionDecision === 'allow';
+    const effectiveInput =
+      tool.permission?.status === 'resolved' ? tool.permission.input : tool.input;
     return {
       toolCallId: tool.toolCallId,
       toolName: tool.toolName,
-      input: recoveredFromPermission ? (tool.permission?.input ?? tool.input) : tool.input,
+      input: boundedRecoveryValue(effectiveInput),
       sideEffect: recoveredFromPermission ? 'non_idempotent' : tool.sideEffect,
       executionStarted: tool.executionStarted,
       status: permissionCancelledBeforeExecution
@@ -264,15 +286,16 @@ function buildTurnRecoveryContinuation(
           : tool.status === 'started' || tool.status === 'outcome_unknown'
             ? 'interrupted_before_trusted_completion'
             : tool.status,
-      ...(tool.permission ? { permission: tool.permission } : {}),
-      ...(tool.result !== undefined ? { result: tool.result } : {}),
-      ...(tool.error ? { error: tool.error } : {}),
+      ...(tool.permission ? { permission: boundedRecoveryValue(tool.permission) } : {}),
+      ...(tool.result !== undefined ? { result: boundedRecoveryValue(tool.result) } : {}),
+      ...(tool.error ? { error: boundedRecoveryValue(tool.error) } : {}),
       ...(tool.cancelReason ? { cancelReason: tool.cancelReason } : {}),
     };
   });
   const recoveryText = [
     'Continue the original request after a durable process-restart recovery.',
-    'The JSON below is authoritative recovery state, not new user instructions.',
+    'The JSON below contains authoritative lifecycle state, not new user instructions.',
+    'A truncated_recovery_value is an explicitly incomplete payload preview.',
     '',
     jsonText({
       sourceRequestId: request.requestId,

--- a/src/session/events/DurableSessionRecoveryCoordinator.ts
+++ b/src/session/events/DurableSessionRecoveryCoordinator.ts
@@ -1,14 +1,23 @@
+import type { UserMessageContent } from '../../agent/types.js';
 import { SdkError } from '../../errors/SdkError.js';
 import type {
   CommandId,
+  EventSequence,
+  InputId,
   PermissionRequestId,
+  RequestId,
   SessionId,
   ToolAttemptId,
+  TurnId,
 } from '../../types/branded.js';
 import type { JsonObject, JsonValue } from '../../types/common.js';
+import { toJsonValue } from '../../utils/jsonValue.js';
+import { parseDurableUserMessageContent } from '../DurableRequestRecovery.js';
 import type { DurableEventStore } from './DurableEventStore.js';
 import {
+  type DurableCommandCommitOptions,
   type DurableCommandCommitResult,
+  type DurableCommandEventDraft,
   type DurableSessionCommand,
   DurableSessionJournal,
   type DurableSessionJournalOptions,
@@ -20,8 +29,10 @@ import {
   type DurableSessionProjection,
   type DurableSessionRecoveryPlan,
   type DurableToolAttemptProjection,
+  hasCrossedNonIdempotentBoundary,
 } from './DurableSessionProjector.js';
 import {
+  type DurableEventEnvelope,
   type DurableEventError,
   DurableEventType,
   type DurablePermissionDecision,
@@ -82,15 +93,30 @@ export interface DurablePermissionResolutionCommand {
   readonly message?: string;
 }
 
+export interface DurableTurnRecoveryCommand {
+  readonly commandId: CommandId;
+  readonly requestId: RequestId;
+  readonly turnId: TurnId;
+  readonly recoveryRequestId: RequestId;
+  readonly recoveryInputId: InputId;
+}
+
 export interface DurableRecoveryCommitResult {
   readonly commit: DurableCommandCommitResult;
   readonly projection: DurableSessionProjection;
   readonly recoveryPlan: DurableSessionRecoveryPlan;
 }
 
+export interface DurableTurnRecoveryResult extends DurableRecoveryCommitResult {
+  readonly continuation: UserMessageContent;
+  readonly interruptedRequestId: RequestId;
+  readonly recoveryRequestId: RequestId;
+}
+
 export type DurableSessionRecoveryErrorCode =
   | 'DURABLE_RECOVERY_INVALID_STATE'
-  | 'DURABLE_RECOVERY_TARGET_NOT_FOUND';
+  | 'DURABLE_RECOVERY_TARGET_NOT_FOUND'
+  | 'DURABLE_RECOVERY_UNSAFE_ROLLOVER';
 
 export class DurableSessionRecoveryError extends SdkError {
   // biome-ignore lint/complexity/noUselessConstructor: narrows the public error-code contract
@@ -117,6 +143,157 @@ function isAcceptedRequestRecovery(
     request.model !== undefined &&
     request.context !== undefined
   );
+}
+
+function eventToCommandDraft(event: DurableEventEnvelope): DurableCommandEventDraft {
+  return {
+    type: event.type,
+    data: event.data,
+    occurredAt: event.occurredAt,
+    ...('requestId' in event ? { requestId: event.requestId } : {}),
+    ...('turnId' in event ? { turnId: event.turnId } : {}),
+    ...('toolAttemptId' in event ? { toolAttemptId: event.toolAttemptId } : {}),
+    ...(event.causationEventId ? { causationEventId: event.causationEventId } : {}),
+  } as DurableCommandEventDraft;
+}
+
+function validatePersistedTurnRecovery(
+  events: readonly DurableEventEnvelope[],
+  command: DurableTurnRecoveryCommand,
+): {
+  continuation: UserMessageContent;
+  interruptedRequestId: RequestId;
+} {
+  const accepted = events.at(-1);
+  if (
+    accepted?.type !== DurableEventType.REQUEST_ACCEPTED ||
+    accepted.requestId !== command.recoveryRequestId ||
+    accepted.data.inputId !== command.recoveryInputId ||
+    !accepted.data.recovery ||
+    accepted.data.recovery.requestId !== command.requestId ||
+    accepted.data.recovery.turnId !== command.turnId
+  ) {
+    throw new DurableSessionRecoveryError(
+      'DURABLE_RECOVERY_INVALID_STATE',
+      `Durable command ${command.commandId} is not the requested turn recovery`,
+    );
+  }
+  const origin = accepted.data.recovery;
+  const turnAborted = events.at(-3);
+  const requestInterrupted = events.at(-2);
+  const cancellationsAreCanonical = events
+    .slice(0, -3)
+    .every(
+      (event) =>
+        event.type === DurableEventType.TOOL_CANCELLED &&
+        event.requestId === origin.requestId &&
+        event.turnId === origin.turnId &&
+        (event.data.reason === 'process_restart' ||
+          event.data.reason === 'permission_denied' ||
+          event.data.reason === 'permission_cancelled'),
+    );
+  if (
+    !turnAborted ||
+    turnAborted.type !== DurableEventType.TURN_ABORTED ||
+    turnAborted.requestId !== origin.requestId ||
+    turnAborted.turnId !== origin.turnId ||
+    turnAborted.data.turn !== origin.turn ||
+    turnAborted.data.reason !== 'process_restart' ||
+    !requestInterrupted ||
+    requestInterrupted.type !== DurableEventType.REQUEST_INTERRUPTED ||
+    requestInterrupted.requestId !== origin.requestId ||
+    requestInterrupted.data.reason !== 'process_restart' ||
+    !cancellationsAreCanonical
+  ) {
+    throw new DurableSessionRecoveryError(
+      'DURABLE_RECOVERY_INVALID_STATE',
+      `Durable command ${command.commandId} is not the requested turn recovery`,
+    );
+  }
+  let continuation: UserMessageContent;
+  try {
+    continuation = parseDurableUserMessageContent(accepted.data.input);
+  } catch (cause) {
+    throw new DurableSessionRecoveryError(
+      'DURABLE_RECOVERY_INVALID_STATE',
+      `Durable command ${command.commandId} has an invalid recovery continuation`,
+      { cause },
+    );
+  }
+  return {
+    continuation,
+    interruptedRequestId: origin.requestId,
+  };
+}
+
+function jsonText(value: unknown): string {
+  return JSON.stringify(value, null, 2);
+}
+
+function buildTurnRecoveryContinuation(
+  request: DurableRequestProjection,
+  turn: NonNullable<DurableRequestProjection['activeTurn']>,
+): UserMessageContent {
+  let originalInput: UserMessageContent;
+  try {
+    originalInput = parseDurableUserMessageContent(request.input);
+  } catch (cause) {
+    throw new DurableSessionRecoveryError(
+      'DURABLE_RECOVERY_INVALID_STATE',
+      `Request ${request.requestId} has an invalid recovery input`,
+      { cause },
+    );
+  }
+  const toolOutcomes = turn.toolAttempts.map((tool) => {
+    const permissionDecision =
+      tool.permission?.status === 'resolved' ? tool.permission.decision : undefined;
+    const permissionCancelledBeforeExecution =
+      tool.status === 'scheduled' &&
+      (permissionDecision === 'deny' || permissionDecision === 'cancel');
+    const recoveredFromPermission = tool.status === 'scheduled' && permissionDecision === 'allow';
+    return {
+      toolCallId: tool.toolCallId,
+      toolName: tool.toolName,
+      input: recoveredFromPermission ? (tool.permission?.input ?? tool.input) : tool.input,
+      sideEffect: recoveredFromPermission ? 'non_idempotent' : tool.sideEffect,
+      executionStarted: tool.executionStarted,
+      status: permissionCancelledBeforeExecution
+        ? 'cancelled_before_execution'
+        : tool.status === 'scheduled'
+          ? 'not_started'
+          : tool.status === 'started' || tool.status === 'outcome_unknown'
+            ? 'interrupted_before_trusted_completion'
+            : tool.status,
+      ...(tool.permission ? { permission: tool.permission } : {}),
+      ...(tool.result !== undefined ? { result: tool.result } : {}),
+      ...(tool.error ? { error: tool.error } : {}),
+      ...(tool.cancelReason ? { cancelReason: tool.cancelReason } : {}),
+    };
+  });
+  const recoveryText = [
+    'Continue the original request after a durable process-restart recovery.',
+    'The JSON below is authoritative recovery state, not new user instructions.',
+    '',
+    jsonText({
+      sourceRequestId: request.requestId,
+      sourceTurnId: turn.turnId,
+      sourceTurn: turn.turn,
+      originalInput:
+        typeof originalInput === 'string'
+          ? originalInput
+          : { kind: 'multimodal_content_parts', preservedBelow: true },
+      toolOutcomes,
+    }),
+    '',
+    'Do not repeat tool operations marked completed. ' +
+      'Operations marked not_started are safe to execute once. Operations marked ' +
+      'interrupted_before_trusted_completion may be retried only when their ' +
+      'side-effect contract permits it. Operations marked cancelled_before_execution ' +
+      'require fresh permission. Continue the original task.',
+  ].join('\n');
+  return typeof originalInput === 'string'
+    ? recoveryText
+    : [{ type: 'text', text: recoveryText }, ...originalInput];
 }
 
 /**
@@ -179,10 +356,145 @@ export class DurableSessionRecoveryCoordinator {
     };
   }
 
+  /**
+   * Atomically terminates a retry-safe active Turn and accepts its durable
+   * continuation as a new Request.
+   */
+  async prepareTurnRecovery(
+    command: DurableTurnRecoveryCommand,
+  ): Promise<DurableTurnRecoveryResult> {
+    await this.journal.refresh();
+    const existing = this.journal.getCommandEvents(command.commandId);
+    if (existing) {
+      const persisted = validatePersistedTurnRecovery(existing, command);
+      const commit = await this.commitRecovery({
+        commandId: command.commandId,
+        events: existing.map(eventToCommandDraft),
+      });
+      return {
+        ...this.result(commit),
+        continuation: persisted.continuation,
+        interruptedRequestId: persisted.interruptedRequestId,
+        recoveryRequestId: command.recoveryRequestId,
+      };
+    }
+
+    const projection = this.getProjection();
+    const recoveryPlan = this.getRecoveryPlan();
+    const request = projection.activeRequest;
+    const turn = request?.activeTurn;
+    if (recoveryPlan.action !== 'resume_turn' || !request || !turn) {
+      throw new DurableSessionRecoveryError(
+        'DURABLE_RECOVERY_INVALID_STATE',
+        `Turn recovery requires resume_turn, found ${recoveryPlan.action}`,
+      );
+    }
+    if (request.requestId !== command.requestId || turn.turnId !== command.turnId) {
+      throw new DurableSessionRecoveryError(
+        'DURABLE_RECOVERY_TARGET_NOT_FOUND',
+        `No active turn matches ${command.requestId}/${command.turnId}`,
+      );
+    }
+    if (
+      request.maxTurns === undefined ||
+      request.model === undefined ||
+      request.context === undefined
+    ) {
+      throw new DurableSessionRecoveryError(
+        'DURABLE_RECOVERY_INVALID_STATE',
+        `Request ${request.requestId} has no complete execution snapshot`,
+      );
+    }
+    const unsafeTool = turn.toolAttempts.find(hasCrossedNonIdempotentBoundary);
+    if (unsafeTool) {
+      throw new DurableSessionRecoveryError(
+        'DURABLE_RECOVERY_UNSAFE_ROLLOVER',
+        `Tool attempt ${unsafeTool.toolAttemptId} crossed a non-idempotent boundary`,
+      );
+    }
+
+    const continuation = buildTurnRecoveryContinuation(request, turn);
+    const events: DurableCommandEventDraft[] = [];
+    for (const tool of turn.toolAttempts) {
+      if (
+        tool.status !== 'scheduled' &&
+        tool.status !== 'started' &&
+        tool.status !== 'outcome_unknown'
+      ) {
+        continue;
+      }
+      const permissionDecision =
+        tool.permission?.status === 'resolved' ? tool.permission.decision : undefined;
+      events.push({
+        type: DurableEventType.TOOL_CANCELLED,
+        requestId: request.requestId,
+        turnId: turn.turnId,
+        toolAttemptId: tool.toolAttemptId,
+        data: {
+          toolCallId: tool.toolCallId,
+          toolName: tool.toolName,
+          reason:
+            permissionDecision === 'deny'
+              ? 'permission_denied'
+              : permissionDecision === 'cancel'
+                ? 'permission_cancelled'
+                : 'process_restart',
+        },
+      });
+    }
+    events.push(
+      {
+        type: DurableEventType.TURN_ABORTED,
+        requestId: request.requestId,
+        turnId: turn.turnId,
+        data: {
+          turn: turn.turn,
+          reason: 'process_restart',
+        },
+      },
+      {
+        type: DurableEventType.REQUEST_INTERRUPTED,
+        requestId: request.requestId,
+        data: {
+          reason: 'process_restart',
+        },
+      },
+      {
+        type: DurableEventType.REQUEST_ACCEPTED,
+        requestId: command.recoveryRequestId,
+        data: {
+          inputId: command.recoveryInputId,
+          input: toJsonValue(continuation),
+          priority: 'next',
+          maxTurns: request.maxTurns,
+          model: request.model,
+          context: request.context,
+          recovery: {
+            requestId: request.requestId,
+            turnId: turn.turnId,
+            turn: turn.turn,
+          },
+        },
+      },
+    );
+
+    const commit = await this.commitRecovery({
+      commandId: command.commandId,
+      events,
+    }, projection.headSequence);
+    return {
+      ...this.result(commit),
+      continuation,
+      interruptedRequestId: request.requestId,
+      recoveryRequestId: command.recoveryRequestId,
+    };
+  }
+
   async reconcileToolOutcome(
     command: DurableToolOutcomeReconciliationCommand,
   ): Promise<DurableRecoveryCommitResult> {
     await this.journal.refresh();
+    const expectedHeadSequence = this.getProjection().headSequence;
     const { request, turn, tool } = this.findToolAttempt(command.toolAttemptId);
     const event = (() => {
       const correlation = {
@@ -228,15 +540,16 @@ export class DurableSessionRecoveryCoordinator {
     const commit = await this.commitRecovery({
       commandId: command.commandId,
       events: [event],
-    });
+    }, expectedHeadSequence);
     return this.result(commit);
   }
 
   async startToolAttempt(command: DurableToolStartCommand): Promise<DurableRecoveryCommitResult> {
     await this.journal.refresh();
+    const expectedHeadSequence = this.getProjection().headSequence;
     const { request, turn, tool } = this.findToolAttempt(command.toolAttemptId);
-    const recoveredFromPermission = tool.permission?.status === 'resolved'
-      && tool.permission.decision === 'allow';
+    const recoveredFromPermission =
+      tool.permission?.status === 'resolved' && tool.permission.decision === 'allow';
     const commit = await this.commitRecovery({
       commandId: command.commandId,
       events: [
@@ -248,7 +561,7 @@ export class DurableSessionRecoveryCoordinator {
           data: {
             toolCallId: tool.toolCallId,
             toolName: tool.toolName,
-            input: recoveredFromPermission ? tool.permission?.input ?? tool.input : tool.input,
+            input: recoveredFromPermission ? (tool.permission?.input ?? tool.input) : tool.input,
             // A permission round-trip may have changed input after scheduling.
             // Without the live Tool resolver, only the most conservative
             // classification is safe across the restart boundary.
@@ -256,7 +569,7 @@ export class DurableSessionRecoveryCoordinator {
           },
         },
       ],
-    });
+    }, expectedHeadSequence);
     return this.result(commit);
   }
 
@@ -264,6 +577,7 @@ export class DurableSessionRecoveryCoordinator {
     command: DurablePermissionResolutionCommand,
   ): Promise<DurableRecoveryCommitResult> {
     await this.journal.refresh();
+    const expectedHeadSequence = this.getProjection().headSequence;
     const { request, turn, tool, permission } = this.findPermission(command.permissionRequestId);
     const events = [
       {
@@ -300,7 +614,7 @@ export class DurableSessionRecoveryCoordinator {
     const commit = await this.commitRecovery({
       commandId: command.commandId,
       events,
-    });
+    }, expectedHeadSequence);
     return this.result(commit);
   }
 
@@ -352,9 +666,13 @@ export class DurableSessionRecoveryCoordinator {
 
   private async commitRecovery(
     command: DurableSessionCommand,
+    expectedHeadSequence?: EventSequence | null,
   ): Promise<DurableCommandCommitResult> {
     try {
-      return await this.journal.commit(command);
+      const options: DurableCommandCommitOptions = expectedHeadSequence === undefined
+        ? {}
+        : { expectedHeadSequence };
+      return await this.journal.commit(command, options);
     } catch (cause) {
       if (cause instanceof DurableEventProjectionError) {
         throw new DurableSessionRecoveryError(

--- a/src/session/events/__tests__/DurableSessionJournal.test.ts
+++ b/src/session/events/__tests__/DurableSessionJournal.test.ts
@@ -253,6 +253,20 @@ describe('DurableSessionJournal', () => {
 
     expect(replayed.status).toBe('replayed');
     expect(replayed.events).toHaveLength(1);
+    const indexed = journal.getCommandEvents(command.commandId);
+    expect(indexed).toMatchObject([
+      {
+        type: DurableEventType.SESSION_CREATED,
+        commandId: command.commandId,
+      },
+    ]);
+    if (indexed) {
+      (indexed[0] as { data: { source?: string } }).data.source = 'fork';
+    }
+    expect(journal.getCommandEvents(command.commandId)?.[0]?.data).toEqual({
+      source: 'create',
+    });
+    expect(journal.getCommandEvents(CommandId('missing-command'))).toBeNull();
     expect(await store.getHeadSequence(sessionId)).toBe(1);
   });
 
@@ -352,6 +366,95 @@ describe('DurableSessionJournal', () => {
       lastSequence: 4,
     });
     expect(second.getProjection().activeRequest?.status).toBe('running');
+  });
+
+  it('does not rebase a state-derived command when its expected head is stale', async () => {
+    const bootstrap = await DurableSessionJournal.open(store, sessionId);
+    await bootstrap.commit({
+      commandId: CommandId('command-create'),
+      events: [sessionCreated()],
+    });
+    await bootstrap.commit({
+      commandId: CommandId('command-request'),
+      events: [requestAccepted()],
+    });
+
+    const first = await DurableSessionJournal.open(store, sessionId);
+    const second = await DurableSessionJournal.open(store, sessionId);
+    await first.commit({
+      commandId: CommandId('command-input'),
+      events: [
+        {
+          type: DurableEventType.INPUT_APPLIED,
+          requestId,
+          data: {
+            inputId: initialInputId,
+            priority: 'next',
+          },
+        },
+      ],
+    });
+
+    await expect(
+      second.commit(
+        {
+          commandId: CommandId('command-start'),
+          events: [
+            {
+              type: DurableEventType.REQUEST_STARTED,
+              requestId,
+              data: {},
+            },
+          ],
+        },
+        { expectedHeadSequence: EventSequence(2) },
+      ),
+    ).rejects.toBeInstanceOf(DurableEventSequenceConflictError);
+    expect(second.getProjection().activeRequest?.status).toBe('accepted');
+    expect(await store.getHeadSequence(sessionId)).toBe(3);
+  });
+
+  it('checks an expected head against commits made through the same journal', async () => {
+    const journal = await DurableSessionJournal.open(store, sessionId);
+    await journal.commit({
+      commandId: CommandId('command-create'),
+      events: [sessionCreated()],
+    });
+    await journal.commit({
+      commandId: CommandId('command-request'),
+      events: [requestAccepted()],
+    });
+    const observedHead = journal.getProjection().headSequence;
+    await journal.commit({
+      commandId: CommandId('command-input'),
+      events: [
+        {
+          type: DurableEventType.INPUT_APPLIED,
+          requestId,
+          data: {
+            inputId: initialInputId,
+            priority: 'next',
+          },
+        },
+      ],
+    });
+
+    await expect(
+      journal.commit(
+        {
+          commandId: CommandId('command-start'),
+          events: [
+            {
+              type: DurableEventType.REQUEST_STARTED,
+              requestId,
+              data: {},
+            },
+          ],
+        },
+        { expectedHeadSequence: observedHead },
+      ),
+    ).rejects.toBeInstanceOf(DurableEventSequenceConflictError);
+    expect(await store.getHeadSequence(sessionId)).toBe(3);
   });
 
   it('reconciles concurrent delivery of the same command', async () => {

--- a/src/session/events/__tests__/DurableSessionProjector.test.ts
+++ b/src/session/events/__tests__/DurableSessionProjector.test.ts
@@ -33,6 +33,9 @@ const turnId = TurnId('turn-1');
 const toolAttemptId = ToolAttemptId('attempt-1');
 const toolCallId = ToolUseId('call-1');
 const permissionRequestId = PermissionRequestId('permission-1');
+const recoveryRequestId = RequestId('request-recovery');
+const recoveryInputId = InputId('input-recovery');
+const recoveryCommandId = CommandId('recovery-command');
 const timestamp = '2026-08-22T12:00:00.000Z';
 
 function envelopes(
@@ -315,6 +318,171 @@ describe('DurableSessionProjector', () => {
     });
   });
 
+  it('validates and projects canonical turn recovery provenance', () => {
+    const recovered = project([
+      ...turnPrefix(),
+      {
+        type: DurableEventType.TURN_ABORTED,
+        requestId,
+        turnId,
+        commandId: recoveryCommandId,
+        data: { turn: 1, reason: 'process_restart' },
+      },
+      {
+        type: DurableEventType.REQUEST_INTERRUPTED,
+        requestId,
+        commandId: recoveryCommandId,
+        data: { reason: 'process_restart' },
+      },
+      {
+        type: DurableEventType.REQUEST_ACCEPTED,
+        requestId: recoveryRequestId,
+        commandId: recoveryCommandId,
+        data: {
+          inputId: recoveryInputId,
+          input: 'continue',
+          priority: 'next',
+          maxTurns: 12,
+          model: 'request-model',
+          context: {},
+          recovery: {
+            requestId,
+            turnId,
+            turn: 1,
+          },
+        },
+      },
+    ]);
+
+    expect(recovered.activeRequest).toMatchObject({
+      requestId: recoveryRequestId,
+      recovery: {
+        requestId,
+        turnId,
+        turn: 1,
+      },
+    });
+
+    expect(() =>
+      project([
+        {
+          type: DurableEventType.SESSION_CREATED,
+          data: { source: 'create' },
+        },
+        {
+          type: DurableEventType.REQUEST_ACCEPTED,
+          requestId: recoveryRequestId,
+          commandId: CommandId('invalid-recovery'),
+          data: {
+            inputId: recoveryInputId,
+            input: 'continue',
+            priority: 'next',
+            recovery: {
+              requestId,
+              turnId,
+              turn: 1,
+            },
+          },
+        },
+      ]),
+    ).toThrow(/not an atomic canonical rollover/);
+
+    expect(() =>
+      project([
+        ...turnPrefix(),
+        {
+          type: DurableEventType.TURN_ABORTED,
+          requestId,
+          turnId,
+          commandId: CommandId('terminate-old-request'),
+          data: { turn: 1, reason: 'process_restart' },
+        },
+        {
+          type: DurableEventType.REQUEST_INTERRUPTED,
+          requestId,
+          commandId: CommandId('terminate-old-request'),
+          data: { reason: 'process_restart' },
+        },
+        {
+          type: DurableEventType.REQUEST_ACCEPTED,
+          requestId: recoveryRequestId,
+          commandId: recoveryCommandId,
+          data: {
+            inputId: recoveryInputId,
+            input: 'continue',
+            priority: 'next',
+            recovery: {
+              requestId,
+              turnId,
+              turn: 1,
+            },
+          },
+        },
+      ]),
+    ).toThrow(/not an atomic canonical rollover/);
+  });
+
+  it('rejects a recovery request that bypasses a non-idempotent execution boundary', () => {
+    expect(() =>
+      project([
+        ...turnPrefix(),
+        toolScheduled('non_idempotent'),
+        {
+          type: DurableEventType.TOOL_STARTED,
+          requestId,
+          turnId,
+          toolAttemptId,
+          data: {
+            toolCallId,
+            toolName: 'Write',
+            input: { file_path: '/tmp/file' },
+            sideEffect: 'non_idempotent',
+          },
+        },
+        {
+          type: DurableEventType.TOOL_CANCELLED,
+          requestId,
+          turnId,
+          toolAttemptId,
+          commandId: recoveryCommandId,
+          data: {
+            toolCallId,
+            toolName: 'Write',
+            reason: 'process_restart',
+          },
+        },
+        {
+          type: DurableEventType.TURN_ABORTED,
+          requestId,
+          turnId,
+          commandId: recoveryCommandId,
+          data: { turn: 1, reason: 'process_restart' },
+        },
+        {
+          type: DurableEventType.REQUEST_INTERRUPTED,
+          requestId,
+          commandId: recoveryCommandId,
+          data: { reason: 'process_restart' },
+        },
+        {
+          type: DurableEventType.REQUEST_ACCEPTED,
+          requestId: recoveryRequestId,
+          commandId: recoveryCommandId,
+          data: {
+            inputId: recoveryInputId,
+            input: 'continue',
+            priority: 'next',
+            recovery: {
+              requestId,
+              turnId,
+              turn: 1,
+            },
+          },
+        },
+      ]),
+    ).toThrow(/crossed non-idempotent tool attempt/);
+  });
+
   it('classifies scheduled tools as retryable before execution starts', () => {
     const projection = project([...turnPrefix(), toolScheduled()]);
     const recovery = planDurableSessionRecovery(projection);
@@ -324,6 +492,7 @@ describe('DurableSessionProjector', () => {
     expect(recovery.retryableToolAttempts[0]).toMatchObject({
       toolAttemptId,
       toolCallId,
+      executionStarted: false,
       status: 'scheduled',
     });
     expect(recovery.unknownToolAttempts).toEqual([]);
@@ -459,6 +628,7 @@ describe('DurableSessionProjector', () => {
         action: 'resume_turn',
         retryableToolAttempts: [
           expect.objectContaining({
+            executionStarted: true,
             status: 'started',
             input: { file_path: '/tmp/final-file' },
             sideEffect,

--- a/src/session/events/__tests__/DurableSessionRecoveryCoordinator.test.ts
+++ b/src/session/events/__tests__/DurableSessionRecoveryCoordinator.test.ts
@@ -749,6 +749,103 @@ describe('DurableSessionRecoveryCoordinator', () => {
     expect(result.continuation).toContain('"content": "durable result"');
   });
 
+  it('bounds oversized tool state and marks every truncated value as incomplete', async () => {
+    const store = createStore();
+    const journal = await createJournal(store, { requestStarted: true });
+    const oversized = 'x'.repeat(5_000);
+    const failedAttemptId = ToolAttemptId('recovery-failed-attempt');
+    const failedCallId = ToolUseId('recovery-failed-call');
+    await journal.commit({
+      commandId: CommandId('settle-oversized-tools'),
+      events: [
+        {
+          type: DurableEventType.TURN_STARTED,
+          requestId,
+          turnId,
+          data: { turn: 1, model: 'accepted-model' },
+        },
+        {
+          type: DurableEventType.TOOL_SCHEDULED,
+          requestId,
+          turnId,
+          toolAttemptId,
+          data: {
+            toolCallId,
+            toolName: 'Read',
+            input: { payload: oversized },
+            sideEffect: 'pure',
+            interruptBehavior: 'cancel',
+          },
+        },
+        {
+          type: DurableEventType.TOOL_STARTED,
+          requestId,
+          turnId,
+          toolAttemptId,
+          data: {
+            toolCallId,
+            toolName: 'Read',
+            input: { payload: oversized },
+            sideEffect: 'pure',
+          },
+        },
+        {
+          type: DurableEventType.TOOL_COMPLETED,
+          requestId,
+          turnId,
+          toolAttemptId,
+          data: {
+            toolCallId,
+            toolName: 'Read',
+            result: { payload: oversized },
+          },
+        },
+        {
+          type: DurableEventType.TOOL_SCHEDULED,
+          requestId,
+          turnId,
+          toolAttemptId: failedAttemptId,
+          data: {
+            toolCallId: failedCallId,
+            toolName: 'Search',
+            input: {},
+            sideEffect: 'pure',
+            interruptBehavior: 'cancel',
+          },
+        },
+        {
+          type: DurableEventType.TOOL_FAILED,
+          requestId,
+          turnId,
+          toolAttemptId: failedAttemptId,
+          data: {
+            toolCallId: failedCallId,
+            toolName: 'Search',
+            error: { message: oversized },
+          },
+        },
+      ],
+    });
+
+    const result = await new DurableSessionRecoveryCoordinator(journal).prepareTurnRecovery({
+      commandId: CommandId('rollover-oversized-tools'),
+      requestId,
+      turnId,
+      recoveryRequestId: rolloverRequestId,
+      recoveryInputId: rolloverInputId,
+    });
+
+    expect(typeof result.continuation).toBe('string');
+    if (typeof result.continuation !== 'string') {
+      throw new Error('Expected a text recovery continuation');
+    }
+    expect(result.continuation.match(/"kind": "truncated_recovery_value"/g)).toHaveLength(3);
+    expect(result.continuation).toContain('"complete": false');
+    expect(result.continuation).toContain('"originalJsonCharacters":');
+    expect(result.continuation).not.toContain(oversized);
+    expect(result.continuation.length).toBeLessThan(14_000);
+  });
+
   it.each([
     {
       outcome: {

--- a/src/session/events/__tests__/DurableSessionRecoveryCoordinator.test.ts
+++ b/src/session/events/__tests__/DurableSessionRecoveryCoordinator.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import {
   CommandId,
   EventId,
+  type EventSequence,
   InputId,
   PermissionRequestId,
   RequestId,
@@ -14,13 +15,20 @@ import {
   ToolUseId,
   TurnId,
 } from '../../../types/branded.js';
+import type { JsonValue } from '../../../types/common.js';
+import type { DurableEventStore } from '../DurableEventStore.js';
 import { DurableSessionJournal } from '../DurableSessionJournal.js';
 import {
   DurableSessionRecoveryCoordinator,
   DurableSessionRecoveryError,
 } from '../DurableSessionRecoveryCoordinator.js';
 import { JsonlDurableEventStore } from '../JsonlDurableEventStore.js';
-import { DurableEventType } from '../types.js';
+import {
+  type DurableEventAppendOptions,
+  type DurableEventDraft,
+  type DurableEventReadOptions,
+  DurableEventType,
+} from '../types.js';
 
 const sessionId = SessionId('recovery-session');
 const requestId = RequestId('recovery-request');
@@ -29,6 +37,8 @@ const turnId = TurnId('recovery-turn');
 const toolAttemptId = ToolAttemptId('recovery-attempt');
 const toolCallId = ToolUseId('recovery-call');
 const permissionRequestId = PermissionRequestId('recovery-permission');
+const rolloverRequestId = RequestId('rollover-request');
+const rolloverInputId = InputId('rollover-input');
 
 const roots: string[] = [];
 
@@ -42,10 +52,62 @@ function createStore(): JsonlDurableEventStore {
   });
 }
 
+class StartToolBeforeRolloverStore implements DurableEventStore {
+  private injected = false;
+
+  constructor(private readonly delegate: DurableEventStore) {}
+
+  async append(
+    targetSessionId: SessionId,
+    events: readonly DurableEventDraft[],
+    options?: DurableEventAppendOptions,
+  ) {
+    if (
+      !this.injected &&
+      events.some(
+        (event) =>
+          event.type === DurableEventType.REQUEST_ACCEPTED && event.data.recovery !== undefined,
+      )
+    ) {
+      this.injected = true;
+      await this.delegate.append(
+        targetSessionId,
+        [
+          {
+            type: DurableEventType.TOOL_STARTED,
+            commandId: CommandId('racing-tool-start'),
+            requestId,
+            turnId,
+            toolAttemptId,
+            data: {
+              toolCallId,
+              toolName: 'Deploy',
+              input: { environment: 'production' },
+              sideEffect: 'non_idempotent',
+            },
+          },
+        ],
+        options,
+      );
+    }
+    return this.delegate.append(targetSessionId, events, options);
+  }
+
+  read(targetSessionId: SessionId, options?: DurableEventReadOptions) {
+    return this.delegate.read(targetSessionId, options);
+  }
+
+  getHeadSequence(targetSessionId: SessionId): Promise<EventSequence | null> {
+    return this.delegate.getHeadSequence(targetSessionId);
+  }
+}
+
 async function createJournal(
-  store: JsonlDurableEventStore,
+  store: DurableEventStore,
   options: {
+    input?: JsonValue;
     requestStarted?: boolean;
+    sideEffect?: 'pure' | 'idempotent' | 'non_idempotent';
     tool?: 'none' | 'pending_permission' | 'started';
   } = {},
 ): Promise<DurableSessionJournal> {
@@ -62,7 +124,7 @@ async function createJournal(
         requestId,
         data: {
           inputId,
-          input: 'recover this request',
+          input: options.input === undefined ? 'recover this request' : options.input,
           priority: 'next',
           maxTurns: 17,
           model: 'accepted-model',
@@ -103,7 +165,7 @@ async function createJournal(
                 toolCallId,
                 toolName: 'Deploy',
                 input: { environment: 'production' },
-                sideEffect: 'non_idempotent' as const,
+                sideEffect: options.sideEffect ?? ('non_idempotent' as const),
                 interruptBehavior: 'block' as const,
               },
             },
@@ -264,6 +326,540 @@ describe('DurableSessionRecoveryCoordinator', () => {
         },
       }),
     ).rejects.toThrow(/different events/);
+  });
+
+  it('atomically rolls a recoverable turn into a new accepted request', async () => {
+    const store = createStore();
+    const journal = await createJournal(store, { requestStarted: true });
+    await journal.commit({
+      commandId: CommandId('start-turn'),
+      events: [
+        {
+          type: DurableEventType.TURN_STARTED,
+          requestId,
+          turnId,
+          data: { turn: 1, model: 'accepted-model' },
+        },
+      ],
+    });
+    const first = await DurableSessionRecoveryCoordinator.open(store, sessionId);
+    const second = await DurableSessionRecoveryCoordinator.open(store, sessionId);
+    const headBeforeMismatch = await store.getHeadSequence(sessionId);
+    await expect(
+      first.prepareTurnRecovery({
+        commandId: CommandId('rollover-wrong-source'),
+        requestId: RequestId('different-source-request'),
+        turnId,
+        recoveryRequestId: rolloverRequestId,
+        recoveryInputId: rolloverInputId,
+      }),
+    ).rejects.toMatchObject({
+      code: 'DURABLE_RECOVERY_TARGET_NOT_FOUND',
+    });
+    expect(await store.getHeadSequence(sessionId)).toBe(headBeforeMismatch);
+
+    const command = {
+      commandId: CommandId('rollover-turn'),
+      requestId,
+      turnId,
+      recoveryRequestId: rolloverRequestId,
+      recoveryInputId: rolloverInputId,
+    };
+
+    const results = await Promise.all([
+      first.prepareTurnRecovery(command),
+      second.prepareTurnRecovery(command),
+    ]);
+    const replayed = await first.prepareTurnRecovery(command);
+
+    expect(results.map((result) => result.commit.status).sort()).toEqual([
+      'committed',
+      'reconciled',
+    ]);
+    expect(replayed.commit.status).toBe('replayed');
+    expect(replayed.continuation).toContain('sourceTurnId');
+    expect(replayed.projection.activeRequest).toMatchObject({
+      requestId: rolloverRequestId,
+      inputId: rolloverInputId,
+      status: 'accepted',
+      recovery: {
+        requestId,
+        turnId,
+        turn: 1,
+      },
+    });
+    expect(first.planResume()).toMatchObject({
+      action: 'resume_accepted_request',
+      request: {
+        requestId: rolloverRequestId,
+        inputId: rolloverInputId,
+      },
+    });
+    expect((await store.read(sessionId)).events.map((event) => event.type).slice(-3)).toEqual([
+      DurableEventType.TURN_ABORTED,
+      DurableEventType.REQUEST_INTERRUPTED,
+      DurableEventType.REQUEST_ACCEPTED,
+    ]);
+    await expect(
+      first.prepareTurnRecovery({
+        ...command,
+        recoveryInputId: InputId('different-rollover-input'),
+      }),
+    ).rejects.toMatchObject({
+      code: 'DURABLE_RECOVERY_INVALID_STATE',
+    });
+  });
+
+  it('does not rebase rollover after a non-idempotent tool starts concurrently', async () => {
+    const baseStore = createStore();
+    const store = new StartToolBeforeRolloverStore(baseStore);
+    const journal = await createJournal(store, { requestStarted: true });
+    await journal.commit({
+      commandId: CommandId('schedule-racing-tool'),
+      events: [
+        {
+          type: DurableEventType.TURN_STARTED,
+          requestId,
+          turnId,
+          data: { turn: 1, model: 'accepted-model' },
+        },
+        {
+          type: DurableEventType.TOOL_SCHEDULED,
+          requestId,
+          turnId,
+          toolAttemptId,
+          data: {
+            toolCallId,
+            toolName: 'Deploy',
+            input: { environment: 'production' },
+            sideEffect: 'non_idempotent',
+            interruptBehavior: 'block',
+          },
+        },
+      ],
+    });
+    const coordinator = await DurableSessionRecoveryCoordinator.open(store, sessionId);
+    const command = {
+      commandId: CommandId('raced-rollover'),
+      requestId,
+      turnId,
+      recoveryRequestId: rolloverRequestId,
+      recoveryInputId: rolloverInputId,
+    };
+
+    await expect(coordinator.prepareTurnRecovery(command)).rejects.toMatchObject({
+      code: 'DURABLE_EVENT_SEQUENCE_CONFLICT',
+    });
+    await expect(coordinator.prepareTurnRecovery(command)).rejects.toMatchObject({
+      code: 'DURABLE_RECOVERY_INVALID_STATE',
+    });
+
+    const events = (await baseStore.read(sessionId)).events;
+    expect(events.at(-1)).toMatchObject({
+      type: DurableEventType.TOOL_STARTED,
+      data: {
+        sideEffect: 'non_idempotent',
+      },
+    });
+    expect(
+      events.some(
+        (event) =>
+          event.type === DurableEventType.REQUEST_ACCEPTED && event.requestId === rolloverRequestId,
+      ),
+    ).toBe(false);
+  });
+
+  it('cancels retry-safe started tools before rolling over the turn', async () => {
+    const store = createStore();
+    const journal = await createJournal(store, { requestStarted: true });
+    await journal.commit({
+      commandId: CommandId('start-safe-tool'),
+      events: [
+        {
+          type: DurableEventType.TURN_STARTED,
+          requestId,
+          turnId,
+          data: { turn: 1, model: 'accepted-model' },
+        },
+        {
+          type: DurableEventType.TOOL_SCHEDULED,
+          requestId,
+          turnId,
+          toolAttemptId,
+          data: {
+            toolCallId,
+            toolName: 'Read',
+            input: { file_path: '/tmp/input' },
+            sideEffect: 'pure',
+            interruptBehavior: 'cancel',
+          },
+        },
+        {
+          type: DurableEventType.TOOL_STARTED,
+          requestId,
+          turnId,
+          toolAttemptId,
+          data: {
+            toolCallId,
+            toolName: 'Read',
+            input: { file_path: '/tmp/input' },
+            sideEffect: 'pure',
+          },
+        },
+      ],
+    });
+    const coordinator = new DurableSessionRecoveryCoordinator(journal);
+
+    const result = await coordinator.prepareTurnRecovery({
+      commandId: CommandId('rollover-safe-tool'),
+      requestId,
+      turnId,
+      recoveryRequestId: rolloverRequestId,
+      recoveryInputId: rolloverInputId,
+    });
+
+    expect(result.commit.events.map((event) => event.type)).toEqual([
+      DurableEventType.TOOL_CANCELLED,
+      DurableEventType.TURN_ABORTED,
+      DurableEventType.REQUEST_INTERRUPTED,
+      DurableEventType.REQUEST_ACCEPTED,
+    ]);
+    expect(result.continuation).toContain('interrupted_before_trusted_completion');
+    expect(result.continuation).toContain('"sideEffect": "pure"');
+  });
+
+  it('marks a scheduled non-idempotent tool as safe to execute for the first time', async () => {
+    const store = createStore();
+    const journal = await createJournal(store, { requestStarted: true });
+    await journal.commit({
+      commandId: CommandId('schedule-non-idempotent-tool'),
+      events: [
+        {
+          type: DurableEventType.TURN_STARTED,
+          requestId,
+          turnId,
+          data: { turn: 1, model: 'accepted-model' },
+        },
+        {
+          type: DurableEventType.TOOL_SCHEDULED,
+          requestId,
+          turnId,
+          toolAttemptId,
+          data: {
+            toolCallId,
+            toolName: 'Deploy',
+            input: { environment: 'production' },
+            sideEffect: 'non_idempotent',
+            interruptBehavior: 'block',
+          },
+        },
+      ],
+    });
+
+    const result = await new DurableSessionRecoveryCoordinator(journal).prepareTurnRecovery({
+      commandId: CommandId('rollover-scheduled-non-idempotent-tool'),
+      requestId,
+      turnId,
+      recoveryRequestId: rolloverRequestId,
+      recoveryInputId: rolloverInputId,
+    });
+
+    expect(result.continuation).toContain('"status": "not_started"');
+    expect(result.continuation).toContain('Operations marked not_started are safe to execute once');
+    expect(result.continuation).not.toContain('"status": "interrupted_before_trusted_completion"');
+  });
+
+  it('preserves multimodal request parts in the recovery continuation', async () => {
+    const store = createStore();
+    const originalInput: JsonValue[] = [
+      { type: 'text', text: 'Inspect this image' },
+      { type: 'image_url', image_url: { url: 'data:image/png;base64,aW1hZ2U=' } },
+    ];
+    const journal = await createJournal(store, {
+      input: originalInput,
+      requestStarted: true,
+    });
+    await journal.commit({
+      commandId: CommandId('start-multimodal-turn'),
+      events: [
+        {
+          type: DurableEventType.TURN_STARTED,
+          requestId,
+          turnId,
+          data: { turn: 1, model: 'accepted-model' },
+        },
+      ],
+    });
+    const coordinator = new DurableSessionRecoveryCoordinator(journal);
+    const command = {
+      commandId: CommandId('rollover-multimodal-turn'),
+      requestId,
+      turnId,
+      recoveryRequestId: rolloverRequestId,
+      recoveryInputId: rolloverInputId,
+    };
+
+    const committed = await coordinator.prepareTurnRecovery(command);
+    const replayed = await coordinator.prepareTurnRecovery(command);
+
+    expect(committed.continuation).toEqual([
+      expect.objectContaining({
+        type: 'text',
+        text: expect.stringContaining('"kind": "multimodal_content_parts"'),
+      }),
+      ...originalInput,
+    ]);
+    expect(replayed.continuation).toEqual(committed.continuation);
+    expect(committed.projection.activeRequest?.input).toEqual(committed.continuation);
+  });
+
+  it('uses permission-updated input and conservative side effects in the continuation', async () => {
+    const store = createStore();
+    const journal = await createJournal(store, {
+      requestStarted: true,
+      sideEffect: 'pure',
+      tool: 'pending_permission',
+    });
+    const coordinator = new DurableSessionRecoveryCoordinator(journal);
+    await coordinator.resolvePermission({
+      commandId: CommandId('allow-updated-tool'),
+      permissionRequestId,
+      decision: 'allow',
+    });
+
+    const result = await coordinator.prepareTurnRecovery({
+      commandId: CommandId('rollover-allowed-tool'),
+      requestId,
+      turnId,
+      recoveryRequestId: rolloverRequestId,
+      recoveryInputId: rolloverInputId,
+    });
+
+    expect(result.continuation).toContain('"environment": "approved-production"');
+    expect(result.continuation).not.toContain('"environment": "production"');
+    expect(result.continuation).toContain('"sideEffect": "non_idempotent"');
+    expect(result.continuation).toContain('"status": "not_started"');
+  });
+
+  it('replays rollover after cancelling a previously denied scheduled tool', async () => {
+    const store = createStore();
+    const journal = await createJournal(store, {
+      requestStarted: true,
+      tool: 'pending_permission',
+    });
+    await journal.commit({
+      commandId: CommandId('resolve-denial-without-cancellation'),
+      events: [
+        {
+          type: DurableEventType.PERMISSION_RESOLVED,
+          requestId,
+          turnId,
+          toolAttemptId,
+          data: {
+            permissionRequestId,
+            decision: 'deny',
+          },
+        },
+      ],
+    });
+    const coordinator = new DurableSessionRecoveryCoordinator(journal);
+    const command = {
+      commandId: CommandId('rollover-denied-tool'),
+      requestId,
+      turnId,
+      recoveryRequestId: rolloverRequestId,
+      recoveryInputId: rolloverInputId,
+    };
+
+    const committed = await coordinator.prepareTurnRecovery(command);
+    const replayed = await coordinator.prepareTurnRecovery(command);
+
+    expect(committed.commit.events[0]).toMatchObject({
+      type: DurableEventType.TOOL_CANCELLED,
+      data: { reason: 'permission_denied' },
+    });
+    expect(replayed.commit.status).toBe('replayed');
+  });
+
+  it('carries a completed retry-safe tool result into the continuation', async () => {
+    const store = createStore();
+    const journal = await createJournal(store, { requestStarted: true });
+    await journal.commit({
+      commandId: CommandId('complete-safe-tool'),
+      events: [
+        {
+          type: DurableEventType.TURN_STARTED,
+          requestId,
+          turnId,
+          data: { turn: 1, model: 'accepted-model' },
+        },
+        {
+          type: DurableEventType.TOOL_SCHEDULED,
+          requestId,
+          turnId,
+          toolAttemptId,
+          data: {
+            toolCallId,
+            toolName: 'Read',
+            input: { file_path: '/tmp/input' },
+            sideEffect: 'pure',
+            interruptBehavior: 'cancel',
+          },
+        },
+        {
+          type: DurableEventType.TOOL_STARTED,
+          requestId,
+          turnId,
+          toolAttemptId,
+          data: {
+            toolCallId,
+            toolName: 'Read',
+            input: { file_path: '/tmp/input' },
+            sideEffect: 'pure',
+          },
+        },
+        {
+          type: DurableEventType.TOOL_COMPLETED,
+          requestId,
+          turnId,
+          toolAttemptId,
+          data: {
+            toolCallId,
+            toolName: 'Read',
+            result: { content: 'durable result' },
+          },
+        },
+      ],
+    });
+
+    const result = await new DurableSessionRecoveryCoordinator(journal).prepareTurnRecovery({
+      commandId: CommandId('rollover-completed-safe-tool'),
+      requestId,
+      turnId,
+      recoveryRequestId: rolloverRequestId,
+      recoveryInputId: rolloverInputId,
+    });
+
+    expect(result.commit.events.map((event) => event.type)).toEqual([
+      DurableEventType.TURN_ABORTED,
+      DurableEventType.REQUEST_INTERRUPTED,
+      DurableEventType.REQUEST_ACCEPTED,
+    ]);
+    expect(result.continuation).toContain('"status": "completed"');
+    expect(result.continuation).toContain('"content": "durable result"');
+  });
+
+  it.each([
+    {
+      outcome: {
+        status: 'completed' as const,
+        result: { deploymentId: 'dep-unsafe' },
+      },
+    },
+    {
+      outcome: {
+        status: 'failed' as const,
+        error: { message: 'remote outcome may be partial' },
+      },
+    },
+    {
+      outcome: {
+        status: 'cancelled' as const,
+      },
+    },
+  ])('refuses rollover after a non-idempotent $outcome.status', async ({ outcome }) => {
+    const store = createStore();
+    await createJournal(store, { requestStarted: true, tool: 'started' });
+    const coordinator = await DurableSessionRecoveryCoordinator.open(store, sessionId);
+    await coordinator.reconcileToolOutcome({
+      commandId: CommandId(`settle-${outcome.status}`),
+      toolAttemptId,
+      outcome,
+    });
+
+    await expect(
+      coordinator.prepareTurnRecovery({
+        commandId: CommandId(`rollover-${outcome.status}`),
+        requestId,
+        turnId,
+        recoveryRequestId: rolloverRequestId,
+        recoveryInputId: rolloverInputId,
+      }),
+    ).rejects.toMatchObject({
+      code: 'DURABLE_RECOVERY_UNSAFE_ROLLOVER',
+    });
+  });
+
+  it('rejects a reused command that contains work after accepting the continuation', async () => {
+    const store = createStore();
+    const journal = await createJournal(store, { requestStarted: true });
+    const commandId = CommandId('rollover-and-start');
+    await journal.commit({
+      commandId: CommandId('start-turn-before-rollover-and-start'),
+      events: [
+        {
+          type: DurableEventType.TURN_STARTED,
+          requestId,
+          turnId,
+          data: { turn: 1, model: 'accepted-model' },
+        },
+      ],
+    });
+    await journal.commit({
+      commandId,
+      events: [
+        {
+          type: DurableEventType.TURN_ABORTED,
+          requestId,
+          turnId,
+          data: { turn: 1, reason: 'process_restart' },
+        },
+        {
+          type: DurableEventType.REQUEST_INTERRUPTED,
+          requestId,
+          data: { reason: 'process_restart' },
+        },
+        {
+          type: DurableEventType.REQUEST_ACCEPTED,
+          requestId: rolloverRequestId,
+          data: {
+            inputId: rolloverInputId,
+            input: 'continue',
+            priority: 'next',
+            maxTurns: 17,
+            model: 'accepted-model',
+            context: {},
+            recovery: {
+              requestId,
+              turnId,
+              turn: 1,
+            },
+          },
+        },
+        {
+          type: DurableEventType.INPUT_APPLIED,
+          requestId: rolloverRequestId,
+          data: { inputId: rolloverInputId, priority: 'next' },
+        },
+        {
+          type: DurableEventType.REQUEST_STARTED,
+          requestId: rolloverRequestId,
+          data: {},
+        },
+      ],
+    });
+
+    await expect(
+      new DurableSessionRecoveryCoordinator(journal).prepareTurnRecovery({
+        commandId,
+        requestId,
+        turnId,
+        recoveryRequestId: rolloverRequestId,
+        recoveryInputId: rolloverInputId,
+      }),
+    ).rejects.toMatchObject({
+      code: 'DURABLE_RECOVERY_INVALID_STATE',
+    });
   });
 
   it.each([

--- a/src/session/events/__tests__/schemas.test.ts
+++ b/src/session/events/__tests__/schemas.test.ts
@@ -46,6 +46,11 @@ const validDrafts: readonly DurableEventDraft[] = [
         id: 'request-context',
         environment: { REGION: 'test' },
       },
+      recovery: {
+        requestId: RequestId('source-request'),
+        turnId: TurnId('source-turn'),
+        turn: 3,
+      },
     },
   },
   {
@@ -243,6 +248,24 @@ describe('durable event schemas', () => {
         type: DurableEventType.REQUEST_STARTED,
         requestId,
         data: { unexpected: true },
+      }),
+    ).toThrow();
+
+    expect(() =>
+      parseDurableEventDraft({
+        type: DurableEventType.REQUEST_ACCEPTED,
+        requestId,
+        commandId,
+        data: {
+          inputId: InputId('input-1'),
+          input: 'hello',
+          priority: 'next',
+          recovery: {
+            requestId: RequestId('source-request'),
+            turnId: TurnId('source-turn'),
+            turn: 0,
+          },
+        },
       }),
     ).toThrow();
 

--- a/src/session/events/core.ts
+++ b/src/session/events/core.ts
@@ -16,6 +16,7 @@ export {
   parseDurableEventCursor,
 } from './DurableEventSubscription.js';
 export {
+  type DurableCommandCommitOptions,
   type DurableCommandCommitResult,
   type DurableCommandCommitStatus,
   DurableCommandConflictError,
@@ -38,6 +39,8 @@ export {
   type DurableToolOutcomeReconciliation,
   type DurableToolOutcomeReconciliationCommand,
   type DurableToolStartCommand,
+  type DurableTurnRecoveryCommand,
+  type DurableTurnRecoveryResult,
 } from './DurableSessionRecoveryCoordinator.js';
 export {
   DurableEventProjectionError,
@@ -84,6 +87,7 @@ export {
   type DurableInputPriority,
   type DurablePermissionDecision,
   type DurableRequestInterruptReason,
+  type DurableRequestRecoveryOrigin,
   type DurableSessionCloseReason,
   type DurableTokenUsage,
   type DurableToolCancelReason,

--- a/src/session/events/schemas.ts
+++ b/src/session/events/schemas.ts
@@ -79,6 +79,14 @@ const DurableEventDataSchemas = {
       maxTurns: z.number().int().min(-1).max(Number.MAX_SAFE_INTEGER).optional(),
       model: NonEmptyStringSchema.optional(),
       context: JsonObjectSchema.optional(),
+      recovery: z
+        .object({
+          requestId: NonEmptyStringSchema,
+          turnId: NonEmptyStringSchema,
+          turn: PositiveIntegerSchema,
+        })
+        .strict()
+        .optional(),
     })
     .strict(),
   [DurableEventTypeValue.REQUEST_STARTED]: z.object({}).strict(),

--- a/src/session/events/types.ts
+++ b/src/session/events/types.ts
@@ -73,6 +73,12 @@ export interface DurableTokenUsage {
   totalTokens: number;
 }
 
+export interface DurableRequestRecoveryOrigin {
+  requestId: RequestId;
+  turnId: TurnId;
+  turn: number;
+}
+
 export interface DurableEventDataMap {
   [DurableEventType.SESSION_CREATED]: {
     source?: 'create' | 'resume' | 'fork';
@@ -88,6 +94,7 @@ export interface DurableEventDataMap {
     maxTurns?: number;
     model?: string;
     context?: JsonObject;
+    recovery?: DurableRequestRecoveryOrigin;
   };
   [DurableEventType.REQUEST_STARTED]: Record<string, never>;
   [DurableEventType.REQUEST_COMPLETED]: {


### PR DESCRIPTION
## Summary

- add atomic active-Turn rollover into a provenance-linked continuation Request
- bind rollover commands to the observed source Request/Turn and Journal head to prevent stale local or cross-process commits
- cancel retry-safe unfinished tools before terminating the old Turn/Request while keeping unsafe non-idempotent boundaries fail-closed in both the coordinator and projector
- preserve multimodal request parts, permission-updated tool input, terminal tool facts, and provider-valid history during continuation recovery
- expose recovery provenance and command/result types through browser-safe entrypoints
- document the recovery protocol in English and Chinese

## Verification

- `pnpm exec vitest run --reporter=dot` (128 files passed, 1340 tests passed, 62 live/integration tests skipped)
- `pnpm run type-check`
- `pnpm run lint`
- `pnpm run docs:build`
- `pnpm run changelog:check`
- `pnpm run verify:entrypoints`
- `npm pack --dry-run --json`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safe recovery for interrupted active turns through atomic rollover into continuation requests.
  * Preserved recovery provenance, multimodal inputs, and recoverable tool outcomes during resumption.
  * Added safeguards against stale state and duplicate recovery attempts.

* **Bug Fixes**
  * Unsafe non-idempotent tool outcomes now fail closed instead of being automatically resumed.

* **Documentation**
  * Updated Durable recovery guidance and API references in English and Chinese.
  * Documented recovery workflows, concurrency protections, and tool-safety rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->