### PR TITLE
feat(durable)!: persist model request attempts

### DIFF
--- a/.changes/durable-model-attempts.json
+++ b/.changes/durable-model-attempts.json
@@ -1,0 +1,5 @@
+{
+  "type": "breaking",
+  "en": "Persist and deterministically settle model request attempts around provider calls, require explicit reconciliation for unknown outcomes, and advance the durable event wire format to schema v3 with schema-v2 read compatibility.",
+  "zh-CN": "在 provider 调用前后持久化并确定性闭合模型请求尝试，对未知结果强制显式对账，并将 durable event wire format 升级至 schema v3，同时保持 schema v2 读取兼容。"
+}

--- a/.changes/durable-model-attempts.json
+++ b/.changes/durable-model-attempts.json
@@ -1,5 +1,5 @@
 {
   "type": "breaking",
-  "en": "Persist and deterministically settle model request attempts around provider calls, require explicit reconciliation for unknown outcomes, and advance the durable event wire format to schema v3 with schema-v2 read compatibility.",
-  "zh-CN": "在 provider 调用前后持久化并确定性闭合模型请求尝试，对未知结果强制显式对账，并将 durable event wire format 升级至 schema v3，同时保持 schema v2 读取兼容。"
+  "en": "Persist and deterministically settle model request attempts around provider calls, bind durable tool schedules to authoritative model responses, require explicit reconciliation for unknown outcomes, and advance the durable event wire format to schema v3 with schema-v2 read compatibility.",
+  "zh-CN": "在 provider 调用前后持久化并确定性闭合模型请求尝试，将 durable 工具调度绑定到权威模型响应，对未知结果强制显式对账，并将 durable event wire format 升级至 schema v3，同时保持 schema v2 读取兼容。"
 }

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ console.log(result.usage);
 
 - Session lifecycle: `createSession()`, `resumeSession()`, `forkSession()`, and `prompt()`
 - Steerable requests: durable `now`, `next`, and `later` inputs with cancellation and pending-input inspection
-- Durable recovery: pre-start resume, safe Request/Turn rollover, explicit reconciliation, and reconnectable cursors
+- Durable recovery: pre-start resume, safe Request/Turn rollover, explicit model/tool reconciliation, and reconnectable cursors
 - Streaming: 17 typed events for turns, content, reasoning, tools, usage, steering, results, and errors
 - Providers: OpenAI, Anthropic, Azure OpenAI, Gemini, DeepSeek, and OpenAI-compatible APIs
 - Tools: generator-only custom tools, capability-grouped built-ins, MCP tools, and typed progress/effects

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -61,7 +61,7 @@ console.log(result.usage);
 
 - Session 生命周期：`createSession()`、`resumeSession()`、`forkSession()`、`prompt()`
 - 可转向请求：持久化的 `now`、`next`、`later` 输入，支持取消和待处理输入查询
-- Durable 恢复：启动前恢复、安全的 Request/Turn rollover、显式对账与 cursor 断线续读
+- Durable 恢复：启动前恢复、安全的 Request/Turn rollover、显式模型/工具对账与 cursor 断线续读
 - 流式事件：17 种类型化事件，覆盖轮次、内容、思维、工具、usage、转向、结果和错误
 - Provider：OpenAI、Anthropic、Azure OpenAI、Gemini、DeepSeek 和 OpenAI-compatible API
 - 工具：仅 generator 的自定义工具、按能力分组的内置工具、MCP 工具和类型化进度/副作用

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -86,7 +86,7 @@ Node-local 能力外，这些函数都从根入口导出；实际 subpath 以“
 | `PendingSessionInput` | 尚未应用的持久化输入 |
 | `InputId` / `RequestId` / `SessionId` | 输入、活动请求与会话的 branded identifiers |
 | `EventId` / `EventSequence` | durable event 标识与 Session 内单调序列 |
-| `CommandId` / `TurnId` / `ToolAttemptId` / `PermissionRequestId` | durable command、turn、工具尝试与权限请求标识 |
+| `CommandId` / `TurnId` / `ModelAttemptId` / `ToolAttemptId` / `PermissionRequestId` | durable command、turn、模型尝试、工具尝试与权限请求标识 |
 | `StreamOptions` | stream() 选项 |
 | `StreamMessage` | Session 流式消息联合类型 |
 | `PromptResult` | prompt() 返回结果 |
@@ -103,7 +103,7 @@ Node-local 能力外，这些函数都从根入口导出；实际 subpath 以“
 | `DurableEventSubscription` | 支持 replay/caught-up/live 阶段的可重连事件流 |
 | `durableEventCursor` / `parseDurableEventCursor` | 创建和严格解析版本化恢复 cursor |
 | `DurableSessionJournal` / `DurableSessionJournalOptions` | command-oriented 串行提交、CAS 重试与对账层 |
-| `DurableSessionRecoveryCoordinator` | Request/Turn rollover、权限消解及工具与 Request 结果对账协调器 |
+| `DurableSessionRecoveryCoordinator` | Request/Turn rollover、权限消解及模型、工具与 Request 结果对账协调器 |
 | `DurableSessionCommand` / `DurableCommandEventDraft` | Journal command 与不含重复 `commandId` 的事件输入 |
 | `DurableCommandCommitOptions` | 通过 `expectedHeadSequence` 固定状态派生 command 的前置 head |
 | `DurableCommandCommitResult` / `DurableCommandCommitStatus` | `committed` / `replayed` / `reconciled` 提交结果 |
@@ -111,12 +111,13 @@ Node-local 能力外，这些函数都从根入口导出；实际 subpath 以“
 | `DurableCommandConflictError` | 同一 `commandId` 被用于不同事件 |
 | `DurableCommandOutcomeUnknownError` | 写入失败后无法确认 command 是否提交 |
 | `DurableSessionRecoveryError` / `DurableSessionRecoveryErrorCode` | 恢复目标缺失或状态不满足恢复契约 |
-| `DurableSessionRecoveryRequiredError` | Session 恢复前需要权限或工具结果对账 |
+| `DurableSessionRecoveryRequiredError` | Session 恢复前需要输入、模型、权限或工具结果对账 |
 | `SessionDurableRecorderError` | Session runtime 观察到非法 durable 生命周期状态 |
 | `DurableEventEnvelope` / `DurableEventDraft` | 已提交事件与待提交事件 |
-| `DurableEventDataMap` / `DurableEventOfType` / `DurableEventError` / `DurableTokenUsage` | 事件类型到严格 payload 的映射、类型提取及公共 payload |
+| `DurableEventDataMap` / `DurableEventOfType` / `DurableEventError` / `DurableEventSchemaVersion` / `DurableTokenUsage` | 事件类型到严格 payload 的映射、类型提取、schema 版本及公共 payload |
+| `DurableModelResponse` / `DurableModelToolCall` / `DurableModelUsage` | 已完成模型响应、工具调用与用量的持久化结构 |
 | `DurableInputPriority` / `DurablePermissionDecision` | 输入优先级与权限结果 |
-| `DurableRequestInterruptReason` / `DurableTurnAbortReason` | Request 与 Turn 中断原因 |
+| `DurableRequestInterruptReason` / `DurableTurnAbortReason` / `DurableModelRequestAbortReason` | Request、Turn 与模型调用中断原因 |
 | `DurableToolInterruptBehavior` / `DurableToolCancelReason` / `DurableToolOutcomeUnknownReason` | 工具中断、取消及未知结果原因 |
 | `DurableSessionCloseReason` | Session 关闭原因 |
 | `DurableEventAppendOptions` / `DurableEventAppendResult` | compare-and-append 参数与结果 |
@@ -132,6 +133,7 @@ Node-local 能力外，这些函数都从根入口导出；实际 subpath 以“
 | `DurableRequestRecoveryOrigin` | continuation Request 的 source Request/Turn provenance |
 | `DurableRequestRecoveryKind` | 区分 active-Turn 与 synthetic pre-Turn recovery |
 | `DurableTurnProjection` / `DurableTurnStatus` | 活动 Turn 状态 |
+| `DurableModelAttemptProjection` / `DurableModelAttemptStatus` | 当前 Turn 的模型调用尝试状态 |
 | `DurableToolAttemptProjection` / `DurableToolAttemptStatus` | 当前 Turn 的工具尝试状态 |
 | `DurablePermissionProjection` / `DurablePermissionStatus` | 工具权限状态 |
 | `DurableSessionRecoveryAction` | 恢复动作判别值 |
@@ -139,6 +141,7 @@ Node-local 能力外，这些函数都从根入口导出；实际 subpath 以“
 | `DurableSessionResumeDecision` | `ready` / `resume_accepted_request` / `recovery_required` 决策 |
 | `DurableRequestRolloverCommand` / `DurableRequestRolloverResult` | 首个 Turn 前的原子 Request rollover 命令及结果 |
 | `DurableRequestOutcomeReconciliation` / `DurableRequestOutcomeReconciliationCommand` | Turn 后缺失 Request 终态时的显式对账输入 |
+| `DurableModelOutcomeReconciliation` / `DurableModelOutcomeReconciliationCommand` | 未知模型调用结果的显式对账输入 |
 | `DurableToolOutcomeReconciliation` / `DurableToolOutcomeReconciliationCommand` | 显式工具结果对账输入 |
 | `DurableToolStartCommand` | 恢复执行前持久化 `tool_started` 的幂等命令 |
 | `DurableTurnRecoveryCommand` / `DurableTurnRecoveryResult` | 原子 Turn rollover 命令及结果 |

--- a/docs/durable-events.md
+++ b/docs/durable-events.md
@@ -8,9 +8,9 @@ Session 生命周期投影。
 Session 只有在显式设置 `SessionOptions.durableEventStore` 时才写入 durable
 事件；现有消息 JSONL 保持不变。`resumeSession()` 会自动恢复已接受但尚未跨过
 `request_started` 边界的 Request。已开始但尚无 Turn 的 Request，以及活动
-Turn，必须先通过 Recovery Coordinator 原子 rollover；待决权限、未知工具结果
-和已完成 Turn 的 Request 仍需显式消解。`non_idempotent` 工具绝不会被自动
-重放。
+Turn，必须先通过 Recovery Coordinator 原子 rollover；待决权限、未知工具结果、
+未知模型结果和已完成 Turn 的 Request 仍需显式消解。`non_idempotent`
+工具和结果未知的模型调用绝不会被自动重放。
 :::
 
 ## 安装与导入
@@ -30,6 +30,7 @@ import {
   EventSequence,
   InputId,
   JsonlDurableEventStore,
+  ModelAttemptId,
   PermissionRequestId,
   RequestId,
   SessionId,
@@ -42,7 +43,7 @@ import {
 
 ```ts
 interface DurableEventEnvelope<TType extends DurableEventType> {
-  schemaVersion: 2;
+  schemaVersion: 2 | 3;
   eventId: EventId;
   sequence: EventSequence;
   sessionId: SessionId;
@@ -53,6 +54,7 @@ interface DurableEventEnvelope<TType extends DurableEventType> {
   commandId?: CommandId;
   requestId?: RequestId;
   turnId?: TurnId;
+  modelAttemptId?: ModelAttemptId;
   toolAttemptId?: ToolAttemptId;
   causationEventId?: EventId;
 }
@@ -80,6 +82,10 @@ interface DurableEventEnvelope<TType extends DurableEventType> {
 | `turn_started` | `requestId`、`turnId` | `turn`、`model?` |
 | `turn_completed` | `requestId`、`turnId` | `turn`、`hasToolCalls` |
 | `turn_aborted` | `requestId`、`turnId` | `turn`、`reason` |
+| `model_request_started` | Request、Turn、`modelAttemptId` | `model`、`streaming` |
+| `model_request_completed` | Request、Turn、`modelAttemptId` | 完整模型 `response` |
+| `model_request_failed` | Request、Turn、`modelAttemptId` | `error` |
+| `model_request_aborted` | Request、Turn、`modelAttemptId` | `reason` |
 | `tool_scheduled` | Request、Turn、`toolAttemptId` | `toolCallId`、`toolName`、`input`、`sideEffect`、`interruptBehavior` |
 | `tool_started` | Request、Turn、`toolAttemptId` | 工具标识、最终 `input`、解析后的 `sideEffect` |
 | `tool_completed` | Request、Turn、`toolAttemptId` | 工具标识、`result` |
@@ -93,7 +99,8 @@ interface DurableEventEnvelope<TType extends DurableEventType> {
 `request_accepted.recovery` 始终使用 v2 的
 `{ requestId, turnId, turn }` wire shape。首个 Turn 前的 Request rollover 会
 在同一 command 中写入一个 synthetic Turn 作为 provenance；projector 通过
-`recoveryKind: 'pre_turn_request'` 暴露该语义，而不修改持久化 schema。
+`recoveryKind: 'pre_turn_request'` 暴露该语义，而不扩展持久化的 recovery
+字段。
 
 ## 追加事件
 
@@ -317,18 +324,29 @@ Store 的写入方必须自行遵守同一契约。
 | `none` | 没有未完成工作 |
 | `resume_request` | Request 已接受且未开始，可恢复同一 Request |
 | `rollover_request` | Request 已开始但首个 Turn 尚未开始，可安全转成新 Request |
-| `resume_turn` | 模型调用、尚未开始的工具或可安全重放的 started tool 可以继续 |
+| `resume_turn` | Turn 尚未调用模型，或模型结果已知且工具可安全继续 |
 | `resolve_permissions` | 必须重新呈现或按策略处理未决权限 |
 | `reconcile_tool_outcomes` | 工具已开始但没有可靠终态，禁止自动重试 |
+| `reconcile_model_outcome` | 模型请求已开始但没有可靠终态，必须先向 provider 或业务记录对账 |
 | `reconcile_request_inputs` | 首个 Turn 前的已应用输入集合不明确，必须显式对账 |
 | `reconcile_request_outcome` | Turn 已结束但 Request 没有终态，必须先确认最终结果 |
 
-Recovery plan 还分别返回 `retryableToolAttempts`、`cancelableToolAttempts`、
-`unknownToolAttempts` 和 `pendingPermissions`。started 或
+Recovery plan 还返回 `activeModelAttempt`，并分别返回
+`retryableToolAttempts`、`cancelableToolAttempts`、`unknownToolAttempts` 和
+`pendingPermissions`。started 或
 `tool_outcome_unknown` 状态的 `pure` / `idempotent` 工具进入 retryable 集合；
 `non_idempotent` 工具进入 unknown 集合，必须在外部对账后由
 `tool_completed`、`tool_failed` 或 `tool_cancelled` 解析。在此之前投影器不会
 允许 Turn 结束。
+
+模型调用使用独立的 `ModelAttemptId`。Session 在调用 provider 前提交
+`model_request_started`，并在调用返回后提交 `model_request_completed`、
+`model_request_failed` 或 `model_request_aborted`。活动 model attempt 会阻止
+Turn 结束；进程崩溃留下 started attempt 时，plan 返回
+`reconcile_model_outcome`，不会把可能已经计费或完成的调用当作从未发生。
+一次 model attempt 表示包含内部 HTTP 重试的一次逻辑模型调用；反应式压缩后的
+重新调用会创建新的 attempt。高频 token delta 仍是临时流，完整响应在任何后续
+Turn 终态前持久化。
 
 ## Recovery Coordinator
 
@@ -355,6 +373,35 @@ await coordinator.reconcileToolOutcome({
   },
 });
 ```
+
+对结果未知的模型调用，必须查询 provider request 日志或上层业务记录后显式
+对账。命令同时绑定 Request、Turn 和 Model Attempt，且通过 Journal CAS
+拒绝 stale decision：
+
+```ts
+await coordinator.reconcileModelOutcome({
+  commandId: CommandId('reconcile-model-42'),
+  requestId: RequestId('request-42'),
+  turnId: TurnId('turn-42'),
+  modelAttemptId: ModelAttemptId('model-attempt-42'),
+  outcome: {
+    status: 'completed',
+    response: {
+      content: 'Inspected result',
+      usage: {
+        promptTokens: 120,
+        completionTokens: 30,
+        totalTokens: 150,
+      },
+    },
+  },
+});
+```
+
+也可以确认 `failed` 或 `aborted`。对账后的 Turn 才能进入
+`prepareTurnRecovery()`；continuation 会携带有界的已确认模型响应和所有工具
+结果，因此不会把未知 provider 调用静默重发。重试同一操作必须复用原
+`commandId`。
 
 `reconcileToolOutcome()` 只允许 projector 当前仍可解析的 Tool Attempt，并复用
 Journal 的 command 幂等和 CAS 语义。`completed`、`failed` 与 `cancelled`
@@ -508,8 +555,11 @@ provenance 还要求前置 synthetic `turn_started`。`requestId` 和 `turnId` �
 `DURABLE_RECOVERY_UNSAFE_ROLLOVER`，必须保持 fail-closed；该 API 不使用提示词
 绕过未知副作用。
 
-Schema v2 为 `tool_scheduled` 增加必填 `sideEffect`。v1 日志不会被静默推断，
-需要显式迁移后才能由当前 runtime 恢复。
+当前 writer 使用 schema v3，并为模型调用增加 `modelAttemptId` 及完整生命周期
+事件。Reader 可继续读取 schema v2 日志，并允许在同一 Session 后续追加 v3
+batch；schema 版本只能单调升级，不能在 v3 后降回 v2，且 v2 batch 不允许伪装
+包含 v3 模型事件。Schema v1 不会被静默推断，需要显式迁移后才能由当前 runtime
+恢复。
 
 ## JSONL 持久化
 
@@ -530,8 +580,8 @@ Schema v2 为 `tool_scheduled` 增加必填 `sideEffect`。v1 日志不会被静
 4. 调用文件 `fsync` 后才返回成功。
 
 事件文件使用 `0600` 权限，Session ID 经过 base64url 编码，不会成为文件路径。
-事件会保存原始请求输入、工具输入和模型侧工具结果；调用方必须将 Store 视为
-敏感数据存储，并自行配置加密、保留期限和访问控制。
+事件会保存原始请求输入、完整模型响应、工具输入和模型侧工具结果；调用方必须将
+Store 视为敏感数据存储，并自行配置加密、保留期限和访问控制。
 
 ## 一致性边界
 

--- a/docs/durable-events.md
+++ b/docs/durable-events.md
@@ -86,7 +86,7 @@ interface DurableEventEnvelope<TType extends DurableEventType> {
 | `model_request_completed` | Request、Turn、`modelAttemptId` | 完整模型 `response` |
 | `model_request_failed` | Request、Turn、`modelAttemptId` | `error` |
 | `model_request_aborted` | Request、Turn、`modelAttemptId` | `reason` |
-| `tool_scheduled` | Request、Turn、`toolAttemptId` | `toolCallId`、`toolName`、`input`、`sideEffect`、`interruptBehavior` |
+| `tool_scheduled` | Request、Turn、`toolAttemptId` | `toolCallId`、`toolName`、`modelInput`、`input`、`sideEffect`、`interruptBehavior` |
 | `tool_started` | Request、Turn、`toolAttemptId` | 工具标识、最终 `input`、解析后的 `sideEffect` |
 | `tool_completed` | Request、Turn、`toolAttemptId` | 工具标识、`result` |
 | `tool_failed` | Request、Turn、`toolAttemptId` | 工具标识、`error` |
@@ -524,8 +524,8 @@ continuation 会把从未执行的工具标记为 `not_started`，把已开始�
 送入模型，因此不会构造跨 Store 的伪造 tool result，也不会留下 provider
 不接受的悬空 tool call。多模态原始输入仍以原始 content parts 传递，不会降级
 成 JSON 文本。权限恢复为 `allow` 但尚未执行的工具使用权限阶段更新后的输入，
-并按 `non_idempotent` 保守分类。每个工具的 input、result、error 和 permission
-最多保留 4,000 个序列化字符；超限值会携带
+并按 `non_idempotent` 保守分类。每个模型 response 及工具的 input、result、
+error 和 permission 最多保留 4,000 个序列化字符；超限值会携带
 `kind: "truncated_recovery_value"`、原始长度和 JSON 前后缀，模型不会把预览误认
 为完整结果。
 
@@ -558,10 +558,14 @@ provenance 还要求前置 synthetic `turn_started`。`requestId` 和 `turnId` �
 绕过未知副作用。
 
 当前 writer 使用 schema v3，并为模型调用增加 `modelAttemptId` 及完整生命周期
-事件。Reader 可继续读取 schema v2 日志，并允许在同一 Session 后续追加 v3
-batch；schema 版本只能单调升级，不能在 v3 后降回 v2，且 v2 batch 不允许伪装
-包含 v3 模型事件。Schema v1 不会被静默推断，需要显式迁移后才能由当前 runtime
-恢复。
+事件。v3 的 `tool_scheduled.modelInput` 保存 provider 原始参数，`input` 保存参数
+修复后的执行值；projector 要求工具属于当前 Model Attempt，并以 canonical JSON
+校验其 ID、名称和原始参数与已确认模型响应完全一致。即使流式工具在
+`model_request_completed` 前开始调度，模型终态到达时也会反向校验已调度工具。
+Reader 可继续读取没有这些字段的 schema v2 日志，并允许在同一 Session 后续追加
+v3 batch；schema 版本只能单调升级，不能在 v3 后降回 v2，且 v2 batch 不允许
+伪装包含 v3 模型事件。Schema v1 不会被静默推断，需要显式迁移后才能由当前
+runtime 恢复。
 
 ## JSONL 持久化
 

--- a/docs/durable-events.md
+++ b/docs/durable-events.md
@@ -347,6 +347,8 @@ Turn 结束；进程崩溃留下 started attempt 时，plan 返回
 一次 model attempt 表示包含内部 HTTP 重试的一次逻辑模型调用；反应式压缩后的
 重新调用会创建新的 attempt。高频 token delta 仍是临时流，完整响应在任何后续
 Turn 终态前持久化。
+活动 model attempt 的对账优先于同一 Turn 的权限和工具结果；模型终态提交后，
+plan 会继续暴露尚未消解的下一层恢复动作。
 
 ## Recovery Coordinator
 

--- a/docs/durable-events.md
+++ b/docs/durable-events.md
@@ -524,7 +524,9 @@ continuation 会把从未执行的工具标记为 `not_started`，把已开始�
 送入模型，因此不会构造跨 Store 的伪造 tool result，也不会留下 provider
 不接受的悬空 tool call。多模态原始输入仍以原始 content parts 传递，不会降级
 成 JSON 文本。权限恢复为 `allow` 但尚未执行的工具使用权限阶段更新后的输入，
-并按 `non_idempotent` 保守分类。continuation 最多保留最近 16 次 Model
+并按 `non_idempotent` 保守分类。来自 `failed` / `aborted` Model Attempt 的
+未完成工具标记为 `discarded_unconfirmed_model_response`，不得重试。continuation
+最多保留最近 16 次 Model
 Attempt；每个模型 response/error 及工具的 input、result、error 和 permission
 最多保留 4,000 个序列化字符；超限值会携带
 `kind: "truncated_recovery_value"`、原始长度和 JSON 前后缀，模型不会把预览误认

--- a/docs/durable-events.md
+++ b/docs/durable-events.md
@@ -86,7 +86,7 @@ interface DurableEventEnvelope<TType extends DurableEventType> {
 | `model_request_completed` | Request、Turn、`modelAttemptId` | 完整模型 `response` |
 | `model_request_failed` | Request、Turn、`modelAttemptId` | `error` |
 | `model_request_aborted` | Request、Turn、`modelAttemptId` | `reason` |
-| `tool_scheduled` | Request、Turn、`toolAttemptId` | `toolCallId`、`toolName`、`modelInput`、`input`、`sideEffect`、`interruptBehavior` |
+| `tool_scheduled` | Request、Turn、`modelAttemptId`、`toolAttemptId` | `toolCallId`、`toolName`、`modelInput`、`input`、`sideEffect`、`interruptBehavior` |
 | `tool_started` | Request、Turn、`toolAttemptId` | 工具标识、最终 `input`、解析后的 `sideEffect` |
 | `tool_completed` | Request、Turn、`toolAttemptId` | 工具标识、`result` |
 | `tool_failed` | Request、Turn、`toolAttemptId` | 工具标识、`error` |
@@ -524,8 +524,9 @@ continuation 会把从未执行的工具标记为 `not_started`，把已开始�
 送入模型，因此不会构造跨 Store 的伪造 tool result，也不会留下 provider
 不接受的悬空 tool call。多模态原始输入仍以原始 content parts 传递，不会降级
 成 JSON 文本。权限恢复为 `allow` 但尚未执行的工具使用权限阶段更新后的输入，
-并按 `non_idempotent` 保守分类。每个模型 response 及工具的 input、result、
-error 和 permission 最多保留 4,000 个序列化字符；超限值会携带
+并按 `non_idempotent` 保守分类。continuation 最多保留最近 16 次 Model
+Attempt；每个模型 response/error 及工具的 input、result、error 和 permission
+最多保留 4,000 个序列化字符；超限值会携带
 `kind: "truncated_recovery_value"`、原始长度和 JSON 前后缀，模型不会把预览误认
 为完整结果。
 
@@ -558,9 +559,10 @@ provenance 还要求前置 synthetic `turn_started`。`requestId` 和 `turnId` �
 绕过未知副作用。
 
 当前 writer 使用 schema v3，并为模型调用增加 `modelAttemptId` 及完整生命周期
-事件。v3 的 `tool_scheduled.modelInput` 保存 provider 原始参数，`input` 保存参数
-修复后的执行值；projector 要求工具属于当前 Model Attempt，并以 canonical JSON
-校验其 ID、名称和原始参数与已确认模型响应完全一致。即使流式工具在
+事件。v3 的 `tool_scheduled.modelAttemptId` 显式绑定产生该工具调用的 Model
+Attempt，`modelInput` 保存 provider 原始参数，`input` 保存参数修复后的执行值；
+projector 以 canonical JSON 校验工具 ID、名称和原始参数与已确认模型响应完全
+一致。即使流式工具在
 `model_request_completed` 前开始调度，模型终态到达时也会反向校验已调度工具。
 Reader 可继续读取没有这些字段的 schema v2 日志，并允许在同一 Session 后续追加
 v3 batch；schema 版本只能单调升级，不能在 v3 后降回 v2，且 v2 batch 不允许

--- a/docs/en/api-reference.md
+++ b/docs/en/api-reference.md
@@ -47,6 +47,7 @@ Constants:
 - `EventSequence`
 - `CommandId`
 - `TurnId`
+- `ModelAttemptId`
 - `ToolAttemptId`
 - `PermissionRequestId`
 - `AgentId`
@@ -101,12 +102,17 @@ Types and errors:
 - `DurableEventDraft`
 - `DurableEventDataMap`
 - `DurableEventError`
+- `DurableEventSchemaVersion`
 - `DurableEventOfType`
+- `DurableModelResponse`
+- `DurableModelToolCall`
+- `DurableModelUsage`
 - `DurableTokenUsage`
 - `DurableInputPriority`
 - `DurablePermissionDecision`
 - `DurableRequestInterruptReason`
 - `DurableRequestRecoveryOrigin`
+- `DurableModelRequestAbortReason`
 - `DurableTurnAbortReason`
 - `DurableToolInterruptBehavior`
 - `DurableToolCancelReason`
@@ -126,6 +132,8 @@ Types and errors:
 - `DurableRequestRolloverResult`
 - `DurableRequestOutcomeReconciliation`
 - `DurableRequestOutcomeReconciliationCommand`
+- `DurableModelOutcomeReconciliation`
+- `DurableModelOutcomeReconciliationCommand`
 - `DurableRequestRecoveryKind`
 - `DurableTurnRecoveryCommand`
 - `DurableTurnRecoveryResult`
@@ -147,6 +155,8 @@ Types and errors:
 - `DurableRecoveryCommitResult`
 - `DurableToolAttemptProjection`
 - `DurableToolAttemptStatus`
+- `DurableModelAttemptProjection`
+- `DurableModelAttemptStatus`
 - `DurableTurnProjection`
 - `DurableTurnStatus`
 

--- a/docs/en/durable-events.md
+++ b/docs/en/durable-events.md
@@ -11,10 +11,10 @@ Session writes durable events only when
 format is unchanged. `resumeSession()` automatically restores a Request that
 was accepted but did not cross the `request_started` boundary. A started
 Request without a Turn, and an active Turn, must first be atomically rolled
-over through the Recovery Coordinator. Pending permissions, unknown tool
-outcomes, and Requests whose latest Turn finished without a Request terminal
-event still require explicit resolution. A `non_idempotent` tool is never
-replayed automatically.
+over through the Recovery Coordinator. Pending permissions, unknown tool or
+model outcomes, and Requests whose latest Turn finished without a Request
+terminal event still require explicit resolution. A `non_idempotent` tool or
+model call with an unknown outcome is never replayed automatically.
 :::
 
 ## Imports
@@ -34,6 +34,7 @@ import {
   EventSequence,
   InputId,
   JsonlDurableEventStore,
+  ModelAttemptId,
   PermissionRequestId,
   RequestId,
   SessionId,
@@ -46,7 +47,7 @@ import {
 
 ```ts
 interface DurableEventEnvelope<TType extends DurableEventType> {
-  schemaVersion: 2;
+  schemaVersion: 2 | 3;
   eventId: EventId;
   sequence: EventSequence;
   sessionId: SessionId;
@@ -57,6 +58,7 @@ interface DurableEventEnvelope<TType extends DurableEventType> {
   commandId?: CommandId;
   requestId?: RequestId;
   turnId?: TurnId;
+  modelAttemptId?: ModelAttemptId;
   toolAttemptId?: ToolAttemptId;
   causationEventId?: EventId;
 }
@@ -85,6 +87,10 @@ are rejected before append.
 | `turn_started` | `requestId`, `turnId` | `turn`, `model?` |
 | `turn_completed` | `requestId`, `turnId` | `turn`, `hasToolCalls` |
 | `turn_aborted` | `requestId`, `turnId` | `turn`, `reason` |
+| `model_request_started` | Request, Turn, `modelAttemptId` | `model`, `streaming` |
+| `model_request_completed` | Request, Turn, `modelAttemptId` | Complete model `response` |
+| `model_request_failed` | Request, Turn, `modelAttemptId` | `error` |
+| `model_request_aborted` | Request, Turn, `modelAttemptId` | `reason` |
 | `tool_scheduled` | Request, Turn, `toolAttemptId` | `toolCallId`, `toolName`, `input`, `sideEffect`, `interruptBehavior` |
 | `tool_started` | Request, Turn, `toolAttemptId` | Tool identity, final `input`, resolved `sideEffect` |
 | `tool_completed` | Request, Turn, `toolAttemptId` | Tool identity, `result` |
@@ -98,8 +104,8 @@ are rejected before append.
 `request_accepted.recovery` always retains the v2
 `{ requestId, turnId, turn }` wire shape. A pre-Turn Request rollover writes a
 synthetic Turn in the same command to provide provenance. The projector exposes
-that meaning as `recoveryKind: 'pre_turn_request'` without changing the
-persistent schema.
+that meaning as `recoveryKind: 'pre_turn_request'` without adding fields to the
+persistent recovery object.
 
 ## Append events
 
@@ -335,18 +341,32 @@ Store directly must preserve the same contract themselves.
 | `none` | No unfinished work exists. |
 | `resume_request` | A Request was accepted but not started and can resume in place. |
 | `rollover_request` | A Request started before its first Turn and can safely roll into a new Request. |
-| `resume_turn` | A model call, scheduled tool, or safely replayable started tool can continue. |
+| `resume_turn` | The Turn has not called the model, or its model outcome is known and tools can continue safely. |
 | `resolve_permissions` | Pending permissions must be presented again or resolved by policy. |
 | `reconcile_tool_outcomes` | A tool started without a reliable terminal outcome and must not be retried automatically. |
+| `reconcile_model_outcome` | A model request started without a reliable terminal outcome and must be reconciled against provider or application records. |
 | `reconcile_request_inputs` | The applied-input set before the first Turn is ambiguous and requires explicit reconciliation. |
 | `reconcile_request_outcome` | A Turn ended without a Request terminal event, so the final outcome must be reconciled. |
 
-The plan also separates `retryableToolAttempts`, `cancelableToolAttempts`,
-`unknownToolAttempts`, and `pendingPermissions`. Started or
+The plan also exposes `activeModelAttempt` and separates
+`retryableToolAttempts`, `cancelableToolAttempts`, `unknownToolAttempts`, and
+`pendingPermissions`. Started or
 `tool_outcome_unknown` tools declared `pure` or `idempotent` are retryable.
 `non_idempotent` tools remain unknown and require external reconciliation with
 `tool_completed`, `tool_failed`, or `tool_cancelled`; the projector does not
 allow the Turn to end before then.
+
+Model calls use independent `ModelAttemptId` values. Session commits
+`model_request_started` before calling the provider, then commits
+`model_request_completed`, `model_request_failed`, or
+`model_request_aborted` after the call settles. An active model attempt blocks
+Turn termination. If a process stops with a started attempt, the plan returns
+`reconcile_model_outcome` instead of treating a possibly completed or billed
+call as if it never happened.
+A model attempt is one logical model operation and may contain internal HTTP
+retries. A reactive-compaction retry creates a new attempt. High-frequency
+token deltas remain transient, while the complete response is durable before
+any later Turn terminal event.
 
 ## Recovery Coordinator
 
@@ -373,6 +393,37 @@ await coordinator.reconcileToolOutcome({
   },
 });
 ```
+
+For a model call with an unknown outcome, inspect provider request logs or
+application records and reconcile it explicitly. The command binds the
+Request, Turn, and Model Attempt and uses Journal CAS to reject stale
+decisions:
+
+```ts
+await coordinator.reconcileModelOutcome({
+  commandId: CommandId('reconcile-model-42'),
+  requestId: RequestId('request-42'),
+  turnId: TurnId('turn-42'),
+  modelAttemptId: ModelAttemptId('model-attempt-42'),
+  outcome: {
+    status: 'completed',
+    response: {
+      content: 'Inspected result',
+      usage: {
+        promptTokens: 120,
+        completionTokens: 30,
+        totalTokens: 150,
+      },
+    },
+  },
+});
+```
+
+The caller may instead confirm `failed` or `aborted`. Only a reconciled Turn
+can proceed to `prepareTurnRecovery()`. Its continuation carries bounded,
+confirmed model responses together with tool outcomes, so an unknown provider
+call is never silently reissued. Reuse the original `commandId` when retrying
+the reconciliation.
 
 `reconcileToolOutcome()` accepts only a Tool Attempt still addressable by the
 current projection and inherits the Journal's command idempotency and CAS
@@ -543,9 +594,12 @@ execution started raises
 `DURABLE_RECOVERY_UNSAFE_ROLLOVER` and remains fail-closed; the API does not use
 prompting to bypass an unknown side effect.
 
-Schema v2 adds the required `sideEffect` field to `tool_scheduled`. Version 1
-logs are not inferred silently and must be migrated before this runtime can
-resume them.
+The current writer uses schema v3, which adds `modelAttemptId` and the complete
+model-request lifecycle. Readers remain compatible with schema-v2 logs and may
+append later v3 batches to the same Session. Schema versions may only increase:
+a v2 batch after v3 is corrupt, and a v2 batch cannot masquerade as containing
+v3 model events. Version 1 logs are not inferred silently and must be migrated
+before this runtime can resume them.
 
 ## JSONL persistence
 
@@ -568,9 +622,9 @@ Each append:
 
 Event files use mode `0600`. Session IDs are base64url encoded and cannot
 become filesystem paths.
-Events contain raw request inputs, tool inputs, and model-facing tool results.
-Treat the Store as sensitive data and configure encryption, retention, and
-access control at the deployment boundary.
+Events contain raw request inputs, complete model responses, tool inputs, and
+model-facing tool results. Treat the Store as sensitive data and configure
+encryption, retention, and access control at the deployment boundary.
 
 ## Consistency boundary
 

--- a/docs/en/durable-events.md
+++ b/docs/en/durable-events.md
@@ -91,7 +91,7 @@ are rejected before append.
 | `model_request_completed` | Request, Turn, `modelAttemptId` | Complete model `response` |
 | `model_request_failed` | Request, Turn, `modelAttemptId` | `error` |
 | `model_request_aborted` | Request, Turn, `modelAttemptId` | `reason` |
-| `tool_scheduled` | Request, Turn, `toolAttemptId` | `toolCallId`, `toolName`, `modelInput`, `input`, `sideEffect`, `interruptBehavior` |
+| `tool_scheduled` | Request, Turn, `modelAttemptId`, `toolAttemptId` | `toolCallId`, `toolName`, `modelInput`, `input`, `sideEffect`, `interruptBehavior` |
 | `tool_started` | Request, Turn, `toolAttemptId` | Tool identity, final `input`, resolved `sideEffect` |
 | `tool_completed` | Request, Turn, `toolAttemptId` | Tool identity, `result` |
 | `tool_failed` | Request, Turn, `toolAttemptId` | Tool identity, `error` |
@@ -562,8 +562,9 @@ durable recovery facts instead, avoiding both cross-store synthetic results
 and provider-invalid dangling tool calls. Multimodal original inputs retain
 their content parts instead of being flattened into JSON text. A permitted but
 not-yet-started tool uses the permission-updated input and is conservatively
-classified as `non_idempotent`. Each model response and tool input, result,
-error, and permission value is limited to 4,000 serialized characters. Oversized values carry
+classified as `non_idempotent`. A continuation retains at most the latest 16
+Model Attempts. Each model response/error and tool input, result, error, and
+permission value is limited to 4,000 serialized characters. Oversized values carry
 `kind: "truncated_recovery_value"`, the original size, and JSON prefix/suffix
 metadata so the model cannot mistake the preview for a complete result.
 
@@ -598,11 +599,11 @@ execution started raises
 prompting to bypass an unknown side effect.
 
 The current writer uses schema v3, which adds `modelAttemptId` and the complete
-model-request lifecycle. In v3, `tool_scheduled.modelInput` preserves the
-provider's original arguments while `input` holds repaired execution input.
-The projector requires each tool to belong to the current Model Attempt and
-uses canonical JSON to match its ID, name, and original arguments to the
-confirmed model response. If streaming dispatches a tool before
+model-request lifecycle. In v3, `tool_scheduled.modelAttemptId` explicitly
+identifies the Model Attempt that produced the call, `modelInput` preserves the
+provider's original arguments, and `input` holds repaired execution input. The
+projector uses canonical JSON to match the tool ID, name, and original
+arguments to the confirmed model response. If streaming dispatches a tool before
 `model_request_completed`, the terminal model event validates all previously
 scheduled tools when it arrives. Readers remain compatible with schema-v2 logs
 that lack these fields and may append later v3 batches to the same Session. Schema

--- a/docs/en/durable-events.md
+++ b/docs/en/durable-events.md
@@ -91,7 +91,7 @@ are rejected before append.
 | `model_request_completed` | Request, Turn, `modelAttemptId` | Complete model `response` |
 | `model_request_failed` | Request, Turn, `modelAttemptId` | `error` |
 | `model_request_aborted` | Request, Turn, `modelAttemptId` | `reason` |
-| `tool_scheduled` | Request, Turn, `toolAttemptId` | `toolCallId`, `toolName`, `input`, `sideEffect`, `interruptBehavior` |
+| `tool_scheduled` | Request, Turn, `toolAttemptId` | `toolCallId`, `toolName`, `modelInput`, `input`, `sideEffect`, `interruptBehavior` |
 | `tool_started` | Request, Turn, `toolAttemptId` | Tool identity, final `input`, resolved `sideEffect` |
 | `tool_completed` | Request, Turn, `toolAttemptId` | Tool identity, `result` |
 | `tool_failed` | Request, Turn, `toolAttemptId` | Tool identity, `error` |
@@ -562,8 +562,8 @@ durable recovery facts instead, avoiding both cross-store synthetic results
 and provider-invalid dangling tool calls. Multimodal original inputs retain
 their content parts instead of being flattened into JSON text. A permitted but
 not-yet-started tool uses the permission-updated input and is conservatively
-classified as `non_idempotent`. Each tool input, result, error, and permission
-value is limited to 4,000 serialized characters. Oversized values carry
+classified as `non_idempotent`. Each model response and tool input, result,
+error, and permission value is limited to 4,000 serialized characters. Oversized values carry
 `kind: "truncated_recovery_value"`, the original size, and JSON prefix/suffix
 metadata so the model cannot mistake the preview for a complete result.
 
@@ -598,11 +598,17 @@ execution started raises
 prompting to bypass an unknown side effect.
 
 The current writer uses schema v3, which adds `modelAttemptId` and the complete
-model-request lifecycle. Readers remain compatible with schema-v2 logs and may
-append later v3 batches to the same Session. Schema versions may only increase:
-a v2 batch after v3 is corrupt, and a v2 batch cannot masquerade as containing
-v3 model events. Version 1 logs are not inferred silently and must be migrated
-before this runtime can resume them.
+model-request lifecycle. In v3, `tool_scheduled.modelInput` preserves the
+provider's original arguments while `input` holds repaired execution input.
+The projector requires each tool to belong to the current Model Attempt and
+uses canonical JSON to match its ID, name, and original arguments to the
+confirmed model response. If streaming dispatches a tool before
+`model_request_completed`, the terminal model event validates all previously
+scheduled tools when it arrives. Readers remain compatible with schema-v2 logs
+that lack these fields and may append later v3 batches to the same Session. Schema
+versions may only increase: a v2 batch after v3 is corrupt, and a v2 batch
+cannot masquerade as containing v3 model events. Version 1 logs are not
+inferred silently and must be migrated before this runtime can resume them.
 
 ## JSONL persistence
 

--- a/docs/en/durable-events.md
+++ b/docs/en/durable-events.md
@@ -367,6 +367,9 @@ A model attempt is one logical model operation and may contain internal HTTP
 retries. A reactive-compaction retry creates a new attempt. High-frequency
 token deltas remain transient, while the complete response is durable before
 any later Turn terminal event.
+Active model reconciliation takes precedence over permission and tool outcomes
+in the same Turn. After the model terminal event commits, the plan exposes the
+next unresolved recovery action.
 
 ## Recovery Coordinator
 

--- a/docs/en/durable-events.md
+++ b/docs/en/durable-events.md
@@ -562,7 +562,9 @@ durable recovery facts instead, avoiding both cross-store synthetic results
 and provider-invalid dangling tool calls. Multimodal original inputs retain
 their content parts instead of being flattened into JSON text. A permitted but
 not-yet-started tool uses the permission-updated input and is conservatively
-classified as `non_idempotent`. A continuation retains at most the latest 16
+classified as `non_idempotent`. Unfinished tools from a `failed` or `aborted`
+Model Attempt are marked `discarded_unconfirmed_model_response` and must not be
+retried. A continuation retains at most the latest 16
 Model Attempts. Each model response/error and tool input, result, error, and
 permission value is limited to 4,000 serialized characters. Oversized values carry
 `kind: "truncated_recovery_value"`, the original size, and JSON prefix/suffix

--- a/docs/en/session.md
+++ b/docs/en/session.md
@@ -268,9 +268,12 @@ Permission, and input-application events with these ordering guarantees:
 - `model_request_started` commits before the provider call. The call then
   settles as `model_request_completed`, `model_request_failed`, or
   `model_request_aborted`.
-- `tool_scheduled` stores both the provider's original `modelInput` and the
-  repaired execution `input`; the schema-v3 projector binds tool ID, name, and
-  original arguments to the corresponding model response.
+- `tool_scheduled` uses `modelAttemptId` to bind the call to its producing
+  model request and stores both the provider's original `modelInput` and the
+  repaired execution `input`. The schema-v3 projector verifies tool ID, name,
+  and original arguments. If streaming schedules a tool early, the complete
+  model response is persisted and validates those schedules before tool
+  settlement is awaited.
 - `tool_started` commits before the tool side effect can run.
 - A standalone Request terminal event links to the latest persisted Request
   boundary through `causationEventId`.

--- a/docs/en/session.md
+++ b/docs/en/session.md
@@ -259,12 +259,15 @@ const session = await createSession({
 });
 ```
 
-When enabled, Session records Session, Request, Turn, Tool, Permission, and
-input-application events with these ordering guarantees:
+When enabled, Session records Session, Request, Turn, Model Attempt, Tool,
+Permission, and input-application events with these ordering guarantees:
 
 - `request_accepted` commits before `send()` returns.
 - A steering input's `input_applied` commits before its hooks and attachment preparation.
 - Turn and tool scheduling events commit before `turn_start` or `tool_use` is published.
+- `model_request_started` commits before the provider call. The call then
+  settles as `model_request_completed`, `model_request_failed`, or
+  `model_request_aborted`.
 - `tool_started` commits before the tool side effect can run.
 - A standalone Request terminal event links to the latest persisted Request
   boundary through `causationEventId`.
@@ -289,8 +292,11 @@ but has no `request_started` event. It preserves the `requestId`, input,
 calling `stream()` directly. Legacy durable Requests without a complete
 execution snapshot are not resumed automatically.
 
-A started Request, active Turn, pending permission, or unknown tool outcome is
-never replayed speculatively and raises `DurableSessionRecoveryRequiredError`.
+A started Request, active Turn, pending permission, unknown model outcome, or
+unknown tool outcome is never replayed speculatively and raises
+`DurableSessionRecoveryRequiredError`. An active `model_request_started`
+produces `reconcile_model_outcome`; inspect provider or application records and
+commit the confirmed result through `reconcileModelOutcome()` before rollover.
 When input preparation is ambiguous before the first or a subsequent Turn, call
 `prepareRequestRecovery()` with the reconciled final input, exact
 `appliedInputIds`, and observed `sourceLastTurn` to atomically roll the old

--- a/docs/en/session.md
+++ b/docs/en/session.md
@@ -268,6 +268,9 @@ Permission, and input-application events with these ordering guarantees:
 - `model_request_started` commits before the provider call. The call then
   settles as `model_request_completed`, `model_request_failed`, or
   `model_request_aborted`.
+- `tool_scheduled` stores both the provider's original `modelInput` and the
+  repaired execution `input`; the schema-v3 projector binds tool ID, name, and
+  original arguments to the corresponding model response.
 - `tool_started` commits before the tool side effect can run.
 - A standalone Request terminal event links to the latest persisted Request
   boundary through `causationEventId`.

--- a/docs/en/tools.md
+++ b/docs/en/tools.md
@@ -284,6 +284,8 @@ interface ToolExecutionLifecycle {
 interface ToolScheduledLifecycle {
   toolCallId: ToolUseId;
   toolName: string;
+  modelAttemptId?: ModelAttemptId;
+  modelInput: JsonObject; // Original provider arguments.
   input: JsonObject;
   sideEffect: ToolSideEffect;
   interruptBehavior: 'block' | 'cancel';

--- a/docs/session.md
+++ b/docs/session.md
@@ -666,8 +666,10 @@ Permission 和输入应用事件，并保证：
 - `model_request_started` 在调用 provider 前提交；模型调用返回后会提交
   `model_request_completed`、`model_request_failed` 或
   `model_request_aborted`。
-- `tool_scheduled` 同时保存 provider 原始 `modelInput` 与参数修复后的执行
-  `input`；schema v3 projector 会把工具 ID、名称和原始参数绑定到对应模型响应。
+- `tool_scheduled` 通过 `modelAttemptId` 绑定产生它的模型调用，并同时保存
+  provider 原始 `modelInput` 与参数修复后的执行 `input`；schema v3 projector
+  会校验工具 ID、名称和原始参数。流式工具提前调度时，完整模型响应一旦收敛就会
+  在等待工具终态前持久化并反向校验。
 - 工具副作用开始前已提交 `tool_started`。
 - 独立写入的 Request 终态通过 `causationEventId` 绑定最后一次持久化的
   Request 边界。

--- a/docs/session.md
+++ b/docs/session.md
@@ -657,12 +657,15 @@ const session = await createSession({
 });
 ```
 
-启用后，Session 会记录 Session、Request、Turn、Tool、Permission 和输入应用
-事件，并保证：
+启用后，Session 会记录 Session、Request、Turn、Model Attempt、Tool、
+Permission 和输入应用事件，并保证：
 
 - `send()` 返回前已提交 `request_accepted`。
 - steering 输入的 `input_applied` 在其 Hook 和附件准备前提交。
 - `turn_start` 和 `tool_use` 对外可见前已提交对应 durable 事件。
+- `model_request_started` 在调用 provider 前提交；模型调用返回后会提交
+  `model_request_completed`、`model_request_failed` 或
+  `model_request_aborted`。
 - 工具副作用开始前已提交 `tool_started`。
 - 独立写入的 Request 终态通过 `causationEventId` 绑定最后一次持久化的
   Request 边界。
@@ -685,9 +688,11 @@ Request，并保留其 `requestId`、输入、`maxTurns` 和 Runtime Context。�
 直接调用 `stream()` 继续这个 pending Request；执行时也会恢复接受请求时的
 模型。缺少完整执行快照的旧 durable Request 不会自动恢复。
 
-已经开始的 Request、活动 Turn、待决权限或未知工具结果不会被推测性重放，而是
-抛出 `DurableSessionRecoveryRequiredError`。首个或后续 Turn 尚未开始但输入
-准备状态不明确时，调用
+已经开始的 Request、活动 Turn、待决权限、未知模型结果或未知工具结果不会被
+推测性重放，而是抛出 `DurableSessionRecoveryRequiredError`。活动
+`model_request_started` 会返回 `reconcile_model_outcome`；调用方必须查询
+provider 或业务记录，并通过 `reconcileModelOutcome()` 提交已确认结果，之后
+才能 rollover。首个或后续 Turn 尚未开始但输入准备状态不明确时，调用
 `prepareRequestRecovery()` 并提供已对账的最终输入与精确
 `appliedInputIds`，把旧 Request 原子 rollover 为新 Request；缺失或额外输入会
 先分类为 `reconcile_request_inputs`。恢复执行会跳过已完成的初始 Hook、附件

--- a/docs/session.md
+++ b/docs/session.md
@@ -666,6 +666,8 @@ Permission 和输入应用事件，并保证：
 - `model_request_started` 在调用 provider 前提交；模型调用返回后会提交
   `model_request_completed`、`model_request_failed` 或
   `model_request_aborted`。
+- `tool_scheduled` 同时保存 provider 原始 `modelInput` 与参数修复后的执行
+  `input`；schema v3 projector 会把工具 ID、名称和原始参数绑定到对应模型响应。
 - 工具副作用开始前已提交 `tool_started`。
 - 独立写入的 Request 终态通过 `causationEventId` 绑定最后一次持久化的
   Request 边界。

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -349,6 +349,8 @@ interface ToolExecutionLifecycle {
 interface ToolScheduledLifecycle {
   toolCallId: ToolUseId;
   toolName: string;
+  modelAttemptId?: ModelAttemptId;
+  modelInput: JsonObject; // provider 原始参数
   input: JsonObject;
   sideEffect: ToolSideEffect;
   interruptBehavior: 'block' | 'cancel';

--- a/src/__tests__/rootExports.test.ts
+++ b/src/__tests__/rootExports.test.ts
@@ -9,6 +9,8 @@ import type {
   DurableEventStore,
   DurableEventSubscriptionMessage,
   DurableEventSubscriptionOptions,
+  DurableModelAttemptProjection,
+  DurableModelOutcomeReconciliationCommand,
   DurableRequestRecoveryOrigin,
   DurableRequestRecoveryKind,
   DurableRequestOutcomeReconciliationCommand,
@@ -70,6 +72,7 @@ import {
   InputPriority,
   JsonlDurableEventStore,
   MemoryManager,
+  ModelAttemptId,
   PermissionRequestId,
   projectDurableSession,
   RequestId,
@@ -101,9 +104,10 @@ describe('root exports', () => {
     expect(new SessionInputError('TEST', 'message')).toBeInstanceOf(Error);
     expect(ToolErrorType.INTERRUPTED).toBe('interrupted');
     expect(ToolSideEffect.NON_IDEMPOTENT).toBe('non_idempotent');
-    expect(DURABLE_EVENT_SCHEMA_VERSION).toBe(2);
+    expect(DURABLE_EVENT_SCHEMA_VERSION).toBe(3);
     expect(DURABLE_EVENT_CURSOR_VERSION).toBe(1);
     expect(DurableEventType.REQUEST_ACCEPTED).toBe('request_accepted');
+    expect(DurableEventType.MODEL_REQUEST_STARTED).toBe('model_request_started');
     expect(DurableEventSubscription.open).toBeTypeOf('function');
     expect(DurableEventSubscriptionError).toBeDefined();
     expect(durableEventCursor).toBeTypeOf('function');
@@ -111,6 +115,7 @@ describe('root exports', () => {
     expect(CommandId('command-1')).toBe('command-1');
     expect(EventId('event-1')).toBe('event-1');
     expect(EventSequence(1)).toBe(1);
+    expect(ModelAttemptId('model-attempt-1')).toBe('model-attempt-1');
     expect(ToolAttemptId('attempt-1')).toBe('attempt-1');
     expect(TurnId('turn-1')).toBe('turn-1');
     expect(PermissionRequestId('permission-1')).toBe('permission-1');
@@ -168,6 +173,7 @@ describe('root exports', () => {
       | 'resume_turn'
       | 'resolve_permissions'
       | 'reconcile_tool_outcomes'
+      | 'reconcile_model_outcome'
       | 'reconcile_request_inputs'
       | 'reconcile_request_outcome'
     >();
@@ -177,6 +183,12 @@ describe('root exports', () => {
     expectTypeOf<DurableAcceptedRequestRecovery['model']>().toEqualTypeOf<string>();
     expectTypeOf<DurableRequestRecoveryOrigin['turnId']>().toEqualTypeOf<TurnId>();
     expectTypeOf<DurableRequestRecoveryKind>().toEqualTypeOf<'turn' | 'pre_turn_request'>();
+    expectTypeOf<DurableModelAttemptProjection['modelAttemptId']>().toEqualTypeOf<
+      ReturnType<typeof ModelAttemptId>
+    >();
+    expectTypeOf<
+      DurableModelOutcomeReconciliationCommand['modelAttemptId']
+    >().toEqualTypeOf<ReturnType<typeof ModelAttemptId>>();
     expectTypeOf<DurableRequestRolloverCommand['inputId']>().toEqualTypeOf<InputId>();
     expectTypeOf<DurableRequestRolloverCommand['sourceLastTurn']>().toEqualTypeOf<number>();
     expectTypeOf<DurableRequestRolloverCommand['recoveryTurnId']>().toEqualTypeOf<TurnId>();

--- a/src/agent/Agent.ts
+++ b/src/agent/Agent.ts
@@ -456,20 +456,12 @@ export class Agent {
     const { enhancedMessage, context, loopOptions } = prepared;
 
     if (context.permissionMode === 'plan') {
-      const planStream = this.planExecutor.runPlanLoopStream(
-        enhancedMessage, context, loopOptions,
+      const planResult = yield* this.planExecutor.runPlanLoopStream(
+        enhancedMessage,
+        context,
+        loopOptions,
         (msg, ctx, opts, sp) => this.loopRunner.executeWithAgentLoop(msg, ctx, opts, sp),
       );
-
-      let planResult: LoopResult | undefined;
-      while (true) {
-        const { value, done } = await planStream.next();
-        if (done) {
-          planResult = value;
-          break;
-        }
-        yield value;
-      }
 
       if (isPlanApprovalResult(planResult)) {
         const targetMode = planResult.metadata.targetMode;
@@ -479,9 +471,6 @@ export class Agent {
         return yield* this.loopRunner.runLoopStream(messageWithPlan, newContext, loopOptions);
       }
 
-      if (!planResult) {
-        throw new Error('Plan stream completed without result');
-      }
       return planResult;
     }
 

--- a/src/agent/AgentLoop.ts
+++ b/src/agent/AgentLoop.ts
@@ -25,6 +25,7 @@ import {
   RECONCILED_INITIAL_INPUT,
 } from './InitialInputPreparation.js';
 import { isOverflowRecoverable } from './isOverflowRecoverable.js';
+import type { ModelExecutionLifecycle } from './ModelExecutionLifecycle.js';
 import { decideNoToolTurn } from './loop/decideNoToolTurn.js';
 import { decideTurnLimit } from './loop/decideTurnLimit.js';
 import { executeToolCalls } from './loop/executeToolCalls.js';
@@ -128,6 +129,7 @@ export interface AgentLoopConfig {
   signal?: AbortSignal;
   tokenBudget?: TokenBudget;
   runControl?: AgentRunControl;
+  modelExecutionLifecycle?: ModelExecutionLifecycle;
   initialInputPreparation?: InitialInputPreparation;
   prepareTurnState: (turn: number) => TurnState;
   hooks?: AgentLoopHooks;
@@ -153,6 +155,7 @@ export async function* agentLoop(
     signal,
     tokenBudget,
     runControl,
+    modelExecutionLifecycle,
     initialInputPreparation,
     hooks,
   } = config;
@@ -278,6 +281,7 @@ export async function* agentLoop(
         epoch,
         executionContext: turnExecutionContext,
         permissionMode: turnPermissionMode,
+        modelExecutionLifecycle,
         logger: config.logger,
         toolHooks: {
           onBeforeExec: toolHooks?.beforeExec,
@@ -286,14 +290,22 @@ export async function* agentLoop(
           onUpdate: toolHooks?.onUpdate,
         },
       });
-      while (true) {
-        const { value, done } = await turnGen.next();
-        if (done) {
-          turnResult = value.chatResponse;
-          streamingExecutionResults = value.streamingExecutionResults;
-          break;
+      let turnStreamCompleted = false;
+      try {
+        while (true) {
+          const { value, done } = await turnGen.next();
+          if (done) {
+            turnResult = value.chatResponse;
+            streamingExecutionResults = value.streamingExecutionResults;
+            turnStreamCompleted = true;
+            break;
+          }
+          yield value;
         }
-        yield value;
+      } finally {
+        if (!turnStreamCompleted) {
+          await turnGen.return(undefined as never);
+        }
       }
     } catch (llmError) {
       const interruptInputId = getSteeringInterruptInputId(stepSignal);

--- a/src/agent/AgentLoop.ts
+++ b/src/agent/AgentLoop.ts
@@ -223,16 +223,11 @@ export async function* agentLoop(
       && !(initialInputPreparation === RECONCILED_INITIAL_INPUT && turnsCount === 0)
       && turnHooks?.beforeTurn
     ) {
-      const beforeTurnStream = turnHooks.beforeTurn({
+      yield* turnHooks.beforeTurn({
         turn: turnsCount,
         messages: convState.toArray(),
         lastPromptTokens,
       });
-      while (true) {
-        const { value, done } = await beforeTurnStream.next();
-        if (done) break;
-        yield value;
-      }
     }
 
     if (recovery.phase !== 'retry_pending') {
@@ -270,7 +265,7 @@ export async function* agentLoop(
 
     const stepSignal = runControl?.stepSignal ?? signal;
     try {
-      const turnGen = runTurn({
+      const turnOutcome = yield* runTurn({
         turnState,
         messages: convState.toArray(),
         executionPipeline,
@@ -290,23 +285,8 @@ export async function* agentLoop(
           onUpdate: toolHooks?.onUpdate,
         },
       });
-      let turnStreamCompleted = false;
-      try {
-        while (true) {
-          const { value, done } = await turnGen.next();
-          if (done) {
-            turnResult = value.chatResponse;
-            streamingExecutionResults = value.streamingExecutionResults;
-            turnStreamCompleted = true;
-            break;
-          }
-          yield value;
-        }
-      } finally {
-        if (!turnStreamCompleted) {
-          await turnGen.return(undefined as never);
-        }
-      }
+      turnResult = turnOutcome.chatResponse;
+      streamingExecutionResults = turnOutcome.streamingExecutionResults;
     } catch (llmError) {
       const interruptInputId = getSteeringInterruptInputId(stepSignal);
       if (!signal?.aborted && interruptInputId && runControl) {
@@ -351,16 +331,9 @@ export async function* agentLoop(
           attempt,
         });
         yield { type: 'recovery', phase: 'started', reason: 'context_overflow' };
-        const compactStream = recoveryHooks.reactiveCompact({ messages: convState.toArray() });
-        let recovered = false;
-        while (true) {
-          const { value, done } = await compactStream.next();
-          if (done) {
-            recovered = value;
-            break;
-          }
-          yield value;
-        }
+        const recovered = yield* recoveryHooks.reactiveCompact({
+          messages: convState.toArray(),
+        });
         if (!recovered) {
           recoveryHooks.onStateChange?.({
             turn: turnsCount,

--- a/src/agent/AgentLoop.ts
+++ b/src/agent/AgentLoop.ts
@@ -12,6 +12,7 @@ import { FallbackTriggeredError } from '../services/RetryPolicy.js';
 import type { ExecutionPipeline } from '../tools/execution/ExecutionPipeline.js';
 import type { ToolEffect, ToolResult } from '../tools/types/index.js';
 import { getSteeringInterruptInputId } from '../types/abort.js';
+import type { ModelAttemptId } from '../types/branded.js';
 import type { JsonObject, PermissionMode } from '../types/common.js';
 import type { AgentEvent, TokenUsageInfo } from './AgentEvent.js';
 import type {
@@ -262,6 +263,7 @@ export async function* agentLoop(
       effects: ToolEffect[];
       toolUseUuid: string | null;
     }> | undefined;
+    let modelAttemptId: ModelAttemptId | undefined;
 
     const stepSignal = runControl?.stepSignal ?? signal;
     try {
@@ -287,6 +289,7 @@ export async function* agentLoop(
       });
       turnResult = turnOutcome.chatResponse;
       streamingExecutionResults = turnOutcome.streamingExecutionResults;
+      modelAttemptId = turnOutcome.modelAttemptId;
     } catch (llmError) {
       const interruptInputId = getSteeringInterruptInputId(stepSignal);
       if (!signal?.aborted && interruptInputId && runControl) {
@@ -595,7 +598,9 @@ export async function* agentLoop(
       executionResults = await executeToolCalls({
         plan: executionPlan,
         executionPipeline,
-        executionContext: turnExecutionContext,
+        executionContext: modelAttemptId
+          ? { ...turnExecutionContext, modelAttemptId }
+          : turnExecutionContext,
         logger: config.logger,
         permissionMode: turnPermissionMode,
         signal,

--- a/src/agent/LoopHookBuilder.ts
+++ b/src/agent/LoopHookBuilder.ts
@@ -381,6 +381,7 @@ export function buildLoopConfig(deps: LoopHookBuilderDeps): AgentLoopConfig {
     isYoloMode,
     signal: options?.signal,
     tokenBudget,
+    modelExecutionLifecycle: options?.modelExecutionLifecycle,
     initialInputPreparation: options?.initialInputPreparation,
     prepareTurnState: (turn) => loopState.buildTurnState(turn),
     hooks,

--- a/src/agent/LoopHookBuilder.ts
+++ b/src/agent/LoopHookBuilder.ts
@@ -137,13 +137,7 @@ export function buildLoopConfig(deps: LoopHookBuilderDeps): AgentLoopConfig {
         const compactionStream = compactionHandler.checkAndCompactInLoop(
           loopState.conversationState, runtimeCtx, ctx.turn, ctx.lastPromptTokens,
         );
-        let didCompact = false;
-        while (true) {
-          const { value, done } = await compactionStream.next();
-          if (done) { didCompact = value; break; }
-          yield value;
-        }
-        return didCompact;
+        return yield* compactionStream;
       },
 
       onTurnLimitReached: options?.onTurnLimitReached,
@@ -338,13 +332,7 @@ export function buildLoopConfig(deps: LoopHookBuilderDeps): AgentLoopConfig {
             };
             const compactStream = compactionHandler?.reactiveCompact(loopState.conversationState, runtimeCtx);
             if (!compactStream) return false;
-            let result = false;
-            while (true) {
-              const { value, done } = await compactStream.next();
-              if (done) { result = value; break; }
-              yield value;
-            }
-            return result;
+            return yield* compactStream;
           }
         : undefined,
     },

--- a/src/agent/LoopRunner.ts
+++ b/src/agent/LoopRunner.ts
@@ -232,21 +232,7 @@ export class LoopRunner {
 
     // 5. 运行 AgentLoop
     try {
-      const loop = agentLoop(loopConfig);
-      let result: LoopResult | undefined;
-
-      while (true) {
-        const { value, done } = await loop.next();
-        if (done) {
-          result = value;
-          break;
-        }
-        yield value;
-      }
-
-      if (!result) {
-        throw new Error('AgentLoop ended without result');
-      }
+      const result = yield* agentLoop(loopConfig);
 
       syncContextMessages(context, loopState.conversationState);
       return result;

--- a/src/agent/ModelExecutionLifecycle.ts
+++ b/src/agent/ModelExecutionLifecycle.ts
@@ -1,0 +1,17 @@
+import type { ChatResponse } from '../services/ChatServiceInterface.js';
+
+export type ModelRequestAbortReason = 'request_interrupted' | 'steering';
+
+export interface ModelRequestLifecycle {
+  onCompleted(response: ChatResponse): Promise<void>;
+  onFailed(error: unknown): Promise<void>;
+  onAborted(reason: ModelRequestAbortReason): Promise<void>;
+}
+
+export interface ModelExecutionLifecycle {
+  onModelRequestStarting(input: {
+    readonly turn: number;
+    readonly model: string;
+    readonly streaming: boolean;
+  }): Promise<ModelRequestLifecycle>;
+}

--- a/src/agent/ModelExecutionLifecycle.ts
+++ b/src/agent/ModelExecutionLifecycle.ts
@@ -1,8 +1,10 @@
 import type { ChatResponse } from '../services/ChatServiceInterface.js';
+import type { ModelAttemptId } from '../types/branded.js';
 
 export type ModelRequestAbortReason = 'request_interrupted' | 'steering';
 
 export interface ModelRequestLifecycle {
+  readonly modelAttemptId?: ModelAttemptId;
   onCompleted(response: ChatResponse): Promise<void>;
   onFailed(error: unknown): Promise<void>;
   onAborted(reason: ModelRequestAbortReason): Promise<void>;

--- a/src/agent/StreamingToolExecutor.ts
+++ b/src/agent/StreamingToolExecutor.ts
@@ -296,20 +296,27 @@ export class StreamingToolExecutor {
   }> {
     const stream = streamChatResponse(this.getChatService, messages, tools, signal, this.logger);
     let chatResponse: ChatResponse | undefined;
+    let streamCompleted = false;
+    try {
+      while (true) {
+        const { value, done } = await stream.next();
+        if (done) {
+          chatResponse = value;
+          streamCompleted = true;
+          break;
+        }
 
-    while (true) {
-      const { value, done } = await stream.next();
-      if (done) {
-        chatResponse = value;
-        break;
+        if (!this.isEpochActive(epoch)) break;
+
+        if (value.type === 'content_delta') {
+          await executionConfig.onContentDelta?.(value.delta);
+        } else {
+          await executionConfig.onThinkingDelta?.(value.delta);
+        }
       }
-
-      if (!this.isEpochActive(epoch)) break;
-
-      if (value.type === 'content_delta') {
-        await executionConfig.onContentDelta?.(value.delta);
-      } else {
-        await executionConfig.onThinkingDelta?.(value.delta);
+    } finally {
+      if (!streamCompleted) {
+        await stream.return(undefined as never);
       }
     }
 

--- a/src/agent/StreamingToolExecutor.ts
+++ b/src/agent/StreamingToolExecutor.ts
@@ -40,6 +40,7 @@ export interface StreamingToolExecutorConfig {
   hooks?: ToolExecutionHooks;
   onContentDelta?: (delta: string) => void | Promise<void>;
   onThinkingDelta?: (delta: string) => void | Promise<void>;
+  onModelResponse?: (response: ChatResponse) => void | Promise<void>;
   onStreamEnd?: () => void | Promise<void>;
   onToolExecutionUpdate?: (update: ToolExecutionUpdate) => void | Promise<void>;
   onToolReady?: (toolCall: FunctionToolCall) => void | Promise<void>;
@@ -167,7 +168,14 @@ export class StreamingToolExecutor {
         return this.collectWithFallback(messages, tools, signal, executionConfig, epoch);
       }
 
+      const chatResponse: ChatResponse = {
+        content: fullContent,
+        reasoningContent: fullReasoningContent || undefined,
+        toolCalls: this.buildFinalToolCalls(toolCallAccumulator),
+        usage: streamUsage,
+      };
       if (!signal?.aborted && this.isEpochActive(epoch)) {
+        await executionConfig.onModelResponse?.(chatResponse);
         await executionConfig.onStreamEnd?.();
       }
 
@@ -221,12 +229,7 @@ export class StreamingToolExecutor {
       }
 
       return {
-        chatResponse: {
-          content: fullContent,
-          reasoningContent: fullReasoningContent || undefined,
-          toolCalls: this.buildFinalToolCalls(toolCallAccumulator),
-          usage: streamUsage,
-        },
+        chatResponse,
         executionResults: executionResults.filter(
           (result): result is ToolExecutionOutcome => result !== undefined,
         ),
@@ -320,7 +323,8 @@ export class StreamingToolExecutor {
       }
     }
 
-    if (!signal?.aborted && this.isEpochActive(epoch)) {
+    if (chatResponse && !signal?.aborted && this.isEpochActive(epoch)) {
+      await executionConfig.onModelResponse?.(chatResponse);
       await executionConfig.onStreamEnd?.();
     }
 

--- a/src/agent/__tests__/AgentLoop.test.ts
+++ b/src/agent/__tests__/AgentLoop.test.ts
@@ -206,6 +206,192 @@ async function collectEvents(
 
 describe('agentLoop', () => {
   describe('basic flow', () => {
+    it('settles the durable model lifecycle around a successful provider call', async () => {
+      const onCompleted = vi.fn(async () => {});
+      const onFailed = vi.fn(async () => {});
+      const onAborted = vi.fn(async () => {});
+      const onModelRequestStarting = vi.fn(async () => ({
+        onCompleted,
+        onFailed,
+        onAborted,
+      }));
+      const config = baseConfig({
+        modelExecutionLifecycle: { onModelRequestStarting },
+      });
+
+      await collectEvents(agentLoop(config));
+
+      expect(onModelRequestStarting).toHaveBeenCalledWith({
+        turn: 1,
+        model: 'test-model',
+        streaming: false,
+      });
+      expect(onCompleted).toHaveBeenCalledWith(
+        expect.objectContaining({ content: 'Hello!' }),
+      );
+      expect(onFailed).not.toHaveBeenCalled();
+      expect(onAborted).not.toHaveBeenCalled();
+    });
+
+    it('does not call the provider when the model start boundary fails', async () => {
+      const boundaryError = new Error('model start persistence failed');
+      const chat = vi.fn(async () => ({
+        content: 'unexpected',
+        toolCalls: [],
+        usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+      }));
+      const chatService = {
+        chat,
+        getConfig: () => ({
+          model: 'test-model',
+          maxContextTokens: 128000,
+        }),
+      } as unknown as TurnState['chatService'];
+      const config = baseConfig({
+        turnState: { chatService },
+        modelExecutionLifecycle: {
+          onModelRequestStarting: vi.fn(async () => {
+            throw boundaryError;
+          }),
+        },
+      });
+
+      await expect(collectEvents(agentLoop(config))).rejects.toBe(boundaryError);
+      expect(chat).not.toHaveBeenCalled();
+    });
+
+    it('aborts the model lifecycle when the generator is closed mid-stream', async () => {
+      const controller = new AbortController();
+      const onCompleted = vi.fn(async () => {});
+      const onFailed = vi.fn(async () => {});
+      const onAborted = vi.fn(async () => {});
+      let providerStreamClosed = false;
+      const chatService = {
+        streamChat: vi.fn(async function* () {
+          try {
+            yield { content: 'partial' };
+          } finally {
+            providerStreamClosed = true;
+          }
+        }),
+        getConfig: () => ({
+          model: 'test-model',
+          maxContextTokens: 128000,
+        }),
+      } as unknown as TurnState['chatService'];
+      const loop = agentLoop(baseConfig({
+        streaming: true,
+        signal: controller.signal,
+        turnState: { chatService },
+        modelExecutionLifecycle: {
+          onModelRequestStarting: vi.fn(async () => ({
+            onCompleted,
+            onFailed,
+            onAborted,
+          })),
+        },
+      }));
+
+      await expect(loop.next()).resolves.toMatchObject({
+        value: { type: 'agent_start' },
+        done: false,
+      });
+      await expect(loop.next()).resolves.toMatchObject({
+        value: { type: 'turn_start' },
+        done: false,
+      });
+      await expect(loop.next()).resolves.toMatchObject({
+        value: { type: 'content_delta', delta: 'partial' },
+        done: false,
+      });
+      controller.abort();
+      await loop.return(undefined as never);
+
+      expect(onAborted).toHaveBeenCalledWith('request_interrupted');
+      expect(providerStreamClosed).toBe(true);
+      expect(onCompleted).not.toHaveBeenCalled();
+      expect(onFailed).not.toHaveBeenCalled();
+    });
+
+    it('records a known model failure before propagating it', async () => {
+      const modelError = new Error('provider unavailable');
+      const onCompleted = vi.fn(async () => {});
+      const onFailed = vi.fn(async () => {});
+      const onAborted = vi.fn(async () => {});
+      const onModelRequestStarting = vi.fn(async () => ({
+        onCompleted,
+        onFailed,
+        onAborted,
+      }));
+      const chatService = {
+        chat: vi.fn(async () => {
+          throw modelError;
+        }),
+        getConfig: () => ({
+          model: 'test-model',
+          maxContextTokens: 128000,
+        }),
+      } as unknown as TurnState['chatService'];
+      const config = baseConfig({
+        modelExecutionLifecycle: { onModelRequestStarting },
+        turnState: { chatService },
+      });
+
+      await expect(collectEvents(agentLoop(config))).rejects.toBe(modelError);
+
+      expect(onFailed).toHaveBeenCalledWith(modelError);
+      expect(onCompleted).not.toHaveBeenCalled();
+      expect(onAborted).not.toHaveBeenCalled();
+    });
+
+    it('does not execute tools when the model completion boundary fails', async () => {
+      const boundaryError = new Error('model response persistence failed');
+      const execute = vi.fn(async function* () {
+        yield* [] as never[];
+        return {
+          status: 'success',
+          model: 'unexpected',
+        } as ToolResult;
+      });
+      const executionPipeline = {
+        getRegistry: () => ({
+          get: (name: string) => ({ kind: 'execute', name }),
+        }),
+        execute,
+      } as unknown as AgentLoopConfig['executionPipeline'];
+      const chatService = createMockChatService([
+        {
+          content: '',
+          toolCalls: [
+            {
+              id: 'call-before-boundary',
+              type: 'function',
+              function: {
+                name: 'Write',
+                arguments: '{"path":"/tmp/file"}',
+              },
+            },
+          ],
+        },
+      ]);
+      const config = baseConfig({
+        executionPipeline,
+        turnState: { chatService },
+        modelExecutionLifecycle: {
+          onModelRequestStarting: vi.fn(async () => ({
+            onCompleted: vi.fn(async () => {
+              throw boundaryError;
+            }),
+            onFailed: vi.fn(async () => {}),
+            onAborted: vi.fn(async () => {}),
+          })),
+        },
+      });
+
+      await expect(collectEvents(agentLoop(config))).rejects.toBe(boundaryError);
+      expect(execute).not.toHaveBeenCalled();
+    });
+
     it('should complete with no tool calls', async () => {
       const config = baseConfig();
       const { events, result } = await collectEvents(agentLoop(config));
@@ -1263,9 +1449,22 @@ describe('agentLoop', () => {
         InputId('initial-input'),
       );
       const onAssistantMessage = vi.fn(async () => {});
+      const modelSettlements: string[] = [];
+      const onModelRequestStarting = vi.fn(async () => ({
+        onCompleted: async () => {
+          modelSettlements.push('completed');
+        },
+        onFailed: async () => {
+          modelSettlements.push('failed');
+        },
+        onAborted: async (reason: string) => {
+          modelSettlements.push(`aborted:${reason}`);
+        },
+      }));
       const config = baseConfig({
         runControl,
         turnState: { chatService },
+        modelExecutionLifecycle: { onModelRequestStarting },
         onAssistantMessage,
         onInputApply: async ({ input }) => ({
           role: 'user',
@@ -1311,6 +1510,8 @@ describe('agentLoop', () => {
           turn: 2,
         }),
       );
+      expect(onModelRequestStarting).toHaveBeenCalledTimes(2);
+      expect(modelSettlements).toEqual(['aborted:steering', 'completed']);
     });
 
     it('closes interrupted tool calls before applying now-priority input', async () => {

--- a/src/agent/__tests__/AgentLoop.test.ts
+++ b/src/agent/__tests__/AgentLoop.test.ts
@@ -313,6 +313,58 @@ describe('agentLoop', () => {
       expect(onFailed).not.toHaveBeenCalled();
     });
 
+    it('actively cancels a streaming-with-tools provider when the generator closes', async () => {
+      const onAborted = vi.fn(async () => {});
+      let providerStreamClosed = false;
+      const chatService = {
+        streamChat: vi.fn(async function* (
+          _messages: readonly Message[],
+          _tools: unknown,
+          signal?: AbortSignal,
+        ) {
+          try {
+            yield { content: 'partial' };
+            await new Promise<void>((_resolve, reject) => {
+              signal?.addEventListener('abort', () => reject(signal.reason), {
+                once: true,
+              });
+            });
+          } finally {
+            providerStreamClosed = true;
+          }
+        }),
+        getConfig: () => ({
+          model: 'test-model',
+          maxContextTokens: 128000,
+        }),
+      } as unknown as TurnState['chatService'];
+      const loop = agentLoop(baseConfig({
+        streaming: true,
+        turnState: {
+          chatService,
+          tools: [{ name: 'Read', description: 'read', parameters: {} }],
+        },
+        modelExecutionLifecycle: {
+          onModelRequestStarting: vi.fn(async () => ({
+            onCompleted: vi.fn(async () => {}),
+            onFailed: vi.fn(async () => {}),
+            onAborted,
+          })),
+        },
+      }));
+
+      await loop.next();
+      await loop.next();
+      await expect(loop.next()).resolves.toMatchObject({
+        value: { type: 'content_delta', delta: 'partial' },
+        done: false,
+      });
+      await loop.return(undefined as never);
+
+      expect(providerStreamClosed).toBe(true);
+      expect(onAborted).toHaveBeenCalledWith('request_interrupted');
+    });
+
     it('records a known model failure before propagating it', async () => {
       const modelError = new Error('provider unavailable');
       const onCompleted = vi.fn(async () => {});

--- a/src/agent/__tests__/AgentLoop.test.ts
+++ b/src/agent/__tests__/AgentLoop.test.ts
@@ -10,6 +10,7 @@ import {
 } from '../../tools/types/index.js';
 import {
     InputId,
+    ModelAttemptId,
     RequestId,
     SessionId,
 } from '../../types/branded.js';
@@ -363,6 +364,178 @@ describe('agentLoop', () => {
 
       expect(providerStreamClosed).toBe(true);
       expect(onAborted).toHaveBeenCalledWith('request_interrupted');
+    });
+
+    it('closes a retry-event provider stream when the consumer stops', async () => {
+      let retryStreamClosed = false;
+      const onAborted = vi.fn(async () => {});
+      const chatService = {
+        chatWithRetryEvents: vi.fn(async function* () {
+          try {
+            yield {
+              attempt: 1,
+              maxRetries: 3,
+              delayMs: 10,
+              error: new Error('retryable'),
+            };
+            await new Promise<never>(() => {});
+          } finally {
+            retryStreamClosed = true;
+          }
+        }),
+        getConfig: () => ({
+          model: 'test-model',
+          maxContextTokens: 128000,
+        }),
+      } as unknown as TurnState['chatService'];
+      const loop = agentLoop(baseConfig({
+        turnState: { chatService },
+        modelExecutionLifecycle: {
+          onModelRequestStarting: vi.fn(async () => ({
+            onCompleted: vi.fn(async () => {}),
+            onFailed: vi.fn(async () => {}),
+            onAborted,
+          })),
+        },
+      }));
+
+      await loop.next();
+      await loop.next();
+      await expect(loop.next()).resolves.toMatchObject({
+        value: { type: 'api_retry', attempt: 1 },
+        done: false,
+      });
+      await loop.return(undefined as never);
+
+      expect(retryStreamClosed).toBe(true);
+      expect(onAborted).toHaveBeenCalledWith('request_interrupted');
+    });
+
+    it('closes the fallback provider stream when a tool turn consumer stops', async () => {
+      let streamCalls = 0;
+      let fallbackStreamClosed = false;
+      const onAborted = vi.fn(async () => {});
+      const chatService = {
+        streamChat: vi.fn(async function* (
+          _messages: readonly Message[],
+          _tools: unknown,
+          signal?: AbortSignal,
+        ) {
+          streamCalls += 1;
+          if (streamCalls === 1) {
+            return;
+          }
+          try {
+            yield { content: 'fallback partial' };
+            await new Promise<void>((_resolve, reject) => {
+              signal?.addEventListener('abort', () => reject(signal.reason), {
+                once: true,
+              });
+            });
+          } finally {
+            fallbackStreamClosed = true;
+          }
+        }),
+        chat: vi.fn(async () => ({
+          content: 'unexpected',
+          toolCalls: [],
+        })),
+        getConfig: () => ({
+          model: 'test-model',
+          maxContextTokens: 128000,
+        }),
+      } as unknown as TurnState['chatService'];
+      const loop = agentLoop(baseConfig({
+        streaming: true,
+        turnState: {
+          chatService,
+          tools: [{ name: 'Read', description: 'read', parameters: {} }],
+        },
+        modelExecutionLifecycle: {
+          onModelRequestStarting: vi.fn(async () => ({
+            onCompleted: vi.fn(async () => {}),
+            onFailed: vi.fn(async () => {}),
+            onAborted,
+          })),
+        },
+      }));
+
+      await loop.next();
+      await loop.next();
+      await expect(loop.next()).resolves.toMatchObject({
+        value: { type: 'content_delta', delta: 'fallback partial' },
+        done: false,
+      });
+      await loop.return(undefined as never);
+
+      expect(streamCalls).toBe(2);
+      expect(fallbackStreamClosed).toBe(true);
+      expect(onAborted).toHaveBeenCalledWith('request_interrupted');
+    });
+
+    it('keeps a completed model outcome when later streaming tool settlement fails', async () => {
+      const toolError = new Error('tool settlement failed');
+      const onCompleted = vi.fn(async () => {});
+      const onFailed = vi.fn(async () => {});
+      const modelAttemptId = ModelAttemptId('streaming-tool-model-attempt');
+      const chatService = {
+        streamChat: vi.fn(async function* () {
+          yield {
+            toolCalls: [
+              {
+                index: 0,
+                id: 'streaming-tool',
+                function: {
+                  name: 'Write',
+                  arguments: '{}',
+                },
+              },
+            ],
+          };
+          yield { finishReason: 'tool_calls' };
+        }),
+        getConfig: () => ({
+          model: 'test-model',
+          maxContextTokens: 128000,
+        }),
+      } as unknown as TurnState['chatService'];
+      const config = baseConfig({
+        streaming: true,
+        turnState: {
+          chatService,
+          tools: [{ name: 'Write', description: 'write', parameters: {} }],
+          executionContext: {
+            sessionId: SessionId('streaming-tool-settlement'),
+            userId: 'test-user',
+            lifecycle: {
+              onToolScheduled: async () => undefined,
+              onToolSettled: async () => {
+                throw toolError;
+              },
+            },
+          },
+        },
+        modelExecutionLifecycle: {
+          onModelRequestStarting: vi.fn(async () => ({
+            modelAttemptId,
+            onCompleted,
+            onFailed,
+            onAborted: vi.fn(async () => {}),
+          })),
+        },
+      });
+
+      await expect(collectEvents(agentLoop(config))).rejects.toBe(toolError);
+      expect(onCompleted).toHaveBeenCalledWith(
+        expect.objectContaining({
+          toolCalls: [
+            expect.objectContaining({
+              id: 'streaming-tool',
+            }),
+          ],
+        }),
+      );
+      expect(onFailed).not.toHaveBeenCalled();
     });
 
     it('records a known model failure before propagating it', async () => {

--- a/src/agent/__tests__/LoopRunner.test.ts
+++ b/src/agent/__tests__/LoopRunner.test.ts
@@ -186,6 +186,56 @@ describe('LoopRunner', () => {
       expect(mm._chat).toHaveBeenCalledTimes(1);
     });
 
+    it('propagates consumer close to the active AgentLoop and provider stream', async () => {
+      const mm = createMockModelManager();
+      const pipeline = createMockPipeline();
+      let providerClosed = false;
+      const chatService = {
+        streamChat: vi.fn(async function* () {
+          try {
+            yield { content: 'partial' };
+          } finally {
+            providerClosed = true;
+          }
+        }),
+        getConfig: () => ({
+          model: 'test-model',
+          maxContextTokens: 128000,
+        }),
+      };
+      vi.spyOn(mm, 'getChatService').mockReturnValue(chatService as never);
+      const onAborted = vi.fn(async () => {});
+      const runner = new LoopRunner(
+        baseConfig,
+        baseOptions,
+        mm,
+        pipeline,
+        undefined,
+        undefined,
+        true,
+      );
+      const stream = runner.runLoopStream('Hello', createContext(), {
+        modelExecutionLifecycle: {
+          onModelRequestStarting: async () => ({
+            onCompleted: async () => {},
+            onFailed: async () => {},
+            onAborted,
+          }),
+        },
+      });
+
+      await stream.next();
+      await stream.next();
+      await expect(stream.next()).resolves.toMatchObject({
+        value: { type: 'content_delta', delta: 'partial' },
+        done: false,
+      });
+      await stream.return(undefined as never);
+
+      expect(providerClosed).toBe(true);
+      expect(onAborted).toHaveBeenCalledWith('request_interrupted');
+    });
+
     it('should persist the user message through the context store facade', async () => {
       const mm = createMockModelManager();
       const pipeline = createMockPipeline();

--- a/src/agent/loop/__tests__/executeToolCalls.test.ts
+++ b/src/agent/loop/__tests__/executeToolCalls.test.ts
@@ -390,9 +390,15 @@ describe('executeToolCalls', () => {
         sessionId: SessionId('session-lifecycle'),
         userId: 'user-1',
         lifecycle: {
-          onToolScheduled: async ({ toolCallId, input, sideEffect, interruptBehavior }) => {
+          onToolScheduled: async ({
+            toolCallId,
+            modelInput,
+            input,
+            sideEffect,
+            interruptBehavior,
+          }) => {
             lifecycle.push(
-              `scheduled:${toolCallId}:${String(input.value)}:${sideEffect}:${interruptBehavior}`,
+              `scheduled:${toolCallId}:${String(modelInput.value)}:${String(input.value)}:${sideEffect}:${interruptBehavior}`,
             );
             input.value = 'mutated';
             return {
@@ -415,7 +421,7 @@ describe('executeToolCalls', () => {
 
     expect(outcome.result.status).toBe('success');
     expect(lifecycle).toEqual([
-      'scheduled:tool-lifecycle:ok:idempotent:block',
+      'scheduled:tool-lifecycle:ok:ok:idempotent:block',
       'update:tool_ready',
       'update:tool_started',
       'pipeline:ok',
@@ -425,6 +431,65 @@ describe('executeToolCalls', () => {
       'update:tool_result',
       'update:tool_completed',
     ]);
+  });
+
+  it('preserves model arguments separately from repaired execution input', async () => {
+    const execute = vi.fn(() =>
+      completeToolExecution({
+        status: 'success',
+        model: 'ok',
+      }),
+    );
+    const onToolScheduled = vi.fn(async () => undefined);
+
+    await executeToolCalls({
+      plan: {
+        mode: 'serial',
+        calls: [
+          {
+            id: 'task-with-repaired-input',
+            type: 'function',
+            function: {
+              name: 'Task',
+              arguments: '{"description":"inspect"}',
+            },
+          },
+        ],
+      },
+      executionPipeline: {
+        execute,
+        getRegistry: () => ({
+          get: () => undefined,
+        }),
+      } as never,
+      executionContext: {
+        sessionId: SessionId('session-repaired-input'),
+        userId: 'user-1',
+        lifecycle: {
+          onToolScheduled,
+        },
+      },
+    });
+
+    expect(onToolScheduled).toHaveBeenCalledWith({
+      toolCallId: 'task-with-repaired-input',
+      toolName: 'Task',
+      modelInput: { description: 'inspect' },
+      input: {
+        description: 'inspect',
+        subagent_session_id: expect.any(String),
+      },
+      sideEffect: 'non_idempotent',
+      interruptBehavior: 'cancel',
+    });
+    expect(execute).toHaveBeenCalledWith(
+      'Task',
+      {
+        description: 'inspect',
+        subagent_session_id: expect.any(String),
+      },
+      expect.any(Object),
+    );
   });
 
   it('does not enter the execution pipeline when durable scheduling fails', async () => {

--- a/src/agent/loop/__tests__/executeToolCalls.test.ts
+++ b/src/agent/loop/__tests__/executeToolCalls.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { createContextSnapshot } from '../../../runtime/index.js';
 import { completeToolExecution, type ExecutionContext } from '../../../tools/types/index.js';
-import { SessionId } from '../../../types/branded.js';
+import { ModelAttemptId, SessionId } from '../../../types/branded.js';
 import type { JsonObject } from '../../../types/common.js';
 import { executeToolCalls } from '../executeToolCalls.js';
 
@@ -465,6 +465,7 @@ describe('executeToolCalls', () => {
       executionContext: {
         sessionId: SessionId('session-repaired-input'),
         userId: 'user-1',
+        modelAttemptId: ModelAttemptId('model-attempt-repaired-input'),
         lifecycle: {
           onToolScheduled,
         },
@@ -474,6 +475,7 @@ describe('executeToolCalls', () => {
     expect(onToolScheduled).toHaveBeenCalledWith({
       toolCallId: 'task-with-repaired-input',
       toolName: 'Task',
+      modelAttemptId: 'model-attempt-repaired-input',
       modelInput: { description: 'inspect' },
       input: {
         description: 'inspect',

--- a/src/agent/loop/runToolCall.ts
+++ b/src/agent/loop/runToolCall.ts
@@ -7,7 +7,7 @@ import type { ConfirmationHandler, ToolExecutionLifecycle } from '../../tools/ty
 import type { ToolEffect, ToolResult, ToolYield } from '../../tools/types/index.js';
 import { resolveToolBehaviorSafely, ToolErrorType, ToolSideEffect } from '../../tools/types/index.js';
 import { isSteeringInterruptSignal } from '../../types/abort.js';
-import { type SessionId, ToolUseId } from '../../types/branded.js';
+import { type ModelAttemptId, type SessionId, ToolUseId } from '../../types/branded.js';
 import type { BladeConfig, JsonObject, PermissionMode } from '../../types/common.js';
 import type { IBackgroundAgentManager } from '../types.js';
 import { repairToolCallParams } from './repairToolCallParams.js';
@@ -74,6 +74,7 @@ export type ToolExecutionUpdate =
 export interface ToolExecutionContext {
   sessionId: SessionId;
   userId: string;
+  modelAttemptId?: ModelAttemptId;
   contextSnapshot?: ContextSnapshot;
   skillActivationPaths?: string[];
   confirmationHandler?: ConfirmationHandler;
@@ -158,6 +159,9 @@ export async function runToolCall(input: RunToolCallInput): Promise<ToolExecutio
   const invocationLifecycle = await input.executionContext.lifecycle?.onToolScheduled?.({
     toolCallId: ToolUseId(input.toolCall.id),
     toolName: input.toolCall.function.name,
+    ...(input.executionContext.modelAttemptId
+      ? { modelAttemptId: input.executionContext.modelAttemptId }
+      : {}),
     modelInput,
     input: structuredClone(params),
     sideEffect,

--- a/src/agent/loop/runToolCall.ts
+++ b/src/agent/loop/runToolCall.ts
@@ -112,6 +112,7 @@ export async function runToolCall(input: RunToolCallInput): Promise<ToolExecutio
   const logger = input.logger ?? NOOP_LOGGER.child(LogCategory.AGENT);
   let interruptBehavior: 'cancel' | 'block' = 'block';
   let sideEffect: ToolSideEffect = ToolSideEffect.NON_IDEMPOTENT;
+  let modelInput: JsonObject;
   let params: JsonObject;
 
   try {
@@ -120,6 +121,7 @@ export async function runToolCall(input: RunToolCallInput): Promise<ToolExecutio
       throw new Error('Tool arguments must be a JSON object');
     }
     params = parsed as JsonObject;
+    modelInput = structuredClone(params);
     await repairToolCallParams(input.toolCall, params);
     interruptBehavior = resolveToolInterruptBehavior(
       input.executionPipeline.getRegistry(),
@@ -156,6 +158,7 @@ export async function runToolCall(input: RunToolCallInput): Promise<ToolExecutio
   const invocationLifecycle = await input.executionContext.lifecycle?.onToolScheduled?.({
     toolCallId: ToolUseId(input.toolCall.id),
     toolName: input.toolCall.function.name,
+    modelInput,
     input: structuredClone(params),
     sideEffect,
     interruptBehavior,

--- a/src/agent/loop/runTurn.ts
+++ b/src/agent/loop/runTurn.ts
@@ -20,6 +20,7 @@ import type { ExecutionPipeline } from '../../tools/execution/ExecutionPipeline.
 import type { ToolEffect, ToolResult } from '../../tools/types/index.js';
 import type { PermissionMode } from '../../types/common.js';
 import { isSteeringInterruptSignal } from '../../types/abort.js';
+import type { ModelAttemptId } from '../../types/branded.js';
 import type { JsonObject } from '../../types/common.js';
 import type { AgentEvent } from '../AgentEvent.js';
 import type { ExecutionEpoch } from '../ExecutionEpoch.js';
@@ -75,6 +76,7 @@ export type StreamingExecutionResult = ToolExecutionOutcome;
 
 export interface TurnOutcome {
   chatResponse: ChatResponse;
+  modelAttemptId?: ModelAttemptId;
   /** 若走了 streaming+tools 分支，工具已顺带执行完；非流式路径为 undefined */
   streamingExecutionResults?: StreamingExecutionResult[];
 }
@@ -99,12 +101,24 @@ export async function* runTurn(
   });
 
   let settlementAttempted = false;
+  const settleCompleted = async (response: ChatResponse): Promise<void> => {
+    if (!requestLifecycle || settlementAttempted) {
+      return;
+    }
+    settlementAttempted = true;
+    await requestLifecycle.onCompleted(response);
+  };
   try {
     let outcome: TurnOutcome;
     try {
       // 分支 1：streaming + 有工具 — 流式边解析边执行
       if (streaming && tools.length > 0) {
-        outcome = yield* runStreamingWithTools(input, tools);
+        outcome = yield* runStreamingWithTools(
+          input,
+          tools,
+          requestLifecycle?.modelAttemptId,
+          settleCompleted,
+        );
       } else if (streaming) {
         // 分支 2：streaming only — 纯流式，无工具执行
         const stream = streamChatResponse(
@@ -115,24 +129,24 @@ export async function* runTurn(
           logger,
         );
         let chatResponse: ChatResponse | undefined;
-      let streamCompleted = false;
-      try {
-        while (true) {
-          const { value, done } = await stream.next();
-          if (done) {
-            chatResponse = value;
-            streamCompleted = true;
-            break;
+        let streamCompleted = false;
+        try {
+          while (true) {
+            const { value, done } = await stream.next();
+            if (done) {
+              chatResponse = value;
+              streamCompleted = true;
+              break;
+            }
+            if (value.type === 'content_delta') {
+              yield { type: 'content_delta', delta: value.delta };
+            } else {
+              yield { type: 'thinking_delta', delta: value.delta };
+            }
           }
-          if (value.type === 'content_delta') {
-            yield { type: 'content_delta', delta: value.delta };
-          } else {
-            yield { type: 'thinking_delta', delta: value.delta };
-          }
-        }
-      } finally {
-        if (!streamCompleted) {
-          await stream.return(undefined as never);
+        } finally {
+          if (!streamCompleted) {
+            await stream.return(undefined as never);
           }
         }
         if (!chatResponse) {
@@ -143,26 +157,26 @@ export async function* runTurn(
         // 分支 3：非流式 + 带重试事件
         const retryGen = turnChatService.chatWithRetryEvents(messages, tools, signal);
         let chatResponse: ChatResponse | undefined;
-      let retryStreamCompleted = false;
-      try {
-        while (true) {
-          const { value, done } = await retryGen.next();
-          if (done) {
-            chatResponse = value;
-            retryStreamCompleted = true;
-            break;
+        let retryStreamCompleted = false;
+        try {
+          while (true) {
+            const { value, done } = await retryGen.next();
+            if (done) {
+              chatResponse = value;
+              retryStreamCompleted = true;
+              break;
+            }
+            yield {
+              type: 'api_retry',
+              attempt: value.attempt,
+              maxRetries: value.maxRetries,
+              delayMs: value.delayMs,
+              error: value.error,
+            };
           }
-          yield {
-            type: 'api_retry',
-            attempt: value.attempt,
-            maxRetries: value.maxRetries,
-            delayMs: value.delayMs,
-            error: value.error,
-          };
-        }
-      } finally {
-        if (!retryStreamCompleted) {
-          await retryGen.return(undefined as never);
+        } finally {
+          if (!retryStreamCompleted) {
+            await retryGen.return(undefined as never);
           }
         }
         if (!chatResponse) {
@@ -176,7 +190,7 @@ export async function* runTurn(
         };
       }
     } catch (error) {
-      if (requestLifecycle) {
+      if (requestLifecycle && !settlementAttempted) {
         settlementAttempted = true;
         try {
           if (signal?.aborted) {
@@ -196,17 +210,22 @@ export async function* runTurn(
       throw error;
     }
 
-    if (requestLifecycle) {
-      settlementAttempted = true;
+    if (requestLifecycle && !settlementAttempted) {
       if (signal?.aborted) {
+        settlementAttempted = true;
         await requestLifecycle.onAborted(
           isSteeringInterruptSignal(signal) ? 'steering' : 'request_interrupted',
         );
       } else {
-        await requestLifecycle.onCompleted(outcome.chatResponse);
+        await settleCompleted(outcome.chatResponse);
       }
     }
-    return outcome;
+    return {
+      ...outcome,
+      ...(requestLifecycle?.modelAttemptId
+        ? { modelAttemptId: requestLifecycle.modelAttemptId }
+        : {}),
+    };
   } finally {
     if (requestLifecycle && !settlementAttempted) {
       await requestLifecycle.onAborted(
@@ -219,6 +238,8 @@ export async function* runTurn(
 async function* runStreamingWithTools(
   input: RunTurnInput,
   tools: Array<{ name: string; description: string; parameters: JSONSchema7 }>,
+  modelAttemptId: ModelAttemptId | undefined,
+  onModelResponse: (response: ChatResponse) => Promise<void>,
 ): AsyncGenerator<AgentEvent, TurnOutcome> {
   const {
     turnState, messages, executionPipeline,
@@ -250,7 +271,9 @@ async function* runStreamingWithTools(
   const executionPromise = streamingExecutor
     .collectAndExecute(messages, tools, modelSignal, {
       executionPipeline,
-      executionContext,
+      executionContext: modelAttemptId
+        ? { ...executionContext, modelAttemptId }
+        : executionContext,
       logger,
       permissionMode,
       requestSignal: toolRequestSignal,
@@ -261,6 +284,7 @@ async function* runStreamingWithTools(
       onAfterToolExecEpochDiscard: toolHooks.onAfterExecEpochDiscard,
       onContentDelta: (delta) => queue.enqueue({ type: 'content_delta', delta }),
       onThinkingDelta: (delta) => queue.enqueue({ type: 'thinking_delta', delta }),
+      onModelResponse,
       onStreamEnd: () => {
         if (!signal?.aborted) queue.enqueue({ type: 'stream_end' });
       },
@@ -298,7 +322,11 @@ async function* runStreamingWithTools(
       throw new Error('Streaming executor completed without chat response');
     }
 
-    return { chatResponse, streamingExecutionResults };
+    return {
+      chatResponse,
+      ...(modelAttemptId ? { modelAttemptId } : {}),
+      streamingExecutionResults,
+    };
   } finally {
     if (!executionCompleted) {
       closeController.abort(new Error('Streaming model turn closed by consumer'));

--- a/src/agent/loop/runTurn.ts
+++ b/src/agent/loop/runTurn.ts
@@ -19,9 +19,11 @@ import type {
 import type { ExecutionPipeline } from '../../tools/execution/ExecutionPipeline.js';
 import type { ToolEffect, ToolResult } from '../../tools/types/index.js';
 import type { PermissionMode } from '../../types/common.js';
+import { isSteeringInterruptSignal } from '../../types/abort.js';
 import type { JsonObject } from '../../types/common.js';
 import type { AgentEvent } from '../AgentEvent.js';
 import type { ExecutionEpoch } from '../ExecutionEpoch.js';
+import type { ModelExecutionLifecycle } from '../ModelExecutionLifecycle.js';
 import { StreamingToolExecutor } from '../StreamingToolExecutor.js';
 import type { TurnState } from '../state/TurnState.js';
 import { AsyncEventQueue } from './AsyncEventQueue.js';
@@ -64,6 +66,7 @@ export interface RunTurnInput {
   epoch: ExecutionEpoch;
   executionContext: ToolExecutionContext;
   permissionMode?: PermissionMode;
+  modelExecutionLifecycle?: ModelExecutionLifecycle;
   toolHooks: RunTurnToolHooks;
   logger?: InternalLogger;
 }
@@ -89,61 +92,128 @@ export async function* runTurn(
     parameters: JSONSchema7;
   }>;
   const turnChatService = turnState.chatService;
+  const requestLifecycle = await input.modelExecutionLifecycle?.onModelRequestStarting({
+    turn: turnState.turn,
+    model: turnChatService.getConfig().model,
+    streaming: streaming === true,
+  });
 
-  // 分支 1：streaming + 有工具 — 流式边解析边执行
-  if (streaming && tools.length > 0) {
-    return yield* runStreamingWithTools(input, tools);
-  }
-
-  // 分支 2：streaming only — 纯流式，无工具执行
-  if (streaming) {
-    const stream = streamChatResponse(
-      () => turnChatService,
-      messages,
-      tools,
-      signal,
-      logger,
-    );
-    let chatResponse: ChatResponse | undefined;
-    while (true) {
-      const { value, done } = await stream.next();
-      if (done) {
-        chatResponse = value;
-        break;
-      }
-      if (value.type === 'content_delta') {
-        yield { type: 'content_delta', delta: value.delta };
+  let settlementAttempted = false;
+  try {
+    let outcome: TurnOutcome;
+    try {
+      // 分支 1：streaming + 有工具 — 流式边解析边执行
+      if (streaming && tools.length > 0) {
+        outcome = yield* runStreamingWithTools(input, tools);
+      } else if (streaming) {
+        // 分支 2：streaming only — 纯流式，无工具执行
+        const stream = streamChatResponse(
+          () => turnChatService,
+          messages,
+          tools,
+          signal,
+          logger,
+        );
+        let chatResponse: ChatResponse | undefined;
+      let streamCompleted = false;
+      try {
+        while (true) {
+          const { value, done } = await stream.next();
+          if (done) {
+            chatResponse = value;
+            streamCompleted = true;
+            break;
+          }
+          if (value.type === 'content_delta') {
+            yield { type: 'content_delta', delta: value.delta };
+          } else {
+            yield { type: 'thinking_delta', delta: value.delta };
+          }
+        }
+      } finally {
+        if (!streamCompleted) {
+          await stream.return(undefined as never);
+          }
+        }
+        if (!chatResponse) {
+          throw new Error('Stream terminated without chat response');
+        }
+        outcome = { chatResponse };
+      } else if (typeof turnChatService.chatWithRetryEvents === 'function') {
+        // 分支 3：非流式 + 带重试事件
+        const retryGen = turnChatService.chatWithRetryEvents(messages, tools, signal);
+        let chatResponse: ChatResponse | undefined;
+      let retryStreamCompleted = false;
+      try {
+        while (true) {
+          const { value, done } = await retryGen.next();
+          if (done) {
+            chatResponse = value;
+            retryStreamCompleted = true;
+            break;
+          }
+          yield {
+            type: 'api_retry',
+            attempt: value.attempt,
+            maxRetries: value.maxRetries,
+            delayMs: value.delayMs,
+            error: value.error,
+          };
+        }
+      } finally {
+        if (!retryStreamCompleted) {
+          await retryGen.return(undefined as never);
+          }
+        }
+        if (!chatResponse) {
+          throw new Error('Model retry stream terminated without a chat response');
+        }
+        outcome = { chatResponse };
       } else {
-        yield { type: 'thinking_delta', delta: value.delta };
+        // 分支 4：纯非流式
+        outcome = {
+          chatResponse: await turnChatService.chat(messages, tools, signal),
+        };
+      }
+    } catch (error) {
+      if (requestLifecycle) {
+        settlementAttempted = true;
+        try {
+          if (signal?.aborted) {
+            await requestLifecycle.onAborted(
+              isSteeringInterruptSignal(signal) ? 'steering' : 'request_interrupted',
+            );
+          } else {
+            await requestLifecycle.onFailed(error);
+          }
+        } catch (lifecycleError) {
+          throw new AggregateError(
+            [error, lifecycleError],
+            'Model request and durable settlement both failed',
+          );
+        }
+      }
+      throw error;
+    }
+
+    if (requestLifecycle) {
+      settlementAttempted = true;
+      if (signal?.aborted) {
+        await requestLifecycle.onAborted(
+          isSteeringInterruptSignal(signal) ? 'steering' : 'request_interrupted',
+        );
+      } else {
+        await requestLifecycle.onCompleted(outcome.chatResponse);
       }
     }
-    if (!chatResponse) {
-      throw new Error('Stream terminated without chat response');
-    }
-    return { chatResponse };
-  }
-
-  // 分支 3：非流式 + 带重试事件
-  if (typeof turnChatService.chatWithRetryEvents === 'function') {
-    const retryGen = turnChatService.chatWithRetryEvents(messages, tools, signal);
-    while (true) {
-      const { value, done } = await retryGen.next();
-      if (done) {
-        return { chatResponse: value };
-      }
-      yield {
-        type: 'api_retry',
-        attempt: value.attempt,
-        maxRetries: value.maxRetries,
-        delayMs: value.delayMs,
-        error: value.error,
-      };
+    return outcome;
+  } finally {
+    if (requestLifecycle && !settlementAttempted) {
+      await requestLifecycle.onAborted(
+        isSteeringInterruptSignal(signal) ? 'steering' : 'request_interrupted',
+      );
     }
   }
-
-  // 分支 4：纯非流式
-  const chatResponse = await turnChatService.chat(messages, tools, signal);
-  return { chatResponse };
 }
 
 async function* runStreamingWithTools(
@@ -204,19 +274,27 @@ async function* runStreamingWithTools(
       queue.close();
     });
 
-  for await (const event of queue) {
-    yield event;
+  let executionCompleted = false;
+  try {
+    for await (const event of queue) {
+      yield event;
+    }
+
+    await executionPromise;
+    executionCompleted = true;
+
+    if (executionError) {
+      throw executionError;
+    }
+
+    if (!chatResponse) {
+      throw new Error('Streaming executor completed without chat response');
+    }
+
+    return { chatResponse, streamingExecutionResults };
+  } finally {
+    if (!executionCompleted) {
+      await executionPromise;
+    }
   }
-
-  await executionPromise;
-
-  if (executionError) {
-    throw executionError;
-  }
-
-  if (!chatResponse) {
-    throw new Error('Streaming executor completed without chat response');
-  }
-
-  return { chatResponse, streamingExecutionResults };
 }

--- a/src/agent/loop/runTurn.ts
+++ b/src/agent/loop/runTurn.ts
@@ -230,6 +230,13 @@ async function* runStreamingWithTools(
     () => turnState.chatService,
     logger,
   );
+  const closeController = new AbortController();
+  const modelSignal = signal
+    ? AbortSignal.any([signal, closeController.signal])
+    : closeController.signal;
+  const toolRequestSignal = requestSignal
+    ? AbortSignal.any([requestSignal, closeController.signal])
+    : closeController.signal;
 
   const queue = new AsyncEventQueue<AgentEvent>({
     isLive: () => epoch.isValid,
@@ -241,12 +248,12 @@ async function* runStreamingWithTools(
   let executionError: unknown;
 
   const executionPromise = streamingExecutor
-    .collectAndExecute(messages, tools, signal, {
+    .collectAndExecute(messages, tools, modelSignal, {
       executionPipeline,
       executionContext,
       logger,
       permissionMode,
-      requestSignal,
+      requestSignal: toolRequestSignal,
       steeringSignal,
       hooks: {
         onBeforeToolExec: toolHooks.onBeforeExec,
@@ -294,6 +301,7 @@ async function* runStreamingWithTools(
     return { chatResponse, streamingExecutionResults };
   } finally {
     if (!executionCompleted) {
+      closeController.abort(new Error('Streaming model turn closed by consumer'));
       await executionPromise;
     }
   }

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -11,6 +11,7 @@ import type { OutputFormat, PermissionMode, PermissionsConfig, SandboxSettings }
 import type { CanUseTool, PermissionHandler } from '../types/permissions.js';
 import type { AgentRunControl, AgentSteeringInput } from './AgentRunControl.js';
 import type { InitialInputPreparation } from './InitialInputPreparation.js';
+import type { ModelExecutionLifecycle } from './ModelExecutionLifecycle.js';
 import type { AgentSession } from './subagents/AgentSessionStore.js';
 import type { StartBackgroundAgentOptions } from './subagents/BackgroundAgentManager.js';
 import type { TokenBudgetConfig, TokenBudgetSnapshot } from './TokenBudget.js';
@@ -148,6 +149,8 @@ export interface LoopOptions {
   toolExecutionLifecycle?: ToolExecutionLifecycle;
   /** @internal Persists a steering input before its preparation side effects. */
   inputApplicationLifecycle?: InputApplicationLifecycle;
+  /** @internal Persists model invocation boundaries for durable recovery. */
+  modelExecutionLifecycle?: ModelExecutionLifecycle;
   /** @internal A recovered Request already completed its initial input preparation. */
   initialInputPreparation?: InitialInputPreparation;
   onTurnLimitReached?: (data: { turnsCount: number }) => Promise<TurnLimitResponse>;

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -43,6 +43,7 @@ export {
   InputId,
   InputPriority,
   MessageRole,
+  ModelAttemptId,
   PermissionDecision,
   PermissionMode,
   PermissionRequestId,

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -72,6 +72,7 @@ export {
   EventId,
   EventSequence,
   InputId,
+  ModelAttemptId,
   PermissionRequestId,
   RequestId,
   SessionId,

--- a/src/index.ts
+++ b/src/index.ts
@@ -213,6 +213,7 @@ export {
   EventSequence,
   InputId,
   MessageId,
+  ModelAttemptId,
   PermissionRequestId,
   RequestId,
   SessionId,

--- a/src/session/Session.ts
+++ b/src/session/Session.ts
@@ -799,6 +799,7 @@ class Session implements ISession {
       },
       runControl: requestController,
       inputApplicationLifecycle: durableRecorder ?? undefined,
+      modelExecutionLifecycle: durableRecorder ?? undefined,
       toolExecutionLifecycle: durableRecorder ?? undefined,
       initialInputPreparation:
         initialInputPreparation === RECONCILED_INITIAL_INPUT

--- a/src/session/__tests__/SessionDurableEvents.test.ts
+++ b/src/session/__tests__/SessionDurableEvents.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { AgentEvent } from '../../agent/AgentEvent.js';
 import { RECONCILED_INITIAL_INPUT } from '../../agent/InitialInputPreparation.js';
+import type { ModelRequestLifecycle } from '../../agent/ModelExecutionLifecycle.js';
 import type { LoopOptions, LoopResult, UserMessageContent } from '../../agent/types.js';
 import { PersistentStore } from '../../context/storage/PersistentStore.js';
 import { HookRuntime } from '../../hooks/HookRuntime.js';
@@ -221,6 +222,69 @@ describe('Session durable events', () => {
     expect((await store.read(session.sessionId)).events.at(-1)?.type).toBe(
       DurableEventType.SESSION_CLOSED,
     );
+  });
+
+  it('persists model request boundaries through the Session runtime', async () => {
+    const { store } = createStore();
+    streamChat = async function* modelLifecycleStream(_message, _context, loopOptions) {
+      yield { type: 'turn_start', turn: 1, maxTurns: 10 };
+      const lifecycle = await loopOptions?.modelExecutionLifecycle?.onModelRequestStarting({
+        turn: 1,
+        model: 'test-model',
+        streaming: true,
+      });
+      if (!lifecycle) {
+        throw new Error('Missing model execution lifecycle');
+      }
+      await lifecycle.onCompleted({
+        content: 'durable response',
+        usage: {
+          promptTokens: 11,
+          completionTokens: 3,
+          totalTokens: 14,
+        },
+      });
+      yield { type: 'turn_end', turn: 1, hasToolCalls: false };
+      return {
+        success: true,
+        finalMessage: 'durable response',
+        metadata: { turnsCount: 1, toolCallsCount: 0, duration: 1 },
+      };
+    };
+    const session = await createSession(options(store));
+    await session.send('persist the model call');
+
+    for await (const _event of session.stream()) {
+      // Drain.
+    }
+
+    const events = (await store.read(session.sessionId)).events;
+    expect(events.map((event) => event.type)).toEqual([
+      DurableEventType.SESSION_CREATED,
+      DurableEventType.REQUEST_ACCEPTED,
+      DurableEventType.INPUT_APPLIED,
+      DurableEventType.REQUEST_STARTED,
+      DurableEventType.TURN_STARTED,
+      DurableEventType.MODEL_REQUEST_STARTED,
+      DurableEventType.MODEL_REQUEST_COMPLETED,
+      DurableEventType.TURN_COMPLETED,
+      DurableEventType.REQUEST_COMPLETED,
+    ]);
+    expect(
+      events.find(
+        (event) => event.type === DurableEventType.MODEL_REQUEST_COMPLETED,
+      )?.data,
+    ).toEqual({
+      response: {
+        content: 'durable response',
+        usage: {
+          promptTokens: 11,
+          completionTokens: 3,
+          totalTokens: 14,
+        },
+      },
+    });
+    await session.close();
   });
 
   it('persists a steering input before its preparation side effects', async () => {
@@ -1210,9 +1274,15 @@ describe('Session durable events', () => {
   it('closes the inner stream and durably interrupts when a consumer stops early', async () => {
     const { store } = createStore();
     let innerClosed = false;
-    streamChat = async function* interruptedByConsumer() {
+    streamChat = async function* interruptedByConsumer(_message, _context, loopOptions) {
+      let modelRequest: ModelRequestLifecycle | undefined;
       try {
         yield { type: 'turn_start', turn: 1, maxTurns: 10 };
+        modelRequest = await loopOptions?.modelExecutionLifecycle?.onModelRequestStarting({
+          turn: 1,
+          model: 'test-model',
+          streaming: true,
+        });
         yield { type: 'content_delta', delta: 'partial' };
         return {
           success: true,
@@ -1220,6 +1290,7 @@ describe('Session durable events', () => {
           metadata: { turnsCount: 1, toolCallsCount: 0, duration: 1 },
         };
       } finally {
+        await modelRequest?.onAborted('request_interrupted');
         innerClosed = true;
       }
     };
@@ -1227,15 +1298,20 @@ describe('Session durable events', () => {
     await session.send('stop early');
 
     for await (const event of session.stream()) {
-      expect(event.type).toBe('turn_start');
-      break;
+      if (event.type === 'content') {
+        break;
+      }
     }
 
     expect(innerClosed).toBe(true);
     expect(session.getDurableRecoveryPlan()?.action).toBe('none');
     expect(
-      (await store.read(session.sessionId)).events.map((event) => event.type).slice(-2),
-    ).toEqual([DurableEventType.TURN_ABORTED, DurableEventType.REQUEST_INTERRUPTED]);
+      (await store.read(session.sessionId)).events.map((event) => event.type).slice(-3),
+    ).toEqual([
+      DurableEventType.MODEL_REQUEST_ABORTED,
+      DurableEventType.TURN_ABORTED,
+      DurableEventType.REQUEST_INTERRUPTED,
+    ]);
     await session.close();
   });
 

--- a/src/session/__tests__/SessionDurableEvents.test.ts
+++ b/src/session/__tests__/SessionDurableEvents.test.ts
@@ -458,6 +458,9 @@ describe('Session durable events', () => {
       if (!modelRequest) {
         throw new Error('Missing model execution lifecycle');
       }
+      if (!modelRequest.modelAttemptId) {
+        throw new Error('Missing model attempt ID');
+      }
       await modelRequest.onCompleted({
         content: '',
         toolCalls: [
@@ -475,6 +478,7 @@ describe('Session durable events', () => {
       const invocation = await lifecycle?.onToolScheduled?.({
         toolCallId: ToolUseId('tool-call-1'),
         toolName: 'Write',
+        modelAttemptId: modelRequest.modelAttemptId,
         modelInput: { file_path: '/tmp/file' },
         input: { file_path: '/tmp/file' },
         sideEffect: 'non_idempotent',
@@ -572,6 +576,9 @@ describe('Session durable events', () => {
       if (!modelRequest) {
         throw new Error('Missing model execution lifecycle');
       }
+      if (!modelRequest.modelAttemptId) {
+        throw new Error('Missing model attempt ID');
+      }
       await modelRequest.onCompleted({
         content: '',
         toolCalls: [
@@ -589,6 +596,7 @@ describe('Session durable events', () => {
       const invocation = await lifecycle?.onToolScheduled?.({
         toolCallId: ToolUseId('tool-call-1'),
         toolName: 'Write',
+        modelAttemptId: modelRequest.modelAttemptId,
         modelInput: {},
         input: {},
         sideEffect: 'non_idempotent',
@@ -996,6 +1004,7 @@ describe('Session durable events', () => {
           type: DurableEventType.TOOL_SCHEDULED,
           requestId,
           turnId: TurnId('turn-rollover-active-turn'),
+          modelAttemptId: ModelAttemptId('turn-rollover-model-attempt'),
           toolAttemptId: ToolAttemptId('turn-rollover-tool-attempt'),
           data: {
             toolCallId: ToolUseId('turn-rollover-tool-call'),

--- a/src/session/__tests__/SessionDurableEvents.test.ts
+++ b/src/session/__tests__/SessionDurableEvents.test.ts
@@ -14,6 +14,7 @@ import {
   CommandId,
   EventId,
   InputId,
+  ModelAttemptId,
   RequestId,
   SessionId,
   ToolAttemptId,
@@ -449,10 +450,32 @@ describe('Session durable events', () => {
     let sideEffectSawToolStarted = false;
     streamChat = async function* toolStream(_message, _context, loopOptions) {
       yield { type: 'turn_start', turn: 1, maxTurns: 10 };
+      const modelRequest = await loopOptions?.modelExecutionLifecycle?.onModelRequestStarting({
+        turn: 1,
+        model: 'test-model',
+        streaming: false,
+      });
+      if (!modelRequest) {
+        throw new Error('Missing model execution lifecycle');
+      }
+      await modelRequest.onCompleted({
+        content: '',
+        toolCalls: [
+          {
+            id: 'tool-call-1',
+            type: 'function',
+            function: {
+              name: 'Write',
+              arguments: '{"file_path":"/tmp/file"}',
+            },
+          },
+        ],
+      });
       const lifecycle = loopOptions?.toolExecutionLifecycle;
       const invocation = await lifecycle?.onToolScheduled?.({
         toolCallId: ToolUseId('tool-call-1'),
         toolName: 'Write',
+        modelInput: { file_path: '/tmp/file' },
         input: { file_path: '/tmp/file' },
         sideEffect: 'non_idempotent',
         interruptBehavior: 'block',
@@ -522,6 +545,8 @@ describe('Session durable events', () => {
       DurableEventType.INPUT_APPLIED,
       DurableEventType.REQUEST_STARTED,
       DurableEventType.TURN_STARTED,
+      DurableEventType.MODEL_REQUEST_STARTED,
+      DurableEventType.MODEL_REQUEST_COMPLETED,
       DurableEventType.TOOL_SCHEDULED,
       DurableEventType.PERMISSION_REQUESTED,
       DurableEventType.PERMISSION_RESOLVED,
@@ -539,10 +564,32 @@ describe('Session durable events', () => {
     let sideEffectRan = false;
     streamChat = async function* failedToolStart(_message, _context, loopOptions) {
       yield { type: 'turn_start', turn: 1, maxTurns: 10 };
+      const modelRequest = await loopOptions?.modelExecutionLifecycle?.onModelRequestStarting({
+        turn: 1,
+        model: 'test-model',
+        streaming: false,
+      });
+      if (!modelRequest) {
+        throw new Error('Missing model execution lifecycle');
+      }
+      await modelRequest.onCompleted({
+        content: '',
+        toolCalls: [
+          {
+            id: 'tool-call-1',
+            type: 'function',
+            function: {
+              name: 'Write',
+              arguments: '{}',
+            },
+          },
+        ],
+      });
       const lifecycle = loopOptions?.toolExecutionLifecycle;
       const invocation = await lifecycle?.onToolScheduled?.({
         toolCallId: ToolUseId('tool-call-1'),
         toolName: 'Write',
+        modelInput: {},
         input: {},
         sideEffect: 'non_idempotent',
         interruptBehavior: 'block',
@@ -918,6 +965,34 @@ describe('Session durable events', () => {
           data: { turn: 1, model: 'rollover-model' },
         },
         {
+          type: DurableEventType.MODEL_REQUEST_STARTED,
+          requestId,
+          turnId: TurnId('turn-rollover-active-turn'),
+          modelAttemptId: ModelAttemptId('turn-rollover-model-attempt'),
+          data: {
+            model: 'rollover-model',
+            streaming: false,
+          },
+        },
+        {
+          type: DurableEventType.MODEL_REQUEST_COMPLETED,
+          requestId,
+          turnId: TurnId('turn-rollover-active-turn'),
+          modelAttemptId: ModelAttemptId('turn-rollover-model-attempt'),
+          data: {
+            response: {
+              content: '',
+              toolCalls: [
+                {
+                  id: ToolUseId('turn-rollover-tool-call'),
+                  name: 'Read',
+                  arguments: '{"file_path":"/tmp/recovery-input"}',
+                },
+              ],
+            },
+          },
+        },
+        {
           type: DurableEventType.TOOL_SCHEDULED,
           requestId,
           turnId: TurnId('turn-rollover-active-turn'),
@@ -925,6 +1000,7 @@ describe('Session durable events', () => {
           data: {
             toolCallId: ToolUseId('turn-rollover-tool-call'),
             toolName: 'Read',
+            modelInput: { file_path: '/tmp/recovery-input' },
             input: { file_path: '/tmp/recovery-input' },
             sideEffect: 'pure',
             interruptBehavior: 'cancel',

--- a/src/session/events/DurableSessionJournal.ts
+++ b/src/session/events/DurableSessionJournal.ts
@@ -14,6 +14,7 @@ import type {
   DurableEventPage,
   DurableEventType,
 } from './types.js';
+import { canonicalJson } from './canonicalJson.js';
 
 const DEFAULT_PAGE_SIZE = 500;
 const DEFAULT_MAX_CONFLICT_RETRIES = 3;
@@ -95,21 +96,6 @@ export class DurableCommandOutcomeUnknownError extends DurableSessionJournalErro
 
 function isErrorCode(error: unknown, code: string): boolean {
   return typeof error === 'object' && error !== null && 'code' in error && error.code === code;
-}
-
-function canonicalJson(value: unknown): string {
-  if (value === null || typeof value !== 'object') {
-    return JSON.stringify(value);
-  }
-  if (Array.isArray(value)) {
-    return `[${value.map(canonicalJson).join(',')}]`;
-  }
-  const record = value as Record<string, unknown>;
-  return `{${Object.keys(record)
-    .filter((key) => record[key] !== undefined)
-    .sort()
-    .map((key) => `${JSON.stringify(key)}:${canonicalJson(record[key])}`)
-    .join(',')}}`;
 }
 
 function comparableDraft(

--- a/src/session/events/DurableSessionJournal.ts
+++ b/src/session/events/DurableSessionJournal.ts
@@ -122,6 +122,7 @@ function comparableDraft(
     commandId: draft.commandId,
     ...('requestId' in draft ? { requestId: draft.requestId } : {}),
     ...('turnId' in draft ? { turnId: draft.turnId } : {}),
+    ...('modelAttemptId' in draft ? { modelAttemptId: draft.modelAttemptId } : {}),
     ...('toolAttemptId' in draft ? { toolAttemptId: draft.toolAttemptId } : {}),
     ...(draft.causationEventId ? { causationEventId: draft.causationEventId } : {}),
     ...(occurredAt ? { occurredAt } : {}),

--- a/src/session/events/DurableSessionProjector.ts
+++ b/src/session/events/DurableSessionProjector.ts
@@ -381,6 +381,59 @@ function assertToolIdentity(
   }
 }
 
+function assertToolMatchesCompletedModelResponse(
+  event: DurableEventEnvelope,
+  turn: MutableTurnProjection,
+  toolCallId: ToolUseId,
+  toolName: string,
+): void {
+  const modelAttempt = Array.from(turn.modelAttempts.values()).at(-1);
+  if (!modelAttempt) {
+    return;
+  }
+  if (modelAttempt.status === 'started') {
+    return;
+  }
+  if (modelAttempt.status !== 'completed') {
+    invalid(
+      event,
+      `Tool call ${toolCallId} follows model attempt ${modelAttempt.modelAttemptId} with status ${modelAttempt.status}`,
+    );
+  }
+  const declared = modelAttempt.response?.toolCalls?.find(
+    (toolCall) => toolCall.id === toolCallId,
+  );
+  if (!declared || declared.name !== toolName) {
+    invalid(
+      event,
+      `Tool call ${toolCallId}/${toolName} was not declared by model attempt ${modelAttempt.modelAttemptId}`,
+    );
+  }
+}
+
+function assertCompletedResponseMatchesScheduledTools(
+  event: DurableEventEnvelope<typeof DurableEventTypeValue.MODEL_REQUEST_COMPLETED>,
+  turn: MutableTurnProjection,
+): void {
+  const toolCalls = event.data.response.toolCalls ?? [];
+  const seenToolCallIds = new Set<ToolUseId>();
+  for (const toolCall of toolCalls) {
+    if (seenToolCallIds.has(toolCall.id)) {
+      invalid(event, `Model response reused tool call ID ${toolCall.id}`);
+    }
+    seenToolCallIds.add(toolCall.id);
+  }
+  for (const tool of turn.toolAttempts.values()) {
+    const declared = toolCalls.find((toolCall) => toolCall.id === tool.toolCallId);
+    if (!declared || declared.name !== tool.toolName) {
+      invalid(
+        event,
+        `Model response does not declare durable tool call ${tool.toolCallId}/${tool.toolName}`,
+      );
+    }
+  }
+}
+
 function assertNoPendingPermission(
   event: DurableEventEnvelope,
   tool: MutableToolAttemptProjection,
@@ -831,6 +884,12 @@ function applyEvent(state: ProjectionAccumulator, event: DurableEventEnvelope): 
           `Model attempt ${previousAttempt.modelAttemptId} ended as ${previousAttempt.status}`,
         );
       }
+      if (previousAttempt && turn.toolAttempts.size > 0) {
+        invalid(
+          event,
+          `Model attempt ${previousAttempt.modelAttemptId} dispatched tools before failing`,
+        );
+      }
       if (state.seenModelAttemptIds.has(event.modelAttemptId)) {
         invalid(event, `Model attempt ID ${event.modelAttemptId} was already used`);
       }
@@ -851,6 +910,7 @@ function applyEvent(state: ProjectionAccumulator, event: DurableEventEnvelope): 
       const request = requireRunningRequest(state, event);
       const turn = requireActiveTurn(state, event);
       const attempt = requireModelAttempt(state, event);
+      assertCompletedResponseMatchesScheduledTools(event, turn);
       attempt.status = 'completed';
       attempt.response = event.data.response;
       turn.activeModelAttempt = null;
@@ -882,6 +942,12 @@ function applyEvent(state: ProjectionAccumulator, event: DurableEventEnvelope): 
 
     case DurableEventTypeValue.TOOL_SCHEDULED: {
       const turn = requireActiveTurn(state, event);
+      assertToolMatchesCompletedModelResponse(
+        event,
+        turn,
+        event.data.toolCallId,
+        event.data.toolName,
+      );
       if (state.seenToolAttemptIds.has(event.toolAttemptId)) {
         invalid(event, `Tool attempt ID ${event.toolAttemptId} was already used`);
       }

--- a/src/session/events/DurableSessionProjector.ts
+++ b/src/session/events/DurableSessionProjector.ts
@@ -74,6 +74,7 @@ export interface DurableToolAttemptProjection {
   readonly toolAttemptId: ToolAttemptId;
   readonly toolCallId: ToolUseId;
   readonly toolName: string;
+  readonly modelAttemptId?: ModelAttemptId;
   readonly modelInput?: JsonValue;
   readonly input: JsonValue;
   readonly sideEffect: ToolSideEffect;
@@ -180,6 +181,7 @@ interface MutableToolAttemptProjection {
   toolAttemptId: ToolAttemptId;
   toolCallId: ToolUseId;
   toolName: string;
+  modelAttemptId?: ModelAttemptId;
   modelInput?: JsonValue;
   input: JsonValue;
   sideEffect: ToolSideEffect;
@@ -389,14 +391,22 @@ function assertToolMatchesModelAttempt(
   turn: MutableTurnProjection,
   toolCallId: ToolUseId,
   toolName: string,
+  modelAttemptId: ModelAttemptId | undefined,
   modelInput: JsonValue | undefined,
 ): void {
-  const modelAttempt = Array.from(turn.modelAttempts.values()).at(-1);
-  if (!modelAttempt) {
+  if (!modelAttemptId) {
     if (event.schemaVersion >= 3) {
-      invalid(event, `Tool call ${toolCallId} has no model attempt`);
+      invalid(event, `Tool call ${toolCallId} has no model attempt identity`);
     }
     return;
+  }
+  const modelAttempt = turn.modelAttempts.get(modelAttemptId);
+  const currentModelAttempt = Array.from(turn.modelAttempts.values()).at(-1);
+  if (
+    !modelAttempt
+    || currentModelAttempt?.modelAttemptId !== modelAttemptId
+  ) {
+    invalid(event, `Tool call ${toolCallId} does not belong to the current model attempt`);
   }
   if (modelAttempt.status === 'started') {
     if (modelInput === undefined) {
@@ -459,6 +469,9 @@ function assertCompletedResponseMatchesScheduledTools(
     seenToolCallIds.add(toolCall.id);
   }
   for (const tool of turn.toolAttempts.values()) {
+    if (tool.modelAttemptId !== event.modelAttemptId) {
+      continue;
+    }
     const declared = toolCalls.find((toolCall) => toolCall.id === tool.toolCallId);
     if (!declared || declared.name !== tool.toolName) {
       invalid(
@@ -998,6 +1011,7 @@ function applyEvent(state: ProjectionAccumulator, event: DurableEventEnvelope): 
         turn,
         event.data.toolCallId,
         event.data.toolName,
+        event.modelAttemptId,
         event.data.modelInput,
       );
       state.seenToolAttemptIds.add(event.toolAttemptId);
@@ -1005,6 +1019,9 @@ function applyEvent(state: ProjectionAccumulator, event: DurableEventEnvelope): 
         toolAttemptId: event.toolAttemptId,
         toolCallId: event.data.toolCallId,
         toolName: event.data.toolName,
+        ...(event.modelAttemptId
+          ? { modelAttemptId: event.modelAttemptId }
+          : {}),
         ...(event.data.modelInput !== undefined
           ? { modelInput: event.data.modelInput }
           : {}),

--- a/src/session/events/DurableSessionProjector.ts
+++ b/src/session/events/DurableSessionProjector.ts
@@ -212,6 +212,7 @@ interface MutableTurnProjection {
   status: DurableTurnStatus;
   preparedInputIds: InputId[];
   modelAttempts: Map<ModelAttemptId, MutableModelAttemptProjection>;
+  lastModelAttempt: MutableModelAttemptProjection | null;
   activeModelAttempt: MutableModelAttemptProjection | null;
   toolAttempts: Map<ToolAttemptId, MutableToolAttemptProjection>;
 }
@@ -395,16 +396,15 @@ function assertToolMatchesModelAttempt(
   modelInput: JsonValue | undefined,
 ): void {
   if (!modelAttemptId) {
-    if (event.schemaVersion >= 3) {
+    if (event.schemaVersion >= DURABLE_EVENT_SCHEMA_VERSION) {
       invalid(event, `Tool call ${toolCallId} has no model attempt identity`);
     }
     return;
   }
   const modelAttempt = turn.modelAttempts.get(modelAttemptId);
-  const currentModelAttempt = Array.from(turn.modelAttempts.values()).at(-1);
   if (
     !modelAttempt
-    || currentModelAttempt?.modelAttemptId !== modelAttemptId
+    || turn.lastModelAttempt?.modelAttemptId !== modelAttemptId
   ) {
     invalid(event, `Tool call ${toolCallId} does not belong to the current model attempt`);
   }
@@ -867,6 +867,7 @@ function applyEvent(state: ProjectionAccumulator, event: DurableEventEnvelope): 
         status: 'running',
         preparedInputIds,
         modelAttempts: new Map(),
+        lastModelAttempt: null,
         activeModelAttempt: null,
         toolAttempts: new Map(),
       };
@@ -931,7 +932,7 @@ function applyEvent(state: ProjectionAccumulator, event: DurableEventEnvelope): 
           `Model attempt ${turn.activeModelAttempt.modelAttemptId} is still active`,
         );
       }
-      const previousAttempt = Array.from(turn.modelAttempts.values()).at(-1);
+      const previousAttempt = turn.lastModelAttempt;
       if (previousAttempt && previousAttempt.status !== 'failed') {
         invalid(
           event,
@@ -955,6 +956,7 @@ function applyEvent(state: ProjectionAccumulator, event: DurableEventEnvelope): 
       };
       state.seenModelAttemptIds.add(event.modelAttemptId);
       turn.modelAttempts.set(event.modelAttemptId, attempt);
+      turn.lastModelAttempt = attempt;
       turn.activeModelAttempt = attempt;
       request.lastBoundaryEventId = event.eventId;
       return;
@@ -1374,31 +1376,54 @@ export function planDurableSessionRecovery(
   const activeModelAttempt = turn?.activeModelAttempt ?? null;
   const pendingInputIds = request?.pendingInputIds ?? [];
   const tools = turn?.toolAttempts ?? [];
+  const modelAttemptStatuses = new Map(
+    (turn?.modelAttempts ?? []).map((attempt) => [attempt.modelAttemptId, attempt.status]),
+  );
+  const hasUnconfirmedModelResponse = (tool: DurableToolAttemptProjection): boolean =>
+    tool.modelAttemptId !== undefined
+    && modelAttemptStatuses.get(tool.modelAttemptId) !== 'completed';
   const unknownToolAttempts = tools.filter(
     (tool) =>
       (tool.status === 'started' || tool.status === 'outcome_unknown')
       && tool.sideEffect === 'non_idempotent',
   );
   const pendingPermissions = tools.flatMap((tool) =>
-    tool.permission?.status === 'pending' ? [tool.permission] : [],
+    tool.permission?.status === 'pending' && !hasUnconfirmedModelResponse(tool)
+      ? [tool.permission]
+      : [],
   );
   const retryableToolAttempts = tools.filter(
     (tool) =>
-      (
+      !hasUnconfirmedModelResponse(tool)
+      && (
+        (
         tool.status === 'scheduled'
         && tool.permission?.status !== 'pending'
         && permissionDecision(tool) !== 'deny'
         && permissionDecision(tool) !== 'cancel'
-      )
-      || (
-        (tool.status === 'started' || tool.status === 'outcome_unknown')
-        && tool.sideEffect !== 'non_idempotent'
+        )
+        || (
+          (tool.status === 'started' || tool.status === 'outcome_unknown')
+          && tool.sideEffect !== 'non_idempotent'
+        )
       ),
   );
   const cancelableToolAttempts = tools.filter(
     (tool) =>
-      tool.status === 'scheduled' &&
-      (permissionDecision(tool) === 'deny' || permissionDecision(tool) === 'cancel'),
+      (
+        tool.status === 'scheduled'
+        && (permissionDecision(tool) === 'deny' || permissionDecision(tool) === 'cancel')
+      )
+      || (
+        hasUnconfirmedModelResponse(tool)
+        && (
+          tool.status === 'scheduled'
+          || (
+            (tool.status === 'started' || tool.status === 'outcome_unknown')
+            && tool.sideEffect !== 'non_idempotent'
+          )
+        )
+      ),
   );
 
   let action: DurableSessionRecoveryAction = 'none';

--- a/src/session/events/DurableSessionProjector.ts
+++ b/src/session/events/DurableSessionProjector.ts
@@ -14,6 +14,7 @@ import {
   type TurnId,
 } from '../../types/branded.js';
 import type { JsonObject, JsonValue } from '../../types/common.js';
+import { canonicalJson } from './canonicalJson.js';
 import { parseDurableEventDraft, parseDurableEventEnvelope } from './schemas.js';
 import {
   DURABLE_EVENT_SCHEMA_VERSION,
@@ -73,6 +74,7 @@ export interface DurableToolAttemptProjection {
   readonly toolAttemptId: ToolAttemptId;
   readonly toolCallId: ToolUseId;
   readonly toolName: string;
+  readonly modelInput?: JsonValue;
   readonly input: JsonValue;
   readonly sideEffect: ToolSideEffect;
   readonly interruptBehavior: DurableToolInterruptBehavior;
@@ -178,6 +180,7 @@ interface MutableToolAttemptProjection {
   toolAttemptId: ToolAttemptId;
   toolCallId: ToolUseId;
   toolName: string;
+  modelInput?: JsonValue;
   input: JsonValue;
   sideEffect: ToolSideEffect;
   interruptBehavior: DurableToolInterruptBehavior;
@@ -381,17 +384,24 @@ function assertToolIdentity(
   }
 }
 
-function assertToolMatchesCompletedModelResponse(
+function assertToolMatchesModelAttempt(
   event: DurableEventEnvelope,
   turn: MutableTurnProjection,
   toolCallId: ToolUseId,
   toolName: string,
+  modelInput: JsonValue | undefined,
 ): void {
   const modelAttempt = Array.from(turn.modelAttempts.values()).at(-1);
   if (!modelAttempt) {
+    if (event.schemaVersion >= 3) {
+      invalid(event, `Tool call ${toolCallId} has no model attempt`);
+    }
     return;
   }
   if (modelAttempt.status === 'started') {
+    if (modelInput === undefined) {
+      invalid(event, `Tool call ${toolCallId} has no original model input`);
+    }
     return;
   }
   if (modelAttempt.status !== 'completed') {
@@ -408,6 +418,31 @@ function assertToolMatchesCompletedModelResponse(
       event,
       `Tool call ${toolCallId}/${toolName} was not declared by model attempt ${modelAttempt.modelAttemptId}`,
     );
+  }
+  assertModelToolInput(event, toolCallId, declared.arguments, modelInput);
+}
+
+function assertModelToolInput(
+  event: DurableEventEnvelope,
+  toolCallId: ToolUseId,
+  argumentsText: string,
+  modelInput: JsonValue | undefined,
+): void {
+  if (modelInput === undefined) {
+    invalid(event, `Tool call ${toolCallId} has no original model input`);
+  }
+  let declaredInput: JsonValue;
+  try {
+    declaredInput = JSON.parse(argumentsText) as JsonValue;
+  } catch (cause) {
+    throw new DurableEventProjectionError(
+      `Tool call ${toolCallId} has invalid model arguments`,
+      event,
+      { cause },
+    );
+  }
+  if (canonicalJson(declaredInput) !== canonicalJson(modelInput)) {
+    invalid(event, `Tool call ${toolCallId} input does not match the model response`);
   }
 }
 
@@ -431,6 +466,12 @@ function assertCompletedResponseMatchesScheduledTools(
         `Model response does not declare durable tool call ${tool.toolCallId}/${tool.toolName}`,
       );
     }
+    assertModelToolInput(
+      event,
+      tool.toolCallId,
+      declared.arguments,
+      tool.modelInput,
+    );
   }
 }
 
@@ -942,20 +983,31 @@ function applyEvent(state: ProjectionAccumulator, event: DurableEventEnvelope): 
 
     case DurableEventTypeValue.TOOL_SCHEDULED: {
       const turn = requireActiveTurn(state, event);
-      assertToolMatchesCompletedModelResponse(
+      if (state.seenToolAttemptIds.has(event.toolAttemptId)) {
+        invalid(event, `Tool attempt ID ${event.toolAttemptId} was already used`);
+      }
+      if (
+        Array.from(turn.toolAttempts.values()).some(
+          (tool) => tool.toolCallId === event.data.toolCallId,
+        )
+      ) {
+        invalid(event, `Tool call ID ${event.data.toolCallId} was already scheduled`);
+      }
+      assertToolMatchesModelAttempt(
         event,
         turn,
         event.data.toolCallId,
         event.data.toolName,
+        event.data.modelInput,
       );
-      if (state.seenToolAttemptIds.has(event.toolAttemptId)) {
-        invalid(event, `Tool attempt ID ${event.toolAttemptId} was already used`);
-      }
       state.seenToolAttemptIds.add(event.toolAttemptId);
       turn.toolAttempts.set(event.toolAttemptId, {
         toolAttemptId: event.toolAttemptId,
         toolCallId: event.data.toolCallId,
         toolName: event.data.toolName,
+        ...(event.data.modelInput !== undefined
+          ? { modelInput: event.data.modelInput }
+          : {}),
         input: event.data.input,
         sideEffect: event.data.sideEffect,
         interruptBehavior: event.data.interruptBehavior,

--- a/src/session/events/DurableSessionProjector.ts
+++ b/src/session/events/DurableSessionProjector.ts
@@ -1333,12 +1333,12 @@ export function planDurableSessionRecovery(
   );
 
   let action: DurableSessionRecoveryAction = 'none';
-  if (unknownToolAttempts.length > 0) {
+  if (activeModelAttempt) {
+    action = 'reconcile_model_outcome';
+  } else if (unknownToolAttempts.length > 0) {
     action = 'reconcile_tool_outcomes';
   } else if (pendingPermissions.length > 0) {
     action = 'resolve_permissions';
-  } else if (activeModelAttempt) {
-    action = 'reconcile_model_outcome';
   } else if (turn) {
     action = 'resume_turn';
   } else if (request?.status === 'accepted') {

--- a/src/session/events/DurableSessionProjector.ts
+++ b/src/session/events/DurableSessionProjector.ts
@@ -5,6 +5,7 @@ import {
   EventId,
   EventSequence,
   type InputId,
+  type ModelAttemptId,
   type PermissionRequestId,
   type RequestId,
   type SessionId,
@@ -20,9 +21,12 @@ import {
   type DurableEventDraft,
   type DurableEventEnvelope,
   type DurableEventError,
+  type DurableEventSchemaVersion,
   type DurableEventType,
   DurableEventType as DurableEventTypeValue,
   type DurableInputPriority,
+  type DurableModelRequestAbortReason,
+  type DurableModelResponse,
   type DurablePermissionDecision,
   type DurableRequestInterruptReason,
   type DurableRequestRecoveryOrigin,
@@ -45,6 +49,7 @@ export type DurableToolAttemptStatus =
   | 'cancelled'
   | 'outcome_unknown';
 export type DurablePermissionStatus = 'pending' | 'resolved';
+export type DurableModelAttemptStatus = 'started' | 'completed' | 'failed' | 'aborted';
 export type DurableSessionRecoveryAction =
   | 'none'
   | 'resume_request'
@@ -52,6 +57,7 @@ export type DurableSessionRecoveryAction =
   | 'resume_turn'
   | 'resolve_permissions'
   | 'reconcile_tool_outcomes'
+  | 'reconcile_model_outcome'
   | 'reconcile_request_inputs'
   | 'reconcile_request_outcome';
 
@@ -79,11 +85,23 @@ export interface DurableToolAttemptProjection {
   readonly unknownReason?: DurableToolOutcomeUnknownReason;
 }
 
+export interface DurableModelAttemptProjection {
+  readonly modelAttemptId: ModelAttemptId;
+  readonly model: string;
+  readonly streaming: boolean;
+  readonly status: DurableModelAttemptStatus;
+  readonly response?: DurableModelResponse;
+  readonly error?: DurableEventError;
+  readonly abortReason?: DurableModelRequestAbortReason;
+}
+
 export interface DurableTurnProjection {
   readonly turnId: TurnId;
   readonly turn: number;
   readonly model?: string;
   readonly status: DurableTurnStatus;
+  readonly modelAttempts: readonly DurableModelAttemptProjection[];
+  readonly activeModelAttempt: DurableModelAttemptProjection | null;
   readonly toolAttempts: readonly DurableToolAttemptProjection[];
 }
 
@@ -110,6 +128,7 @@ export interface DurableRequestProjection {
 
 export interface DurableSessionProjection {
   readonly sessionId: SessionId | null;
+  readonly schemaVersion: DurableEventSchemaVersion | null;
   readonly status: DurableSessionProjectionStatus;
   readonly headSequence: EventSequence | null;
   readonly lastEventId: EventId | null;
@@ -125,6 +144,7 @@ export interface DurableSessionRecoveryPlan {
   readonly action: DurableSessionRecoveryAction;
   readonly requestId: RequestId | null;
   readonly turnId: TurnId | null;
+  readonly activeModelAttempt: DurableModelAttemptProjection | null;
   readonly retryableToolAttempts: readonly DurableToolAttemptProjection[];
   readonly cancelableToolAttempts: readonly DurableToolAttemptProjection[];
   readonly unknownToolAttempts: readonly DurableToolAttemptProjection[];
@@ -170,12 +190,24 @@ interface MutableToolAttemptProjection {
   unknownReason?: DurableToolOutcomeUnknownReason;
 }
 
+interface MutableModelAttemptProjection {
+  modelAttemptId: ModelAttemptId;
+  model: string;
+  streaming: boolean;
+  status: DurableModelAttemptStatus;
+  response?: DurableModelResponse;
+  error?: DurableEventError;
+  abortReason?: DurableModelRequestAbortReason;
+}
+
 interface MutableTurnProjection {
   turnId: TurnId;
   turn: number;
   model?: string;
   status: DurableTurnStatus;
   preparedInputIds: InputId[];
+  modelAttempts: Map<ModelAttemptId, MutableModelAttemptProjection>;
+  activeModelAttempt: MutableModelAttemptProjection | null;
   toolAttempts: Map<ToolAttemptId, MutableToolAttemptProjection>;
 }
 
@@ -203,6 +235,7 @@ interface MutableRequestProjection {
 
 interface ProjectionAccumulator {
   sessionId: SessionId | null;
+  schemaVersion: DurableEventSchemaVersion | null;
   status: DurableSessionProjectionStatus;
   headSequence: EventSequence | null;
   lastEventId: EventId | null;
@@ -249,6 +282,7 @@ interface ProjectionAccumulator {
     sequence: EventSequence;
     reason: DurableRequestInterruptReason;
   } | null;
+  seenModelAttemptIds: Set<ModelAttemptId>;
   seenToolAttemptIds: Set<ToolAttemptId>;
   seenPermissionRequestIds: Set<PermissionRequestId>;
   seenInputIds: Set<InputId>;
@@ -258,6 +292,7 @@ interface ProjectionAccumulator {
 
 type RequestScopedEvent = DurableEventEnvelope & { readonly requestId: RequestId };
 type TurnScopedEvent = RequestScopedEvent & { readonly turnId: TurnId };
+type ModelScopedEvent = TurnScopedEvent & { readonly modelAttemptId: ModelAttemptId };
 type ToolScopedEvent = TurnScopedEvent & { readonly toolAttemptId: ToolAttemptId };
 
 function invalid(event: DurableEventEnvelope, message: string): never {
@@ -320,6 +355,22 @@ function requireToolAttempt(
   return tool;
 }
 
+function requireModelAttempt(
+  state: ProjectionAccumulator,
+  event: ModelScopedEvent,
+): MutableModelAttemptProjection {
+  const turn = requireActiveTurn(state, event);
+  const attempt = turn.modelAttempts.get(event.modelAttemptId);
+  if (
+    !attempt
+    || turn.activeModelAttempt?.modelAttemptId !== event.modelAttemptId
+    || attempt.status !== 'started'
+  ) {
+    invalid(event, `No active model attempt matches ${String(event.modelAttemptId)}`);
+  }
+  return attempt;
+}
+
 function assertToolIdentity(
   event: DurableEventEnvelope,
   tool: MutableToolAttemptProjection,
@@ -340,6 +391,9 @@ function assertNoPendingPermission(
 }
 
 function assertTurnCanEnd(event: DurableEventEnvelope, turn: MutableTurnProjection): void {
+  if (turn.activeModelAttempt) {
+    invalid(event, `Model attempt ${turn.activeModelAttempt.modelAttemptId} is not terminal`);
+  }
   const unfinished = Array.from(turn.toolAttempts.values()).find(
     (tool) =>
       tool.status === 'scheduled' ||
@@ -436,6 +490,14 @@ function cloneTool(tool: MutableToolAttemptProjection): DurableToolAttemptProjec
   };
 }
 
+function cloneModelAttempt(
+  attempt: MutableModelAttemptProjection,
+): DurableModelAttemptProjection {
+  return {
+    ...attempt,
+  };
+}
+
 function cloneTurn(turn: MutableTurnProjection | null): DurableTurnProjection | null {
   if (!turn) {
     return null;
@@ -445,6 +507,10 @@ function cloneTurn(turn: MutableTurnProjection | null): DurableTurnProjection | 
     turn: turn.turn,
     ...(turn.model ? { model: turn.model } : {}),
     status: turn.status,
+    modelAttempts: Array.from(turn.modelAttempts.values(), cloneModelAttempt),
+    activeModelAttempt: turn.activeModelAttempt
+      ? cloneModelAttempt(turn.activeModelAttempt)
+      : null,
     toolAttempts: Array.from(turn.toolAttempts.values(), cloneTool),
   };
 }
@@ -693,6 +759,8 @@ function applyEvent(state: ProjectionAccumulator, event: DurableEventEnvelope): 
         ...(event.data.model ? { model: event.data.model } : {}),
         status: 'running',
         preparedInputIds,
+        modelAttempts: new Map(),
+        activeModelAttempt: null,
         toolAttempts: new Map(),
       };
       return;
@@ -744,6 +812,71 @@ function applyEvent(state: ProjectionAccumulator, event: DurableEventEnvelope): 
         preparedInputIds: [...turn.preparedInputIds],
         unsafeNonIdempotentToolAttemptId: unsafeNonIdempotentTool?.toolAttemptId ?? null,
       };
+      return;
+    }
+
+    case DurableEventTypeValue.MODEL_REQUEST_STARTED: {
+      const request = requireRunningRequest(state, event);
+      const turn = requireActiveTurn(state, event);
+      if (turn.activeModelAttempt) {
+        invalid(
+          event,
+          `Model attempt ${turn.activeModelAttempt.modelAttemptId} is still active`,
+        );
+      }
+      const previousAttempt = Array.from(turn.modelAttempts.values()).at(-1);
+      if (previousAttempt && previousAttempt.status !== 'failed') {
+        invalid(
+          event,
+          `Model attempt ${previousAttempt.modelAttemptId} ended as ${previousAttempt.status}`,
+        );
+      }
+      if (state.seenModelAttemptIds.has(event.modelAttemptId)) {
+        invalid(event, `Model attempt ID ${event.modelAttemptId} was already used`);
+      }
+      const attempt: MutableModelAttemptProjection = {
+        modelAttemptId: event.modelAttemptId,
+        model: event.data.model,
+        streaming: event.data.streaming,
+        status: 'started',
+      };
+      state.seenModelAttemptIds.add(event.modelAttemptId);
+      turn.modelAttempts.set(event.modelAttemptId, attempt);
+      turn.activeModelAttempt = attempt;
+      request.lastBoundaryEventId = event.eventId;
+      return;
+    }
+
+    case DurableEventTypeValue.MODEL_REQUEST_COMPLETED: {
+      const request = requireRunningRequest(state, event);
+      const turn = requireActiveTurn(state, event);
+      const attempt = requireModelAttempt(state, event);
+      attempt.status = 'completed';
+      attempt.response = event.data.response;
+      turn.activeModelAttempt = null;
+      request.lastBoundaryEventId = event.eventId;
+      return;
+    }
+
+    case DurableEventTypeValue.MODEL_REQUEST_FAILED: {
+      const request = requireRunningRequest(state, event);
+      const turn = requireActiveTurn(state, event);
+      const attempt = requireModelAttempt(state, event);
+      attempt.status = 'failed';
+      attempt.error = event.data.error;
+      turn.activeModelAttempt = null;
+      request.lastBoundaryEventId = event.eventId;
+      return;
+    }
+
+    case DurableEventTypeValue.MODEL_REQUEST_ABORTED: {
+      const request = requireRunningRequest(state, event);
+      const turn = requireActiveTurn(state, event);
+      const attempt = requireModelAttempt(state, event);
+      attempt.status = 'aborted';
+      attempt.abortReason = event.data.reason;
+      turn.activeModelAttempt = null;
+      request.lastBoundaryEventId = event.eventId;
       return;
     }
 
@@ -933,6 +1066,7 @@ function applyEvent(state: ProjectionAccumulator, event: DurableEventEnvelope): 
 function createProjectionAccumulator(): ProjectionAccumulator {
   return {
     sessionId: null,
+    schemaVersion: null,
     status: 'empty',
     headSequence: null,
     lastEventId: null,
@@ -949,6 +1083,7 @@ function createProjectionAccumulator(): ProjectionAccumulator {
     lastTurnAbort: null,
     lastTurnTerminal: null,
     lastRequestInterruption: null,
+    seenModelAttemptIds: new Set(),
     seenToolAttemptIds: new Set(),
     seenPermissionRequestIds: new Set(),
     seenInputIds: new Set(),
@@ -984,6 +1119,7 @@ export class DurableSessionProjector {
     const state = this.state;
     return structuredClone({
       sessionId: state.sessionId,
+      schemaVersion: state.schemaVersion,
       status: state.status,
       headSequence: state.headSequence,
       lastEventId: state.lastEventId,
@@ -1062,6 +1198,12 @@ export class DurableSessionProjector {
     if (state.sessionId && event.sessionId !== state.sessionId) {
       invalid(event, `Expected session ${state.sessionId}, received ${event.sessionId}`);
     }
+    if (state.schemaVersion !== null && event.schemaVersion < state.schemaVersion) {
+      invalid(
+        event,
+        `Durable event schema regressed from v${state.schemaVersion} to v${event.schemaVersion}`,
+      );
+    }
     if (state.seenEventIds.has(event.eventId)) {
       invalid(event, `Event ID ${event.eventId} was already used`);
     }
@@ -1071,6 +1213,7 @@ export class DurableSessionProjector {
 
     state.seenEventIds.add(event.eventId);
     applyEvent(state, event);
+    state.schemaVersion = event.schemaVersion;
     state.headSequence = event.sequence;
     state.lastEventId = event.eventId;
   }
@@ -1093,6 +1236,7 @@ export function planDurableSessionRecovery(
 ): DurableSessionRecoveryPlan {
   const request = projection.activeRequest;
   const turn = request?.activeTurn ?? null;
+  const activeModelAttempt = turn?.activeModelAttempt ?? null;
   const pendingInputIds = request?.pendingInputIds ?? [];
   const tools = turn?.toolAttempts ?? [];
   const unknownToolAttempts = tools.filter(
@@ -1127,6 +1271,8 @@ export function planDurableSessionRecovery(
     action = 'reconcile_tool_outcomes';
   } else if (pendingPermissions.length > 0) {
     action = 'resolve_permissions';
+  } else if (activeModelAttempt) {
+    action = 'reconcile_model_outcome';
   } else if (turn) {
     action = 'resume_turn';
   } else if (request?.status === 'accepted') {
@@ -1150,6 +1296,7 @@ export function planDurableSessionRecovery(
     action,
     requestId: request?.requestId ?? null,
     turnId: turn?.turnId ?? null,
+    activeModelAttempt,
     retryableToolAttempts,
     cancelableToolAttempts,
     unknownToolAttempts,

--- a/src/session/events/DurableSessionRecoveryCoordinator.ts
+++ b/src/session/events/DurableSessionRecoveryCoordinator.ts
@@ -44,6 +44,7 @@ import {
 } from './types.js';
 
 const MAX_RECOVERY_VALUE_CHARS = 4_000;
+const MAX_RECOVERY_MODEL_ATTEMPTS = 16;
 
 export type DurableAcceptedRequestRecovery = DurableRequestProjection & {
   readonly maxTurns: number;
@@ -482,6 +483,8 @@ function buildTurnRecoveryContinuation(
   turn: NonNullable<DurableRequestProjection['activeTurn']>,
 ): UserMessageContent {
   const originalInput = parseRecoveryInput(request);
+  const retainedModelAttempts = turn.modelAttempts.slice(-MAX_RECOVERY_MODEL_ATTEMPTS);
+  const omittedModelAttempts = turn.modelAttempts.length - retainedModelAttempts.length;
   const toolOutcomes = turn.toolAttempts.map((tool) => {
     const permissionDecision =
       tool.permission?.status === 'resolved' ? tool.permission.decision : undefined;
@@ -494,6 +497,7 @@ function buildTurnRecoveryContinuation(
     return {
       toolCallId: tool.toolCallId,
       toolName: tool.toolName,
+      ...(tool.modelAttemptId ? { modelAttemptId: tool.modelAttemptId } : {}),
       input: boundedRecoveryValue(effectiveInput),
       sideEffect: recoveredFromPermission ? 'non_idempotent' : tool.sideEffect,
       executionStarted: tool.executionStarted,
@@ -516,9 +520,9 @@ function buildTurnRecoveryContinuation(
       sourceRequestId: request.requestId,
       sourceTurnId: turn.turnId,
       sourceTurn: turn.turn,
-      ...(turn.modelAttempts.length > 0
+      ...(retainedModelAttempts.length > 0
         ? {
-            modelAttempts: turn.modelAttempts.map((attempt) => ({
+            modelAttempts: retainedModelAttempts.map((attempt) => ({
               modelAttemptId: attempt.modelAttemptId,
               model: attempt.model,
               streaming: attempt.streaming,
@@ -526,9 +530,14 @@ function buildTurnRecoveryContinuation(
               ...(attempt.response
                 ? { response: boundedRecoveryValue(attempt.response) }
                 : {}),
-              ...(attempt.error ? { error: attempt.error } : {}),
+              ...(attempt.error
+                ? { error: boundedRecoveryValue(attempt.error) }
+                : {}),
               ...(attempt.abortReason ? { abortReason: attempt.abortReason } : {}),
             })),
+            ...(omittedModelAttempts > 0
+              ? { modelAttemptsOmitted: omittedModelAttempts }
+              : {}),
           }
         : {}),
       toolOutcomes,

--- a/src/session/events/DurableSessionRecoveryCoordinator.ts
+++ b/src/session/events/DurableSessionRecoveryCoordinator.ts
@@ -5,6 +5,7 @@ import type {
   EventId,
   EventSequence,
   InputId,
+  ModelAttemptId,
   PermissionRequestId,
   RequestId,
   SessionId,
@@ -25,6 +26,7 @@ import {
 } from './DurableSessionJournal.js';
 import {
   DurableEventProjectionError,
+  type DurableModelAttemptProjection,
   type DurablePermissionProjection,
   type DurableRequestProjection,
   type DurableSessionProjection,
@@ -36,6 +38,7 @@ import {
   type DurableEventEnvelope,
   type DurableEventError,
   DurableEventType,
+  type DurableModelResponse,
   type DurablePermissionDecision,
   type DurableTokenUsage,
 } from './types.js';
@@ -95,6 +98,27 @@ export interface DurablePermissionResolutionCommand {
   readonly permissionRequestId: PermissionRequestId;
   readonly decision: DurablePermissionDecision;
   readonly message?: string;
+}
+
+export type DurableModelOutcomeReconciliation =
+  | {
+      readonly status: 'completed';
+      readonly response: DurableModelResponse;
+    }
+  | {
+      readonly status: 'failed';
+      readonly error: DurableEventError;
+    }
+  | {
+      readonly status: 'aborted';
+    };
+
+export interface DurableModelOutcomeReconciliationCommand {
+  readonly commandId: CommandId;
+  readonly requestId: RequestId;
+  readonly turnId: TurnId;
+  readonly modelAttemptId: ModelAttemptId;
+  readonly outcome: DurableModelOutcomeReconciliation;
 }
 
 export interface DurableRequestRolloverCommand {
@@ -199,6 +223,7 @@ function eventToCommandDraft(event: DurableEventEnvelope): DurableCommandEventDr
     occurredAt: event.occurredAt,
     ...('requestId' in event ? { requestId: event.requestId } : {}),
     ...('turnId' in event ? { turnId: event.turnId } : {}),
+    ...('modelAttemptId' in event ? { modelAttemptId: event.modelAttemptId } : {}),
     ...('toolAttemptId' in event ? { toolAttemptId: event.toolAttemptId } : {}),
     ...(event.causationEventId ? { causationEventId: event.causationEventId } : {}),
   } as DurableCommandEventDraft;
@@ -491,9 +516,30 @@ function buildTurnRecoveryContinuation(
       sourceRequestId: request.requestId,
       sourceTurnId: turn.turnId,
       sourceTurn: turn.turn,
+      ...(turn.modelAttempts.length > 0
+        ? {
+            modelAttempts: turn.modelAttempts.map((attempt) => ({
+              modelAttemptId: attempt.modelAttemptId,
+              model: attempt.model,
+              streaming: attempt.streaming,
+              status: attempt.status,
+              ...(attempt.response
+                ? { response: boundedRecoveryValue(attempt.response) }
+                : {}),
+              ...(attempt.error ? { error: attempt.error } : {}),
+              ...(attempt.abortReason ? { abortReason: attempt.abortReason } : {}),
+            })),
+          }
+        : {}),
       toolOutcomes,
     },
     [
+      ...(turn.modelAttempts.length > 0
+        ? [
+            'Treat completed model responses as authoritative prior output and do not regenerate them. '
+              + 'Failed or aborted model attempts have no trusted response.',
+          ]
+        : []),
       'Do not repeat tool operations marked completed. '
         + 'Operations marked not_started are safe to execute once. Operations marked '
         + 'interrupted_before_trusted_completion may be retried only when their '
@@ -566,11 +612,48 @@ function requestOutcomeEvent(
   }
 }
 
+function modelOutcomeEvent(
+  command: DurableModelOutcomeReconciliationCommand,
+): DurableCommandEventDraft {
+  const correlation = {
+    requestId: command.requestId,
+    turnId: command.turnId,
+    modelAttemptId: command.modelAttemptId,
+  };
+  switch (command.outcome.status) {
+    case 'completed':
+      return {
+        type: DurableEventType.MODEL_REQUEST_COMPLETED,
+        ...correlation,
+        data: {
+          response: command.outcome.response,
+        },
+      };
+    case 'failed':
+      return {
+        type: DurableEventType.MODEL_REQUEST_FAILED,
+        ...correlation,
+        data: {
+          error: command.outcome.error,
+        },
+      };
+    case 'aborted':
+      return {
+        type: DurableEventType.MODEL_REQUEST_ABORTED,
+        ...correlation,
+        data: {
+          reason: 'process_restart',
+        },
+      };
+  }
+}
+
 /**
  * Coordinates explicit recovery mutations against one durable Session journal.
  *
- * Recovery never guesses the outcome of a started tool. Callers must supply a
- * stable command ID so retries remain idempotent across process restarts.
+ * Recovery never guesses the outcome of a started model request or tool.
+ * Callers must supply a stable command ID so retries remain idempotent across
+ * process restarts.
  */
 export class DurableSessionRecoveryCoordinator {
   constructor(private readonly journal: DurableSessionJournal) {}
@@ -960,6 +1043,50 @@ export class DurableSessionRecoveryCoordinator {
     };
   }
 
+  /**
+   * Records the externally reconciled outcome of a model request that may
+   * have completed before the process stopped.
+   */
+  async reconcileModelOutcome(
+    command: DurableModelOutcomeReconciliationCommand,
+  ): Promise<DurableRecoveryCommitResult> {
+    await this.journal.refresh();
+    const event = modelOutcomeEvent(command);
+    if (this.journal.getCommandEvents(command.commandId)) {
+      return this.result(await this.commitRecovery({
+        commandId: command.commandId,
+        events: [event],
+      }));
+    }
+
+    const expectedHeadSequence = this.getProjection().headSequence;
+    const recoveryPlan = this.getRecoveryPlan();
+    const { request, turn, attempt } = this.findModelAttempt(command.modelAttemptId);
+    if (recoveryPlan.action !== 'reconcile_model_outcome') {
+      throw new DurableSessionRecoveryError(
+        'DURABLE_RECOVERY_INVALID_STATE',
+        `Model outcome reconciliation requires reconcile_model_outcome, found ${recoveryPlan.action}`,
+      );
+    }
+    if (
+      request.requestId !== command.requestId
+      || turn.turnId !== command.turnId
+      || attempt.modelAttemptId !== command.modelAttemptId
+      || attempt.status !== 'started'
+    ) {
+      throw new DurableSessionRecoveryError(
+        'DURABLE_RECOVERY_TARGET_NOT_FOUND',
+        `No active model attempt matches ${command.requestId}/${command.turnId}/${command.modelAttemptId}`,
+      );
+    }
+
+    const commit = await this.commitRecovery({
+      commandId: command.commandId,
+      events: [event],
+    }, expectedHeadSequence);
+    return this.result(commit);
+  }
+
   async reconcileToolOutcome(
     command: DurableToolOutcomeReconciliationCommand,
   ): Promise<DurableRecoveryCommitResult> {
@@ -1103,6 +1230,25 @@ export class DurableSessionRecoveryCoordinator {
       );
     }
     return { request, turn, tool };
+  }
+
+  private findModelAttempt(modelAttemptId: ModelAttemptId): {
+    request: DurableRequestProjection;
+    turn: NonNullable<DurableRequestProjection['activeTurn']>;
+    attempt: DurableModelAttemptProjection;
+  } {
+    const request = this.getProjection().activeRequest;
+    const turn = request?.activeTurn;
+    const attempt = turn?.modelAttempts.find(
+      (candidate) => candidate.modelAttemptId === modelAttemptId,
+    );
+    if (!request || !turn || !attempt) {
+      throw new DurableSessionRecoveryError(
+        'DURABLE_RECOVERY_TARGET_NOT_FOUND',
+        `No model attempt matches ${modelAttemptId}`,
+      );
+    }
+    return { request, turn, attempt };
   }
 
   private findPermission(permissionRequestId: PermissionRequestId): {

--- a/src/session/events/DurableSessionRecoveryCoordinator.ts
+++ b/src/session/events/DurableSessionRecoveryCoordinator.ts
@@ -485,6 +485,9 @@ function buildTurnRecoveryContinuation(
   const originalInput = parseRecoveryInput(request);
   const retainedModelAttempts = turn.modelAttempts.slice(-MAX_RECOVERY_MODEL_ATTEMPTS);
   const omittedModelAttempts = turn.modelAttempts.length - retainedModelAttempts.length;
+  const modelAttemptStatuses = new Map(
+    turn.modelAttempts.map((attempt) => [attempt.modelAttemptId, attempt.status]),
+  );
   const toolOutcomes = turn.toolAttempts.map((tool) => {
     const permissionDecision =
       tool.permission?.status === 'resolved' ? tool.permission.decision : undefined;
@@ -492,6 +495,13 @@ function buildTurnRecoveryContinuation(
       tool.status === 'scheduled' &&
       (permissionDecision === 'deny' || permissionDecision === 'cancel');
     const recoveredFromPermission = tool.status === 'scheduled' && permissionDecision === 'allow';
+    const unconfirmedModelResponse =
+      tool.modelAttemptId !== undefined
+      && modelAttemptStatuses.get(tool.modelAttemptId) !== 'completed';
+    const unfinished =
+      tool.status === 'scheduled'
+      || tool.status === 'started'
+      || tool.status === 'outcome_unknown';
     const effectiveInput =
       tool.permission?.status === 'resolved' ? tool.permission.input : tool.input;
     return {
@@ -501,7 +511,9 @@ function buildTurnRecoveryContinuation(
       input: boundedRecoveryValue(effectiveInput),
       sideEffect: recoveredFromPermission ? 'non_idempotent' : tool.sideEffect,
       executionStarted: tool.executionStarted,
-      status: permissionCancelledBeforeExecution
+      status: unconfirmedModelResponse && unfinished
+        ? 'discarded_unconfirmed_model_response'
+        : permissionCancelledBeforeExecution
         ? 'cancelled_before_execution'
         : tool.status === 'scheduled'
           ? 'not_started'
@@ -553,7 +565,8 @@ function buildTurnRecoveryContinuation(
         + 'Operations marked not_started are safe to execute once. Operations marked '
         + 'interrupted_before_trusted_completion may be retried only when their '
         + 'side-effect contract permits it. Operations marked cancelled_before_execution '
-        + 'require fresh permission. Continue the original task.',
+        + 'require fresh permission. Operations marked discarded_unconfirmed_model_response '
+        + 'must not be retried. Continue the original task.',
     ],
   );
 }

--- a/src/session/events/DurableSessionRecoveryCoordinator.ts
+++ b/src/session/events/DurableSessionRecoveryCoordinator.ts
@@ -43,7 +43,7 @@ import {
   type DurableTokenUsage,
 } from './types.js';
 
-const MAX_RECOVERY_TOOL_VALUE_CHARS = 4_000;
+const MAX_RECOVERY_VALUE_CHARS = 4_000;
 
 export type DurableAcceptedRequestRecovery = DurableRequestProjection & {
   readonly maxTurns: number;
@@ -462,11 +462,11 @@ function composeRecoveryContinuation(
 function boundedRecoveryValue(value: unknown): JsonValue {
   const normalized = toJsonValue(value);
   const serialized = JSON.stringify(normalized);
-  if (serialized.length <= MAX_RECOVERY_TOOL_VALUE_CHARS) {
+  if (serialized.length <= MAX_RECOVERY_VALUE_CHARS) {
     return normalized;
   }
 
-  const retainedPerEdge = Math.floor(MAX_RECOVERY_TOOL_VALUE_CHARS / 2);
+  const retainedPerEdge = Math.floor(MAX_RECOVERY_VALUE_CHARS / 2);
   return {
     kind: 'truncated_recovery_value',
     complete: false,

--- a/src/session/events/JsonlDurableEventStore.ts
+++ b/src/session/events/JsonlDurableEventStore.ts
@@ -1,8 +1,8 @@
+import { Mutex } from 'async-mutex';
+import { nanoid } from 'nanoid';
 import { Buffer } from 'node:buffer';
 import { mkdir, open, readFile, truncate } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
-import { Mutex } from 'async-mutex';
-import { nanoid } from 'nanoid';
 import { EventId, EventSequence, type SessionId } from '../../types/branded.js';
 import {
   DurableEventSequenceConflictError,
@@ -23,6 +23,7 @@ import {
   type DurableEventEnvelope,
   type DurableEventPage,
   type DurableEventReadOptions,
+  type DurableEventSchemaVersion,
 } from './types.js';
 
 const DEFAULT_PAGE_SIZE = 100;
@@ -289,6 +290,7 @@ export class JsonlDurableEventStore implements DurableEventStore {
     const events: DurableEventEnvelope[] = [];
     const eventIds = new Set<string>();
     let expectedSequence = 1;
+    let previousSchemaVersion: DurableEventSchemaVersion | null = null;
 
     for (const [index, line] of lines.entries()) {
       let batch: PersistedDurableEventBatch;
@@ -302,9 +304,16 @@ export class JsonlDurableEventStore implements DurableEventStore {
         );
       }
 
-      this.assertBatchIntegrity(batch, sessionId, expectedSequence, eventIds);
+      this.assertBatchIntegrity(
+        batch,
+        sessionId,
+        expectedSequence,
+        previousSchemaVersion,
+        eventIds,
+      );
       events.push(...batch.events);
       expectedSequence = Number(batch.lastSequence) + 1;
+      previousSchemaVersion = batch.schemaVersion;
     }
 
     return {
@@ -318,6 +327,7 @@ export class JsonlDurableEventStore implements DurableEventStore {
     batch: PersistedDurableEventBatch,
     sessionId: SessionId,
     expectedFirstSequence: number,
+    previousSchemaVersion: DurableEventSchemaVersion | null,
     eventIds: Set<string>,
   ): void {
     const firstSequence = Number(batch.firstSequence);
@@ -330,6 +340,12 @@ export class JsonlDurableEventStore implements DurableEventStore {
       throw new DurableEventStoreError(
         'DURABLE_EVENT_CORRUPT_LOG',
         `Non-contiguous durable event batch for session ${sessionId}`,
+      );
+    }
+    if (previousSchemaVersion !== null && batch.schemaVersion < previousSchemaVersion) {
+      throw new DurableEventStoreError(
+        'DURABLE_EVENT_CORRUPT_LOG',
+        `Durable event schema regressed from v${previousSchemaVersion} to v${batch.schemaVersion}`,
       );
     }
 

--- a/src/session/events/SessionDurableRecorder.ts
+++ b/src/session/events/SessionDurableRecorder.ts
@@ -412,6 +412,7 @@ export class SessionDurableRecorder implements
           data: {
             toolCallId: tool.toolCallId,
             toolName: tool.toolName,
+            modelInput: event.modelInput,
             input: event.input,
             sideEffect: event.sideEffect,
             interruptBehavior: event.interruptBehavior,

--- a/src/session/events/SessionDurableRecorder.ts
+++ b/src/session/events/SessionDurableRecorder.ts
@@ -61,6 +61,7 @@ interface ActiveTool {
 interface ActiveTurn {
   turnId: TurnId;
   turn: number;
+  modelAttemptId: ModelAttemptId | null;
   tools: Map<ToolUseId, ActiveTool>;
 }
 
@@ -313,8 +314,10 @@ export class SessionDurableRecorder implements
       }
       throw error;
     }
+    turn.modelAttemptId = attempt.modelAttemptId;
 
     return {
+      modelAttemptId: attempt.modelAttemptId,
       onCompleted: (response) => this.completeModelRequest(attempt, response),
       onFailed: (error) => this.failModelRequest(attempt, error),
       onAborted: (reason) => this.abortModelRequest(attempt, reason),
@@ -390,6 +393,11 @@ export class SessionDurableRecorder implements
 
   async onToolScheduled(event: ToolScheduledLifecycle): Promise<ToolInvocationLifecycle> {
     const turn = this.requireActiveTurn();
+    if (!event.modelAttemptId || event.modelAttemptId !== turn.modelAttemptId) {
+      throw new SessionDurableRecorderError(
+        `Tool call ${event.toolCallId} does not belong to the current model attempt`,
+      );
+    }
     if (turn.tools.has(event.toolCallId)) {
       throw new SessionDurableRecorderError(
         `Tool call ${event.toolCallId} was already scheduled in turn ${turn.turnId}`,
@@ -408,6 +416,7 @@ export class SessionDurableRecorder implements
           type: DurableEventType.TOOL_SCHEDULED,
           requestId: this.requestId,
           turnId: turn.turnId,
+          modelAttemptId: event.modelAttemptId,
           toolAttemptId: tool.toolAttemptId,
           data: {
             toolCallId: tool.toolCallId,
@@ -500,6 +509,7 @@ export class SessionDurableRecorder implements
     const activeTurn: ActiveTurn = {
       turnId: TurnId(nanoid()),
       turn,
+      modelAttemptId: null,
       tools: new Map(),
     };
     await this.commitRequestBoundary([
@@ -609,7 +619,7 @@ export class SessionDurableRecorder implements
     response: Parameters<ModelRequestLifecycle['onCompleted']>[0],
   ): Promise<void> {
     this.requireModelAttempt(attempt);
-    await this.commitRequestBoundary([
+    await this.commitRebasableRequestBoundary([
       {
         type: DurableEventType.MODEL_REQUEST_COMPLETED,
         requestId: this.requestId,
@@ -628,7 +638,7 @@ export class SessionDurableRecorder implements
     error: unknown,
   ): Promise<void> {
     this.requireModelAttempt(attempt);
-    await this.commitRequestBoundary([
+    await this.commitRebasableRequestBoundary([
       {
         type: DurableEventType.MODEL_REQUEST_FAILED,
         requestId: this.requestId,
@@ -647,7 +657,7 @@ export class SessionDurableRecorder implements
     reason: ModelRequestAbortReason,
   ): Promise<void> {
     this.requireModelAttempt(attempt);
-    await this.commitRequestBoundary([
+    await this.commitRebasableRequestBoundary([
       {
         type: DurableEventType.MODEL_REQUEST_ABORTED,
         requestId: this.requestId,
@@ -873,6 +883,27 @@ export class SessionDurableRecorder implements
     events: Parameters<DurableSessionJournal['commit']>[0]['events'],
   ): Promise<DurableCommandCommitResult> {
     const commit = await this.commitAtCurrentHead(events);
+    this.updateLastBoundary(commit);
+    return commit;
+  }
+
+  private async commitRebasableRequestBoundary(
+    events: Parameters<DurableSessionJournal['commit']>[0]['events'],
+  ): Promise<DurableCommandCommitResult> {
+    this.assertBoundaryHealthy();
+    let commit: DurableCommandCommitResult;
+    try {
+      commit = await this.commit(events);
+    } catch (error) {
+      this.boundaryFailed = true;
+      this.boundaryFailure = error;
+      throw error;
+    }
+    this.updateLastBoundary(commit);
+    return commit;
+  }
+
+  private updateLastBoundary(commit: DurableCommandCommitResult): void {
     const boundary = commit.events.at(-1);
     if (!boundary) {
       throw new SessionDurableRecorderError(
@@ -880,7 +911,6 @@ export class SessionDurableRecorder implements
       );
     }
     this.lastBoundaryEventId = boundary.eventId;
-    return commit;
   }
 
   private async commitAtCurrentHead(

--- a/src/session/events/SessionDurableRecorder.ts
+++ b/src/session/events/SessionDurableRecorder.ts
@@ -1,6 +1,11 @@
 import { nanoid } from 'nanoid';
 import type { AgentEvent, TokenUsageInfo } from '../../agent/AgentEvent.js';
 import type {
+  ModelExecutionLifecycle,
+  ModelRequestAbortReason,
+  ModelRequestLifecycle,
+} from '../../agent/ModelExecutionLifecycle.js';
+import type {
   InputApplicationLifecycle,
   LoopResult,
   UserMessageContent,
@@ -19,10 +24,11 @@ import {
   CommandId,
   type EventId,
   type InputId,
+  ModelAttemptId,
   PermissionRequestId,
   type RequestId,
   ToolAttemptId,
-  type ToolUseId,
+  ToolUseId,
   TurnId,
 } from '../../types/branded.js';
 import type { JsonObject, JsonValue } from '../../types/common.js';
@@ -34,7 +40,9 @@ import type {
 } from './DurableSessionJournal.js';
 import type { DurableSessionRecoveryPlan } from './DurableSessionProjector.js';
 import {
+  type DurableEventError,
   DurableEventType,
+  type DurableModelResponse,
   type DurableRequestInterruptReason,
   type DurableToolCancelReason,
 } from './types.js';
@@ -54,6 +62,33 @@ interface ActiveTurn {
   turnId: TurnId;
   turn: number;
   tools: Map<ToolUseId, ActiveTool>;
+}
+
+interface ActiveModelAttempt {
+  modelAttemptId: ModelAttemptId;
+  turnId: TurnId;
+}
+
+function toDurableEventError(error: unknown, fallbackMessage: string): DurableEventError {
+  const record =
+    typeof error === 'object' && error !== null
+      ? error as Record<string, unknown>
+      : undefined;
+  const rawMessage =
+    error instanceof Error
+      ? error.message
+      : typeof record?.message === 'string'
+        ? record.message
+        : String(error);
+  return {
+    message: rawMessage.trim() === '' ? fallbackMessage : rawMessage,
+    ...(typeof record?.code === 'string' && record.code.trim() !== ''
+      ? { code: record.code }
+      : {}),
+    ...(typeof record?.retryable === 'boolean'
+      ? { retryable: record.retryable }
+      : {}),
+  };
 }
 
 export type DurableRequestFinish =
@@ -90,8 +125,13 @@ export class DurableSessionRecoveryRequiredError extends SdkError {
   }
 }
 
-export class SessionDurableRecorder implements ToolExecutionLifecycle, InputApplicationLifecycle {
+export class SessionDurableRecorder implements
+  ToolExecutionLifecycle,
+  InputApplicationLifecycle,
+  ModelExecutionLifecycle
+{
   private activeTurn: ActiveTurn | null = null;
+  private activeModelAttempt: ActiveModelAttempt | null = null;
   private readonly persistedInputApplications = new Map<InputId, 'now' | 'next'>();
   private lastBoundaryEventId: EventId | null = null;
   private boundaryFailed = false;
@@ -238,6 +278,49 @@ export class SessionDurableRecorder implements ToolExecutionLifecycle, InputAppl
     }
   }
 
+  async onModelRequestStarting(input: {
+    readonly turn: number;
+    readonly model: string;
+    readonly streaming: boolean;
+  }): Promise<ModelRequestLifecycle> {
+    const turn = this.requireTurnNumber(input.turn);
+    if (this.activeModelAttempt) {
+      throw new SessionDurableRecorderError(
+        `Model attempt ${this.activeModelAttempt.modelAttemptId} is still active`,
+      );
+    }
+    const attempt: ActiveModelAttempt = {
+      modelAttemptId: ModelAttemptId(nanoid()),
+      turnId: turn.turnId,
+    };
+    this.activeModelAttempt = attempt;
+    try {
+      await this.commitRequestBoundary([
+        {
+          type: DurableEventType.MODEL_REQUEST_STARTED,
+          requestId: this.requestId,
+          turnId: turn.turnId,
+          modelAttemptId: attempt.modelAttemptId,
+          data: {
+            model: input.model,
+            streaming: input.streaming,
+          },
+        },
+      ]);
+    } catch (error) {
+      if (this.activeModelAttempt === attempt) {
+        this.activeModelAttempt = null;
+      }
+      throw error;
+    }
+
+    return {
+      onCompleted: (response) => this.completeModelRequest(attempt, response),
+      onFailed: (error) => this.failModelRequest(attempt, error),
+      onAborted: (reason) => this.abortModelRequest(attempt, reason),
+    };
+  }
+
   async finish(finish: DurableRequestFinish): Promise<boolean> {
     this.assertRequestOpen();
     if (this.activeTurn) {
@@ -282,10 +365,7 @@ export class SessionDurableRecorder implements ToolExecutionLifecycle, InputAppl
             requestId: this.requestId,
             causationEventId,
             data: {
-              error: {
-                message:
-                  finish.error instanceof Error ? finish.error.message : String(finish.error),
-              },
+              error: toDurableEventError(finish.error, 'Request failed'),
             },
           },
         ]);
@@ -437,6 +517,7 @@ export class SessionDurableRecorder implements ToolExecutionLifecycle, InputAppl
 
   private async completeTurn(turn: number, hasToolCalls: boolean): Promise<void> {
     const activeTurn = this.requireTurnNumber(turn);
+    this.assertNoActiveModelAttempt(activeTurn);
     await this.commitRequestBoundary([
       {
         type: DurableEventType.TURN_COMPLETED,
@@ -453,6 +534,7 @@ export class SessionDurableRecorder implements ToolExecutionLifecycle, InputAppl
 
   private async abortTurn(turn: number, reason: 'request_interrupted' | 'error'): Promise<boolean> {
     const activeTurn = this.requireTurnNumber(turn);
+    this.assertNoActiveModelAttempt(activeTurn);
     const drafts = [];
     const cancelledPermissions: ActiveTool[] = [];
     const settledTools: ActiveTool[] = [];
@@ -519,6 +601,105 @@ export class SessionDurableRecorder implements ToolExecutionLifecycle, InputAppl
     ]);
     this.activeTurn = null;
     return true;
+  }
+
+  private async completeModelRequest(
+    attempt: ActiveModelAttempt,
+    response: Parameters<ModelRequestLifecycle['onCompleted']>[0],
+  ): Promise<void> {
+    this.requireModelAttempt(attempt);
+    await this.commitRequestBoundary([
+      {
+        type: DurableEventType.MODEL_REQUEST_COMPLETED,
+        requestId: this.requestId,
+        turnId: attempt.turnId,
+        modelAttemptId: attempt.modelAttemptId,
+        data: {
+          response: this.toDurableModelResponse(response),
+        },
+      },
+    ]);
+    this.activeModelAttempt = null;
+  }
+
+  private async failModelRequest(
+    attempt: ActiveModelAttempt,
+    error: unknown,
+  ): Promise<void> {
+    this.requireModelAttempt(attempt);
+    await this.commitRequestBoundary([
+      {
+        type: DurableEventType.MODEL_REQUEST_FAILED,
+        requestId: this.requestId,
+        turnId: attempt.turnId,
+        modelAttemptId: attempt.modelAttemptId,
+        data: {
+          error: toDurableEventError(error, 'Model request failed'),
+        },
+      },
+    ]);
+    this.activeModelAttempt = null;
+  }
+
+  private async abortModelRequest(
+    attempt: ActiveModelAttempt,
+    reason: ModelRequestAbortReason,
+  ): Promise<void> {
+    this.requireModelAttempt(attempt);
+    await this.commitRequestBoundary([
+      {
+        type: DurableEventType.MODEL_REQUEST_ABORTED,
+        requestId: this.requestId,
+        turnId: attempt.turnId,
+        modelAttemptId: attempt.modelAttemptId,
+        data: { reason },
+      },
+    ]);
+    this.activeModelAttempt = null;
+  }
+
+  private toDurableModelResponse(
+    response: Parameters<ModelRequestLifecycle['onCompleted']>[0],
+  ): DurableModelResponse {
+    return {
+      content: response.content,
+      ...(response.reasoningContent !== undefined
+        ? { reasoningContent: response.reasoningContent }
+        : {}),
+      ...(response.toolCalls && response.toolCalls.length > 0
+        ? {
+            toolCalls: response.toolCalls.map((toolCall) => ({
+              id: ToolUseId(toolCall.id),
+              name: toolCall.function.name,
+              arguments: toolCall.function.arguments,
+            })),
+          }
+        : {}),
+      ...(response.usage
+        ? {
+            usage: {
+              promptTokens: response.usage.promptTokens,
+              completionTokens: response.usage.completionTokens,
+              totalTokens: response.usage.totalTokens,
+              ...(response.usage.reasoningTokens !== undefined
+                ? { reasoningTokens: response.usage.reasoningTokens }
+                : {}),
+              ...(response.usage.cacheCreationInputTokens !== undefined
+                ? { cacheCreationInputTokens: response.usage.cacheCreationInputTokens }
+                : {}),
+              ...(response.usage.cacheReadInputTokens !== undefined
+                ? { cacheReadInputTokens: response.usage.cacheReadInputTokens }
+                : {}),
+              ...(response.usage.cacheMissInputTokens !== undefined
+                ? { cacheMissInputTokens: response.usage.cacheMissInputTokens }
+                : {}),
+              ...(response.usage.billableInputTokens !== undefined
+                ? { billableInputTokens: response.usage.billableInputTokens }
+                : {}),
+            },
+          }
+        : {}),
+    };
   }
 
   private async recordPermissionRequested(
@@ -652,6 +833,26 @@ export class SessionDurableRecorder implements ToolExecutionLifecycle, InputAppl
       );
     }
     return activeTurn;
+  }
+
+  private requireModelAttempt(attempt: ActiveModelAttempt): void {
+    this.assertRequestOpen();
+    if (
+      this.activeModelAttempt !== attempt
+      || this.activeTurn?.turnId !== attempt.turnId
+    ) {
+      throw new SessionDurableRecorderError(
+        `No active model attempt matches ${attempt.modelAttemptId}`,
+      );
+    }
+  }
+
+  private assertNoActiveModelAttempt(turn: ActiveTurn): void {
+    if (this.activeModelAttempt?.turnId === turn.turnId) {
+      throw new SessionDurableRecorderError(
+        `Model attempt ${this.activeModelAttempt.modelAttemptId} is still active`,
+      );
+    }
   }
 
   private async commit(

--- a/src/session/events/__tests__/DurableSessionJournal.test.ts
+++ b/src/session/events/__tests__/DurableSessionJournal.test.ts
@@ -700,6 +700,22 @@ describe('DurableSessionJournal', () => {
             type: DurableEventType.MODEL_REQUEST_STARTED,
             requestId,
             turnId,
+            modelAttemptId: ModelAttemptId('model-attempt-original'),
+            data: { model: 'test-model', streaming: true },
+          },
+        ],
+      }),
+    ).resolves.toMatchObject({
+      status: 'replayed',
+    });
+    await expect(
+      journal.commit({
+        commandId,
+        events: [
+          {
+            type: DurableEventType.MODEL_REQUEST_STARTED,
+            requestId,
+            turnId,
             modelAttemptId: ModelAttemptId('model-attempt-different'),
             data: { model: 'test-model', streaming: true },
           },

--- a/src/session/events/__tests__/DurableSessionJournal.test.ts
+++ b/src/session/events/__tests__/DurableSessionJournal.test.ts
@@ -7,8 +7,10 @@ import {
   EventId,
   EventSequence,
   InputId,
+  ModelAttemptId,
   RequestId,
   SessionId,
+  TurnId,
 } from '../../../types/branded.js';
 import type { JsonValue } from '../../../types/common.js';
 import {
@@ -653,6 +655,57 @@ describe('DurableSessionJournal', () => {
     expect(reopened.getProjection().headSequence).toBe(3);
     expect(reopened.getProjection().activeRequest?.status).toBe('running');
     expect(replayed.status).toBe('replayed');
+  });
+
+  it('includes modelAttemptId when validating command replay identity', async () => {
+    const journal = await DurableSessionJournal.open(store, sessionId);
+    const turnId = TurnId('turn-model-replay');
+    await journal.commit({
+      commandId: CommandId('command-bootstrap-model'),
+      events: [
+        sessionCreated(),
+        requestAccepted(),
+        {
+          type: DurableEventType.REQUEST_STARTED,
+          requestId,
+          data: {},
+        },
+        {
+          type: DurableEventType.TURN_STARTED,
+          requestId,
+          turnId,
+          data: { turn: 1 },
+        },
+      ],
+    });
+    const commandId = CommandId('command-model-start');
+    await journal.commit({
+      commandId,
+      events: [
+        {
+          type: DurableEventType.MODEL_REQUEST_STARTED,
+          requestId,
+          turnId,
+          modelAttemptId: ModelAttemptId('model-attempt-original'),
+          data: { model: 'test-model', streaming: true },
+        },
+      ],
+    });
+
+    await expect(
+      journal.commit({
+        commandId,
+        events: [
+          {
+            type: DurableEventType.MODEL_REQUEST_STARTED,
+            requestId,
+            turnId,
+            modelAttemptId: ModelAttemptId('model-attempt-different'),
+            data: { model: 'test-model', streaming: true },
+          },
+        ],
+      }),
+    ).rejects.toBeInstanceOf(DurableCommandConflictError);
   });
 
   it('bounds CAS retries for competing commands', async () => {

--- a/src/session/events/__tests__/DurableSessionProjector.test.ts
+++ b/src/session/events/__tests__/DurableSessionProjector.test.ts
@@ -1017,6 +1017,70 @@ describe('DurableSessionProjector', () => {
     ).toThrow(/reused tool call ID/);
   });
 
+  it.each([
+    {
+      type: DurableEventType.MODEL_REQUEST_FAILED,
+      data: { error: { message: 'stream failed' } },
+      status: 'failed',
+    },
+    {
+      type: DurableEventType.MODEL_REQUEST_ABORTED,
+      data: { reason: 'request_interrupted' as const },
+      status: 'aborted',
+    },
+  ])('does not retry tools from a model attempt that ended as $status', ({
+    type,
+    data,
+    status,
+  }) => {
+    const projection = project([
+      ...turnPrefix(),
+      {
+        type: DurableEventType.MODEL_REQUEST_STARTED,
+        requestId,
+        turnId,
+        modelAttemptId,
+        data: {
+          model: 'claude-sonnet',
+          streaming: true,
+        },
+      },
+      toolScheduled('pure'),
+      {
+        type,
+        requestId,
+        turnId,
+        modelAttemptId,
+        data,
+      },
+    ] as readonly DurableEventDraft[]);
+
+    expect(projection.activeRequest?.activeTurn).toMatchObject({
+      modelAttempts: [
+        expect.objectContaining({
+          modelAttemptId,
+          status,
+        }),
+      ],
+      toolAttempts: [
+        expect.objectContaining({
+          modelAttemptId,
+          status: 'scheduled',
+        }),
+      ],
+    });
+    expect(planDurableSessionRecovery(projection)).toMatchObject({
+      action: 'resume_turn',
+      retryableToolAttempts: [],
+      cancelableToolAttempts: [
+        expect.objectContaining({
+          toolAttemptId,
+          modelAttemptId,
+        }),
+      ],
+    });
+  });
+
   it('distinguishes accepted, pre-turn, post-turn, and active-turn recovery', () => {
     const accepted = project([
       requestPrefix()[0] as DurableEventDraft,

--- a/src/session/events/__tests__/DurableSessionProjector.test.ts
+++ b/src/session/events/__tests__/DurableSessionProjector.test.ts
@@ -690,6 +690,101 @@ describe('DurableSessionProjector', () => {
         },
       ]),
     ).toThrow(/ended as completed/);
+    expect(() =>
+      project([
+        ...turnPrefix(),
+        failedAttempt[failedAttempt.length - 2],
+        toolScheduled('pure'),
+        failedAttempt[failedAttempt.length - 1],
+        {
+          type: DurableEventType.MODEL_REQUEST_STARTED,
+          requestId,
+          turnId,
+          modelAttemptId: retryAttemptId,
+          data: {
+            model: 'claude-sonnet',
+            streaming: false,
+          },
+        },
+      ] as readonly DurableEventDraft[]),
+    ).toThrow(/dispatched tools before failing/);
+  });
+
+  it('binds durable tool calls to the completed model response', () => {
+    const modelStarted = {
+      type: DurableEventType.MODEL_REQUEST_STARTED,
+      requestId,
+      turnId,
+      modelAttemptId,
+      data: {
+        model: 'claude-sonnet',
+        streaming: false,
+      },
+    } as const;
+    const matchingResponse = {
+      type: DurableEventType.MODEL_REQUEST_COMPLETED,
+      requestId,
+      turnId,
+      modelAttemptId,
+      data: {
+        response: {
+          content: '',
+          toolCalls: [
+            {
+              id: toolCallId,
+              name: 'Write',
+              arguments: '{"file_path":"/tmp/file"}',
+            },
+          ],
+        },
+      },
+    } as const;
+
+    expect(
+      project([
+        ...turnPrefix(),
+        modelStarted,
+        matchingResponse,
+        toolScheduled(),
+      ]).activeRequest?.activeTurn?.toolAttempts,
+    ).toHaveLength(1);
+    expect(() =>
+      project([
+        ...turnPrefix(),
+        modelStarted,
+        {
+          ...matchingResponse,
+          data: {
+            response: {
+              content: '',
+              toolCalls: [
+                {
+                  id: toolCallId,
+                  name: 'Read',
+                  arguments: '{"file_path":"/tmp/file"}',
+                },
+              ],
+            },
+          },
+        },
+        toolScheduled(),
+      ]),
+    ).toThrow(/was not declared by model attempt/);
+    expect(() =>
+      project([
+        ...turnPrefix(),
+        modelStarted,
+        toolScheduled(),
+        {
+          ...matchingResponse,
+          data: {
+            response: {
+              content: '',
+            },
+          },
+        },
+      ]),
+    ).toThrow(/does not declare durable tool call/);
   });
 
   it('distinguishes accepted, pre-turn, post-turn, and active-turn recovery', () => {

--- a/src/session/events/__tests__/DurableSessionProjector.test.ts
+++ b/src/session/events/__tests__/DurableSessionProjector.test.ts
@@ -505,6 +505,41 @@ describe('DurableSessionProjector', () => {
     expect(planDurableSessionRecovery(completed).action).toBe('resume_turn');
   });
 
+  it('prioritizes an unknown model outcome before tool and permission reconciliation', () => {
+    const projection = project([
+      ...turnPrefix(),
+      {
+        type: DurableEventType.MODEL_REQUEST_STARTED,
+        requestId,
+        turnId,
+        modelAttemptId,
+        data: {
+          model: 'claude-sonnet',
+          streaming: true,
+        },
+      },
+      toolScheduled('non_idempotent'),
+      {
+        type: DurableEventType.TOOL_STARTED,
+        requestId,
+        turnId,
+        toolAttemptId,
+        data: {
+          toolCallId,
+          toolName: 'Write',
+          input: { file_path: '/tmp/file' },
+          sideEffect: 'non_idempotent',
+        },
+      },
+    ]);
+
+    expect(planDurableSessionRecovery(projection)).toMatchObject({
+      action: 'reconcile_model_outcome',
+      activeModelAttempt: { modelAttemptId },
+      unknownToolAttempts: [{ toolAttemptId }],
+    });
+  });
+
   it('requires a model attempt to settle before its Turn can end', () => {
     expect(() =>
       project([

--- a/src/session/events/__tests__/DurableSessionProjector.test.ts
+++ b/src/session/events/__tests__/DurableSessionProjector.test.ts
@@ -111,6 +111,7 @@ function toolScheduled(
     type: DurableEventType.TOOL_SCHEDULED,
     requestId,
     turnId,
+    modelAttemptId,
     toolAttemptId,
     data: {
       toolCallId,
@@ -885,6 +886,7 @@ describe('DurableSessionProjector', () => {
       ]).activeRequest?.activeTurn?.toolAttempts,
     ).toEqual([
       expect.objectContaining({
+        modelAttemptId,
         modelInput: { file_path: '/tmp/file' },
         input: { file_path: '/tmp/repaired-file' },
       }),
@@ -945,7 +947,74 @@ describe('DurableSessionProjector', () => {
         ...turnPrefix(),
         toolScheduled(),
       ]),
-    ).toThrow(/has no model attempt/);
+    ).toThrow(/does not belong to the current model attempt/);
+  });
+
+  it('rejects stale tool-attempt bindings and duplicate model tool-call IDs', () => {
+    const retryAttemptId = ModelAttemptId('model-attempt-2');
+    expect(() =>
+      project([
+        ...turnPrefix(),
+        {
+          type: DurableEventType.MODEL_REQUEST_STARTED,
+          requestId,
+          turnId,
+          modelAttemptId,
+          data: { model: 'claude-sonnet', streaming: false },
+        },
+        {
+          type: DurableEventType.MODEL_REQUEST_FAILED,
+          requestId,
+          turnId,
+          modelAttemptId,
+          data: { error: { message: 'retry' } },
+        },
+        {
+          type: DurableEventType.MODEL_REQUEST_STARTED,
+          requestId,
+          turnId,
+          modelAttemptId: retryAttemptId,
+          data: { model: 'claude-sonnet', streaming: false },
+        },
+        toolScheduled(),
+      ]),
+    ).toThrow(/does not belong to the current model attempt/);
+
+    expect(() =>
+      project([
+        ...turnPrefix(),
+        {
+          type: DurableEventType.MODEL_REQUEST_STARTED,
+          requestId,
+          turnId,
+          modelAttemptId,
+          data: { model: 'claude-sonnet', streaming: false },
+        },
+        {
+          type: DurableEventType.MODEL_REQUEST_COMPLETED,
+          requestId,
+          turnId,
+          modelAttemptId,
+          data: {
+            response: {
+              content: '',
+              toolCalls: [
+                {
+                  id: toolCallId,
+                  name: 'Write',
+                  arguments: '{"file_path":"/tmp/file"}',
+                },
+                {
+                  id: toolCallId,
+                  name: 'Write',
+                  arguments: '{"file_path":"/tmp/file"}',
+                },
+              ],
+            },
+          },
+        },
+      ]),
+    ).toThrow(/reused tool call ID/);
   });
 
   it('distinguishes accepted, pre-turn, post-turn, and active-turn recovery', () => {
@@ -2022,6 +2091,7 @@ describe('DurableSessionProjector', () => {
           type: DurableEventType.TOOL_SCHEDULED,
           requestId,
           turnId,
+          modelAttemptId,
           toolAttemptId: ToolAttemptId('attempt-2'),
           data: {
             toolCallId: ToolUseId('call-2'),

--- a/src/session/events/__tests__/DurableSessionProjector.test.ts
+++ b/src/session/events/__tests__/DurableSessionProjector.test.ts
@@ -106,7 +106,7 @@ function turnPrefix(): DurableEventDraft[] {
 
 function toolScheduled(
   sideEffect: 'pure' | 'idempotent' | 'non_idempotent' = 'non_idempotent',
-): DurableEventDraft {
+): DurableEventDraft<typeof DurableEventType.TOOL_SCHEDULED> {
   return {
     type: DurableEventType.TOOL_SCHEDULED,
     requestId,
@@ -115,11 +115,61 @@ function toolScheduled(
     data: {
       toolCallId,
       toolName: 'Write',
+      modelInput: { file_path: '/tmp/file' },
       input: { file_path: '/tmp/file' },
       sideEffect,
       interruptBehavior: 'block',
     },
   };
+}
+
+function completedModelAttempt(
+  toolCalls: Array<{
+    id: ToolUseId;
+    name: string;
+    arguments: string;
+  }> = [
+    {
+      id: toolCallId,
+      name: 'Write',
+      arguments: '{"file_path":"/tmp/file"}',
+    },
+  ],
+): DurableEventDraft[] {
+  return [
+    {
+      type: DurableEventType.MODEL_REQUEST_STARTED,
+      requestId,
+      turnId,
+      modelAttemptId,
+      data: {
+        model: 'claude-sonnet',
+        streaming: false,
+      },
+    },
+    {
+      type: DurableEventType.MODEL_REQUEST_COMPLETED,
+      requestId,
+      turnId,
+      modelAttemptId,
+      data: {
+        response: {
+          content: '',
+          toolCalls,
+        },
+      },
+    },
+  ];
+}
+
+function toolTurnPrefix(
+  toolCalls?: Array<{
+    id: ToolUseId;
+    name: string;
+    arguments: string;
+  }>,
+): DurableEventDraft[] {
+  return [...turnPrefix(), ...completedModelAttempt(toolCalls)];
 }
 
 function permissionRequested(): DurableEventDraft {
@@ -145,7 +195,7 @@ function project(drafts: readonly DurableEventDraft[]) {
 describe('DurableSessionProjector', () => {
   it('projects a complete session lifecycle', () => {
     const projection = project([
-      ...turnPrefix(),
+      ...toolTurnPrefix(),
       toolScheduled(),
       permissionRequested(),
       {
@@ -201,8 +251,8 @@ describe('DurableSessionProjector', () => {
     expect(projection).toMatchObject({
       sessionId,
       status: 'closed',
-      headSequence: 13,
-      lastEventId: 'event-13',
+      headSequence: 15,
+      lastEventId: 'event-15',
       closeReason: 'completed',
       activeRequest: null,
       appliedInputIds: [initialInputId],
@@ -228,7 +278,7 @@ describe('DurableSessionProjector', () => {
 
   it('returns defensive snapshots that cannot mutate projector state', () => {
     const projector = new DurableSessionProjector().apply(
-      envelopes([...turnPrefix(), toolScheduled()]),
+      envelopes([...toolTurnPrefix(), toolScheduled()]),
     );
     const first = projector.snapshot();
     const tool = first.activeRequest?.activeTurn?.toolAttempts[0];
@@ -329,6 +379,51 @@ describe('DurableSessionProjector', () => {
         }),
       ]),
     ).toThrow(/schema regressed from v3 to v2/);
+  });
+
+  it('continues to project schema-v2 tool events without model attempt metadata', () => {
+    const legacyDrafts: DurableEventDraft[] = [
+      ...turnPrefix(),
+      {
+        type: DurableEventType.TOOL_SCHEDULED,
+        requestId,
+        turnId,
+        toolAttemptId,
+        data: {
+          toolCallId,
+          toolName: 'Write',
+          input: { file_path: '/tmp/file' },
+          sideEffect: 'non_idempotent',
+          interruptBehavior: 'block',
+        },
+      },
+    ];
+    const legacyEvents = legacyDrafts.map((draft, index) =>
+      parseDurableEventEnvelope({
+        ...draft,
+        schemaVersion: 2,
+        eventId: EventId(`legacy-event-${index + 1}`),
+        sequence: EventSequence(index + 1),
+        sessionId,
+        recordedAt: timestamp,
+        occurredAt: timestamp,
+      }),
+    );
+
+    expect(projectDurableSession(legacyEvents)).toMatchObject({
+      schemaVersion: 2,
+      activeRequest: {
+        activeTurn: {
+          toolAttempts: [
+            expect.objectContaining({
+              toolAttemptId,
+              toolCallId,
+              input: { file_path: '/tmp/file' },
+            }),
+          ],
+        },
+      },
+    });
   });
 
   it('requires latest-boundary causation for new standalone Request terminal writes', () => {
@@ -780,9 +875,20 @@ describe('DurableSessionProjector', () => {
         ...turnPrefix(),
         modelStarted,
         matchingResponse,
-        toolScheduled(),
+        {
+          ...toolScheduled(),
+          data: {
+            ...toolScheduled().data,
+            input: { file_path: '/tmp/repaired-file' },
+          },
+        },
       ]).activeRequest?.activeTurn?.toolAttempts,
-    ).toHaveLength(1);
+    ).toEqual([
+      expect.objectContaining({
+        modelInput: { file_path: '/tmp/file' },
+        input: { file_path: '/tmp/repaired-file' },
+      }),
+    ]);
     expect(() =>
       project([
         ...turnPrefix(),
@@ -809,6 +915,20 @@ describe('DurableSessionProjector', () => {
       project([
         ...turnPrefix(),
         modelStarted,
+        matchingResponse,
+        {
+          ...toolScheduled(),
+          data: {
+            ...toolScheduled().data,
+            modelInput: { file_path: '/tmp/other-file' },
+          },
+        },
+      ]),
+    ).toThrow(/input does not match the model response/);
+    expect(() =>
+      project([
+        ...turnPrefix(),
+        modelStarted,
         toolScheduled(),
         {
           ...matchingResponse,
@@ -820,6 +940,12 @@ describe('DurableSessionProjector', () => {
         },
       ]),
     ).toThrow(/does not declare durable tool call/);
+    expect(() =>
+      project([
+        ...turnPrefix(),
+        toolScheduled(),
+      ]),
+    ).toThrow(/has no model attempt/);
   });
 
   it('distinguishes accepted, pre-turn, post-turn, and active-turn recovery', () => {
@@ -1193,7 +1319,7 @@ describe('DurableSessionProjector', () => {
   it('rejects a recovery request that bypasses a non-idempotent execution boundary', () => {
     expect(() =>
       project([
-        ...turnPrefix(),
+        ...toolTurnPrefix(),
         toolScheduled('non_idempotent'),
         {
           type: DurableEventType.TOOL_STARTED,
@@ -1252,7 +1378,7 @@ describe('DurableSessionProjector', () => {
   });
 
   it('classifies scheduled tools as retryable before execution starts', () => {
-    const projection = project([...turnPrefix(), toolScheduled()]);
+    const projection = project([...toolTurnPrefix(), toolScheduled()]);
     const recovery = planDurableSessionRecovery(projection);
 
     expect(recovery.action).toBe('resume_turn');
@@ -1267,7 +1393,7 @@ describe('DurableSessionProjector', () => {
   });
 
   it('prioritizes unresolved permissions over retrying a scheduled tool', () => {
-    const projection = project([...turnPrefix(), toolScheduled(), permissionRequested()]);
+    const projection = project([...toolTurnPrefix(), toolScheduled(), permissionRequested()]);
     const recovery = planDurableSessionRecovery(projection);
 
     expect(recovery.action).toBe('resolve_permissions');
@@ -1283,7 +1409,7 @@ describe('DurableSessionProjector', () => {
 
   it('classifies denied scheduled tools for terminal cancellation', () => {
     const projection = project([
-      ...turnPrefix(),
+      ...toolTurnPrefix(),
       toolScheduled(),
       permissionRequested(),
       {
@@ -1312,7 +1438,7 @@ describe('DurableSessionProjector', () => {
 
   it('requires reconciliation for a started tool until its outcome is resolved', () => {
     const started = [
-      ...turnPrefix(),
+      ...toolTurnPrefix(),
       toolScheduled(),
       {
         type: DurableEventType.TOOL_STARTED,
@@ -1376,7 +1502,7 @@ describe('DurableSessionProjector', () => {
     'classifies a started %s tool as replayable',
     (sideEffect) => {
       const projection = project([
-        ...turnPrefix(),
+        ...toolTurnPrefix(),
         toolScheduled('non_idempotent'),
         {
           type: DurableEventType.TOOL_STARTED,
@@ -1440,7 +1566,7 @@ describe('DurableSessionProjector', () => {
     expect(abortedTurn.activeRequest?.activeTurn).toBeNull();
 
     const failedTool = project([
-      ...turnPrefix(),
+      ...toolTurnPrefix(),
       toolScheduled(),
       {
         type: DurableEventType.TOOL_FAILED,
@@ -1457,7 +1583,7 @@ describe('DurableSessionProjector', () => {
     expect(failedTool.activeRequest?.activeTurn?.toolAttempts[0]?.status).toBe('failed');
 
     const cancelledTool = project([
-      ...turnPrefix(),
+      ...toolTurnPrefix(),
       toolScheduled(),
       {
         type: DurableEventType.TOOL_CANCELLED,
@@ -1553,7 +1679,7 @@ describe('DurableSessionProjector', () => {
     {
       name: 'tool start while permission is unresolved',
       drafts: [
-        ...turnPrefix(),
+        ...toolTurnPrefix(),
         toolScheduled(),
         permissionRequested(),
         {
@@ -1574,7 +1700,7 @@ describe('DurableSessionProjector', () => {
     {
       name: 'turn completion with unfinished tool',
       drafts: [
-        ...turnPrefix(),
+        ...toolTurnPrefix(),
         toolScheduled(),
         {
           type: DurableEventType.TURN_COMPLETED,
@@ -1611,7 +1737,7 @@ describe('DurableSessionProjector', () => {
     {
       name: 'tool identity mismatch',
       drafts: [
-        ...turnPrefix(),
+        ...toolTurnPrefix(),
         toolScheduled(),
         {
           type: DurableEventType.TOOL_STARTED,
@@ -1832,7 +1958,7 @@ describe('DurableSessionProjector', () => {
     {
       name: 'tool attempt ID',
       drafts: [
-        ...turnPrefix(),
+        ...toolTurnPrefix(),
         toolScheduled(),
         {
           type: DurableEventType.TOOL_FAILED,
@@ -1852,7 +1978,18 @@ describe('DurableSessionProjector', () => {
     {
       name: 'permission request ID',
       drafts: [
-        ...turnPrefix(),
+        ...toolTurnPrefix([
+          {
+            id: toolCallId,
+            name: 'Write',
+            arguments: '{"file_path":"/tmp/file"}',
+          },
+          {
+            id: ToolUseId('call-2'),
+            name: 'Read',
+            arguments: '{"file_path":"/tmp/file"}',
+          },
+        ]),
         toolScheduled(),
         permissionRequested(),
         {
@@ -1889,6 +2026,7 @@ describe('DurableSessionProjector', () => {
           data: {
             toolCallId: ToolUseId('call-2'),
             toolName: 'Read',
+            modelInput: { file_path: '/tmp/file' },
             input: { file_path: '/tmp/file' },
             sideEffect: 'pure',
             interruptBehavior: 'cancel',

--- a/src/session/events/__tests__/DurableSessionProjector.test.ts
+++ b/src/session/events/__tests__/DurableSessionProjector.test.ts
@@ -4,6 +4,7 @@ import {
   EventId,
   EventSequence,
   InputId,
+  ModelAttemptId,
   PermissionRequestId,
   RequestId,
   SessionId,
@@ -30,6 +31,7 @@ const requestId = RequestId('request-1');
 const commandId = CommandId('command-1');
 const initialInputId = InputId('input-1');
 const turnId = TurnId('turn-1');
+const modelAttemptId = ModelAttemptId('model-attempt-1');
 const toolAttemptId = ToolAttemptId('attempt-1');
 const toolCallId = ToolUseId('call-1');
 const permissionRequestId = PermissionRequestId('permission-1');
@@ -279,6 +281,56 @@ describe('DurableSessionProjector', () => {
     expect(projector.snapshot().activeRequest?.status).toBe('accepted');
   });
 
+  it('allows schema upgrades but rejects schema downgrades', () => {
+    const legacy = parseDurableEventEnvelope({
+      schemaVersion: 2,
+      eventId: EventId('legacy-session-created'),
+      sequence: 1,
+      sessionId,
+      type: DurableEventType.SESSION_CREATED,
+      data: { source: 'create' },
+      recordedAt: timestamp,
+      occurredAt: timestamp,
+    });
+    const upgraded = parseDurableEventEnvelope({
+      schemaVersion: DURABLE_EVENT_SCHEMA_VERSION,
+      eventId: EventId('current-request-accepted'),
+      sequence: 2,
+      sessionId,
+      type: DurableEventType.REQUEST_ACCEPTED,
+      requestId,
+      commandId,
+      data: {
+        inputId: initialInputId,
+        input: 'upgrade',
+        priority: 'next',
+      },
+      recordedAt: timestamp,
+      occurredAt: timestamp,
+    });
+    const projector = new DurableSessionProjector().apply([legacy, upgraded]);
+    expect(projector.snapshot()).toMatchObject({
+      schemaVersion: 3,
+      activeRequest: { requestId },
+    });
+
+    expect(() =>
+      projector.apply([
+        parseDurableEventEnvelope({
+          schemaVersion: 2,
+          eventId: EventId('downgraded-request-started'),
+          sequence: 3,
+          sessionId,
+          type: DurableEventType.REQUEST_STARTED,
+          requestId,
+          data: {},
+          recordedAt: timestamp,
+          occurredAt: timestamp,
+        }),
+      ]),
+    ).toThrow(/schema regressed from v3 to v2/);
+  });
+
   it('requires latest-boundary causation for new standalone Request terminal writes', () => {
     const projector = new DurableSessionProjector().apply(
       envelopes([
@@ -382,6 +434,262 @@ describe('DurableSessionProjector', () => {
         },
       ]),
     ).toThrow(/requires a completed or aborted Turn/);
+  });
+
+  it('projects model attempts and blocks recovery while an outcome is unknown', () => {
+    const started = project([
+      ...turnPrefix(),
+      {
+        type: DurableEventType.MODEL_REQUEST_STARTED,
+        requestId,
+        turnId,
+        modelAttemptId,
+        data: {
+          model: 'claude-sonnet',
+          streaming: true,
+        },
+      },
+    ]);
+
+    expect(started.activeRequest?.activeTurn?.activeModelAttempt).toMatchObject({
+      modelAttemptId,
+      model: 'claude-sonnet',
+      streaming: true,
+      status: 'started',
+    });
+    expect(planDurableSessionRecovery(started)).toMatchObject({
+      action: 'reconcile_model_outcome',
+      requestId,
+      turnId,
+    });
+
+    const completed = project([
+      ...turnPrefix(),
+      {
+        type: DurableEventType.MODEL_REQUEST_STARTED,
+        requestId,
+        turnId,
+        modelAttemptId,
+        data: {
+          model: 'claude-sonnet',
+          streaming: true,
+        },
+      },
+      {
+        type: DurableEventType.MODEL_REQUEST_COMPLETED,
+        requestId,
+        turnId,
+        modelAttemptId,
+        data: {
+          response: {
+            content: 'done',
+            usage: {
+              promptTokens: 10,
+              completionTokens: 2,
+              totalTokens: 12,
+            },
+          },
+        },
+      },
+    ]);
+    expect(completed.activeRequest?.activeTurn).toMatchObject({
+      activeModelAttempt: null,
+      modelAttempts: [
+        expect.objectContaining({
+          modelAttemptId,
+          status: 'completed',
+          response: expect.objectContaining({ content: 'done' }),
+        }),
+      ],
+    });
+    expect(planDurableSessionRecovery(completed).action).toBe('resume_turn');
+  });
+
+  it('requires a model attempt to settle before its Turn can end', () => {
+    expect(() =>
+      project([
+        ...turnPrefix(),
+        {
+          type: DurableEventType.MODEL_REQUEST_STARTED,
+          requestId,
+          turnId,
+          modelAttemptId,
+          data: {
+            model: 'claude-sonnet',
+            streaming: false,
+          },
+        },
+        {
+          type: DurableEventType.TURN_ABORTED,
+          requestId,
+          turnId,
+          data: {
+            turn: 1,
+            reason: 'process_restart',
+          },
+        },
+      ]),
+    ).toThrow(/Model attempt model-attempt-1 is not terminal/);
+  });
+
+  it.each([
+    {
+      type: DurableEventType.MODEL_REQUEST_FAILED,
+      data: { error: { message: 'provider unavailable', retryable: true } },
+      status: 'failed',
+    },
+    {
+      type: DurableEventType.MODEL_REQUEST_ABORTED,
+      data: { reason: 'steering' as const },
+      status: 'aborted',
+    },
+  ])('projects a terminal $status model attempt', ({ type, data, status }) => {
+    const projection = project([
+      ...turnPrefix(),
+      {
+        type: DurableEventType.MODEL_REQUEST_STARTED,
+        requestId,
+        turnId,
+        modelAttemptId,
+        data: {
+          model: 'claude-sonnet',
+          streaming: false,
+        },
+      },
+      {
+        type,
+        requestId,
+        turnId,
+        modelAttemptId,
+        data,
+      },
+    ] as readonly DurableEventDraft[]);
+
+    expect(projection.activeRequest?.activeTurn).toMatchObject({
+      activeModelAttempt: null,
+      modelAttempts: [
+        expect.objectContaining({
+          modelAttemptId,
+          status,
+        }),
+      ],
+    });
+    expect(planDurableSessionRecovery(projection).action).toBe('resume_turn');
+  });
+
+  it('rejects overlapping and mismatched model attempts', () => {
+    const started = [
+      ...turnPrefix(),
+      {
+        type: DurableEventType.MODEL_REQUEST_STARTED,
+        requestId,
+        turnId,
+        modelAttemptId,
+        data: {
+          model: 'claude-sonnet',
+          streaming: true,
+        },
+      },
+    ] as const;
+
+    expect(() =>
+      project([
+        ...started,
+        {
+          type: DurableEventType.MODEL_REQUEST_STARTED,
+          requestId,
+          turnId,
+          modelAttemptId: ModelAttemptId('model-attempt-2'),
+          data: {
+            model: 'claude-sonnet',
+            streaming: true,
+          },
+        },
+      ]),
+    ).toThrow(/is still active/);
+    expect(() =>
+      project([
+        ...started,
+        {
+          type: DurableEventType.MODEL_REQUEST_COMPLETED,
+          requestId,
+          turnId,
+          modelAttemptId: ModelAttemptId('different-model-attempt'),
+          data: {
+            response: { content: 'wrong attempt' },
+          },
+        },
+      ]),
+    ).toThrow(/No active model attempt matches/);
+  });
+
+  it('allows a retry after model failure but not after a completed response', () => {
+    const failedAttempt = [
+      ...turnPrefix(),
+      {
+        type: DurableEventType.MODEL_REQUEST_STARTED,
+        requestId,
+        turnId,
+        modelAttemptId,
+        data: {
+          model: 'claude-sonnet',
+          streaming: false,
+        },
+      },
+      {
+        type: DurableEventType.MODEL_REQUEST_FAILED,
+        requestId,
+        turnId,
+        modelAttemptId,
+        data: {
+          error: { message: 'context overflow', retryable: true },
+        },
+      },
+    ] as const;
+    const retryAttemptId = ModelAttemptId('model-attempt-2');
+    expect(
+      project([
+        ...failedAttempt,
+        {
+          type: DurableEventType.MODEL_REQUEST_STARTED,
+          requestId,
+          turnId,
+          modelAttemptId: retryAttemptId,
+          data: {
+            model: 'claude-sonnet',
+            streaming: false,
+          },
+        },
+      ]).activeRequest?.activeTurn?.activeModelAttempt,
+    ).toMatchObject({
+      modelAttemptId: retryAttemptId,
+      status: 'started',
+    });
+
+    expect(() =>
+      project([
+        ...failedAttempt.slice(0, -1),
+        {
+          type: DurableEventType.MODEL_REQUEST_COMPLETED,
+          requestId,
+          turnId,
+          modelAttemptId,
+          data: {
+            response: { content: 'done' },
+          },
+        },
+        {
+          type: DurableEventType.MODEL_REQUEST_STARTED,
+          requestId,
+          turnId,
+          modelAttemptId: retryAttemptId,
+          data: {
+            model: 'claude-sonnet',
+            streaming: false,
+          },
+        },
+      ]),
+    ).toThrow(/ended as completed/);
   });
 
   it('distinguishes accepted, pre-turn, post-turn, and active-turn recovery', () => {

--- a/src/session/events/__tests__/DurableSessionRecoveryCoordinator.test.ts
+++ b/src/session/events/__tests__/DurableSessionRecoveryCoordinator.test.ts
@@ -8,6 +8,7 @@ import {
   EventId,
   type EventSequence,
   InputId,
+  ModelAttemptId,
   PermissionRequestId,
   RequestId,
   SessionId,
@@ -34,6 +35,7 @@ const sessionId = SessionId('recovery-session');
 const requestId = RequestId('recovery-request');
 const inputId = InputId('recovery-input');
 const turnId = TurnId('recovery-turn');
+const modelAttemptId = ModelAttemptId('recovery-model-attempt');
 const toolAttemptId = ToolAttemptId('recovery-attempt');
 const toolCallId = ToolUseId('recovery-call');
 const permissionRequestId = PermissionRequestId('recovery-permission');
@@ -133,6 +135,50 @@ class StartTurnBeforeRequestRolloverStore implements DurableEventStore {
             data: {
               turn: 1,
               model: 'accepted-model',
+            },
+          },
+        ],
+        options,
+      );
+    }
+    return this.delegate.append(targetSessionId, events, options);
+  }
+
+  read(targetSessionId: SessionId, options?: DurableEventReadOptions) {
+    return this.delegate.read(targetSessionId, options);
+  }
+
+  getHeadSequence(targetSessionId: SessionId): Promise<EventSequence | null> {
+    return this.delegate.getHeadSequence(targetSessionId);
+  }
+}
+
+class SettleModelBeforeReconciliationStore implements DurableEventStore {
+  private injected = false;
+
+  constructor(private readonly delegate: DurableEventStore) {}
+
+  async append(
+    targetSessionId: SessionId,
+    events: readonly DurableEventDraft[],
+    options?: DurableEventAppendOptions,
+  ) {
+    if (
+      !this.injected
+      && events.some((event) => event.type === DurableEventType.MODEL_REQUEST_COMPLETED)
+    ) {
+      this.injected = true;
+      await this.delegate.append(
+        targetSessionId,
+        [
+          {
+            type: DurableEventType.MODEL_REQUEST_FAILED,
+            commandId: CommandId('competing-model-outcome'),
+            requestId,
+            turnId,
+            modelAttemptId,
+            data: {
+              error: { message: 'provider confirmed failure' },
             },
           },
         ],
@@ -901,6 +947,270 @@ describe('DurableSessionRecoveryCoordinator', () => {
         },
       }),
     ).rejects.toThrow(/different events/);
+  });
+
+  it('reconciles an unknown model response idempotently and carries it into rollover', async () => {
+    const store = createStore();
+    const journal = await createJournal(store, { requestStarted: true });
+    await journal.commit({
+      commandId: CommandId('start-model-request'),
+      events: [
+        {
+          type: DurableEventType.TURN_STARTED,
+          requestId,
+          turnId,
+          data: { turn: 1, model: 'accepted-model' },
+        },
+        {
+          type: DurableEventType.MODEL_REQUEST_STARTED,
+          requestId,
+          turnId,
+          modelAttemptId,
+          data: {
+            model: 'accepted-model',
+            streaming: true,
+          },
+        },
+      ],
+    });
+    const first = await DurableSessionRecoveryCoordinator.open(store, sessionId);
+    const second = await DurableSessionRecoveryCoordinator.open(store, sessionId);
+    expect(first.getRecoveryPlan()).toMatchObject({
+      action: 'reconcile_model_outcome',
+      requestId,
+      turnId,
+    });
+    const command = {
+      commandId: CommandId('reconcile-model-response'),
+      requestId,
+      turnId,
+      modelAttemptId,
+      outcome: {
+        status: 'completed' as const,
+        response: {
+          content: 'Use the inspected state',
+          toolCalls: [
+            {
+              id: ToolUseId('recovered-tool-call'),
+              name: 'Read',
+              arguments: '{"file_path":"/tmp/state"}',
+            },
+          ],
+          usage: {
+            promptTokens: 100,
+            completionTokens: 20,
+            totalTokens: 120,
+          },
+        },
+      },
+    };
+
+    const results = await Promise.all([
+      first.reconcileModelOutcome(command),
+      second.reconcileModelOutcome(command),
+    ]);
+
+    expect(results.map((result) => result.commit.status).sort()).toEqual([
+      'committed',
+      'reconciled',
+    ]);
+    expect(results.every((result) => result.recoveryPlan.action === 'resume_turn')).toBe(true);
+    expect(
+      first.getProjection().activeRequest?.activeTurn?.modelAttempts,
+    ).toEqual([
+      expect.objectContaining({
+        modelAttemptId,
+        status: 'completed',
+        response: expect.objectContaining({
+          content: 'Use the inspected state',
+        }),
+      }),
+    ]);
+
+    const rollover = await first.prepareTurnRecovery({
+      commandId: CommandId('rollover-after-model-response'),
+      requestId,
+      turnId,
+      recoveryRequestId: rolloverRequestId,
+      recoveryInputId: rolloverInputId,
+    });
+    expect(rollover.continuation).toContain('"modelAttempts"');
+    expect(rollover.continuation).toContain('Use the inspected state');
+    expect(rollover.continuation).toContain(
+      'Treat completed model responses as authoritative prior output',
+    );
+    expect(rollover.recoveryPlan.action).toBe('resume_request');
+
+    await expect(
+      first.reconcileModelOutcome({
+        ...command,
+        outcome: {
+          status: 'completed',
+          response: { content: 'different response' },
+        },
+      }),
+    ).rejects.toThrow(/different events/);
+  });
+
+  it.each([
+    {
+      outcome: {
+        status: 'failed' as const,
+        error: { message: 'provider rejected the request', retryable: true },
+      },
+      eventType: DurableEventType.MODEL_REQUEST_FAILED,
+      status: 'failed',
+    },
+    {
+      outcome: {
+        status: 'aborted' as const,
+      },
+      eventType: DurableEventType.MODEL_REQUEST_ABORTED,
+      status: 'aborted',
+    },
+  ])('reconciles an unknown model outcome as $status', async ({
+    outcome,
+    eventType,
+    status,
+  }) => {
+    const store = createStore();
+    const journal = await createJournal(store, { requestStarted: true });
+    await journal.commit({
+      commandId: CommandId(`start-model-before-${status}`),
+      events: [
+        {
+          type: DurableEventType.TURN_STARTED,
+          requestId,
+          turnId,
+          data: { turn: 1, model: 'accepted-model' },
+        },
+        {
+          type: DurableEventType.MODEL_REQUEST_STARTED,
+          requestId,
+          turnId,
+          modelAttemptId,
+          data: {
+            model: 'accepted-model',
+            streaming: false,
+          },
+        },
+      ],
+    });
+    const coordinator = await DurableSessionRecoveryCoordinator.open(store, sessionId);
+
+    const result = await coordinator.reconcileModelOutcome({
+      commandId: CommandId(`reconcile-model-${status}`),
+      requestId,
+      turnId,
+      modelAttemptId,
+      outcome,
+    });
+
+    expect(result.commit.events).toEqual([
+      expect.objectContaining({
+        type: eventType,
+        modelAttemptId,
+      }),
+    ]);
+    expect(
+      result.projection.activeRequest?.activeTurn?.modelAttempts[0],
+    ).toMatchObject({ status });
+    expect(result.recoveryPlan.action).toBe('resume_turn');
+  });
+
+  it('rejects model reconciliation against a stale attempt target', async () => {
+    const store = createStore();
+    const journal = await createJournal(store, { requestStarted: true });
+    await journal.commit({
+      commandId: CommandId('start-model-for-stale-target'),
+      events: [
+        {
+          type: DurableEventType.TURN_STARTED,
+          requestId,
+          turnId,
+          data: { turn: 1, model: 'accepted-model' },
+        },
+        {
+          type: DurableEventType.MODEL_REQUEST_STARTED,
+          requestId,
+          turnId,
+          modelAttemptId,
+          data: {
+            model: 'accepted-model',
+            streaming: true,
+          },
+        },
+      ],
+    });
+    const coordinator = await DurableSessionRecoveryCoordinator.open(store, sessionId);
+
+    await expect(
+      coordinator.reconcileModelOutcome({
+        commandId: CommandId('reconcile-stale-model'),
+        requestId,
+        turnId,
+        modelAttemptId: ModelAttemptId('different-model-attempt'),
+        outcome: { status: 'aborted' },
+      }),
+    ).rejects.toMatchObject({
+      code: 'DURABLE_RECOVERY_TARGET_NOT_FOUND',
+    });
+  });
+
+  it('does not rebase model reconciliation after a competing outcome wins', async () => {
+    const baseStore = createStore();
+    const store = new SettleModelBeforeReconciliationStore(baseStore);
+    const journal = await createJournal(store, { requestStarted: true });
+    await journal.commit({
+      commandId: CommandId('start-model-before-race'),
+      events: [
+        {
+          type: DurableEventType.TURN_STARTED,
+          requestId,
+          turnId,
+          data: { turn: 1, model: 'accepted-model' },
+        },
+        {
+          type: DurableEventType.MODEL_REQUEST_STARTED,
+          requestId,
+          turnId,
+          modelAttemptId,
+          data: {
+            model: 'accepted-model',
+            streaming: true,
+          },
+        },
+      ],
+    });
+    const coordinator = new DurableSessionRecoveryCoordinator(journal);
+
+    await expect(
+      coordinator.reconcileModelOutcome({
+        commandId: CommandId('stale-model-reconciliation'),
+        requestId,
+        turnId,
+        modelAttemptId,
+        outcome: {
+          status: 'completed',
+          response: { content: 'stale response' },
+        },
+      }),
+    ).rejects.toMatchObject({
+      code: 'DURABLE_EVENT_SEQUENCE_CONFLICT',
+    });
+    expect(
+      coordinator.getProjection().activeRequest?.activeTurn?.modelAttempts[0],
+    ).toMatchObject({
+      modelAttemptId,
+      status: 'failed',
+      error: { message: 'provider confirmed failure' },
+    });
+    expect(coordinator.getRecoveryPlan().action).toBe('resume_turn');
+    expect(
+      (await baseStore.read(sessionId)).events.some(
+        (event) => event.type === DurableEventType.MODEL_REQUEST_COMPLETED,
+      ),
+    ).toBe(false);
   });
 
   it('atomically rolls a recoverable turn into a new accepted request', async () => {

--- a/src/session/events/__tests__/DurableSessionRecoveryCoordinator.test.ts
+++ b/src/session/events/__tests__/DurableSessionRecoveryCoordinator.test.ts
@@ -282,7 +282,7 @@ async function createJournal(
               type: DurableEventType.TURN_STARTED,
               requestId,
               turnId,
-              data: { turn: 1, model: 'test-model' },
+              data: { turn: 1, model: 'accepted-model' },
             },
             ...completedModelToolEvents([
               {
@@ -295,6 +295,7 @@ async function createJournal(
               type: DurableEventType.TOOL_SCHEDULED,
               requestId,
               turnId,
+              modelAttemptId,
               toolAttemptId,
               data: {
                 toolCallId,
@@ -1119,6 +1120,7 @@ describe('DurableSessionRecoveryCoordinator', () => {
           type: DurableEventType.TOOL_SCHEDULED,
           requestId,
           turnId,
+          modelAttemptId,
           toolAttemptId,
           data: {
             toolCallId,
@@ -1431,6 +1433,7 @@ describe('DurableSessionRecoveryCoordinator', () => {
           type: DurableEventType.TOOL_SCHEDULED,
           requestId,
           turnId,
+          modelAttemptId,
           toolAttemptId,
           data: {
             toolCallId,
@@ -1497,6 +1500,7 @@ describe('DurableSessionRecoveryCoordinator', () => {
           type: DurableEventType.TOOL_SCHEDULED,
           requestId,
           turnId,
+          modelAttemptId,
           toolAttemptId,
           data: {
             toolCallId,
@@ -1564,6 +1568,7 @@ describe('DurableSessionRecoveryCoordinator', () => {
           type: DurableEventType.TOOL_SCHEDULED,
           requestId,
           turnId,
+          modelAttemptId,
           toolAttemptId,
           data: {
             toolCallId,
@@ -1725,6 +1730,7 @@ describe('DurableSessionRecoveryCoordinator', () => {
           type: DurableEventType.TOOL_SCHEDULED,
           requestId,
           turnId,
+          modelAttemptId,
           toolAttemptId,
           data: {
             toolCallId,
@@ -1809,6 +1815,7 @@ describe('DurableSessionRecoveryCoordinator', () => {
           type: DurableEventType.TOOL_SCHEDULED,
           requestId,
           turnId,
+          modelAttemptId,
           toolAttemptId,
           data: {
             toolCallId,
@@ -1846,6 +1853,7 @@ describe('DurableSessionRecoveryCoordinator', () => {
           type: DurableEventType.TOOL_SCHEDULED,
           requestId,
           turnId,
+          modelAttemptId,
           toolAttemptId: failedAttemptId,
           data: {
             toolCallId: failedCallId,
@@ -1887,6 +1895,70 @@ describe('DurableSessionRecoveryCoordinator', () => {
     expect(result.continuation).toContain('"originalJsonCharacters":');
     expect(result.continuation).not.toContain(oversized);
     expect(result.continuation.length).toBeLessThan(20_000);
+  });
+
+  it('bounds model-attempt history and model errors in recovery continuations', async () => {
+    const store = createStore();
+    const journal = await createJournal(store, { requestStarted: true });
+    const oversizedError = 'model-error'.repeat(600);
+    const attempts = Array.from({ length: 20 }, (_, index) => {
+      const attemptId = ModelAttemptId(
+        `bounded-model-attempt-${String(index).padStart(2, '0')}`,
+      );
+      return [
+        {
+          type: DurableEventType.MODEL_REQUEST_STARTED,
+          requestId,
+          turnId,
+          modelAttemptId: attemptId,
+          data: {
+            model: 'accepted-model',
+            streaming: false,
+          },
+        },
+        {
+          type: DurableEventType.MODEL_REQUEST_FAILED,
+          requestId,
+          turnId,
+          modelAttemptId: attemptId,
+          data: {
+            error: {
+              message: index === 19 ? oversizedError : `failure-${index}`,
+            },
+          },
+        },
+      ] satisfies DurableEventDraft[];
+    }).flat();
+    await journal.commit({
+      commandId: CommandId('bounded-model-attempts'),
+      events: [
+        {
+          type: DurableEventType.TURN_STARTED,
+          requestId,
+          turnId,
+          data: { turn: 1, model: 'accepted-model' },
+        },
+        ...attempts,
+      ],
+    });
+
+    const result = await new DurableSessionRecoveryCoordinator(journal).prepareTurnRecovery({
+      commandId: CommandId('rollover-bounded-model-attempts'),
+      requestId,
+      turnId,
+      recoveryRequestId: rolloverRequestId,
+      recoveryInputId: rolloverInputId,
+    });
+
+    expect(typeof result.continuation).toBe('string');
+    if (typeof result.continuation !== 'string') {
+      throw new Error('Expected a text recovery continuation');
+    }
+    expect(result.continuation).toContain('"modelAttemptsOmitted": 4');
+    expect(result.continuation).not.toContain('bounded-model-attempt-00');
+    expect(result.continuation).toContain('bounded-model-attempt-19');
+    expect(result.continuation).toContain('"kind": "truncated_recovery_value"');
+    expect(result.continuation).not.toContain(oversizedError);
   });
 
   it.each([

--- a/src/session/events/__tests__/DurableSessionRecoveryCoordinator.test.ts
+++ b/src/session/events/__tests__/DurableSessionRecoveryCoordinator.test.ts
@@ -1166,6 +1166,77 @@ describe('DurableSessionRecoveryCoordinator', () => {
     });
   });
 
+  it('discards an unstarted tool when its model attempt has no confirmed response', async () => {
+    const store = createStore();
+    const journal = await createJournal(store, { requestStarted: true });
+    await journal.commit({
+      commandId: CommandId('start-unconfirmed-model-tool'),
+      events: [
+        {
+          type: DurableEventType.TURN_STARTED,
+          requestId,
+          turnId,
+          data: { turn: 1, model: 'accepted-model' },
+        },
+        {
+          type: DurableEventType.MODEL_REQUEST_STARTED,
+          requestId,
+          turnId,
+          modelAttemptId,
+          data: {
+            model: 'accepted-model',
+            streaming: true,
+          },
+        },
+        {
+          type: DurableEventType.TOOL_SCHEDULED,
+          requestId,
+          turnId,
+          modelAttemptId,
+          toolAttemptId,
+          data: {
+            toolCallId,
+            toolName: 'Read',
+            modelInput: { file_path: '/tmp/input' },
+            input: { file_path: '/tmp/input' },
+            sideEffect: 'pure',
+            interruptBehavior: 'cancel',
+          },
+        },
+      ],
+    });
+    const coordinator = new DurableSessionRecoveryCoordinator(journal);
+    const reconciled = await coordinator.reconcileModelOutcome({
+      commandId: CommandId('fail-unconfirmed-model-tool'),
+      requestId,
+      turnId,
+      modelAttemptId,
+      outcome: {
+        status: 'failed',
+        error: { message: 'provider stream failed' },
+      },
+    });
+    expect(reconciled.recoveryPlan).toMatchObject({
+      action: 'resume_turn',
+      retryableToolAttempts: [],
+      cancelableToolAttempts: [{ toolAttemptId }],
+    });
+
+    const rollover = await coordinator.prepareTurnRecovery({
+      commandId: CommandId('rollover-unconfirmed-model-tool'),
+      requestId,
+      turnId,
+      recoveryRequestId: rolloverRequestId,
+      recoveryInputId: rolloverInputId,
+    });
+    expect(rollover.commit.events[0]).toMatchObject({
+      type: DurableEventType.TOOL_CANCELLED,
+      toolAttemptId,
+    });
+    expect(rollover.continuation).toContain('discarded_unconfirmed_model_response');
+    expect(rollover.continuation).toContain('must not be retried');
+  });
+
   it.each([
     {
       outcome: {

--- a/src/session/events/__tests__/DurableSessionRecoveryCoordinator.test.ts
+++ b/src/session/events/__tests__/DurableSessionRecoveryCoordinator.test.ts
@@ -1052,6 +1052,76 @@ describe('DurableSessionRecoveryCoordinator', () => {
     ).rejects.toThrow(/different events/);
   });
 
+  it('reconciles the active model before exposing an unknown tool outcome', async () => {
+    const store = createStore();
+    const journal = await createJournal(store, { requestStarted: true });
+    await journal.commit({
+      commandId: CommandId('start-streaming-model-and-tool'),
+      events: [
+        {
+          type: DurableEventType.TURN_STARTED,
+          requestId,
+          turnId,
+          data: { turn: 1, model: 'accepted-model' },
+        },
+        {
+          type: DurableEventType.MODEL_REQUEST_STARTED,
+          requestId,
+          turnId,
+          modelAttemptId,
+          data: {
+            model: 'accepted-model',
+            streaming: true,
+          },
+        },
+        {
+          type: DurableEventType.TOOL_SCHEDULED,
+          requestId,
+          turnId,
+          toolAttemptId,
+          data: {
+            toolCallId,
+            toolName: 'Deploy',
+            input: { environment: 'production' },
+            sideEffect: 'non_idempotent',
+            interruptBehavior: 'block',
+          },
+        },
+        {
+          type: DurableEventType.TOOL_STARTED,
+          requestId,
+          turnId,
+          toolAttemptId,
+          data: {
+            toolCallId,
+            toolName: 'Deploy',
+            input: { environment: 'production' },
+            sideEffect: 'non_idempotent',
+          },
+        },
+      ],
+    });
+    const coordinator = new DurableSessionRecoveryCoordinator(journal);
+    expect(coordinator.getRecoveryPlan().action).toBe('reconcile_model_outcome');
+
+    const result = await coordinator.reconcileModelOutcome({
+      commandId: CommandId('settle-streaming-model'),
+      requestId,
+      turnId,
+      modelAttemptId,
+      outcome: {
+        status: 'failed',
+        error: { message: 'stream ended unexpectedly' },
+      },
+    });
+
+    expect(result.recoveryPlan).toMatchObject({
+      action: 'reconcile_tool_outcomes',
+      activeModelAttempt: null,
+      unknownToolAttempts: [{ toolAttemptId }],
+    });
+  });
+
   it.each([
     {
       outcome: {

--- a/src/session/events/__tests__/DurableSessionRecoveryCoordinator.test.ts
+++ b/src/session/events/__tests__/DurableSessionRecoveryCoordinator.test.ts
@@ -45,6 +45,39 @@ const requestRolloverTurnId = TurnId('request-rollover-turn');
 
 const roots: string[] = [];
 
+function completedModelToolEvents(
+  toolCalls: Array<{
+    id: ToolUseId;
+    name: string;
+    arguments: string;
+  }>,
+): DurableEventDraft[] {
+  return [
+    {
+      type: DurableEventType.MODEL_REQUEST_STARTED,
+      requestId,
+      turnId,
+      modelAttemptId,
+      data: {
+        model: 'accepted-model',
+        streaming: false,
+      },
+    },
+    {
+      type: DurableEventType.MODEL_REQUEST_COMPLETED,
+      requestId,
+      turnId,
+      modelAttemptId,
+      data: {
+        response: {
+          content: '',
+          toolCalls,
+        },
+      },
+    },
+  ];
+}
+
 function createStore(): JsonlDurableEventStore {
   const root = mkdtempSync(join(tmpdir(), 'durable-recovery-coordinator-'));
   roots.push(root);
@@ -251,6 +284,13 @@ async function createJournal(
               turnId,
               data: { turn: 1, model: 'test-model' },
             },
+            ...completedModelToolEvents([
+              {
+                id: toolCallId,
+                name: 'Deploy',
+                arguments: '{"environment":"production"}',
+              },
+            ]),
             {
               type: DurableEventType.TOOL_SCHEDULED,
               requestId,
@@ -259,6 +299,7 @@ async function createJournal(
               data: {
                 toolCallId,
                 toolName: 'Deploy',
+                modelInput: { environment: 'production' },
                 input: { environment: 'production' },
                 sideEffect: options.sideEffect ?? ('non_idempotent' as const),
                 interruptBehavior: 'block' as const,
@@ -1082,6 +1123,7 @@ describe('DurableSessionRecoveryCoordinator', () => {
           data: {
             toolCallId,
             toolName: 'Deploy',
+            modelInput: { environment: 'production' },
             input: { environment: 'production' },
             sideEffect: 'non_idempotent',
             interruptBehavior: 'block',
@@ -1378,6 +1420,13 @@ describe('DurableSessionRecoveryCoordinator', () => {
           turnId,
           data: { turn: 1, model: 'accepted-model' },
         },
+        ...completedModelToolEvents([
+          {
+            id: toolCallId,
+            name: 'Deploy',
+            arguments: '{"environment":"production"}',
+          },
+        ]),
         {
           type: DurableEventType.TOOL_SCHEDULED,
           requestId,
@@ -1386,6 +1435,7 @@ describe('DurableSessionRecoveryCoordinator', () => {
           data: {
             toolCallId,
             toolName: 'Deploy',
+            modelInput: { environment: 'production' },
             input: { environment: 'production' },
             sideEffect: 'non_idempotent',
             interruptBehavior: 'block',
@@ -1436,6 +1486,13 @@ describe('DurableSessionRecoveryCoordinator', () => {
           turnId,
           data: { turn: 1, model: 'accepted-model' },
         },
+        ...completedModelToolEvents([
+          {
+            id: toolCallId,
+            name: 'Read',
+            arguments: '{"file_path":"/tmp/input"}',
+          },
+        ]),
         {
           type: DurableEventType.TOOL_SCHEDULED,
           requestId,
@@ -1444,6 +1501,7 @@ describe('DurableSessionRecoveryCoordinator', () => {
           data: {
             toolCallId,
             toolName: 'Read',
+            modelInput: { file_path: '/tmp/input' },
             input: { file_path: '/tmp/input' },
             sideEffect: 'pure',
             interruptBehavior: 'cancel',
@@ -1495,6 +1553,13 @@ describe('DurableSessionRecoveryCoordinator', () => {
           turnId,
           data: { turn: 1, model: 'accepted-model' },
         },
+        ...completedModelToolEvents([
+          {
+            id: toolCallId,
+            name: 'Deploy',
+            arguments: '{"environment":"production"}',
+          },
+        ]),
         {
           type: DurableEventType.TOOL_SCHEDULED,
           requestId,
@@ -1503,6 +1568,7 @@ describe('DurableSessionRecoveryCoordinator', () => {
           data: {
             toolCallId,
             toolName: 'Deploy',
+            modelInput: { environment: 'production' },
             input: { environment: 'production' },
             sideEffect: 'non_idempotent',
             interruptBehavior: 'block',
@@ -1648,6 +1714,13 @@ describe('DurableSessionRecoveryCoordinator', () => {
           turnId,
           data: { turn: 1, model: 'accepted-model' },
         },
+        ...completedModelToolEvents([
+          {
+            id: toolCallId,
+            name: 'Read',
+            arguments: '{"file_path":"/tmp/input"}',
+          },
+        ]),
         {
           type: DurableEventType.TOOL_SCHEDULED,
           requestId,
@@ -1656,6 +1729,7 @@ describe('DurableSessionRecoveryCoordinator', () => {
           data: {
             toolCallId,
             toolName: 'Read',
+            modelInput: { file_path: '/tmp/input' },
             input: { file_path: '/tmp/input' },
             sideEffect: 'pure',
             interruptBehavior: 'cancel',
@@ -1719,6 +1793,18 @@ describe('DurableSessionRecoveryCoordinator', () => {
           turnId,
           data: { turn: 1, model: 'accepted-model' },
         },
+        ...completedModelToolEvents([
+          {
+            id: toolCallId,
+            name: 'Read',
+            arguments: JSON.stringify({ payload: oversized }),
+          },
+          {
+            id: failedCallId,
+            name: 'Search',
+            arguments: '{}',
+          },
+        ]),
         {
           type: DurableEventType.TOOL_SCHEDULED,
           requestId,
@@ -1727,6 +1813,7 @@ describe('DurableSessionRecoveryCoordinator', () => {
           data: {
             toolCallId,
             toolName: 'Read',
+            modelInput: { payload: oversized },
             input: { payload: oversized },
             sideEffect: 'pure',
             interruptBehavior: 'cancel',
@@ -1763,6 +1850,7 @@ describe('DurableSessionRecoveryCoordinator', () => {
           data: {
             toolCallId: failedCallId,
             toolName: 'Search',
+            modelInput: {},
             input: {},
             sideEffect: 'pure',
             interruptBehavior: 'cancel',
@@ -1794,11 +1882,11 @@ describe('DurableSessionRecoveryCoordinator', () => {
     if (typeof result.continuation !== 'string') {
       throw new Error('Expected a text recovery continuation');
     }
-    expect(result.continuation.match(/"kind": "truncated_recovery_value"/g)).toHaveLength(3);
+    expect(result.continuation.match(/"kind": "truncated_recovery_value"/g)).toHaveLength(4);
     expect(result.continuation).toContain('"complete": false');
     expect(result.continuation).toContain('"originalJsonCharacters":');
     expect(result.continuation).not.toContain(oversized);
-    expect(result.continuation.length).toBeLessThan(14_000);
+    expect(result.continuation.length).toBeLessThan(20_000);
   });
 
   it.each([

--- a/src/session/events/__tests__/JsonlDurableEventStore.test.ts
+++ b/src/session/events/__tests__/JsonlDurableEventStore.test.ts
@@ -1,4 +1,12 @@
-import { appendFile, mkdtemp, readFile, rm, stat } from 'node:fs/promises';
+import {
+  appendFile,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+} from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -98,6 +106,88 @@ describe('JsonlDurableEventStore', () => {
       'event-2',
       'event-3',
     ]);
+  });
+
+  it('reads schema-v2 batches and appends new schema-v3 events', async () => {
+    const sessionId = SessionId('session-schema-upgrade');
+    const filePath = store.getFilePath(sessionId);
+    const timestamp = '2026-08-22T12:00:00.000Z';
+    await mkdir(dirname(filePath), { recursive: true });
+    await writeFile(
+      filePath,
+      `${JSON.stringify({
+        format: DURABLE_EVENT_LOG_FORMAT,
+        schemaVersion: 2,
+        sessionId,
+        firstSequence: 1,
+        lastSequence: 1,
+        events: [
+          {
+            schemaVersion: 2,
+            eventId: 'legacy-event',
+            sequence: 1,
+            sessionId,
+            type: DurableEventType.SESSION_CREATED,
+            data: { source: 'create' },
+            recordedAt: timestamp,
+            occurredAt: timestamp,
+          },
+        ],
+      })}\n`,
+      { encoding: 'utf8', mode: 0o600 },
+    );
+
+    expect((await store.read(sessionId)).events[0]?.schemaVersion).toBe(2);
+    const appended = await store.append(
+      sessionId,
+      [
+        {
+          type: DurableEventType.REQUEST_ACCEPTED,
+          requestId: RequestId('schema-v3-request'),
+          commandId: CommandId('schema-v3-command'),
+          data: {
+            inputId: InputId('schema-v3-input'),
+            input: 'continue',
+            priority: 'next',
+          },
+        },
+      ],
+      { expectedLastSequence: EventSequence(1) },
+    );
+
+    expect(appended.events[0]?.schemaVersion).toBe(3);
+    expect((await store.read(sessionId)).events.map((event) => event.schemaVersion)).toEqual([
+      2,
+      3,
+    ]);
+
+    await appendFile(
+      filePath,
+      `${JSON.stringify({
+        format: DURABLE_EVENT_LOG_FORMAT,
+        schemaVersion: 2,
+        sessionId,
+        firstSequence: 3,
+        lastSequence: 3,
+        events: [
+          {
+            schemaVersion: 2,
+            eventId: 'downgraded-event',
+            sequence: 3,
+            sessionId,
+            type: DurableEventType.REQUEST_STARTED,
+            requestId: RequestId('schema-v3-request'),
+            data: {},
+            recordedAt: timestamp,
+            occurredAt: timestamp,
+          },
+        ],
+      })}\n`,
+    );
+    await expect(store.read(sessionId)).rejects.toMatchObject({
+      code: 'DURABLE_EVENT_CORRUPT_LOG',
+      message: expect.stringContaining('schema regressed'),
+    });
   });
 
   it('reads exclusive cursor pages without gaps', async () => {

--- a/src/session/events/__tests__/SessionDurableRecorder.test.ts
+++ b/src/session/events/__tests__/SessionDurableRecorder.test.ts
@@ -7,6 +7,7 @@ import {
   CommandId,
   EventId,
   InputId,
+  ModelAttemptId,
   RequestId,
   SessionId,
   ToolUseId,
@@ -54,7 +55,7 @@ describe('SessionDurableRecorder', () => {
     toolCallId: ToolUseId,
     toolName: string,
     modelInput: JsonObject,
-  ): Promise<void> {
+  ): Promise<ModelAttemptId> {
     const modelRequest = await recorder.onModelRequestStarting({
       turn: 1,
       model: 'test-model',
@@ -73,6 +74,10 @@ describe('SessionDurableRecorder', () => {
         },
       ],
     });
+    if (!modelRequest.modelAttemptId) {
+      throw new Error('Expected durable model attempt ID');
+    }
+    return modelRequest.modelAttemptId;
   }
 
   afterEach(async () => {
@@ -116,10 +121,14 @@ describe('SessionDurableRecorder', () => {
         totalTokens: 12,
       },
     });
+    if (!modelRequest.modelAttemptId) {
+      throw new Error('Expected durable model attempt ID');
+    }
 
     const lifecycle = await recorder.onToolScheduled({
       toolCallId: ToolUseId('tool-call-1'),
       toolName: 'Write',
+      modelAttemptId: modelRequest.modelAttemptId,
       modelInput: { file_path: '/tmp/file' },
       input: { file_path: '/tmp/file' },
       sideEffect: 'non_idempotent',
@@ -198,14 +207,15 @@ describe('SessionDurableRecorder', () => {
         environment: { REGION: 'test' },
       },
     });
-    expect(
-      events.find(
-        (event) => event.type === DurableEventType.TOOL_SCHEDULED,
-      )?.data,
-    ).toMatchObject({
-      modelInput: { file_path: '/tmp/file' },
-      input: { file_path: '/tmp/file' },
-      sideEffect: 'non_idempotent',
+    expect(events.find(
+      (event) => event.type === DurableEventType.TOOL_SCHEDULED,
+    )).toMatchObject({
+      modelAttemptId: modelRequest.modelAttemptId,
+      data: {
+        modelInput: { file_path: '/tmp/file' },
+        input: { file_path: '/tmp/file' },
+        sideEffect: 'non_idempotent',
+      },
     });
     expect(
       (await store.read(sessionId)).events.find(
@@ -278,6 +288,129 @@ describe('SessionDurableRecorder', () => {
       },
     });
     expect(journal.getRecoveryPlan().action).toBe('resume_turn');
+  });
+
+  it('rejects a tool schedule from a superseded model attempt', async () => {
+    await recorder.recordAccepted(inputId, 'retry');
+    await recorder.recordStarted(inputId);
+    await recorder.recordAgentEvent({
+      type: 'turn_start',
+      turn: 1,
+      maxTurns: 10,
+    });
+    const first = await recorder.onModelRequestStarting({
+      turn: 1,
+      model: 'test-model',
+      streaming: false,
+    });
+    if (!first.modelAttemptId) {
+      throw new Error('Expected durable model attempt ID');
+    }
+    const activeTurnId = journal.getProjection().activeRequest?.activeTurn?.turnId;
+    if (!activeTurnId) {
+      throw new Error('Expected active turn ID');
+    }
+    const competingAttemptId = ModelAttemptId('competing-model-attempt');
+    const competingJournal = await DurableSessionJournal.open(store, sessionId);
+    await competingJournal.commit({
+      commandId: CommandId('competing-model-retry'),
+      events: [
+        {
+          type: DurableEventType.MODEL_REQUEST_FAILED,
+          requestId,
+          turnId: activeTurnId,
+          modelAttemptId: first.modelAttemptId,
+          data: {
+            error: { message: 'retry' },
+          },
+        },
+        {
+          type: DurableEventType.MODEL_REQUEST_STARTED,
+          requestId,
+          turnId: activeTurnId,
+          modelAttemptId: competingAttemptId,
+          data: {
+            model: 'test-model',
+            streaming: false,
+          },
+        },
+      ],
+    });
+
+    await expect(
+      recorder.onToolScheduled({
+        toolCallId: ToolUseId('stale-tool-call'),
+        toolName: 'Read',
+        modelAttemptId: first.modelAttemptId,
+        modelInput: {},
+        input: {},
+        sideEffect: 'pure',
+        interruptBehavior: 'cancel',
+      }),
+    ).rejects.toThrow(/does not belong to the current model attempt/);
+    expect(journal.getRecoveryPlan()).toMatchObject({
+      action: 'reconcile_model_outcome',
+      activeModelAttempt: {
+        modelAttemptId: competingAttemptId,
+      },
+    });
+  });
+
+  it('serializes model completion after a concurrent tool schedule', async () => {
+    await recorder.recordAccepted(inputId, 'stream a tool');
+    await recorder.recordStarted(inputId);
+    await recorder.recordAgentEvent({
+      type: 'turn_start',
+      turn: 1,
+      maxTurns: 10,
+    });
+    const modelRequest = await recorder.onModelRequestStarting({
+      turn: 1,
+      model: 'test-model',
+      streaming: true,
+    });
+    if (!modelRequest.modelAttemptId) {
+      throw new Error('Expected durable model attempt ID');
+    }
+
+    const scheduled = recorder.onToolScheduled({
+      toolCallId: ToolUseId('streaming-tool-call'),
+      toolName: 'Read',
+      modelAttemptId: modelRequest.modelAttemptId,
+      modelInput: { file_path: '/tmp/file' },
+      input: { file_path: '/tmp/file' },
+      sideEffect: 'pure',
+      interruptBehavior: 'cancel',
+    });
+    const completed = modelRequest.onCompleted({
+      content: '',
+      toolCalls: [
+        {
+          id: 'streaming-tool-call',
+          type: 'function',
+          function: {
+            name: 'Read',
+            arguments: '{"file_path":"/tmp/file"}',
+          },
+        },
+      ],
+    });
+
+    await expect(Promise.all([scheduled, completed])).resolves.toHaveLength(2);
+    expect((await store.read(sessionId)).events.slice(-2).map((event) => event.type)).toEqual([
+      DurableEventType.TOOL_SCHEDULED,
+      DurableEventType.MODEL_REQUEST_COMPLETED,
+    ]);
+    expect(journal.getRecoveryPlan()).toMatchObject({
+      action: 'resume_turn',
+      activeModelAttempt: null,
+      retryableToolAttempts: [
+        expect.objectContaining({
+          toolCallId: 'streaming-tool-call',
+          modelAttemptId: modelRequest.modelAttemptId,
+        }),
+      ],
+    });
   });
 
   it('persists steering input application before preparation and confirms it once', async () => {
@@ -453,10 +586,15 @@ describe('SessionDurableRecorder', () => {
       turn: 1,
       maxTurns: 10,
     });
-    await recordCompletedModelTool(ToolUseId('tool-call-1'), 'Write', {});
+    const modelAttemptId = await recordCompletedModelTool(
+      ToolUseId('tool-call-1'),
+      'Write',
+      {},
+    );
     const lifecycle = await recorder.onToolScheduled({
       toolCallId: ToolUseId('tool-call-1'),
       toolName: 'Write',
+      modelAttemptId,
       modelInput: {},
       input: {},
       sideEffect: 'non_idempotent',
@@ -498,10 +636,15 @@ describe('SessionDurableRecorder', () => {
       turn: 1,
       maxTurns: 10,
     });
-    await recordCompletedModelTool(ToolUseId('tool-call-1'), 'Write', {});
+    const modelAttemptId = await recordCompletedModelTool(
+      ToolUseId('tool-call-1'),
+      'Write',
+      {},
+    );
     await recorder.onToolScheduled({
       toolCallId: ToolUseId('tool-call-1'),
       toolName: 'Write',
+      modelAttemptId,
       modelInput: {},
       input: {},
       sideEffect: 'non_idempotent',
@@ -533,10 +676,15 @@ describe('SessionDurableRecorder', () => {
       turn: 1,
       maxTurns: 10,
     });
-    await recordCompletedModelTool(ToolUseId('tool-call-1'), 'Write', {});
+    const modelAttemptId = await recordCompletedModelTool(
+      ToolUseId('tool-call-1'),
+      'Write',
+      {},
+    );
     await recorder.onToolScheduled({
       toolCallId: ToolUseId('tool-call-1'),
       toolName: 'Write',
+      modelAttemptId,
       modelInput: {},
       input: {},
       sideEffect: 'non_idempotent',
@@ -581,10 +729,15 @@ describe('SessionDurableRecorder', () => {
       turn: 1,
       maxTurns: 10,
     });
-    await recordCompletedModelTool(ToolUseId('tool-call-1'), 'Write', {});
+    const modelAttemptId = await recordCompletedModelTool(
+      ToolUseId('tool-call-1'),
+      'Write',
+      {},
+    );
     const lifecycle = await recorder.onToolScheduled({
       toolCallId: ToolUseId('tool-call-1'),
       toolName: 'Write',
+      modelAttemptId,
       modelInput: {},
       input: {},
       sideEffect: 'non_idempotent',
@@ -622,10 +775,15 @@ describe('SessionDurableRecorder', () => {
       turn: 1,
       maxTurns: 10,
     });
-    await recordCompletedModelTool(ToolUseId('tool-call-1'), 'Write', {});
+    const modelAttemptId = await recordCompletedModelTool(
+      ToolUseId('tool-call-1'),
+      'Write',
+      {},
+    );
     const lifecycle = await recorder.onToolScheduled({
       toolCallId: ToolUseId('tool-call-1'),
       toolName: 'Write',
+      modelAttemptId,
       modelInput: {},
       input: {},
       sideEffect: 'non_idempotent',
@@ -656,10 +814,11 @@ describe('SessionDurableRecorder', () => {
       maxTurns: 10,
     });
     const toolCallId = ToolUseId('tool-call-1');
-    await recordCompletedModelTool(toolCallId, 'Read', {});
+    const modelAttemptId = await recordCompletedModelTool(toolCallId, 'Read', {});
     const lifecycle = await recorder.onToolScheduled({
       toolCallId,
       toolName: 'Read',
+      modelAttemptId,
       modelInput: {},
       input: {},
       sideEffect: 'pure',
@@ -693,11 +852,12 @@ describe('SessionDurableRecorder', () => {
       maxTurns: 10,
     });
     const toolCallId = ToolUseId('tool-call-1');
-    await recordCompletedModelTool(toolCallId, 'Read', {});
+    const modelAttemptId = await recordCompletedModelTool(toolCallId, 'Read', {});
 
     const first = recorder.onToolScheduled({
       toolCallId,
       toolName: 'Read',
+      modelAttemptId,
       modelInput: {},
       input: {},
       sideEffect: 'pure',
@@ -706,6 +866,7 @@ describe('SessionDurableRecorder', () => {
     const duplicate = recorder.onToolScheduled({
       toolCallId,
       toolName: 'Read',
+      modelAttemptId,
       modelInput: {},
       input: {},
       sideEffect: 'pure',

--- a/src/session/events/__tests__/SessionDurableRecorder.test.ts
+++ b/src/session/events/__tests__/SessionDurableRecorder.test.ts
@@ -11,6 +11,7 @@ import {
   SessionId,
   ToolUseId,
 } from '../../../types/branded.js';
+import type { JsonObject } from '../../../types/common.js';
 import { DurableSessionJournal } from '../DurableSessionJournal.js';
 import { JsonlDurableEventStore } from '../JsonlDurableEventStore.js';
 import {
@@ -48,6 +49,31 @@ describe('SessionDurableRecorder', () => {
     });
     recorder = new SessionDurableRecorder(journal, requestId, 'test-model');
   });
+
+  async function recordCompletedModelTool(
+    toolCallId: ToolUseId,
+    toolName: string,
+    modelInput: JsonObject,
+  ): Promise<void> {
+    const modelRequest = await recorder.onModelRequestStarting({
+      turn: 1,
+      model: 'test-model',
+      streaming: false,
+    });
+    await modelRequest.onCompleted({
+      content: '',
+      toolCalls: [
+        {
+          id: toolCallId,
+          type: 'function',
+          function: {
+            name: toolName,
+            arguments: JSON.stringify(modelInput),
+          },
+        },
+      ],
+    });
+  }
 
   afterEach(async () => {
     await rm(storageRoot, { recursive: true, force: true });
@@ -94,6 +120,7 @@ describe('SessionDurableRecorder', () => {
     const lifecycle = await recorder.onToolScheduled({
       toolCallId: ToolUseId('tool-call-1'),
       toolName: 'Write',
+      modelInput: { file_path: '/tmp/file' },
       input: { file_path: '/tmp/file' },
       sideEffect: 'non_idempotent',
       interruptBehavior: 'block',
@@ -175,7 +202,11 @@ describe('SessionDurableRecorder', () => {
       events.find(
         (event) => event.type === DurableEventType.TOOL_SCHEDULED,
       )?.data,
-    ).toMatchObject({ sideEffect: 'non_idempotent' });
+    ).toMatchObject({
+      modelInput: { file_path: '/tmp/file' },
+      input: { file_path: '/tmp/file' },
+      sideEffect: 'non_idempotent',
+    });
     expect(
       (await store.read(sessionId)).events.find(
         (event) => event.type === DurableEventType.TOOL_STARTED,
@@ -422,9 +453,11 @@ describe('SessionDurableRecorder', () => {
       turn: 1,
       maxTurns: 10,
     });
+    await recordCompletedModelTool(ToolUseId('tool-call-1'), 'Write', {});
     const lifecycle = await recorder.onToolScheduled({
       toolCallId: ToolUseId('tool-call-1'),
       toolName: 'Write',
+      modelInput: {},
       input: {},
       sideEffect: 'non_idempotent',
       interruptBehavior: 'block',
@@ -465,9 +498,11 @@ describe('SessionDurableRecorder', () => {
       turn: 1,
       maxTurns: 10,
     });
+    await recordCompletedModelTool(ToolUseId('tool-call-1'), 'Write', {});
     await recorder.onToolScheduled({
       toolCallId: ToolUseId('tool-call-1'),
       toolName: 'Write',
+      modelInput: {},
       input: {},
       sideEffect: 'non_idempotent',
       interruptBehavior: 'block',
@@ -498,9 +533,11 @@ describe('SessionDurableRecorder', () => {
       turn: 1,
       maxTurns: 10,
     });
+    await recordCompletedModelTool(ToolUseId('tool-call-1'), 'Write', {});
     await recorder.onToolScheduled({
       toolCallId: ToolUseId('tool-call-1'),
       toolName: 'Write',
+      modelInput: {},
       input: {},
       sideEffect: 'non_idempotent',
       interruptBehavior: 'block',
@@ -544,9 +581,11 @@ describe('SessionDurableRecorder', () => {
       turn: 1,
       maxTurns: 10,
     });
+    await recordCompletedModelTool(ToolUseId('tool-call-1'), 'Write', {});
     const lifecycle = await recorder.onToolScheduled({
       toolCallId: ToolUseId('tool-call-1'),
       toolName: 'Write',
+      modelInput: {},
       input: {},
       sideEffect: 'non_idempotent',
       interruptBehavior: 'block',
@@ -583,9 +622,11 @@ describe('SessionDurableRecorder', () => {
       turn: 1,
       maxTurns: 10,
     });
+    await recordCompletedModelTool(ToolUseId('tool-call-1'), 'Write', {});
     const lifecycle = await recorder.onToolScheduled({
       toolCallId: ToolUseId('tool-call-1'),
       toolName: 'Write',
+      modelInput: {},
       input: {},
       sideEffect: 'non_idempotent',
       interruptBehavior: 'block',
@@ -615,9 +656,11 @@ describe('SessionDurableRecorder', () => {
       maxTurns: 10,
     });
     const toolCallId = ToolUseId('tool-call-1');
+    await recordCompletedModelTool(toolCallId, 'Read', {});
     const lifecycle = await recorder.onToolScheduled({
       toolCallId,
       toolName: 'Read',
+      modelInput: {},
       input: {},
       sideEffect: 'pure',
       interruptBehavior: 'cancel',
@@ -650,10 +693,12 @@ describe('SessionDurableRecorder', () => {
       maxTurns: 10,
     });
     const toolCallId = ToolUseId('tool-call-1');
+    await recordCompletedModelTool(toolCallId, 'Read', {});
 
     const first = recorder.onToolScheduled({
       toolCallId,
       toolName: 'Read',
+      modelInput: {},
       input: {},
       sideEffect: 'pure',
       interruptBehavior: 'cancel',
@@ -661,6 +706,7 @@ describe('SessionDurableRecorder', () => {
     const duplicate = recorder.onToolScheduled({
       toolCallId,
       toolName: 'Read',
+      modelInput: {},
       input: {},
       sideEffect: 'pure',
       interruptBehavior: 'cancel',

--- a/src/session/events/__tests__/SessionDurableRecorder.test.ts
+++ b/src/session/events/__tests__/SessionDurableRecorder.test.ts
@@ -67,6 +67,29 @@ describe('SessionDurableRecorder', () => {
       turn: 1,
       maxTurns: 10,
     });
+    const modelRequest = await recorder.onModelRequestStarting({
+      turn: 1,
+      model: 'test-model',
+      streaming: false,
+    });
+    await modelRequest.onCompleted({
+      content: '',
+      toolCalls: [
+        {
+          id: 'tool-call-1',
+          type: 'function',
+          function: {
+            name: 'Write',
+            arguments: '{"file_path":"/tmp/file"}',
+          },
+        },
+      ],
+      usage: {
+        promptTokens: 10,
+        completionTokens: 2,
+        totalTokens: 12,
+      },
+    });
 
     const lifecycle = await recorder.onToolScheduled({
       toolCallId: ToolUseId('tool-call-1'),
@@ -121,6 +144,8 @@ describe('SessionDurableRecorder', () => {
       'input_applied',
       'request_started',
       'turn_started',
+      'model_request_started',
+      'model_request_completed',
       'tool_scheduled',
       'permission_requested',
       'permission_resolved',
@@ -160,6 +185,68 @@ describe('SessionDurableRecorder', () => {
       sideEffect: 'idempotent',
     });
     expect(journal.getProjection().activeRequest).toBeNull();
+  });
+
+  it('requires reconciliation when a model request has no durable outcome', async () => {
+    await recorder.recordAccepted(inputId, 'run');
+    await recorder.recordStarted(inputId);
+    await recorder.recordAgentEvent({
+      type: 'turn_start',
+      turn: 1,
+      maxTurns: 10,
+    });
+    await recorder.onModelRequestStarting({
+      turn: 1,
+      model: 'test-model',
+      streaming: true,
+    });
+
+    expect(journal.getRecoveryPlan()).toMatchObject({
+      action: 'reconcile_model_outcome',
+      requestId,
+    });
+    await expect(
+      recorder.finish({
+        status: 'failed',
+        error: new Error('worker stopped'),
+      }),
+    ).rejects.toThrow(/Model attempt .* is still active/);
+    expect((await store.read(sessionId)).events.at(-1)?.type).toBe(
+      DurableEventType.MODEL_REQUEST_STARTED,
+    );
+  });
+
+  it('preserves model failure classification in the durable outcome', async () => {
+    await recorder.recordAccepted(inputId, 'run');
+    await recorder.recordStarted(inputId);
+    await recorder.recordAgentEvent({
+      type: 'turn_start',
+      turn: 1,
+      maxTurns: 10,
+    });
+    const modelRequest = await recorder.onModelRequestStarting({
+      turn: 1,
+      model: 'test-model',
+      streaming: false,
+    });
+    const modelError = Object.assign(new Error('provider overloaded'), {
+      code: 'MODEL_OVERLOADED',
+      retryable: true,
+    });
+
+    await modelRequest.onFailed(modelError);
+
+    expect((await store.read(sessionId)).events.at(-1)).toMatchObject({
+      type: DurableEventType.MODEL_REQUEST_FAILED,
+      data: {
+        error: {
+          message: 'provider overloaded',
+          code: 'MODEL_OVERLOADED',
+          retryable: true,
+        },
+      },
+    });
+    expect(journal.getRecoveryPlan().action).toBe('resume_turn');
   });
 
   it('persists steering input application before preparation and confirms it once', async () => {

--- a/src/session/events/__tests__/schemas.test.ts
+++ b/src/session/events/__tests__/schemas.test.ts
@@ -3,13 +3,19 @@ import {
   CommandId,
   EventId,
   InputId,
+  ModelAttemptId,
   PermissionRequestId,
   RequestId,
   ToolAttemptId,
   ToolUseId,
   TurnId,
 } from '../../../types/branded.js';
-import { parseDurableEventDraft, parseDurableEventEnvelope } from '../schemas.js';
+import {
+  DURABLE_EVENT_LOG_FORMAT,
+  parseDurableEventDraft,
+  parseDurableEventEnvelope,
+  parsePersistedDurableEventBatch,
+} from '../schemas.js';
 import {
   DURABLE_EVENT_SCHEMA_VERSION,
   type DurableEventDraft,
@@ -19,6 +25,7 @@ import {
 const requestId = RequestId('request-1');
 const commandId = CommandId('command-1');
 const turnId = TurnId('turn-1');
+const modelAttemptId = ModelAttemptId('model-attempt-1');
 const toolAttemptId = ToolAttemptId('attempt-1');
 const toolCallId = ToolUseId('call-1');
 const permissionRequestId = PermissionRequestId('permission-1');
@@ -98,6 +105,59 @@ const validDrafts: readonly DurableEventDraft[] = [
     requestId,
     turnId,
     data: { turn: 1, reason: 'request_interrupted' },
+  },
+  {
+    type: DurableEventType.MODEL_REQUEST_STARTED,
+    requestId,
+    turnId,
+    modelAttemptId,
+    data: {
+      model: 'claude-sonnet',
+      streaming: true,
+    },
+  },
+  {
+    type: DurableEventType.MODEL_REQUEST_COMPLETED,
+    requestId,
+    turnId,
+    modelAttemptId,
+    data: {
+      response: {
+        content: 'done',
+        reasoningContent: 'reasoning',
+        toolCalls: [
+          {
+            id: toolCallId,
+            name: 'Write',
+            arguments: '{"file_path":"/tmp/file"}',
+          },
+        ],
+        usage: {
+          promptTokens: 10,
+          completionTokens: 2,
+          totalTokens: 12,
+          cacheReadInputTokens: 4,
+        },
+      },
+    },
+  },
+  {
+    type: DurableEventType.MODEL_REQUEST_FAILED,
+    requestId,
+    turnId,
+    modelAttemptId,
+    data: {
+      error: { message: 'provider failed', code: 'MODEL_ERROR', retryable: true },
+    },
+  },
+  {
+    type: DurableEventType.MODEL_REQUEST_ABORTED,
+    requestId,
+    turnId,
+    modelAttemptId,
+    data: {
+      reason: 'steering',
+    },
   },
   {
     type: DurableEventType.TOOL_SCHEDULED,
@@ -381,5 +441,65 @@ describe('durable event schemas', () => {
         occurredAt: '2026-08-22T12:00:00.000Z',
       }),
     ).toThrow();
+  });
+
+  it('reads schema-v2 logs but forbids model-attempt events in v2', () => {
+    const legacyEvent = {
+      ...validDrafts[0],
+      schemaVersion: 2,
+      eventId: EventId('legacy-event'),
+      sequence: 1,
+      sessionId: 'legacy-session',
+      recordedAt: '2026-08-22T12:00:00.000Z',
+      occurredAt: '2026-08-22T12:00:00.000Z',
+    };
+    expect(parseDurableEventEnvelope(legacyEvent).schemaVersion).toBe(2);
+    expect(
+      parsePersistedDurableEventBatch({
+        format: DURABLE_EVENT_LOG_FORMAT,
+        schemaVersion: 2,
+        sessionId: 'legacy-session',
+        firstSequence: 1,
+        lastSequence: 1,
+        events: [legacyEvent],
+      }).schemaVersion,
+    ).toBe(2);
+
+    expect(() =>
+      parseDurableEventEnvelope({
+        ...validDrafts.find(
+          (draft) => draft.type === DurableEventType.MODEL_REQUEST_STARTED,
+        ),
+        schemaVersion: 2,
+        eventId: EventId('invalid-v2-model-event'),
+        sequence: 1,
+        sessionId: 'legacy-session',
+        recordedAt: '2026-08-22T12:00:00.000Z',
+        occurredAt: '2026-08-22T12:00:00.000Z',
+      }),
+    ).toThrow(/requires durable event schema v3/);
+  });
+
+  it('rejects a persisted batch whose event version does not match', () => {
+    expect(() =>
+      parsePersistedDurableEventBatch({
+        format: DURABLE_EVENT_LOG_FORMAT,
+        schemaVersion: DURABLE_EVENT_SCHEMA_VERSION,
+        sessionId: 'session-1',
+        firstSequence: 1,
+        lastSequence: 1,
+        events: [
+          {
+            ...validDrafts[0],
+            schemaVersion: 2,
+            eventId: EventId('mixed-version-event'),
+            sequence: 1,
+            sessionId: 'session-1',
+            recordedAt: '2026-08-22T12:00:00.000Z',
+            occurredAt: '2026-08-22T12:00:00.000Z',
+          },
+        ],
+      }),
+    ).toThrow(/must match its batch/);
   });
 });

--- a/src/session/events/__tests__/schemas.test.ts
+++ b/src/session/events/__tests__/schemas.test.ts
@@ -167,6 +167,7 @@ const validDrafts: readonly DurableEventDraft[] = [
     data: {
       toolCallId,
       toolName: 'Write',
+      modelInput: { file_path: '/tmp/file' },
       input: { file_path: '/tmp/file' },
       sideEffect: 'non_idempotent',
       interruptBehavior: 'block',
@@ -478,6 +479,38 @@ describe('durable event schemas', () => {
         occurredAt: '2026-08-22T12:00:00.000Z',
       }),
     ).toThrow(/requires durable event schema v3/);
+  });
+
+  it('requires original model input for schema-v3 tool schedules only', () => {
+    const toolScheduled = validDrafts.find(
+      (draft) => draft.type === DurableEventType.TOOL_SCHEDULED,
+    );
+    if (!toolScheduled || toolScheduled.type !== DurableEventType.TOOL_SCHEDULED) {
+      throw new Error('Expected tool_scheduled fixture');
+    }
+    const { modelInput: _modelInput, ...legacyData } = toolScheduled.data;
+    const envelope = {
+      ...toolScheduled,
+      data: legacyData,
+      eventId: EventId('tool-without-model-input'),
+      sequence: 1,
+      sessionId: 'session-1',
+      recordedAt: '2026-08-22T12:00:00.000Z',
+      occurredAt: '2026-08-22T12:00:00.000Z',
+    };
+
+    expect(() =>
+      parseDurableEventEnvelope({
+        ...envelope,
+        schemaVersion: DURABLE_EVENT_SCHEMA_VERSION,
+      }),
+    ).toThrow(/requires modelInput/);
+    expect(
+      parseDurableEventEnvelope({
+        ...envelope,
+        schemaVersion: 2,
+      }).schemaVersion,
+    ).toBe(2);
   });
 
   it('rejects a persisted batch whose event version does not match', () => {

--- a/src/session/events/__tests__/schemas.test.ts
+++ b/src/session/events/__tests__/schemas.test.ts
@@ -163,6 +163,7 @@ const validDrafts: readonly DurableEventDraft[] = [
     type: DurableEventType.TOOL_SCHEDULED,
     requestId,
     turnId,
+    modelAttemptId,
     toolAttemptId,
     data: {
       toolCallId,
@@ -481,7 +482,7 @@ describe('durable event schemas', () => {
     ).toThrow(/requires durable event schema v3/);
   });
 
-  it('requires original model input for schema-v3 tool schedules only', () => {
+  it('requires model-attempt identity and original input for schema-v3 tool schedules only', () => {
     const toolScheduled = validDrafts.find(
       (draft) => draft.type === DurableEventType.TOOL_SCHEDULED,
     );
@@ -489,8 +490,9 @@ describe('durable event schemas', () => {
       throw new Error('Expected tool_scheduled fixture');
     }
     const { modelInput: _modelInput, ...legacyData } = toolScheduled.data;
+    const { modelAttemptId: _modelAttemptId, ...legacyToolScheduled } = toolScheduled;
     const envelope = {
-      ...toolScheduled,
+      ...legacyToolScheduled,
       data: legacyData,
       eventId: EventId('tool-without-model-input'),
       sequence: 1,
@@ -502,15 +504,37 @@ describe('durable event schemas', () => {
     expect(() =>
       parseDurableEventEnvelope({
         ...envelope,
+        modelAttemptId,
         schemaVersion: DURABLE_EVENT_SCHEMA_VERSION,
       }),
     ).toThrow(/requires modelInput/);
+    expect(() =>
+      parseDurableEventEnvelope({
+        ...envelope,
+        data: toolScheduled.data,
+        schemaVersion: DURABLE_EVENT_SCHEMA_VERSION,
+      }),
+    ).toThrow(/requires modelAttemptId/);
     expect(
       parseDurableEventEnvelope({
         ...envelope,
         schemaVersion: 2,
       }).schemaVersion,
     ).toBe(2);
+    expect(() =>
+      parseDurableEventEnvelope({
+        ...envelope,
+        modelAttemptId,
+        schemaVersion: 2,
+      }),
+    ).toThrow(/does not allow modelAttemptId/);
+    expect(() =>
+      parseDurableEventEnvelope({
+        ...envelope,
+        data: toolScheduled.data,
+        schemaVersion: 2,
+      }),
+    ).toThrow(/does not allow modelInput/);
   });
 
   it('rejects a persisted batch whose event version does not match', () => {

--- a/src/session/events/canonicalJson.ts
+++ b/src/session/events/canonicalJson.ts
@@ -1,0 +1,14 @@
+export function canonicalJson(value: unknown): string {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalJson).join(',')}]`;
+  }
+  const record = value as Record<string, unknown>;
+  return `{${Object.keys(record)
+    .filter((key) => record[key] !== undefined)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${canonicalJson(record[key])}`)
+    .join(',')}}`;
+}

--- a/src/session/events/core.ts
+++ b/src/session/events/core.ts
@@ -30,6 +30,8 @@ export {
 } from './DurableSessionJournal.js';
 export {
   type DurableAcceptedRequestRecovery,
+  type DurableModelOutcomeReconciliation,
+  type DurableModelOutcomeReconciliationCommand,
   type DurablePermissionResolutionCommand,
   type DurableRecoveryCommitResult,
   type DurableRequestOutcomeReconciliation,
@@ -48,6 +50,8 @@ export {
 } from './DurableSessionRecoveryCoordinator.js';
 export {
   DurableEventProjectionError,
+  type DurableModelAttemptProjection,
+  type DurableModelAttemptStatus,
   type DurablePermissionProjection,
   type DurablePermissionStatus,
   type DurableRequestProjection,
@@ -88,8 +92,13 @@ export {
   type DurableEventOfType,
   type DurableEventPage,
   type DurableEventReadOptions,
+  type DurableEventSchemaVersion,
   DurableEventType,
   type DurableInputPriority,
+  type DurableModelRequestAbortReason,
+  type DurableModelResponse,
+  type DurableModelToolCall,
+  type DurableModelUsage,
   type DurablePermissionDecision,
   type DurableRequestInterruptReason,
   type DurableRequestRecoveryOrigin,

--- a/src/session/events/schemas.ts
+++ b/src/session/events/schemas.ts
@@ -181,6 +181,7 @@ const DurableEventDataSchemas = {
   [DurableEventTypeValue.TOOL_SCHEDULED]: z
     .object({
       ...ToolIdentitySchema,
+      modelInput: JsonValueSchema.optional(),
       input: JsonValueSchema,
       sideEffect: z.enum(['pure', 'idempotent', 'non_idempotent']),
       interruptBehavior: z.enum(['block', 'cancel']),
@@ -299,6 +300,17 @@ const DurableEventEnvelopeSchema = z
         code: z.ZodIssueCode.custom,
         path: ['type'],
         message: `${value.type} requires durable event schema v3`,
+      });
+    }
+    if (
+      value.schemaVersion === DURABLE_EVENT_SCHEMA_VERSION
+      && value.type === DurableEventTypeValue.TOOL_SCHEDULED
+      && value.data.modelInput === undefined
+    ) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['data', 'modelInput'],
+        message: `${value.type} requires modelInput in durable event schema v3`,
       });
     }
   });

--- a/src/session/events/schemas.ts
+++ b/src/session/events/schemas.ts
@@ -305,13 +305,40 @@ const DurableEventEnvelopeSchema = z
     if (
       value.schemaVersion === DURABLE_EVENT_SCHEMA_VERSION
       && value.type === DurableEventTypeValue.TOOL_SCHEDULED
-      && value.data.modelInput === undefined
     ) {
-      context.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ['data', 'modelInput'],
-        message: `${value.type} requires modelInput in durable event schema v3`,
-      });
+      if (value.modelAttemptId === undefined) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['modelAttemptId'],
+          message: `${value.type} requires modelAttemptId in durable event schema v3`,
+        });
+      }
+      if (value.data.modelInput === undefined) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['data', 'modelInput'],
+          message: `${value.type} requires modelInput in durable event schema v3`,
+        });
+      }
+    }
+    if (
+      value.schemaVersion === 2
+      && value.type === DurableEventTypeValue.TOOL_SCHEDULED
+    ) {
+      if (value.modelAttemptId !== undefined) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['modelAttemptId'],
+          message: `${value.type} does not allow modelAttemptId in durable event schema v2`,
+        });
+      }
+      if (value.data.modelInput !== undefined) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['data', 'modelInput'],
+          message: `${value.type} does not allow modelInput in durable event schema v2`,
+        });
+      }
     }
   });
 
@@ -422,6 +449,10 @@ function validateEventScope(value: ParsedEventScope, context: z.RefinementCtx): 
       forbidField('toolAttemptId');
       return;
     case DurableEventTypeValue.TOOL_SCHEDULED:
+      requireField('requestId');
+      requireField('turnId');
+      requireField('toolAttemptId');
+      return;
     case DurableEventTypeValue.TOOL_STARTED:
     case DurableEventTypeValue.TOOL_COMPLETED:
     case DurableEventTypeValue.TOOL_FAILED:

--- a/src/session/events/schemas.ts
+++ b/src/session/events/schemas.ts
@@ -3,6 +3,7 @@ import {
   CommandId,
   EventId,
   EventSequence,
+  ModelAttemptId,
   RequestId,
   SessionId,
   ToolAttemptId,
@@ -14,6 +15,7 @@ import {
   type DurableEventDataMap,
   type DurableEventDraft,
   type DurableEventEnvelope,
+  type DurableEventSchemaVersion,
   type DurableEventType,
   DurableEventType as DurableEventTypeValue,
 } from './types.js';
@@ -52,6 +54,36 @@ const DurableTokenUsageSchema = z
     inputTokens: NonNegativeIntegerSchema,
     outputTokens: NonNegativeIntegerSchema,
     totalTokens: NonNegativeIntegerSchema,
+  })
+  .strict();
+const DurableModelUsageSchema = z
+  .object({
+    promptTokens: NonNegativeIntegerSchema,
+    completionTokens: NonNegativeIntegerSchema,
+    totalTokens: NonNegativeIntegerSchema,
+    reasoningTokens: NonNegativeIntegerSchema.optional(),
+    cacheCreationInputTokens: NonNegativeIntegerSchema.optional(),
+    cacheReadInputTokens: NonNegativeIntegerSchema.optional(),
+    cacheMissInputTokens: NonNegativeIntegerSchema.optional(),
+    billableInputTokens: NonNegativeIntegerSchema.optional(),
+  })
+  .strict();
+const DurableModelResponseSchema = z
+  .object({
+    content: z.string(),
+    reasoningContent: z.string().optional(),
+    toolCalls: z
+      .array(
+        z
+          .object({
+            id: NonEmptyStringSchema,
+            name: NonEmptyStringSchema,
+            arguments: z.string(),
+          })
+          .strict(),
+      )
+      .optional(),
+    usage: DurableModelUsageSchema.optional(),
   })
   .strict();
 const ToolIdentitySchema = {
@@ -123,6 +155,27 @@ const DurableEventDataSchemas = {
     .object({
       turn: PositiveIntegerSchema,
       reason: z.enum(['request_interrupted', 'error', 'process_restart', 'recovery_required']),
+    })
+    .strict(),
+  [DurableEventTypeValue.MODEL_REQUEST_STARTED]: z
+    .object({
+      model: NonEmptyStringSchema,
+      streaming: z.boolean(),
+    })
+    .strict(),
+  [DurableEventTypeValue.MODEL_REQUEST_COMPLETED]: z
+    .object({
+      response: DurableModelResponseSchema,
+    })
+    .strict(),
+  [DurableEventTypeValue.MODEL_REQUEST_FAILED]: z
+    .object({
+      error: DurableEventErrorSchema,
+    })
+    .strict(),
+  [DurableEventTypeValue.MODEL_REQUEST_ABORTED]: z
+    .object({
+      reason: z.enum(['request_interrupted', 'steering', 'process_restart']),
     })
     .strict(),
   [DurableEventTypeValue.TOOL_SCHEDULED]: z
@@ -201,15 +254,21 @@ const DurableEventDraftBaseSchema = z
     commandId: NonEmptyStringSchema.optional(),
     requestId: NonEmptyStringSchema.optional(),
     turnId: NonEmptyStringSchema.optional(),
+    modelAttemptId: NonEmptyStringSchema.optional(),
     toolAttemptId: NonEmptyStringSchema.optional(),
     causationEventId: NonEmptyStringSchema.optional(),
   })
   .strict()
   .superRefine(validateEventScope);
 
+const DurableEventSchemaVersionSchema = z.union([
+  z.literal(2),
+  z.literal(DURABLE_EVENT_SCHEMA_VERSION),
+]);
+
 const DurableEventEnvelopeSchema = z
   .object({
-    schemaVersion: z.literal(DURABLE_EVENT_SCHEMA_VERSION),
+    schemaVersion: DurableEventSchemaVersionSchema,
     eventId: NonEmptyStringSchema,
     sequence: EventSequenceSchema,
     sessionId: NonEmptyStringSchema,
@@ -220,34 +279,69 @@ const DurableEventEnvelopeSchema = z
     commandId: NonEmptyStringSchema.optional(),
     requestId: NonEmptyStringSchema.optional(),
     turnId: NonEmptyStringSchema.optional(),
+    modelAttemptId: NonEmptyStringSchema.optional(),
     toolAttemptId: NonEmptyStringSchema.optional(),
     causationEventId: NonEmptyStringSchema.optional(),
   })
   .strict()
-  .superRefine(validateEventScope);
+  .superRefine((value, context) => {
+    validateEventScope(value, context);
+    if (
+      value.schemaVersion === 2
+      && (
+        value.type === DurableEventTypeValue.MODEL_REQUEST_STARTED
+        || value.type === DurableEventTypeValue.MODEL_REQUEST_COMPLETED
+        || value.type === DurableEventTypeValue.MODEL_REQUEST_FAILED
+        || value.type === DurableEventTypeValue.MODEL_REQUEST_ABORTED
+      )
+    ) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['type'],
+        message: `${value.type} requires durable event schema v3`,
+      });
+    }
+  });
 
 const PersistedDurableEventBatchSchema = z
   .object({
     format: z.literal(DURABLE_EVENT_LOG_FORMAT),
-    schemaVersion: z.literal(DURABLE_EVENT_SCHEMA_VERSION),
+    schemaVersion: DurableEventSchemaVersionSchema,
     sessionId: NonEmptyStringSchema,
     firstSequence: EventSequenceSchema,
     lastSequence: EventSequenceSchema,
     events: z.array(z.unknown()).min(1),
   })
-  .strict();
+  .strict()
+  .superRefine((value, context) => {
+    for (const [index, event] of value.events.entries()) {
+      if (
+        typeof event === 'object'
+        && event !== null
+        && 'schemaVersion' in event
+        && event.schemaVersion !== value.schemaVersion
+      ) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['events', index, 'schemaVersion'],
+          message: 'Event schema version must match its batch',
+        });
+      }
+    }
+  });
 
 interface ParsedEventScope {
   type: DurableEventType;
   commandId?: string;
   requestId?: string;
   turnId?: string;
+  modelAttemptId?: string;
   toolAttemptId?: string;
 }
 
 export interface PersistedDurableEventBatch {
   readonly format: typeof DURABLE_EVENT_LOG_FORMAT;
-  readonly schemaVersion: typeof DURABLE_EVENT_SCHEMA_VERSION;
+  readonly schemaVersion: DurableEventSchemaVersion;
   readonly sessionId: SessionId;
   readonly firstSequence: EventSequence;
   readonly lastSequence: EventSequence;
@@ -279,12 +373,14 @@ function validateEventScope(value: ParsedEventScope, context: z.RefinementCtx): 
     case DurableEventTypeValue.SESSION_CLOSED:
       forbidField('requestId');
       forbidField('turnId');
+      forbidField('modelAttemptId');
       forbidField('toolAttemptId');
       return;
     case DurableEventTypeValue.REQUEST_ACCEPTED:
       requireField('commandId');
       requireField('requestId');
       forbidField('turnId');
+      forbidField('modelAttemptId');
       forbidField('toolAttemptId');
       return;
     case DurableEventTypeValue.REQUEST_STARTED:
@@ -293,6 +389,7 @@ function validateEventScope(value: ParsedEventScope, context: z.RefinementCtx): 
     case DurableEventTypeValue.REQUEST_INTERRUPTED:
       requireField('requestId');
       forbidField('turnId');
+      forbidField('modelAttemptId');
       forbidField('toolAttemptId');
       return;
     case DurableEventTypeValue.TURN_STARTED:
@@ -300,6 +397,16 @@ function validateEventScope(value: ParsedEventScope, context: z.RefinementCtx): 
     case DurableEventTypeValue.TURN_ABORTED:
       requireField('requestId');
       requireField('turnId');
+      forbidField('modelAttemptId');
+      forbidField('toolAttemptId');
+      return;
+    case DurableEventTypeValue.MODEL_REQUEST_STARTED:
+    case DurableEventTypeValue.MODEL_REQUEST_COMPLETED:
+    case DurableEventTypeValue.MODEL_REQUEST_FAILED:
+    case DurableEventTypeValue.MODEL_REQUEST_ABORTED:
+      requireField('requestId');
+      requireField('turnId');
+      requireField('modelAttemptId');
       forbidField('toolAttemptId');
       return;
     case DurableEventTypeValue.TOOL_SCHEDULED:
@@ -312,10 +419,12 @@ function validateEventScope(value: ParsedEventScope, context: z.RefinementCtx): 
     case DurableEventTypeValue.PERMISSION_RESOLVED:
       requireField('requestId');
       requireField('turnId');
+      forbidField('modelAttemptId');
       requireField('toolAttemptId');
       return;
     case DurableEventTypeValue.INPUT_APPLIED:
       requireField('requestId');
+      forbidField('modelAttemptId');
       forbidField('toolAttemptId');
       return;
   }
@@ -338,6 +447,9 @@ function toDurableEventDraft(
     ...(parsed.commandId ? { commandId: CommandId(parsed.commandId) } : {}),
     ...(parsed.requestId ? { requestId: RequestId(parsed.requestId) } : {}),
     ...(parsed.turnId ? { turnId: TurnId(parsed.turnId) } : {}),
+    ...(parsed.modelAttemptId
+      ? { modelAttemptId: ModelAttemptId(parsed.modelAttemptId) }
+      : {}),
     ...(parsed.toolAttemptId ? { toolAttemptId: ToolAttemptId(parsed.toolAttemptId) } : {}),
     ...(parsed.causationEventId ? { causationEventId: EventId(parsed.causationEventId) } : {}),
   } as DurableEventDraft;

--- a/src/session/events/types.ts
+++ b/src/session/events/types.ts
@@ -4,6 +4,7 @@ import type {
   EventId,
   EventSequence,
   InputId,
+  ModelAttemptId,
   PermissionRequestId,
   RequestId,
   SessionId,
@@ -13,7 +14,8 @@ import type {
 } from '../../types/branded.js';
 import type { JsonObject, JsonValue } from '../../types/common.js';
 
-export const DURABLE_EVENT_SCHEMA_VERSION = 2 as const;
+export const DURABLE_EVENT_SCHEMA_VERSION = 3 as const;
+export type DurableEventSchemaVersion = 2 | typeof DURABLE_EVENT_SCHEMA_VERSION;
 
 export const DurableEventType = {
   SESSION_CREATED: 'session_created',
@@ -26,6 +28,10 @@ export const DurableEventType = {
   TURN_STARTED: 'turn_started',
   TURN_COMPLETED: 'turn_completed',
   TURN_ABORTED: 'turn_aborted',
+  MODEL_REQUEST_STARTED: 'model_request_started',
+  MODEL_REQUEST_COMPLETED: 'model_request_completed',
+  MODEL_REQUEST_FAILED: 'model_request_failed',
+  MODEL_REQUEST_ABORTED: 'model_request_aborted',
   TOOL_SCHEDULED: 'tool_scheduled',
   TOOL_STARTED: 'tool_started',
   TOOL_COMPLETED: 'tool_completed',
@@ -60,6 +66,10 @@ export type DurableToolCancelReason =
   | 'cascade_abort'
   | 'process_restart';
 export type DurableToolOutcomeUnknownReason = 'process_restart' | 'commit_outcome_unknown';
+export type DurableModelRequestAbortReason =
+  | 'request_interrupted'
+  | 'steering'
+  | 'process_restart';
 
 export interface DurableEventError {
   message: string;
@@ -71,6 +81,30 @@ export interface DurableTokenUsage {
   inputTokens: number;
   outputTokens: number;
   totalTokens: number;
+}
+
+export interface DurableModelUsage {
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+  reasoningTokens?: number;
+  cacheCreationInputTokens?: number;
+  cacheReadInputTokens?: number;
+  cacheMissInputTokens?: number;
+  billableInputTokens?: number;
+}
+
+export interface DurableModelToolCall {
+  id: ToolUseId;
+  name: string;
+  arguments: string;
+}
+
+export interface DurableModelResponse {
+  content: string;
+  reasoningContent?: string;
+  toolCalls?: readonly DurableModelToolCall[];
+  usage?: DurableModelUsage;
 }
 
 export interface DurableRequestRecoveryOrigin {
@@ -119,6 +153,19 @@ export interface DurableEventDataMap {
   [DurableEventType.TURN_ABORTED]: {
     turn: number;
     reason: DurableTurnAbortReason;
+  };
+  [DurableEventType.MODEL_REQUEST_STARTED]: {
+    model: string;
+    streaming: boolean;
+  };
+  [DurableEventType.MODEL_REQUEST_COMPLETED]: {
+    response: DurableModelResponse;
+  };
+  [DurableEventType.MODEL_REQUEST_FAILED]: {
+    error: DurableEventError;
+  };
+  [DurableEventType.MODEL_REQUEST_ABORTED]: {
+    reason: DurableModelRequestAbortReason;
   };
   [DurableEventType.TOOL_SCHEDULED]: {
     toolCallId: ToolUseId;
@@ -187,6 +234,12 @@ type TurnEventType =
   | typeof DurableEventType.TURN_COMPLETED
   | typeof DurableEventType.TURN_ABORTED;
 
+type ModelEventType =
+  | typeof DurableEventType.MODEL_REQUEST_STARTED
+  | typeof DurableEventType.MODEL_REQUEST_COMPLETED
+  | typeof DurableEventType.MODEL_REQUEST_FAILED
+  | typeof DurableEventType.MODEL_REQUEST_ABORTED;
+
 type ToolEventType =
   | typeof DurableEventType.TOOL_SCHEDULED
   | typeof DurableEventType.TOOL_STARTED
@@ -202,32 +255,43 @@ type PermissionEventType =
 type DurableEventCorrelation<TType extends DurableEventType> =
   TType extends typeof DurableEventType.REQUEST_ACCEPTED
     ? { readonly requestId: RequestId; readonly commandId: CommandId }
-    : TType extends ToolEventType | PermissionEventType
+    : TType extends ModelEventType
+      ? {
+          readonly requestId: RequestId;
+          readonly turnId: TurnId;
+          readonly modelAttemptId: ModelAttemptId;
+          readonly commandId?: CommandId;
+        }
+      : TType extends ToolEventType | PermissionEventType
       ? {
           readonly requestId: RequestId;
           readonly turnId: TurnId;
           readonly toolAttemptId: ToolAttemptId;
+          readonly modelAttemptId?: never;
           readonly commandId?: CommandId;
         }
       : TType extends TurnEventType
         ? {
             readonly requestId: RequestId;
             readonly turnId: TurnId;
+            readonly modelAttemptId?: never;
             readonly commandId?: CommandId;
           }
         : TType extends typeof DurableEventType.INPUT_APPLIED
           ? {
               readonly requestId: RequestId;
               readonly turnId?: TurnId;
+              readonly modelAttemptId?: never;
               readonly commandId?: CommandId;
             }
           : TType extends Exclude<RequestEventType, typeof DurableEventType.REQUEST_ACCEPTED>
             ? {
                 readonly requestId: RequestId;
+                readonly modelAttemptId?: never;
                 readonly commandId?: CommandId;
               }
             : TType extends SessionEventType
-              ? { readonly commandId?: CommandId }
+              ? { readonly commandId?: CommandId; readonly modelAttemptId?: never }
               : never;
 
 type DurableEventDraftVariant<TType extends DurableEventType> = {
@@ -241,7 +305,7 @@ export type DurableEventDraft<TType extends DurableEventType = DurableEventType>
   TType extends DurableEventType ? DurableEventDraftVariant<TType> : never;
 
 type DurableEventEnvelopeFields = {
-  readonly schemaVersion: typeof DURABLE_EVENT_SCHEMA_VERSION;
+  readonly schemaVersion: DurableEventSchemaVersion;
   readonly eventId: EventId;
   readonly sequence: EventSequence;
   readonly sessionId: SessionId;

--- a/src/session/events/types.ts
+++ b/src/session/events/types.ts
@@ -170,6 +170,7 @@ export interface DurableEventDataMap {
   [DurableEventType.TOOL_SCHEDULED]: {
     toolCallId: ToolUseId;
     toolName: string;
+    modelInput?: JsonValue;
     input: JsonValue;
     sideEffect: ToolSideEffect;
     interruptBehavior: DurableToolInterruptBehavior;

--- a/src/session/events/types.ts
+++ b/src/session/events/types.ts
@@ -242,7 +242,6 @@ type ModelEventType =
   | typeof DurableEventType.MODEL_REQUEST_ABORTED;
 
 type ToolEventType =
-  | typeof DurableEventType.TOOL_SCHEDULED
   | typeof DurableEventType.TOOL_STARTED
   | typeof DurableEventType.TOOL_COMPLETED
   | typeof DurableEventType.TOOL_FAILED
@@ -263,37 +262,47 @@ type DurableEventCorrelation<TType extends DurableEventType> =
           readonly modelAttemptId: ModelAttemptId;
           readonly commandId?: CommandId;
         }
-      : TType extends ToolEventType | PermissionEventType
-      ? {
-          readonly requestId: RequestId;
-          readonly turnId: TurnId;
-          readonly toolAttemptId: ToolAttemptId;
-          readonly modelAttemptId?: never;
-          readonly commandId?: CommandId;
-        }
-      : TType extends TurnEventType
+      : TType extends typeof DurableEventType.TOOL_SCHEDULED
         ? {
             readonly requestId: RequestId;
             readonly turnId: TurnId;
-            readonly modelAttemptId?: never;
+            readonly modelAttemptId?: ModelAttemptId;
+            readonly toolAttemptId: ToolAttemptId;
             readonly commandId?: CommandId;
           }
-        : TType extends typeof DurableEventType.INPUT_APPLIED
+        : TType extends ToolEventType | PermissionEventType
           ? {
               readonly requestId: RequestId;
-              readonly turnId?: TurnId;
+              readonly turnId: TurnId;
+              readonly toolAttemptId: ToolAttemptId;
               readonly modelAttemptId?: never;
               readonly commandId?: CommandId;
             }
-          : TType extends Exclude<RequestEventType, typeof DurableEventType.REQUEST_ACCEPTED>
+          : TType extends TurnEventType
             ? {
                 readonly requestId: RequestId;
+                readonly turnId: TurnId;
                 readonly modelAttemptId?: never;
+                readonly toolAttemptId?: never;
                 readonly commandId?: CommandId;
               }
-            : TType extends SessionEventType
-              ? { readonly commandId?: CommandId; readonly modelAttemptId?: never }
-              : never;
+            : TType extends typeof DurableEventType.INPUT_APPLIED
+              ? {
+                  readonly requestId: RequestId;
+                  readonly turnId?: TurnId;
+                  readonly modelAttemptId?: never;
+                  readonly toolAttemptId?: never;
+                  readonly commandId?: CommandId;
+                }
+              : TType extends Exclude<RequestEventType, typeof DurableEventType.REQUEST_ACCEPTED>
+                ? {
+                    readonly requestId: RequestId;
+                    readonly modelAttemptId?: never;
+                    readonly commandId?: CommandId;
+                  }
+                : TType extends SessionEventType
+                  ? { readonly commandId?: CommandId; readonly modelAttemptId?: never }
+                  : never;
 
 type DurableEventDraftVariant<TType extends DurableEventType> = {
   readonly type: TType;

--- a/src/tools/types/ExecutionTypes.ts
+++ b/src/tools/types/ExecutionTypes.ts
@@ -1,4 +1,10 @@
-import type { MessageId, PermissionRequestId, SessionId, ToolUseId } from '@/types/branded.js';
+import type {
+  MessageId,
+  ModelAttemptId,
+  PermissionRequestId,
+  SessionId,
+  ToolUseId,
+} from '@/types/branded.js';
 import type { IBackgroundAgentManager } from '../../agent/types.js';
 import type { ContextSnapshot } from '../../runtime/index.js';
 import type { BladeConfig, JsonObject, PermissionMode } from '../../types/common.js';
@@ -80,6 +86,7 @@ export interface ToolInvocationLifecycle {
 export interface ToolScheduledLifecycle {
   toolCallId: ToolUseId;
   toolName: string;
+  modelAttemptId?: ModelAttemptId;
   modelInput: JsonObject;
   input: JsonObject;
   sideEffect: ToolSideEffect;

--- a/src/tools/types/ExecutionTypes.ts
+++ b/src/tools/types/ExecutionTypes.ts
@@ -80,6 +80,7 @@ export interface ToolInvocationLifecycle {
 export interface ToolScheduledLifecycle {
   toolCallId: ToolUseId;
   toolName: string;
+  modelInput: JsonObject;
   input: JsonObject;
   sideEffect: ToolSideEffect;
   interruptBehavior: 'block' | 'cancel';

--- a/src/types/branded.ts
+++ b/src/types/branded.ts
@@ -11,6 +11,7 @@ export type InputId = Brand<string, 'InputId'>;
 export type EventId = Brand<string, 'EventId'>;
 export type EventSequence = Brand<number, 'EventSequence'>;
 export type TurnId = Brand<string, 'TurnId'>;
+export type ModelAttemptId = Brand<string, 'ModelAttemptId'>;
 export type ToolAttemptId = Brand<string, 'ToolAttemptId'>;
 export type CommandId = Brand<string, 'CommandId'>;
 export type PermissionRequestId = Brand<string, 'PermissionRequestId'>;
@@ -24,6 +25,7 @@ export const InputId = (value: string): InputId => value as InputId;
 export const EventId = (value: string): EventId => value as EventId;
 export const EventSequence = (value: number): EventSequence => value as EventSequence;
 export const TurnId = (value: string): TurnId => value as TurnId;
+export const ModelAttemptId = (value: string): ModelAttemptId => value as ModelAttemptId;
 export const ToolAttemptId = (value: string): ToolAttemptId => value as ToolAttemptId;
 export const CommandId = (value: string): CommandId => value as CommandId;
 export const PermissionRequestId = (value: string): PermissionRequestId =>


### PR DESCRIPTION
## Summary
- advance the durable event protocol to schema v3 while retaining schema-v2 read compatibility
- persist model request start and terminal outcomes, with exact CAS-backed reconciliation for unknown attempts
- propagate consumer cancellation through nested agent, provider, retry, fallback, and tool streams
- bind every v3 tool schedule to its producing model attempt and canonical original arguments
- document the recovery protocol and public types in English and Chinese

## Safety invariants
- model start is committed before provider invocation
- completed model responses are committed before post-response tool settlement is awaited
- stale model/tool targets and schema regressions fail closed
- tool side effects remain behind durable scheduling and execution boundaries

## Validation
- `pnpm run type-check`
- `pnpm run lint`
- `pnpm test` (1409 passed, 62 live/external tests skipped by environment)
- `pnpm run docs:build`
- `pnpm run verify:entrypoints`
- `pnpm run changelog:check`
- independent Standards review: no findings
- independent Spec review: no findings
- semantic-release dry analysis: next version `5.0.0`

## Breaking change
The durable event writer now emits schema v3. Readers continue to accept schema v2, but custom durable tooling integrations must preserve model-attempt identity and original model tool arguments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added durable tracking for individual model attempts, including responses, usage, failures, and interruptions.
  - Added explicit reconciliation for model requests with unknown outcomes, preventing silent replays during recovery.
  - Linked scheduled tools to their originating model attempt while preserving original and repaired inputs.
  - Added public model-attempt identifiers and related recovery types.

- **Breaking Changes**
  - Durable event format advances to schema v3. Existing schema v2 logs remain readable, but schema versions cannot regress.

- **Documentation**
  - Updated English and Simplified Chinese documentation with model recovery, reconciliation, event, and security details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->