### PR TITLE
fix(storage): harden session transcript durability

### DIFF
--- a/.changes/session-jsonl-integrity.json
+++ b/.changes/session-jsonl-integrity.json
@@ -1,0 +1,5 @@
+{
+  "type": "fix",
+  "en": "Serialize local Session transcript access across processes, durably sync appends, recover torn crash tails, reject path-unsafe Session IDs, and fail closed on committed record corruption.",
+  "zh-CN": "跨进程串行化本地 Session transcript 访问，持久同步追加写入，恢复崩溃造成的残缺尾部，拒绝路径不安全的 Session ID，并对已提交记录损坏执行 fail-closed。"
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,9 +88,10 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Test native durable locks
+      - name: Test native file locks
         run: >-
           pnpm exec vitest run
+          src/context/storage/__tests__/JSONLStore.test.ts
           src/session/events/__tests__/JsonlDurableEventStore.test.ts
           src/session/events/__tests__/JsonlDurableEventStoreCompromise.test.ts
           src/session/events/__tests__/JsonlDurableEventStoreUnavailableLock.test.ts

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ console.log(result.usage);
 - Tools: generator-only custom tools, capability-grouped built-ins, MCP tools, and typed progress/effects
 - Collaboration: foreground and background subagents, task tools, and project Skills
 - Safety: permission modes, policy callbacks, hooks, path checks, and optional OS sandbox integration
-- Runtime: optional workspace context, structured output, persistence, context compaction, token budgets, and traces
+- Runtime: optional workspace context, structured output, crash-safe local transcripts, context compaction, token budgets, and traces
 
 ## Steer an Active Request
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -67,7 +67,7 @@ console.log(result.usage);
 - 工具：仅 generator 的自定义工具、按能力分组的内置工具、MCP 工具和类型化进度/副作用
 - 协作：前台/后台子 Agent、任务工具，以及项目级 Skills
 - 安全：权限模式、策略回调、Hooks、路径检查和可选 OS 沙箱集成
-- 运行时：可选 workspace、结构化输出、持久化、上下文压缩、token 预算和 trace
+- 运行时：可选 workspace、结构化输出、崩溃安全的本地会话记录、上下文压缩、token 预算和 trace
 
 ## 转向活动请求
 

--- a/docs/blade-agent-sdk.md
+++ b/docs/blade-agent-sdk.md
@@ -157,6 +157,9 @@ Session 默认只保存在内存中。配置 `storagePath` 后才会写入磁盘
 | 仅内存（默认） | 不设置 `storagePath`，或 `persistSession: false` | Web / Serverless / 无状态 |
 | 持久化 | `storagePath: '/path/to/sessions'` | CLI / IDE / 本地服务 |
 
+本地 transcript 写入支持同机多进程协调和崩溃尾部恢复；恢复时遇到已完整写入但
+格式损坏的记录会 fail-closed。文件系统与原生锁约束详见[会话](./session)。
+
 ## 多模型支持
 
 原生支持 6 种 Provider：

--- a/docs/en/blade-agent-sdk.md
+++ b/docs/en/blade-agent-sdk.md
@@ -150,6 +150,9 @@ const session = await createSession({
 ```
 
 Persistent sessions can be restored with `resumeSession()` or forked with `forkSession()`. Set `persistSession: false` to force in-memory behavior even when a path is present.
+Local transcript writes are process-safe and crash-tail-aware; malformed
+committed records fail closed during restore. See [Session](./session) for the
+filesystem and native-lock constraints.
 
 ## Providers
 

--- a/docs/en/blade-agent-sdk.md
+++ b/docs/en/blade-agent-sdk.md
@@ -150,7 +150,7 @@ const session = await createSession({
 ```
 
 Persistent sessions can be restored with `resumeSession()` or forked with `forkSession()`. Set `persistSession: false` to force in-memory behavior even when a path is present.
-Local transcript writes are process-safe and crash-tail-aware; malformed
+Local transcript writes are same-host process-safe and crash-tail-aware; malformed
 committed records fail closed during restore. See [Session](./session) for the
 filesystem and native-lock constraints.
 

--- a/docs/en/session.md
+++ b/docs/en/session.md
@@ -237,6 +237,31 @@ const session = await createSession({
 ```
 
 Session files are written under `{storagePath}/sessions/`. `persistSession: false` forces in-memory behavior.
+Caller-supplied Session IDs must be non-empty single path segments; `/`, `\`,
+and NUL are rejected before resolving a transcript path.
+
+Each local transcript append is serialized across Node.js processes with an OS
+advisory lock and synced before the write resolves. A final record without a
+newline is treated as an uncommitted crash tail: reads ignore it and the next
+append truncates it before writing. A malformed complete record fails Session
+loading instead of silently dropping history.
+
+The persistent `{sessionId}.jsonl.lock` sidecar is part of the storage protocol.
+Do not delete, replace, or move a transcript or its sidecar while a Session may
+be active. This coordination is for same-host local filesystems, not NFS or
+distributed storage, and requires the native lock targets supported by
+`fs-native-extensions` (macOS, glibc Linux, and Windows on x64/arm64). In-memory
+Sessions remain available when the native addon is unavailable, but
+`storagePath` persistence fails closed.
+
+Transcript locking protects file integrity; it does not grant exclusive
+execution ownership for a Session. Use `durableEventStore` for recoverable
+Request, Turn, model, permission, and tool lifecycle coordination.
+
+Persistence failures use stable `SdkError.code` values:
+`SESSION_JSONL_CORRUPT_LOG`, `SESSION_JSONL_LOCK_FAILED`,
+`SESSION_JSONL_LOCK_TIMEOUT`, `SESSION_JSONL_READ_FAILED`, and
+`SESSION_JSONL_WRITE_FAILED`.
 
 ### Durable execution events
 
@@ -317,9 +342,8 @@ terminal event reports `reconcile_request_outcome`; settle it with
 `reconcileRequestOutcome()` rather than replaying it. A `non_idempotent` tool
 that completed, failed, or was cancelled after execution started always
 remains fail-closed.
-The JSONL adapter supports only one process;
-multi-process deployments need a `DurableEventStore` with transactional CAS or
-fencing.
+The bundled JSONL adapters coordinate processes on one host. Distributed
+deployments still need a `DurableEventStore` with transactional CAS or fencing.
 
 ### Resume
 

--- a/docs/session.md
+++ b/docs/session.md
@@ -637,6 +637,29 @@ const session = await createSession({
 - `session.fork()` 仍然可用，因为它直接复制内存中的消息
   :::
 
+调用方提供的 Session ID 必须是非空的单一路径段；SDK 会在解析 transcript
+路径前拒绝 `/`、`\` 和 NUL。
+
+每次本地 transcript 追加都会通过操作系统 advisory lock 在多个 Node.js
+进程间串行化，并在写入返回前完成同步。末尾没有换行符的记录视为未提交的崩溃
+尾部：读取时忽略，下一次追加前截断。任何已经完整写入但格式损坏的记录都会使
+Session 加载失败，不会静默丢弃历史。
+
+持久的 `{sessionId}.jsonl.lock` sidecar 属于存储协议的一部分。当 Session
+可能仍在运行时，不要删除、替换或移动 transcript 及其 sidecar。该协调只适用于
+同机本地文件系统，不支持 NFS 或分布式存储，并依赖
+`fs-native-extensions` 支持的原生目标（macOS、glibc Linux 及 Windows 的
+x64/arm64）。原生 addon 不可用时，内存 Session 仍可使用，但
+`storagePath` 持久化会 fail-closed。
+
+Transcript 锁只保护文件完整性，不授予 Session 独占执行所有权。需要对 Request、
+Turn、模型、权限及工具生命周期做可恢复协调时，应配置 `durableEventStore`。
+
+持久化失败通过稳定的 `SdkError.code` 暴露：
+`SESSION_JSONL_CORRUPT_LOG`、`SESSION_JSONL_LOCK_FAILED`、
+`SESSION_JSONL_LOCK_TIMEOUT`、`SESSION_JSONL_READ_FAILED` 和
+`SESSION_JSONL_WRITE_FAILED`。
+
 ### Durable 执行事件
 
 通过 `durableEventStore` 显式启用可恢复执行日志。该 Store 与消息历史存储相互
@@ -707,8 +730,8 @@ Request 已完成至少一个 Turn 但缺少 Request 终态，则返回
 `reconcile_request_outcome`；使用 `reconcileRequestOutcome()` 确认终态，禁止
 自动重放。已完成、失败，或在开始执行后被取消的 `non_idempotent` 工具始终保持
 fail-closed。
-JSONL adapter 只支持单进程 writer，多进程部署需要实现带事务 CAS 或 fencing
-的 `DurableEventStore`。
+内置 JSONL adapter 支持同机多进程协调；分布式部署仍需实现带事务 CAS 或
+fencing 的 `DurableEventStore`。
 
 ### 自定义存储路径
 

--- a/src/context/ContextManager.ts
+++ b/src/context/ContextManager.ts
@@ -204,27 +204,22 @@ export class ContextManager {
    * 加载现有会话
    */
   async loadSession(sessionId: SessionId): Promise<boolean> {
-    try {
-      // 先尝试从内存加载
-      let contextData = this.memory.getContext();
+    // 先尝试从内存加载
+    let contextData = this.memory.getContext();
 
-      if (!contextData || contextData.layers.session.sessionId !== sessionId) {
-        const state = await this.sessionStore.loadState(sessionId);
-        if (!state) {
-          return false;
-        }
-
-        contextData = await this.buildContextDataFromState(state);
-        this.memory.setContext(contextData);
+    if (!contextData || contextData.layers.session.sessionId !== sessionId) {
+      const state = await this.sessionStore.loadState(sessionId);
+      if (!state) {
+        return false;
       }
 
-      this.currentSessionId = sessionId;
-      console.log(`会话已加载: ${sessionId}`);
-      return true;
-    } catch (error) {
-      console.error('加载会话失败:', error);
-      return false;
+      contextData = await this.buildContextDataFromState(state);
+      this.memory.setContext(contextData);
     }
+
+    this.currentSessionId = sessionId;
+    console.log(`会话已加载: ${sessionId}`);
+    return true;
   }
 
   /**

--- a/src/context/storage/JSONLStore.ts
+++ b/src/context/storage/JSONLStore.ts
@@ -1,148 +1,147 @@
-import * as fsSync from 'node:fs';
-import { createReadStream } from 'node:fs';
-import * as fs from 'node:fs/promises';
-import * as path from 'node:path';
-import { createInterface } from 'node:readline';
+import { open, readFile, stat, truncate, unlink } from 'node:fs/promises';
+import { TextDecoder } from 'node:util';
+import { SdkError } from '../../errors/SdkError.js';
 import type { JsonValue } from '../../types/common.js';
+import { withAdvisoryFileLock } from '../../utils/advisoryFileLock.js';
 import type { SessionEvent } from '../types.js';
+
+const DEFAULT_LOCK_TIMEOUT_MS = 10_000;
+const UTF8_DECODER = new TextDecoder('utf-8', { fatal: true });
+const SESSION_EVENT_TYPES = new Set([
+  'session_created',
+  'session_updated',
+  'message_created',
+  'part_created',
+  'part_updated',
+  'input_enqueued',
+  'input_applied',
+  'input_cancelled',
+]);
+
+export type JSONLStoreErrorCode =
+  | 'SESSION_JSONL_CORRUPT_LOG'
+  | 'SESSION_JSONL_LOCK_FAILED'
+  | 'SESSION_JSONL_LOCK_TIMEOUT'
+  | 'SESSION_JSONL_READ_FAILED'
+  | 'SESSION_JSONL_WRITE_FAILED';
+
+export class JSONLStoreError extends SdkError {
+  // biome-ignore lint/complexity/noUselessConstructor: narrows the internal error-code contract
+  constructor(
+    code: JSONLStoreErrorCode,
+    message: string,
+    options?: { cause?: unknown },
+  ) {
+    super(code, message, options);
+  }
+}
+
+export interface JSONLStoreOptions {
+  /** Maximum total time to wait for local or cross-process file ownership. */
+  lockTimeoutMs?: number;
+}
+
+interface LoadedFile {
+  entries: SessionEvent[];
+  exists: boolean;
+  committedBytes: number;
+  totalBytes: number;
+}
 
 function isSessionEvent(data: unknown): data is SessionEvent {
   if (!data || typeof data !== 'object' || Array.isArray(data)) return false;
   const obj = data as Record<string, unknown>;
-  return typeof obj.id === 'string' && typeof obj.type === 'string' && typeof obj.timestamp === 'string';
+  return typeof obj.id === 'string'
+    && typeof obj.sessionId === 'string'
+    && typeof obj.timestamp === 'string'
+    && typeof obj.type === 'string'
+    && SESSION_EVENT_TYPES.has(obj.type)
+    && typeof obj.version === 'string'
+    && typeof obj.data === 'object'
+    && obj.data !== null
+    && !Array.isArray(obj.data);
+}
+
+function hasErrorCode(error: unknown, code: string): boolean {
+  return typeof error === 'object'
+    && error !== null
+    && 'code' in error
+    && error.code === code;
 }
 
 /**
- * JSONL 存储类 - 处理 JSONL 格式的读写
+ * JSONL storage for Session transcript events.
+ *
+ * Every operation is serialized across instances and local Node.js processes.
+ * A trailing record without a newline is treated as an uncommitted crash tail;
+ * the next append truncates it before writing. Corruption in any complete
+ * record fails closed.
  */
 export class JSONLStore {
-  private readonly filePath: string;
+  private readonly lockTimeoutMs: number;
 
-  constructor(filePath: string) {
-    this.filePath = filePath;
+  constructor(
+    private readonly filePath: string,
+    options: JSONLStoreOptions = {},
+  ) {
+    this.lockTimeoutMs = options.lockTimeoutMs ?? DEFAULT_LOCK_TIMEOUT_MS;
+    if (!Number.isSafeInteger(this.lockTimeoutMs) || this.lockTimeoutMs < 0) {
+      throw new JSONLStoreError(
+        'SESSION_JSONL_LOCK_FAILED',
+        'Session JSONL lockTimeoutMs must be a non-negative safe integer',
+      );
+    }
   }
 
-  /**
-   * 追加一条 JSONL 记录到文件
-   * @param entry JSONL 条目
-   */
+  /** Append one committed JSONL record. */
   async append(entry: SessionEvent): Promise<void> {
-    try {
-      // 确保父目录存在
-      await fs.mkdir(path.dirname(this.filePath), { recursive: true, mode: 0o755 });
-
-      // 将对象序列化为 JSON 字符串并追加换行符
-      const line = `${JSON.stringify(entry)}\n`;
-
-      // 追加写入文件
-      await fs.appendFile(this.filePath, line, 'utf-8');
-    } catch (error) {
-      console.error(`[JSONLStore] 追加写入失败: ${this.filePath}`, error);
-      throw error;
-    }
+    await this.appendEntries([entry]);
   }
 
-  /**
-   * 批量追加多条 JSONL 记录
-   * @param entries JSONL 条目数组
-   */
+  /** Append one committed batch without allowing records from other writers to interleave. */
   async appendBatch(entries: SessionEvent[]): Promise<void> {
-    try {
-      // 确保父目录存在
-      await fs.mkdir(path.dirname(this.filePath), { recursive: true, mode: 0o755 });
-
-      // 将所有条目序列化为一个字符串
-      const lines = `${entries.map((entry) => JSON.stringify(entry)).join('\n')}\n`;
-
-      // 批量追加写入
-      await fs.appendFile(this.filePath, lines, 'utf-8');
-    } catch (error) {
-      console.error(`[JSONLStore] 批量追加写入失败: ${this.filePath}`, error);
-      throw error;
+    if (entries.length === 0) {
+      return;
     }
+    await this.appendEntries(entries);
   }
 
   /**
-   * 读取所有 JSONL 记录
-   * @returns JSONL 条目数组
+   * Append a record only when the file has no committed records.
+   * Returns true when the record was written.
    */
-  async readAll(): Promise<SessionEvent[]> {
-    try {
-      // 检查文件是否存在
-      if (!fsSync.existsSync(this.filePath)) {
-        return [];
+  async appendIfEmpty(entry: SessionEvent): Promise<boolean> {
+    const content = this.serializeEntries([entry]);
+    return this.runWithLock('write', async () => {
+      const loaded = await this.loadFileUnlocked();
+      if (loaded.entries.length > 0) {
+        return false;
       }
-
-      const content = await fs.readFile(this.filePath, 'utf-8');
-      const lines = content.split('\n').filter((line) => line.trim().length > 0);
-
-      const entries: SessionEvent[] = [];
-      for (const line of lines) {
-        try {
-          const parsed: JsonValue = JSON.parse(line) as JsonValue;
-          if (isSessionEvent(parsed)) {
-            entries.push(parsed);
-          } else {
-            console.warn(`[JSONLStore] 无效的 SessionEvent 格式: ${line}`);
-          }
-        } catch (parseError) {
-          console.warn(`[JSONLStore] 解析 JSON 行失败: ${line}`, parseError);
-        }
-      }
-
-      return entries;
-    } catch (error) {
-      console.error(`[JSONLStore] 读取文件失败: ${this.filePath}`, error);
-      return [];
-    }
-  }
-
-  /**
-   * 流式读取 JSONL 记录（适合大文件）
-   * @param callback 每条记录的回调函数
-   */
-  async readStream(
-    callback: (entry: SessionEvent) => void | Promise<void>
-  ): Promise<void> {
-    return new Promise((resolve, reject) => {
-      if (!fsSync.existsSync(this.filePath)) {
-        resolve();
-        return;
-      }
-
-      const fileStream = createReadStream(this.filePath, 'utf-8');
-      const rl = createInterface({
-        input: fileStream,
-        crlfDelay: Number.POSITIVE_INFINITY,
-      });
-
-      rl.on('line', async (line) => {
-        const trimmed = line.trim();
-        if (trimmed.length === 0) return;
-
-        try {
-          const parsed: JsonValue = JSON.parse(trimmed) as JsonValue;
-          if (isSessionEvent(parsed)) {
-            await callback(parsed);
-          }
-        } catch (error) {
-          console.warn(`[JSONLStore] 解析 JSON 行失败: ${trimmed}`, error);
-        }
-      });
-
-      rl.on('close', () => resolve());
-      rl.on('error', reject);
-      fileStream.on('error', reject);
+      await this.writeUnlocked(content, loaded);
+      return true;
     });
   }
 
-  /**
-   * 按条件过滤读取 JSONL 记录
-   * @param predicate 过滤条件
-   * @returns 符合条件的 JSONL 条目数组
-   */
+  /** Read all committed records. */
+  async readAll(): Promise<SessionEvent[]> {
+    return this.runWithLock('read', async () => {
+      const loaded = await this.loadFileUnlocked();
+      return loaded.entries;
+    });
+  }
+
+  /** Read a stable snapshot and await each callback in file order. */
+  async readStream(
+    callback: (entry: SessionEvent) => void | Promise<void>,
+  ): Promise<void> {
+    const entries = await this.readAll();
+    for (const entry of entries) {
+      await callback(entry);
+    }
+  }
+
   async filter(
-    predicate: (entry: SessionEvent) => boolean
+    predicate: (entry: SessionEvent) => boolean,
   ): Promise<SessionEvent[]> {
     const results: SessionEvent[] = [];
     await this.readStream((entry) => {
@@ -153,79 +152,238 @@ export class JSONLStore {
     return results;
   }
 
-  /**
-   * 获取最后 N 条记录
-   * @param count 记录数量
-   * @returns JSONL 条目数组
-   */
   async readLast(count: number): Promise<SessionEvent[]> {
     const all = await this.readAll();
     return all.slice(-count);
   }
 
-  /**
-   * 获取文件统计信息
-   * @returns 统计信息
-   */
   async getStats(): Promise<{
     exists: boolean;
-    size: number; // 字节
+    size: number;
     lineCount: number;
   }> {
-    try {
-      if (!fsSync.existsSync(this.filePath)) {
-        return { exists: false, size: 0, lineCount: 0 };
-      }
-
-      const stats = await fs.stat(this.filePath);
-      const content = await fs.readFile(this.filePath, 'utf-8');
-      const lineCount = content
-        .split('\n')
-        .filter((line) => line.trim().length > 0).length;
-
+    return this.runWithLock('read', async () => {
+      const loaded = await this.loadFileUnlocked();
       return {
-        exists: true,
-        size: stats.size,
-        lineCount,
+        exists: loaded.exists,
+        size: loaded.totalBytes,
+        lineCount: loaded.entries.length,
       };
-    } catch (error) {
-      console.error(`[JSONLStore] 获取统计信息失败: ${this.filePath}`, error);
-      return { exists: false, size: 0, lineCount: 0 };
-    }
+    });
   }
 
-  /**
-   * 检查文件是否存在
-   * @returns 文件是否存在
-   */
   async exists(): Promise<boolean> {
     try {
-      await fs.access(this.filePath);
+      await stat(this.filePath);
       return true;
-    } catch {
-      return false;
-    }
-  }
-
-  /**
-   * 删除 JSONL 文件
-   */
-  async delete(): Promise<void> {
-    try {
-      if (await this.exists()) {
-        await fs.unlink(this.filePath);
-      }
     } catch (error) {
-      console.error(`[JSONLStore] 删除文件失败: ${this.filePath}`, error);
-      throw error;
+      if (hasErrorCode(error, 'ENOENT')) {
+        return false;
+      }
+      throw new JSONLStoreError(
+        'SESSION_JSONL_READ_FAILED',
+        `Failed to inspect Session JSONL file ${this.filePath}`,
+        { cause: error },
+      );
     }
   }
 
-  /**
-   * 获取文件路径
-   */
+  async delete(): Promise<void> {
+    await this.runWithLock('write', async () => {
+      try {
+        await unlink(this.filePath);
+      } catch (error) {
+        if (!hasErrorCode(error, 'ENOENT')) {
+          throw new JSONLStoreError(
+            'SESSION_JSONL_WRITE_FAILED',
+            `Failed to delete Session JSONL file ${this.filePath}`,
+            { cause: error },
+          );
+        }
+      }
+    });
+  }
+
   getFilePath(): string {
     return this.filePath;
   }
-}
 
+  private async appendEntries(entries: readonly SessionEvent[]): Promise<void> {
+    const content = this.serializeEntries(entries);
+    await this.runWithLock('write', async () => {
+      const loaded = await this.loadRawFileUnlocked();
+      await this.writeUnlocked(content, loaded);
+    });
+  }
+
+  private serializeEntries(entries: readonly SessionEvent[]): string {
+    try {
+      return `${entries.map((entry) => JSON.stringify(entry)).join('\n')}\n`;
+    } catch (error) {
+      throw new JSONLStoreError(
+        'SESSION_JSONL_WRITE_FAILED',
+        `Failed to serialize Session JSONL records for ${this.filePath}`,
+        { cause: error },
+      );
+    }
+  }
+
+  private async writeUnlocked(
+    content: string,
+    loaded: Pick<LoadedFile, 'committedBytes' | 'totalBytes'>,
+  ): Promise<void> {
+    try {
+      if (loaded.totalBytes > loaded.committedBytes) {
+        await truncate(this.filePath, loaded.committedBytes);
+      }
+      const file = await open(this.filePath, 'a', 0o600);
+      try {
+        await file.writeFile(content, 'utf8');
+        await file.sync();
+      } finally {
+        await file.close();
+      }
+    } catch (error) {
+      if (error instanceof JSONLStoreError) {
+        throw error;
+      }
+      throw new JSONLStoreError(
+        'SESSION_JSONL_WRITE_FAILED',
+        `Failed to append Session JSONL records to ${this.filePath}`,
+        { cause: error },
+      );
+    }
+  }
+
+  private async loadFileUnlocked(): Promise<LoadedFile> {
+    const loaded = await this.loadRawFileUnlocked();
+    let committed: string;
+    try {
+      committed = UTF8_DECODER.decode(
+        loaded.bytes.subarray(0, loaded.committedBytes),
+      );
+    } catch (error) {
+      throw new JSONLStoreError(
+        'SESSION_JSONL_CORRUPT_LOG',
+        `Session JSONL file contains invalid UTF-8: ${this.filePath}`,
+        { cause: error },
+      );
+    }
+    const entries: SessionEvent[] = [];
+    const eventIds = new Set<string>();
+    let sessionId: string | undefined;
+    for (const [index, line] of committed.split('\n').entries()) {
+      if (line.trim().length === 0) {
+        continue;
+      }
+      try {
+        const parsed: JsonValue = JSON.parse(line) as JsonValue;
+        if (!isSessionEvent(parsed)) {
+          throw new Error('Record is not a SessionEvent');
+        }
+        if (eventIds.has(parsed.id)) {
+          throw new Error(`Duplicate Session event ID: ${parsed.id}`);
+        }
+        if (sessionId !== undefined && parsed.sessionId !== sessionId) {
+          throw new Error(
+            `Session ID changed from ${sessionId} to ${parsed.sessionId}`,
+          );
+        }
+        eventIds.add(parsed.id);
+        sessionId ??= parsed.sessionId;
+        entries.push(parsed);
+      } catch (error) {
+        throw new JSONLStoreError(
+          'SESSION_JSONL_CORRUPT_LOG',
+          `Invalid Session JSONL record at line ${index + 1} in ${this.filePath}`,
+          { cause: error },
+        );
+      }
+    }
+    return {
+      entries,
+      exists: loaded.exists,
+      committedBytes: loaded.committedBytes,
+      totalBytes: loaded.totalBytes,
+    };
+  }
+
+  private async loadRawFileUnlocked(): Promise<{
+    bytes: Buffer;
+    exists: boolean;
+    committedBytes: number;
+    totalBytes: number;
+  }> {
+    let bytes: Buffer;
+    try {
+      bytes = await readFile(this.filePath);
+    } catch (error) {
+      if (hasErrorCode(error, 'ENOENT')) {
+        return {
+          bytes: Buffer.alloc(0),
+          exists: false,
+          committedBytes: 0,
+          totalBytes: 0,
+        };
+      }
+      throw new JSONLStoreError(
+        'SESSION_JSONL_READ_FAILED',
+        `Failed to read Session JSONL file ${this.filePath}`,
+        { cause: error },
+      );
+    }
+    const lastNewline = bytes.lastIndexOf(0x0a);
+    return {
+      bytes,
+      exists: true,
+      committedBytes: lastNewline === -1 ? 0 : lastNewline + 1,
+      totalBytes: bytes.length,
+    };
+  }
+
+  private runWithLock<T>(
+    operation: 'read' | 'write',
+    callback: () => Promise<T>,
+  ): Promise<T> {
+    const operationErrorCode =
+      operation === 'write' ? 'SESSION_JSONL_WRITE_FAILED' : 'SESSION_JSONL_READ_FAILED';
+    return withAdvisoryFileLock(
+      this.filePath,
+      {
+        timeoutMs: this.lockTimeoutMs,
+        errors: {
+          prepare: (cause) =>
+            new JSONLStoreError(
+              'SESSION_JSONL_LOCK_FAILED',
+              `Failed to prepare Session JSONL lock for ${this.filePath}`,
+              { cause },
+            ),
+          initialize: (cause) =>
+            new JSONLStoreError(
+              'SESSION_JSONL_LOCK_FAILED',
+              `Failed to initialize Session JSONL lock for ${this.filePath}`,
+              { cause },
+            ),
+          acquire: (cause) =>
+            new JSONLStoreError(
+              'SESSION_JSONL_LOCK_FAILED',
+              `Failed to acquire Session JSONL lock for ${this.filePath}`,
+              { cause },
+            ),
+          timeout: () =>
+            new JSONLStoreError(
+              'SESSION_JSONL_LOCK_TIMEOUT',
+              `Timed out acquiring Session JSONL lock for ${this.filePath}`,
+            ),
+          release: (cause) =>
+            new JSONLStoreError(
+              operationErrorCode,
+              `Session JSONL ${operation} failed while holding the file lock for ${this.filePath}`,
+              { cause },
+            ),
+        },
+      },
+      callback,
+    );
+  }
+}

--- a/src/context/storage/JSONLStore.ts
+++ b/src/context/storage/JSONLStore.ts
@@ -1,22 +1,15 @@
 import { open, readFile, stat, truncate, unlink } from 'node:fs/promises';
 import { TextDecoder } from 'node:util';
 import { SdkError } from '../../errors/SdkError.js';
-import type { JsonValue } from '../../types/common.js';
-import { withAdvisoryFileLock } from '../../utils/advisoryFileLock.js';
+import {
+  syncParentDirectory,
+  withAdvisoryFileLock,
+} from '../../utils/advisoryFileLock.js';
 import type { SessionEvent } from '../types.js';
+import { parseSessionEvent } from './sessionEventSchema.js';
 
 const DEFAULT_LOCK_TIMEOUT_MS = 10_000;
 const UTF8_DECODER = new TextDecoder('utf-8', { fatal: true });
-const SESSION_EVENT_TYPES = new Set([
-  'session_created',
-  'session_updated',
-  'message_created',
-  'part_created',
-  'part_updated',
-  'input_enqueued',
-  'input_applied',
-  'input_cancelled',
-]);
 
 export type JSONLStoreErrorCode =
   | 'SESSION_JSONL_CORRUPT_LOG'
@@ -46,20 +39,6 @@ interface LoadedFile {
   exists: boolean;
   committedBytes: number;
   totalBytes: number;
-}
-
-function isSessionEvent(data: unknown): data is SessionEvent {
-  if (!data || typeof data !== 'object' || Array.isArray(data)) return false;
-  const obj = data as Record<string, unknown>;
-  return typeof obj.id === 'string'
-    && typeof obj.sessionId === 'string'
-    && typeof obj.timestamp === 'string'
-    && typeof obj.type === 'string'
-    && SESSION_EVENT_TYPES.has(obj.type)
-    && typeof obj.version === 'string'
-    && typeof obj.data === 'object'
-    && obj.data !== null
-    && !Array.isArray(obj.data);
 }
 
 function hasErrorCode(error: unknown, code: string): boolean {
@@ -230,7 +209,7 @@ export class JSONLStore {
 
   private async writeUnlocked(
     content: string,
-    loaded: Pick<LoadedFile, 'committedBytes' | 'totalBytes'>,
+    loaded: Pick<LoadedFile, 'committedBytes' | 'exists' | 'totalBytes'>,
   ): Promise<void> {
     try {
       if (loaded.totalBytes > loaded.committedBytes) {
@@ -242,6 +221,9 @@ export class JSONLStore {
         await file.sync();
       } finally {
         await file.close();
+      }
+      if (!loaded.exists) {
+        await syncParentDirectory(this.filePath);
       }
     } catch (error) {
       if (error instanceof JSONLStoreError) {
@@ -277,10 +259,7 @@ export class JSONLStore {
         continue;
       }
       try {
-        const parsed: JsonValue = JSON.parse(line) as JsonValue;
-        if (!isSessionEvent(parsed)) {
-          throw new Error('Record is not a SessionEvent');
-        }
+        const parsed = parseSessionEvent(JSON.parse(line));
         if (eventIds.has(parsed.id)) {
           throw new Error(`Duplicate Session event ID: ${parsed.id}`);
         }

--- a/src/context/storage/PersistentStore.ts
+++ b/src/context/storage/PersistentStore.ts
@@ -11,21 +11,21 @@ import {
 } from '../../types/branded.js';
 import type { JsonObject, JsonValue, MessageRole } from '../../types/common.js';
 import type {
-    ContextData,
-    ConversationContext,
-    MessageInfo,
-    PendingInputInfo,
-    PartInfo,
-    SessionContext,
-    SessionEvent,
-    SessionInfo,
+  ContextData,
+  ConversationContext,
+  MessageInfo,
+  PendingInputInfo,
+  PartInfo,
+  SessionContext,
+  SessionEvent,
+  SessionInfo,
 } from '../types.js';
 import { JSONLStore } from './JSONLStore.js';
 import {
-    detectGitBranch,
-    getSessionFilePathFromStorageRoot,
-    listProjectDirectories,
-    normalizeSessionStorageRoot
+  detectGitBranch,
+  getSessionFilePathFromStorageRoot,
+  listProjectDirectories,
+  normalizeSessionStorageRoot,
 } from './pathUtils.js';
 
 function extractMimeType(url: string): string | undefined {
@@ -122,15 +122,6 @@ export class PersistentStore {
     const filePath = getSessionFilePathFromStorageRoot(this.storageRoot, sessionId);
     const store = new JSONLStore(filePath);
 
-    // 冷路径：用单次 access 检查文件是否已存在，而非读取整个文件
-    try {
-      await fs.access(filePath);
-      this.knownSessions.add(sessionId);
-      return;
-    } catch {
-      // 文件不存在，需要写入 session_created 事件
-    }
-
     const now = new Date().toISOString();
     const sessionInfo: SessionInfo = {
       sessionId,
@@ -146,7 +137,7 @@ export class PersistentStore {
       updatedAt: now,
     };
     const entry = this.createEvent('session_created', sessionId, sessionInfo);
-    await store.append(entry);
+    await store.appendIfEmpty(entry);
     this.knownSessions.add(sessionId);
   }
 
@@ -172,7 +163,7 @@ export class PersistentStore {
   async initialize(): Promise<void> {
     try {
       const storagePath = this.storageRoot;
-      await fs.mkdir(storagePath, { recursive: true, mode: 0o755 });
+      await fs.mkdir(storagePath, { recursive: true, mode: 0o700 });
       console.log(`[PersistentStore] 初始化存储目录: ${storagePath}`);
     } catch (error) {
       console.warn('[PersistentStore] 无法创建持久化存储目录:', error);

--- a/src/context/storage/PersistentStore.ts
+++ b/src/context/storage/PersistentStore.ts
@@ -683,7 +683,7 @@ export class PersistentStore {
       const storagePath = this.storageRoot;
 
       // 尝试创建目录
-      await fs.mkdir(storagePath, { recursive: true, mode: 0o755 });
+      await fs.mkdir(storagePath, { recursive: true, mode: 0o700 });
 
       // 尝试写入测试文件
       const testFile = path.join(storagePath, '.health-check');

--- a/src/context/storage/__tests__/JSONLStore.test.ts
+++ b/src/context/storage/__tests__/JSONLStore.test.ts
@@ -1,0 +1,335 @@
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import {
+  appendFile,
+  mkdir,
+  mkdtemp,
+  open,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+} from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { tryLock, unlock } from 'fs-native-extensions';
+import { afterEach, describe, expect, it } from 'vitest';
+import { SessionId } from '../../../types/branded.js';
+import type { SessionEvent } from '../../types.js';
+import { JSONLStore } from '../JSONLStore.js';
+import { PersistentStore } from '../PersistentStore.js';
+
+const temporaryRoots: string[] = [];
+const lockHolderPath = join(
+  dirname(fileURLToPath(import.meta.url)),
+  'fixtures',
+  'advisoryLockHolder.mjs',
+);
+
+async function withTimeout<T>(
+  promise: Promise<T>,
+  message: string,
+): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_resolve, reject) => {
+        timeout = setTimeout(() => reject(new Error(message)), 5_000);
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
+async function createStore(options?: { lockTimeoutMs?: number }): Promise<{
+  filePath: string;
+  store: JSONLStore;
+}> {
+  const root = await mkdtemp(join(tmpdir(), 'session-jsonl-store-'));
+  temporaryRoots.push(root);
+  const filePath = join(root, 'sessions', 'session.jsonl');
+  return {
+    filePath,
+    store: new JSONLStore(filePath, options),
+  };
+}
+
+function event(
+  id: string,
+  sessionId = SessionId('session'),
+): SessionEvent {
+  return {
+    id,
+    sessionId,
+    timestamp: '2026-08-23T00:00:00.000Z',
+    type: 'session_updated',
+    version: '1.0.0',
+    data: { title: id },
+  };
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots.splice(0).map((root) =>
+      rm(root, { recursive: true, force: true }),
+    ),
+  );
+});
+
+describe('JSONLStore', () => {
+  it('serializes concurrent appends across independent Store instances', async () => {
+    const { filePath, store } = await createStore();
+    const otherStore = new JSONLStore(filePath);
+    const entries = Array.from({ length: 100 }, (_, index) => event(`event-${index}`));
+
+    await Promise.all(
+      entries.map((entry, index) =>
+        (index % 2 === 0 ? store : otherStore).append(entry),
+      ),
+    );
+
+    const persisted = await store.readAll();
+    expect(persisted).toHaveLength(entries.length);
+    expect(new Set(persisted.map((entry) => entry.id))).toEqual(
+      new Set(entries.map((entry) => entry.id)),
+    );
+  });
+
+  it('appends an initialization record exactly once across Store instances', async () => {
+    const { filePath } = await createStore();
+    const stores = Array.from({ length: 20 }, () => new JSONLStore(filePath));
+
+    const results = await Promise.all(
+      stores.map((store, index) => store.appendIfEmpty(event(`initializer-${index}`))),
+    );
+
+    expect(results.filter(Boolean)).toHaveLength(1);
+    await expect(stores[0]?.readAll()).resolves.toHaveLength(1);
+  });
+
+  it('initializes a Session transcript exactly once across PersistentStore instances', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'persistent-store-init-'));
+    temporaryRoots.push(root);
+    const sessionId = SessionId('shared-session');
+    const stores = Array.from({ length: 20 }, () => new PersistentStore(root));
+
+    await Promise.all(stores.map((store) => store.createSession(sessionId)));
+
+    const transcript = new JSONLStore(
+      join(root, 'sessions', `${sessionId}.jsonl`),
+    );
+    const entries = await transcript.readAll();
+    expect(entries.filter((entry) => entry.type === 'session_created')).toHaveLength(1);
+  });
+
+  it('ignores an uncommitted crash tail and truncates it before the next append', async () => {
+    const { filePath, store } = await createStore();
+    await store.append(event('before'));
+    await appendFile(filePath, '{"id":"torn"', 'utf8');
+
+    await expect(store.readAll()).resolves.toEqual([event('before')]);
+
+    await store.append(event('after'));
+
+    const content = await readFile(filePath, 'utf8');
+    expect(content).not.toContain('"torn"');
+    await expect(store.readAll()).resolves.toEqual([
+      event('before'),
+      event('after'),
+    ]);
+  });
+
+  it('fails closed when a committed record is corrupt', async () => {
+    const { filePath, store } = await createStore();
+    await store.append(event('valid'));
+    await appendFile(filePath, 'not-json\n', 'utf8');
+
+    await expect(store.readAll()).rejects.toMatchObject({
+      code: 'SESSION_JSONL_CORRUPT_LOG',
+      message: expect.stringContaining('line 2'),
+    });
+  });
+
+  it('fails closed when a committed record is not a Session event', async () => {
+    const { filePath, store } = await createStore();
+    await store.append(event('valid'));
+    await appendFile(
+      filePath,
+      `${JSON.stringify({
+        id: 'foreign',
+        sessionId: 'session',
+        timestamp: '2026-08-23T00:00:00.000Z',
+        type: 'foreign_event',
+        version: '1.0.0',
+        data: {},
+      })}\n`,
+      'utf8',
+    );
+
+    await expect(store.readAll()).rejects.toMatchObject({
+      code: 'SESSION_JSONL_CORRUPT_LOG',
+      message: expect.stringContaining('line 2'),
+    });
+  });
+
+  it('fails closed when a committed record contains invalid UTF-8', async () => {
+    const { filePath, store } = await createStore();
+    await store.append(event('valid'));
+    await appendFile(
+      filePath,
+      Buffer.concat([
+        Buffer.from('{"id":"'),
+        Buffer.from([0xe2, 0x82]),
+        Buffer.from('"}\n'),
+      ]),
+    );
+
+    await expect(store.readAll()).rejects.toMatchObject({
+      code: 'SESSION_JSONL_CORRUPT_LOG',
+      message: expect.stringContaining('invalid UTF-8'),
+    });
+  });
+
+  it.each([
+    [
+      'a duplicate event ID',
+      event('first'),
+    ],
+    [
+      'a different Session ID',
+      event('second', SessionId('other-session')),
+    ],
+  ])('fails closed when the log contains %s', async (_description, invalidEvent) => {
+    const { filePath, store } = await createStore();
+    await store.append(event('first'));
+    await appendFile(filePath, `${JSON.stringify(invalidEvent)}\n`, 'utf8');
+
+    await expect(store.readAll()).rejects.toMatchObject({
+      code: 'SESSION_JSONL_CORRUPT_LOG',
+      message: expect.stringContaining('line 2'),
+    });
+  });
+
+  it('fails closed when the transcript path cannot be read', async () => {
+    const { filePath, store } = await createStore();
+    await mkdir(filePath, { recursive: true });
+
+    await expect(store.readAll()).rejects.toMatchObject({
+      code: 'SESSION_JSONL_READ_FAILED',
+    });
+  });
+
+  it('awaits asynchronous stream callbacks in file order', async () => {
+    const { store } = await createStore();
+    await store.appendBatch([event('first'), event('second')]);
+    const observed: string[] = [];
+
+    await store.readStream(async (entry) => {
+      await new Promise<void>((resolve) => setTimeout(resolve, 5));
+      observed.push(entry.id);
+    });
+
+    expect(observed).toEqual(['first', 'second']);
+  });
+
+  it('fails immediately when another owner holds the process lock', async () => {
+    const { filePath } = await createStore();
+    await mkdir(dirname(filePath), { recursive: true });
+    const lockFile = await open(`${filePath}.lock`, 'a+', 0o600);
+    expect(tryLock(lockFile.fd)).toBe(true);
+
+    try {
+      const store = new JSONLStore(filePath, { lockTimeoutMs: 0 });
+      await expect(store.append(event('blocked'))).rejects.toMatchObject({
+        code: 'SESSION_JSONL_LOCK_TIMEOUT',
+      });
+    } finally {
+      unlock(lockFile.fd);
+      await lockFile.close();
+    }
+  });
+
+  it('honors a lock held by an independent Node.js process', async () => {
+    const { filePath } = await createStore();
+    await mkdir(dirname(filePath), { recursive: true });
+    const child = spawn(process.execPath, [
+      lockHolderPath,
+      `${filePath}.lock`,
+      '500',
+    ]);
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    let stderr = '';
+    child.stderr.on('data', (chunk: string) => {
+      stderr += chunk;
+    });
+    const closed = once(child, 'close');
+
+    try {
+      const [ready] = await withTimeout(
+        once(child.stdout, 'data'),
+        'Lock holder did not become ready',
+      );
+      expect(String(ready)).toContain('locked');
+
+      const store = new JSONLStore(filePath, { lockTimeoutMs: 25 });
+      await expect(store.append(event('blocked'))).rejects.toMatchObject({
+        code: 'SESSION_JSONL_LOCK_TIMEOUT',
+      });
+    } finally {
+      if (child.exitCode === null && child.signalCode === null) {
+        child.kill('SIGTERM');
+      }
+      const [code, signal] = await withTimeout(
+        closed,
+        `Lock holder did not exit: ${stderr}`,
+      );
+      expect(code ?? signal).not.toBeNull();
+    }
+  });
+
+  it.skipIf(process.platform === 'win32')(
+    'creates transcript and sidecar files with owner-only permissions',
+    async () => {
+      const { filePath, store } = await createStore();
+      await store.append(event('private'));
+
+      expect((await stat(dirname(filePath))).mode & 0o777).toBe(0o700);
+      expect((await stat(filePath)).mode & 0o777).toBe(0o600);
+      expect((await stat(`${filePath}.lock`)).mode & 0o777).toBe(0o600);
+    },
+  );
+
+  it('treats a missing transcript as an empty store', async () => {
+    const { store } = await createStore();
+    await expect(store.readAll()).resolves.toEqual([]);
+    await expect(store.getStats()).resolves.toEqual({
+      exists: false,
+      size: 0,
+      lineCount: 0,
+    });
+  });
+
+  it('distinguishes an existing empty transcript from a missing file', async () => {
+    const { filePath, store } = await createStore();
+    await mkdir(dirname(filePath), { recursive: true });
+    await writeFile(filePath, '');
+
+    await expect(store.getStats()).resolves.toEqual({
+      exists: true,
+      size: 0,
+      lineCount: 0,
+    });
+  });
+
+  it('does not overwrite a non-empty transcript with appendIfEmpty', async () => {
+    const { store } = await createStore();
+    await store.append(event('existing'));
+
+    await expect(store.appendIfEmpty(event('replacement'))).resolves.toBe(false);
+    await expect(store.readAll()).resolves.toEqual([event('existing')]);
+  });
+});

--- a/src/context/storage/__tests__/JSONLStore.test.ts
+++ b/src/context/storage/__tests__/JSONLStore.test.ts
@@ -175,6 +175,28 @@ describe('JSONLStore', () => {
     });
   });
 
+  it('fails closed when a committed event has an invalid payload', async () => {
+    const { filePath, store } = await createStore();
+    await store.append(event('valid'));
+    await appendFile(
+      filePath,
+      `${JSON.stringify({
+        id: 'invalid-message',
+        sessionId: 'session',
+        timestamp: '2026-08-23T00:00:00.000Z',
+        type: 'message_created',
+        version: '1.0.0',
+        data: {},
+      })}\n`,
+      'utf8',
+    );
+
+    await expect(store.readAll()).rejects.toMatchObject({
+      code: 'SESSION_JSONL_CORRUPT_LOG',
+      message: expect.stringContaining('line 2'),
+    });
+  });
+
   it('fails closed when a committed record contains invalid UTF-8', async () => {
     const { filePath, store } = await createStore();
     await store.append(event('valid'));
@@ -300,6 +322,22 @@ describe('JSONLStore', () => {
       expect((await stat(dirname(filePath))).mode & 0o777).toBe(0o700);
       expect((await stat(filePath)).mode & 0o777).toBe(0o600);
       expect((await stat(`${filePath}.lock`)).mode & 0o777).toBe(0o600);
+    },
+  );
+
+  it.skipIf(process.platform === 'win32')(
+    'keeps the Session directory private when a health check creates it first',
+    async () => {
+      const root = await mkdtemp(join(tmpdir(), 'persistent-store-health-'));
+      temporaryRoots.push(root);
+      const store = new PersistentStore(root);
+
+      await expect(store.checkStorageHealth()).resolves.toMatchObject({
+        isAvailable: true,
+        canWrite: true,
+      });
+
+      expect((await stat(join(root, 'sessions'))).mode & 0o777).toBe(0o700);
     },
   );
 

--- a/src/context/storage/__tests__/fixtures/advisoryLockHolder.mjs
+++ b/src/context/storage/__tests__/fixtures/advisoryLockHolder.mjs
@@ -1,0 +1,24 @@
+import { writeSync } from 'node:fs';
+import { open } from 'node:fs/promises';
+import { tryLock, unlock } from 'fs-native-extensions';
+
+const [lockPath, rawHoldMs = '1000'] = process.argv.slice(2);
+const holdMs = Number(rawHoldMs);
+
+if (!lockPath || !Number.isSafeInteger(holdMs) || holdMs < 0) {
+  process.stderr.write('Usage: advisoryLockHolder.mjs <lock-path> [hold-ms]\n');
+  process.exit(2);
+}
+
+const waitArray = new Int32Array(new SharedArrayBuffer(4));
+const lockFile = await open(lockPath, 'a+', 0o600);
+if (!tryLock(lockFile.fd)) {
+  await lockFile.close();
+  process.stderr.write(`Failed to acquire ${lockPath}\n`);
+  process.exit(1);
+}
+
+writeSync(process.stdout.fd, 'locked\n');
+Atomics.wait(waitArray, 0, 0, holdMs);
+unlock(lockFile.fd);
+await lockFile.close();

--- a/src/context/storage/__tests__/pathUtils.test.ts
+++ b/src/context/storage/__tests__/pathUtils.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest';
+import { join } from 'node:path';
 import {
-  unescapeProjectPath,
   getProjectStoragePath,
   getSessionFilePath,
+  getSessionFilePathFromStorageRoot,
+  unescapeProjectPath,
 } from '../pathUtils.js';
 import { SessionId } from '../../../types/branded.js';
 
@@ -51,6 +53,33 @@ describe('pathUtils', () => {
       const storagePath = getProjectStoragePath(STORAGE_ROOT, projectPath);
       const sessionPath = getSessionFilePath(STORAGE_ROOT, projectPath, SessionId('session-123'));
       expect(sessionPath.startsWith(storagePath)).toBe(true);
+    });
+
+    it.each([
+      '',
+      '../outside',
+      '..\\outside',
+      'nested/session',
+      'nested\\session',
+      'nul\0byte',
+    ])('rejects unsafe Session ID %j', (sessionId) => {
+      expect(() =>
+        getSessionFilePath(
+          STORAGE_ROOT,
+          '/Users/john/project',
+          SessionId(sessionId),
+        ),
+      ).toThrow(/path-segment-safe/);
+      expect(() =>
+        getSessionFilePathFromStorageRoot(STORAGE_ROOT, SessionId(sessionId)),
+      ).toThrow(/path-segment-safe/);
+    });
+
+    it('preserves safe opaque Session IDs', () => {
+      const sessionId = SessionId('session.v2_custom-123');
+
+      expect(getSessionFilePathFromStorageRoot(STORAGE_ROOT, sessionId))
+        .toBe(join(STORAGE_ROOT, 'sessions', `${sessionId}.jsonl`));
     });
   });
 });

--- a/src/context/storage/pathUtils.ts
+++ b/src/context/storage/pathUtils.ts
@@ -66,6 +66,18 @@ export function normalizeSessionStorageRoot(storageRoot: string): string {
     : getSessionStoragePath(storageRoot);
 }
 
+function sessionFileName(sessionId: SessionId): string {
+  if (
+    sessionId.length === 0
+    || sessionId.includes('\0')
+    || sessionId.includes('/')
+    || sessionId.includes('\\')
+  ) {
+    throw new TypeError('Session ID must be a non-empty path-segment-safe string');
+  }
+  return `${sessionId}.jsonl`;
+}
+
 /**
  * 获取项目的会话文件路径
  *
@@ -75,7 +87,7 @@ export function normalizeSessionStorageRoot(storageRoot: string): string {
  * @returns {storageRoot}/projects/{escaped-path}/{sessionId}.jsonl
  */
 export function getSessionFilePath(storageRoot: string, projectPath: string, sessionId: SessionId): string {
-  return path.join(getProjectStoragePath(storageRoot, projectPath), `${sessionId}.jsonl`);
+  return path.join(getProjectStoragePath(storageRoot, projectPath), sessionFileName(sessionId));
 }
 
 /**
@@ -88,7 +100,7 @@ export function getSessionFilePathFromStorageRoot(
   storageRoot: string,
   sessionId: SessionId,
 ): string {
-  return path.join(normalizeSessionStorageRoot(storageRoot), `${sessionId}.jsonl`);
+  return path.join(normalizeSessionStorageRoot(storageRoot), sessionFileName(sessionId));
 }
 
 /**

--- a/src/context/storage/sessionEventSchema.ts
+++ b/src/context/storage/sessionEventSchema.ts
@@ -1,0 +1,159 @@
+import { z } from 'zod';
+import type { JsonValue } from '../../types/common.js';
+import type { SessionEvent } from '../types.js';
+
+const JsonValueSchema: z.ZodType<JsonValue> = z.lazy(() =>
+  z.union([
+    z.string(),
+    z.number().finite(),
+    z.boolean(),
+    z.null(),
+    z.array(JsonValueSchema),
+    z.record(z.string(), JsonValueSchema),
+  ]),
+);
+
+const NonEmptyStringSchema = z.string().min(1);
+const TimestampSchema = NonEmptyStringSchema;
+const MessageRoleSchema = z.enum(['system', 'user', 'assistant', 'tool']);
+const PartTypeSchema = z.enum([
+  'text',
+  'reasoning',
+  'image',
+  'tool_call',
+  'tool_result',
+  'diff',
+  'patch',
+  'summary',
+  'subtask_ref',
+]);
+const InputPrioritySchema = z.enum(['now', 'next', 'later']);
+
+const SessionInfoFields = {
+  sessionId: NonEmptyStringSchema,
+  rootId: NonEmptyStringSchema,
+  parentId: z.string().optional(),
+  relationType: z.literal('subagent').optional(),
+  title: z.string().optional(),
+  status: z.enum(['running', 'completed', 'failed']).optional(),
+  agentType: z.string().optional(),
+  model: z.string().optional(),
+  permission: JsonValueSchema.optional(),
+  createdAt: TimestampSchema,
+  updatedAt: TimestampSchema,
+};
+
+const SessionEventBase = {
+  id: NonEmptyStringSchema,
+  sessionId: NonEmptyStringSchema,
+  timestamp: TimestampSchema,
+  cwd: z.string().optional(),
+  gitBranch: z.string().optional(),
+  version: NonEmptyStringSchema,
+};
+
+const SessionEventSchema = z.discriminatedUnion('type', [
+  z.object({
+    ...SessionEventBase,
+    type: z.literal('session_created'),
+    data: z.object(SessionInfoFields).passthrough(),
+  }).passthrough(),
+  z.object({
+    ...SessionEventBase,
+    type: z.literal('session_updated'),
+    data: z.object({
+      sessionId: NonEmptyStringSchema.optional(),
+      rootId: NonEmptyStringSchema.optional(),
+      parentId: z.string().optional(),
+      relationType: z.literal('subagent').optional(),
+      title: z.string().optional(),
+      status: z.enum(['running', 'completed', 'failed']).optional(),
+      agentType: z.string().optional(),
+      model: z.string().optional(),
+      permission: JsonValueSchema.optional(),
+      createdAt: TimestampSchema.optional(),
+      updatedAt: TimestampSchema.optional(),
+    }).passthrough(),
+  }).passthrough(),
+  z.object({
+    ...SessionEventBase,
+    type: z.literal('message_created'),
+    data: z.object({
+      messageId: NonEmptyStringSchema,
+      role: MessageRoleSchema,
+      parentMessageId: z.string().optional(),
+      createdAt: TimestampSchema,
+      model: z.string().optional(),
+      usage: z.object({
+        input_tokens: z.number().finite().nonnegative(),
+        output_tokens: z.number().finite().nonnegative(),
+      }).passthrough().optional(),
+      customMetadata: z.record(z.string(), JsonValueSchema).optional(),
+    }).passthrough(),
+  }).passthrough(),
+  z.object({
+    ...SessionEventBase,
+    type: z.literal('part_created'),
+    data: z.object({
+      partId: NonEmptyStringSchema,
+      messageId: NonEmptyStringSchema,
+      partType: PartTypeSchema,
+      payload: JsonValueSchema,
+      createdAt: TimestampSchema,
+    }).passthrough(),
+  }).passthrough(),
+  z.object({
+    ...SessionEventBase,
+    type: z.literal('part_updated'),
+    data: z.object({
+      partId: NonEmptyStringSchema,
+      messageId: NonEmptyStringSchema,
+      partType: PartTypeSchema,
+      payload: JsonValueSchema,
+      createdAt: TimestampSchema,
+    }).passthrough(),
+  }).passthrough(),
+  z.object({
+    ...SessionEventBase,
+    type: z.literal('input_enqueued'),
+    data: z.object({
+      inputId: NonEmptyStringSchema,
+      content: JsonValueSchema,
+      priority: InputPrioritySchema,
+      targetRequestId: NonEmptyStringSchema.optional(),
+      acceptedAt: z.number().finite().nonnegative(),
+    }).passthrough(),
+  }).passthrough(),
+  z.object({
+    ...SessionEventBase,
+    type: z.literal('input_applied'),
+    data: z.object({
+      inputId: NonEmptyStringSchema,
+      requestId: NonEmptyStringSchema,
+      messageId: NonEmptyStringSchema,
+      appliedAt: z.number().finite().nonnegative(),
+    }).passthrough(),
+  }).passthrough(),
+  z.object({
+    ...SessionEventBase,
+    type: z.literal('input_cancelled'),
+    data: z.object({
+      inputId: NonEmptyStringSchema,
+      reason: z.string(),
+      cancelledAt: z.number().finite().nonnegative(),
+    }).passthrough(),
+  }).passthrough(),
+]);
+
+export function parseSessionEvent(value: unknown): SessionEvent {
+  const event = SessionEventSchema.parse(value);
+  if (
+    event.type === 'session_created'
+    && event.data.sessionId !== event.sessionId
+  ) {
+    throw new Error(
+      `Session creation payload ${event.data.sessionId} does not match envelope ${event.sessionId}`,
+    );
+  }
+  return event as unknown as SessionEvent;
+}

--- a/src/session/Session.ts
+++ b/src/session/Session.ts
@@ -294,7 +294,7 @@ class Session implements ISession {
           { cause: error },
         );
       }
-      this.logger.warn(`[Session] Failed to load history for session ${this.sessionId}:`, error);
+      throw error;
     }
     const durableProjection = this.durableJournal?.getProjection();
     const reconciledHistoryInputIds = new Set<string>(

--- a/src/session/SessionStore.ts
+++ b/src/session/SessionStore.ts
@@ -1,5 +1,8 @@
 import * as fs from 'node:fs/promises';
-import { JSONLStore } from '@/context/storage/JSONLStore.js';
+import {
+  JSONLStore,
+  JSONLStoreError,
+} from '@/context/storage/JSONLStore.js';
 import {
   getSessionFilePathFromStorageRoot,
   normalizeSessionStorageRoot,
@@ -582,7 +585,15 @@ export class JsonlSessionStore implements SessionStore {
   private async readEntries(sessionId: SessionId): Promise<SessionEvent[]> {
     const filePath = getSessionFilePathFromStorageRoot(this.storageRoot, sessionId);
     const store = new JSONLStore(filePath);
-    return store.readAll();
+    const entries = await store.readAll();
+    const mismatched = entries.find((entry) => entry.sessionId !== sessionId);
+    if (mismatched) {
+      throw new JSONLStoreError(
+        'SESSION_JSONL_CORRUPT_LOG',
+        `Session JSONL record ${mismatched.id} belongs to ${mismatched.sessionId}, expected ${sessionId}`,
+      );
+    }
+    return entries;
   }
 
   private applyPartToMessage(params: {

--- a/src/session/__tests__/SessionPersistence.test.ts
+++ b/src/session/__tests__/SessionPersistence.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { LogEntry } from '../../types/logging.js';
 import { existsSync, mkdtempSync } from 'node:fs';
+import { appendFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { JSONLStore } from '../../context/storage/JSONLStore.js';
@@ -314,5 +315,24 @@ describe('Session persistence', () => {
     expect(session.messages[0]?.content).toEqual(content);
 
     await session.close();
+  });
+
+  it('fails closed instead of resuming from a partially projected corrupt transcript', async () => {
+    const workspaceRoot = createWorkspaceRoot();
+    const persistentStore = new PersistentStore(workspaceRoot);
+    const sessionId = SessionId('session-corrupt');
+    await persistentStore.saveMessage(sessionId, 'user', 'preserve me');
+    await appendFile(
+      getSessionFilePathFromStorageRoot(workspaceRoot, sessionId),
+      'not-json\n',
+      'utf8',
+    );
+
+    await expect(resumeSession({
+      sessionId,
+      ...createOptions(workspaceRoot),
+    })).rejects.toMatchObject({
+      code: 'SESSION_JSONL_CORRUPT_LOG',
+    });
   });
 });

--- a/src/session/__tests__/SessionStore.test.ts
+++ b/src/session/__tests__/SessionStore.test.ts
@@ -423,6 +423,31 @@ describe('JsonlSessionStore', () => {
     ]);
   });
 
+  it('rejects a transcript containing events for another Session', async () => {
+    const workspaceRoot = createWorkspaceRoot();
+    const expectedSessionId = SessionId('expected-session');
+    const actualSessionId = SessionId('other-session');
+    const now = new Date().toISOString();
+    await new JSONLStore(
+      getSessionFilePathFromStorageRoot(workspaceRoot, expectedSessionId),
+    ).append(
+      sessionEvent(actualSessionId, now, 'foreign-session', 'session_created', {
+        sessionId: actualSessionId,
+        rootId: actualSessionId,
+        status: 'running',
+        createdAt: now,
+        updatedAt: now,
+      }),
+    );
+
+    await expect(
+      new JsonlSessionStore(workspaceRoot).loadState(expectedSessionId),
+    ).rejects.toMatchObject({
+      code: 'SESSION_JSONL_CORRUPT_LOG',
+      message: expect.stringContaining(`expected ${expectedSessionId}`),
+    });
+  });
+
   it('should preserve assistant reasoning content with tool calls for resume', async () => {
     const workspaceRoot = createWorkspaceRoot();
     const persistentStore = new PersistentStore(workspaceRoot);

--- a/src/session/events/JsonlDurableEventStore.ts
+++ b/src/session/events/JsonlDurableEventStore.ts
@@ -1,10 +1,9 @@
-import { Mutex, withTimeout } from 'async-mutex';
 import { nanoid } from 'nanoid';
 import { Buffer } from 'node:buffer';
-import { type FileHandle, mkdir, open, readFile, realpath, truncate } from 'node:fs/promises';
-import { basename, join, resolve } from 'node:path';
-import { performance } from 'node:perf_hooks';
+import { mkdir, open, readFile, truncate } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
 import { EventId, EventSequence, type SessionId } from '../../types/branded.js';
+import { withAdvisoryFileLock } from '../../utils/advisoryFileLock.js';
 import {
   DurableEventSequenceConflictError,
   type DurableEventStore,
@@ -31,48 +30,6 @@ const DEFAULT_PAGE_SIZE = 100;
 const MAX_PAGE_SIZE = 1000;
 const EVENT_DIRECTORY = 'durable-events';
 const DEFAULT_LOCK_TIMEOUT_MS = 10_000;
-const LOCK_RETRY_DELAY_MS = 25;
-
-interface FileMutexEntry {
-  mutex: Mutex;
-  users: number;
-}
-
-const FILE_MUTEXES = new Map<string, FileMutexEntry>();
-
-type NativeFileLock = Pick<typeof import('fs-native-extensions'), 'tryLock' | 'unlock'>;
-
-let nativeFileLockPromise: Promise<NativeFileLock> | undefined;
-
-function loadNativeFileLock(): Promise<NativeFileLock> {
-  nativeFileLockPromise ??= import('fs-native-extensions').catch((error: unknown) => {
-    nativeFileLockPromise = undefined;
-    throw error;
-  });
-  return nativeFileLockPromise;
-}
-
-async function runWithFileMutex<T>(
-  filePath: string,
-  timeoutMs: number,
-  timeoutError: Error,
-  callback: () => Promise<T>,
-): Promise<T> {
-  let entry = FILE_MUTEXES.get(filePath);
-  if (!entry) {
-    entry = { mutex: new Mutex(), users: 0 };
-    FILE_MUTEXES.set(filePath, entry);
-  }
-  entry.users += 1;
-  try {
-    return await withTimeout(entry.mutex, timeoutMs, timeoutError).runExclusive(callback);
-  } finally {
-    entry.users -= 1;
-    if (entry.users === 0) {
-      FILE_MUTEXES.delete(filePath);
-    }
-  }
-}
 
 export interface JsonlDurableEventStoreOptions {
   clock?: () => Date;
@@ -265,137 +222,42 @@ export class JsonlDurableEventStore implements DurableEventStore {
     operation: 'read' | 'write',
     callback: () => Promise<T>,
   ): Promise<T> {
-    const deadline = performance.now() + this.lockTimeoutMs;
-    let lockTarget: string;
-    try {
-      await mkdir(this.rootDirectory, { recursive: true, mode: 0o700 });
-      const canonicalRoot = await realpath(this.rootDirectory);
-      lockTarget = join(canonicalRoot, basename(this.getFilePath(sessionId)));
-    } catch (error) {
-      throw new DurableEventStoreError(
-        'DURABLE_EVENT_LOCK_FAILED',
-        `Failed to prepare durable event lock for session ${sessionId}`,
-        { cause: error },
-      );
-    }
-
-    const timeoutError = this.createLockTimeoutError(sessionId);
-    const localWaitMs = Math.max(0, deadline - performance.now());
-    return runWithFileMutex(lockTarget, localWaitMs, timeoutError, async () => {
-      const release = await this.acquireProcessLock(lockTarget, sessionId, deadline);
-      const operationErrorCode =
-        operation === 'write' ? 'DURABLE_EVENT_WRITE_FAILED' : 'DURABLE_EVENT_READ_FAILED';
-
-      let result: T;
-      try {
-        result = await callback();
-      } catch (error) {
-        try {
-          await release();
-        } catch {
-          // Preserve the operation error; its result did not complete successfully.
-        }
-        throw error;
-      }
-
-      try {
-        await release();
-      } catch (error) {
-        throw new DurableEventStoreError(
-          operationErrorCode,
-          `Durable event ${operation} failed while holding the Session lock for ${sessionId}`,
-          { cause: error },
-        );
-      }
-      return result;
-    });
-  }
-
-  private async acquireProcessLock(
-    filePath: string,
-    sessionId: SessionId,
-    deadline: number,
-  ): Promise<() => Promise<void>> {
-    let nativeFileLock: NativeFileLock;
-    let lockFile: FileHandle;
-    try {
-      nativeFileLock = await loadNativeFileLock();
-      lockFile = await open(`${filePath}.lock`, 'a+', 0o600);
-    } catch (error) {
-      throw new DurableEventStoreError(
-        'DURABLE_EVENT_LOCK_FAILED',
-        `Failed to initialize durable event locking for session ${sessionId}`,
-        { cause: error },
-      );
-    }
-
-    try {
-      let attempted = false;
-      while (true) {
-        const remainingMs = deadline - performance.now();
-        if (remainingMs <= 0 && (attempted || this.lockTimeoutMs > 0)) {
-          throw this.createLockTimeoutError(sessionId);
-        }
-        attempted = true;
-
-        let acquired: boolean;
-        try {
-          acquired = nativeFileLock.tryLock(lockFile.fd);
-        } catch (error) {
-          throw new DurableEventStoreError(
-            'DURABLE_EVENT_LOCK_FAILED',
-            `Failed to acquire durable event lock for session ${sessionId}`,
-            { cause: error },
-          );
-        }
-        if (acquired) {
-          return this.createProcessLockRelease(lockFile, nativeFileLock.unlock);
-        }
-
-        const retryWaitMs = deadline - performance.now();
-        if (retryWaitMs <= 0) {
-          throw this.createLockTimeoutError(sessionId);
-        }
-        await new Promise<void>((resolveDelay) => {
-          setTimeout(resolveDelay, Math.min(LOCK_RETRY_DELAY_MS, retryWaitMs));
-        });
-      }
-    } catch (error) {
-      try {
-        await lockFile.close();
-      } catch {
-        // Preserve the acquisition error; no lock was acquired.
-      }
-      throw error;
-    }
-  }
-
-  private createProcessLockRelease(
-    lockFile: FileHandle,
-    unlockFile: NativeFileLock['unlock'],
-  ): () => Promise<void> {
-    let released = false;
-    return async () => {
-      if (released) {
-        return;
-      }
-      released = true;
-
-      let releaseError: unknown;
-      try {
-        unlockFile(lockFile.fd);
-      } catch (error) {
-        releaseError = error;
-      }
-      try {
-        await lockFile.close();
-      } catch (error) {
-        releaseError ??= error;
-      }
-      if (releaseError) {
-        throw releaseError;
-      }
-    };
+    const operationErrorCode =
+      operation === 'write' ? 'DURABLE_EVENT_WRITE_FAILED' : 'DURABLE_EVENT_READ_FAILED';
+    return withAdvisoryFileLock(
+      this.getFilePath(sessionId),
+      {
+        timeoutMs: this.lockTimeoutMs,
+        errors: {
+          prepare: (cause) =>
+            new DurableEventStoreError(
+              'DURABLE_EVENT_LOCK_FAILED',
+              `Failed to prepare durable event lock for session ${sessionId}`,
+              { cause },
+            ),
+          initialize: (cause) =>
+            new DurableEventStoreError(
+              'DURABLE_EVENT_LOCK_FAILED',
+              `Failed to initialize durable event locking for session ${sessionId}`,
+              { cause },
+            ),
+          acquire: (cause) =>
+            new DurableEventStoreError(
+              'DURABLE_EVENT_LOCK_FAILED',
+              `Failed to acquire durable event lock for session ${sessionId}`,
+              { cause },
+            ),
+          timeout: () => this.createLockTimeoutError(sessionId),
+          release: (cause) =>
+            new DurableEventStoreError(
+              operationErrorCode,
+              `Durable event ${operation} failed while holding the Session lock for ${sessionId}`,
+              { cause },
+            ),
+        },
+      },
+      callback,
+    );
   }
 
   private createLockTimeoutError(sessionId: SessionId): DurableEventStoreError {

--- a/src/session/events/JsonlDurableEventStore.ts
+++ b/src/session/events/JsonlDurableEventStore.ts
@@ -3,7 +3,10 @@ import { Buffer } from 'node:buffer';
 import { mkdir, open, readFile, truncate } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import { EventId, EventSequence, type SessionId } from '../../types/branded.js';
-import { withAdvisoryFileLock } from '../../utils/advisoryFileLock.js';
+import {
+  syncParentDirectory,
+  withAdvisoryFileLock,
+} from '../../utils/advisoryFileLock.js';
 import {
   DurableEventSequenceConflictError,
   type DurableEventStore,
@@ -40,6 +43,7 @@ export interface JsonlDurableEventStoreOptions {
 
 interface LoadedLog {
   events: DurableEventEnvelope[];
+  exists: boolean;
   committedBytes: number;
   totalBytes: number;
 }
@@ -294,6 +298,9 @@ export class JsonlDurableEventStore implements DurableEventStore {
       } finally {
         await file.close();
       }
+      if (!loaded.exists) {
+        await syncParentDirectory(filePath);
+      }
     } catch (error) {
       if (error instanceof DurableEventStoreError) {
         throw error;
@@ -313,7 +320,12 @@ export class JsonlDurableEventStore implements DurableEventStore {
       bytes = await readFile(filePath);
     } catch (error) {
       if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
-        return { events: [], committedBytes: 0, totalBytes: 0 };
+        return {
+          events: [],
+          exists: false,
+          committedBytes: 0,
+          totalBytes: 0,
+        };
       }
       throw new DurableEventStoreError(
         'DURABLE_EVENT_READ_FAILED',
@@ -357,6 +369,7 @@ export class JsonlDurableEventStore implements DurableEventStore {
 
     return {
       events,
+      exists: true,
       committedBytes,
       totalBytes: bytes.length,
     };

--- a/src/session/events/__tests__/JsonlDurableEventStoreUnavailableLock.test.ts
+++ b/src/session/events/__tests__/JsonlDurableEventStoreUnavailableLock.test.ts
@@ -9,8 +9,9 @@ vi.mock('fs-native-extensions', () => {
 });
 
 import { JsonlDurableEventStore } from '../JsonlDurableEventStore.js';
+import { JSONLStore } from '../../../context/storage/JSONLStore.js';
 
-describe('JsonlDurableEventStore native lock availability', () => {
+describe('native file lock availability', () => {
   it('loads the Store module but fails closed on the first operation', async () => {
     const storageRoot = await mkdtemp(join(tmpdir(), 'durable-event-lock-unavailable-'));
     try {
@@ -18,6 +19,20 @@ describe('JsonlDurableEventStore native lock availability', () => {
 
       await expect(store.read(SessionId('session-lock-unavailable'))).rejects.toMatchObject({
         code: 'DURABLE_EVENT_LOCK_FAILED',
+        message: expect.stringContaining('Failed to initialize'),
+      });
+    } finally {
+      await rm(storageRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('fails closed when Session transcript persistence first uses the unavailable addon', async () => {
+    const storageRoot = await mkdtemp(join(tmpdir(), 'session-jsonl-lock-unavailable-'));
+    try {
+      const store = new JSONLStore(join(storageRoot, 'sessions', 'session.jsonl'));
+
+      await expect(store.readAll()).rejects.toMatchObject({
+        code: 'SESSION_JSONL_LOCK_FAILED',
         message: expect.stringContaining('Failed to initialize'),
       });
     } finally {

--- a/src/utils/advisoryFileLock.ts
+++ b/src/utils/advisoryFileLock.ts
@@ -187,3 +187,16 @@ export async function withAdvisoryFileLock<T>(
     },
   );
 }
+
+/** Persist a newly created file's directory entry on filesystems that support it. */
+export async function syncParentDirectory(filePath: string): Promise<void> {
+  if (process.platform === 'win32') {
+    return;
+  }
+  const directory = await open(dirname(filePath), 'r');
+  try {
+    await directory.sync();
+  } finally {
+    await directory.close();
+  }
+}

--- a/src/utils/advisoryFileLock.ts
+++ b/src/utils/advisoryFileLock.ts
@@ -1,0 +1,189 @@
+import { Mutex, withTimeout } from 'async-mutex';
+import { type FileHandle, mkdir, open, realpath } from 'node:fs/promises';
+import { basename, dirname, join } from 'node:path';
+import { performance } from 'node:perf_hooks';
+
+const LOCK_RETRY_DELAY_MS = 25;
+
+interface FileMutexEntry {
+  mutex: Mutex;
+  users: number;
+}
+
+const FILE_MUTEXES = new Map<string, FileMutexEntry>();
+
+type NativeFileLock = Pick<typeof import('fs-native-extensions'), 'tryLock' | 'unlock'>;
+
+let nativeFileLockPromise: Promise<NativeFileLock> | undefined;
+
+function loadNativeFileLock(): Promise<NativeFileLock> {
+  nativeFileLockPromise ??= import('fs-native-extensions').catch((error: unknown) => {
+    nativeFileLockPromise = undefined;
+    throw error;
+  });
+  return nativeFileLockPromise;
+}
+
+export interface AdvisoryFileLockErrors {
+  prepare(cause: unknown): Error;
+  initialize(cause: unknown): Error;
+  acquire(cause: unknown): Error;
+  timeout(): Error;
+  release(cause: unknown): Error;
+}
+
+export interface AdvisoryFileLockOptions {
+  timeoutMs: number;
+  errors: AdvisoryFileLockErrors;
+}
+
+async function runWithFileMutex<T>(
+  filePath: string,
+  timeoutMs: number,
+  timeoutError: Error,
+  callback: () => Promise<T>,
+): Promise<T> {
+  let entry = FILE_MUTEXES.get(filePath);
+  if (!entry) {
+    entry = { mutex: new Mutex(), users: 0 };
+    FILE_MUTEXES.set(filePath, entry);
+  }
+  entry.users += 1;
+  try {
+    return await withTimeout(entry.mutex, timeoutMs, timeoutError).runExclusive(callback);
+  } finally {
+    entry.users -= 1;
+    if (entry.users === 0) {
+      FILE_MUTEXES.delete(filePath);
+    }
+  }
+}
+
+async function releaseProcessLock(
+  lockFile: FileHandle,
+  unlockFile: NativeFileLock['unlock'],
+): Promise<void> {
+  let releaseError: unknown;
+  try {
+    unlockFile(lockFile.fd);
+  } catch (error) {
+    releaseError = error;
+  }
+  try {
+    await lockFile.close();
+  } catch (error) {
+    releaseError ??= error;
+  }
+  if (releaseError) {
+    throw releaseError;
+  }
+}
+
+async function acquireProcessLock(
+  filePath: string,
+  timeoutMs: number,
+  deadline: number,
+  errors: AdvisoryFileLockErrors,
+): Promise<() => Promise<void>> {
+  let nativeFileLock: NativeFileLock;
+  let lockFile: FileHandle;
+  try {
+    nativeFileLock = await loadNativeFileLock();
+    lockFile = await open(`${filePath}.lock`, 'a+', 0o600);
+  } catch (error) {
+    throw errors.initialize(error);
+  }
+
+  try {
+    let attempted = false;
+    while (true) {
+      const remainingMs = deadline - performance.now();
+      if (remainingMs <= 0 && (attempted || timeoutMs > 0)) {
+        throw errors.timeout();
+      }
+      attempted = true;
+
+      let acquired: boolean;
+      try {
+        acquired = nativeFileLock.tryLock(lockFile.fd);
+      } catch (error) {
+        throw errors.acquire(error);
+      }
+      if (acquired) {
+        let released = false;
+        return async () => {
+          if (released) {
+            return;
+          }
+          released = true;
+          await releaseProcessLock(lockFile, nativeFileLock.unlock);
+        };
+      }
+
+      const retryWaitMs = deadline - performance.now();
+      if (retryWaitMs <= 0) {
+        throw errors.timeout();
+      }
+      await new Promise<void>((resolveDelay) => {
+        setTimeout(resolveDelay, Math.min(LOCK_RETRY_DELAY_MS, retryWaitMs));
+      });
+    }
+  } catch (error) {
+    try {
+      await lockFile.close();
+    } catch {
+      // Preserve the acquisition error; no lock was acquired.
+    }
+    throw error;
+  }
+}
+
+export async function withAdvisoryFileLock<T>(
+  filePath: string,
+  options: AdvisoryFileLockOptions,
+  callback: () => Promise<T>,
+): Promise<T> {
+  const deadline = performance.now() + options.timeoutMs;
+  let lockTarget: string;
+  try {
+    await mkdir(dirname(filePath), { recursive: true, mode: 0o700 });
+    const canonicalDirectory = await realpath(dirname(filePath));
+    lockTarget = join(canonicalDirectory, basename(filePath));
+  } catch (error) {
+    throw options.errors.prepare(error);
+  }
+
+  const localWaitMs = Math.max(0, deadline - performance.now());
+  return runWithFileMutex(
+    lockTarget,
+    localWaitMs,
+    options.errors.timeout(),
+    async () => {
+      const release = await acquireProcessLock(
+        lockTarget,
+        options.timeoutMs,
+        deadline,
+        options.errors,
+      );
+
+      let result: T;
+      try {
+        result = await callback();
+      } catch (error) {
+        try {
+          await release();
+        } catch {
+          // Preserve the operation error; its result did not complete successfully.
+        }
+        throw error;
+      }
+
+      try {
+        await release();
+      } catch (error) {
+        throw options.errors.release(error);
+      }
+      return result;
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- share the existing bounded OS advisory-lock primitive between durable journals and Session transcripts
- serialize transcript reads, appends, initialization, and deletion across local Node.js processes
- `fsync` successful appends, discard only unterminated crash tails, and fail closed on committed corruption or invalid UTF-8
- reject path-unsafe caller-supplied Session IDs before transcript path resolution
- await asynchronous read callbacks in order and create transcript storage with owner-only permissions
- document the local-filesystem/native-platform contract in English and Chinese

## Reference alignment
- Claude Code: per-file ordered transcript writes and explicit persistence flushes
- Codex: per-thread writer ownership and durable flush boundaries
- Grok: locked JSONL appends, torn-tail isolation, and corruption-aware recovery

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm run audit:prod`
- `pnpm run lint`
- `pnpm run type-check`
- `pnpm run verify:entrypoints`
- `pnpm run docs:build`
- `pnpm run changelog:check`
- `pnpm test` (1450 passed, 62 credential-gated live tests skipped)
- real independent-process lock contention test on the transcript sidecar


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved session transcript reliability during crashes, concurrent access, and resumed sessions.
  - Recoverable incomplete trailing data is repaired automatically, while committed corruption now fails safely with clear errors.
  - Added validation to prevent unsafe session identifiers and cross-session transcript mismatches.
  - Storage now uses durable writes and stricter file permissions.

- **Documentation**
  - Clarified crash-safe persistence, locking requirements, platform limitations, recovery behavior, and error handling in English and Chinese documentation.

- **Tests**
  - Expanded coverage for concurrency, corruption recovery, locking, permissions, and invalid session data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->