### PR TITLE
fix(session): await active request cancellation

### DIFF
--- a/.changes/awaitable-request-abort.json
+++ b/.changes/awaitable-request-abort.json
@@ -1,5 +1,5 @@
 {
   "type": "fix",
-  "en": "Make running Session abort and close operations wait for Agent stream cleanup, model and tool settlement, durable Request finalization, and request ownership release without consumer deadlocks.",
-  "zh-CN": "使运行中 Session 的 abort 与 close 操作在无消费者死锁的情况下，等待 Agent stream 清理、模型与工具收敛、durable Request 终态持久化及请求所有权释放。"
+  "en": "Make running Session abort and close operations wait for Agent stream cleanup, model and tool settlement, request ownership release, and configured durable Request finalization without consumer deadlocks.",
+  "zh-CN": "使运行中 Session 的 abort 与 close 操作在无消费者死锁的情况下，等待 Agent stream 清理、模型与工具收敛及请求所有权释放，并在配置 durableEventStore 时等待 Request 终态持久化。"
 }

--- a/.changes/awaitable-request-abort.json
+++ b/.changes/awaitable-request-abort.json
@@ -1,0 +1,5 @@
+{
+  "type": "fix",
+  "en": "Make running Session abort and close operations wait for Agent stream cleanup, model and tool settlement, durable Request finalization, and request ownership release without consumer deadlocks.",
+  "zh-CN": "使运行中 Session 的 abort 与 close 操作在无消费者死锁的情况下，等待 Agent stream 清理、模型与工具收敛、durable Request 终态持久化及请求所有权释放。"
+}

--- a/docs/en/session.md
+++ b/docs/en/session.md
@@ -188,9 +188,10 @@ for await (const event of session.stream()) {
 `abort()` terminates the whole active request and does not close the Session. It
 can be awaited from inside stream consumption without deadlocking. The Promise
 resolves only after the inner Agent stream has closed, model and tool lifecycle
-cleanup has settled, the durable Request terminal event has committed, and
-request ownership has been released. Any already buffered stream events remain
-readable afterward, but draining them is not required for cleanup.
+cleanup has settled, and request ownership has been released. When
+`durableEventStore` is configured, it also waits for the durable Request
+terminal event to commit. Any already buffered stream events remain readable
+afterward, but draining them is not required for cleanup.
 
 If durable terminal persistence fails or has an unknown outcome, `abort()`
 rejects and recovery fencing prevents another Request from starting. This
@@ -514,9 +515,10 @@ console.log(session.isClosed);
 ```
 
 `close()` aborts active work and waits for the same request-completion barrier
-as `abort()` before closing MCP connections, running the `SessionEnd` hook, and
-committing `session_closed`. Concurrent calls share one close Promise. A closed
-Session cannot be reinitialized.
+as `abort()` before closing MCP connections and running the `SessionEnd` hook.
+When `durableEventStore` is configured, it also waits for `session_closed` to
+commit. Concurrent calls share one close Promise. A closed Session cannot be
+reinitialized.
 
 Use explicit resource management when available:
 

--- a/docs/en/session.md
+++ b/docs/en/session.md
@@ -61,7 +61,9 @@ type InputSubmission =
     };
 ```
 
-Call `stream()` once for each pending request and drain it through completion.
+Call `stream()` once for each pending request and normally drain it through
+completion. `abort()` and `close()` own cancellation cleanup if consumption is
+paused or stopped early.
 
 ## Steer an active request
 
@@ -176,15 +178,26 @@ Partial model output produced before `turn_interrupted` can be displayed, but it
 ## Abort a request
 
 ```ts
-const stream = session.stream();
-await session.abort();
-
-for await (const event of stream) {
-  // Drain cleanup and terminal events.
+for await (const event of session.stream()) {
+  if (event.type === 'content' && event.delta.includes('stop now')) {
+    await session.abort();
+  }
 }
 ```
 
-`abort()` terminates the whole active request and does not close the Session. It differs from `priority: 'now'`, which steers the same request at a safe point.
+`abort()` terminates the whole active request and does not close the Session. It
+can be awaited from inside stream consumption without deadlocking. The Promise
+resolves only after the inner Agent stream has closed, model and tool lifecycle
+cleanup has settled, the durable Request terminal event has committed, and
+request ownership has been released. Any already buffered stream events remain
+readable afterward, but draining them is not required for cleanup.
+
+If durable terminal persistence fails or has an unknown outcome, `abort()`
+rejects and recovery fencing prevents another Request from starting. This
+differs from `priority: 'now'`, which steers the same request at a safe point.
+Cancellation is cooperative at the JavaScript boundary: custom providers and
+tools must honor their `AbortSignal` and release resources in `finally`;
+otherwise the Promise remains pending until that operation settles.
 
 An external `AbortSignal` can also cancel a request:
 
@@ -303,8 +316,9 @@ Permission, and input-application events with these ordering guarantees:
 - A standalone Request terminal event links to the latest persisted Request
   boundary through `causationEventId`.
 - Terminal events commit before `tool_result`, `result`, or `error` is published.
-- A pending request commits `request_interrupted` before
-  `await session.abort()` resolves.
+- Pending and running requests commit `request_interrupted` before
+  `await session.abort()` resolves. A running abort also waits for the inner
+  execution and model/tool lifecycle cleanup.
 
 If a durable boundary cannot be committed, Session fences the current Recorder
 and rejects the stream instead of fabricating a normal terminal event after the
@@ -499,7 +513,10 @@ await session.close();
 console.log(session.isClosed);
 ```
 
-`close()` aborts active work, closes MCP connections, runs the `SessionEnd` hook, and permanently closes the object. A closed Session cannot be reinitialized.
+`close()` aborts active work and waits for the same request-completion barrier
+as `abort()` before closing MCP connections, running the `SessionEnd` hook, and
+committing `session_closed`. Concurrent calls share one close Promise. A closed
+Session cannot be reinitialized.
 
 Use explicit resource management when available:
 

--- a/docs/en/tools.md
+++ b/docs/en/tools.md
@@ -200,6 +200,8 @@ const tool = createTool({
 ```
 
 Explicit `session.abort()` and `session.close()` are request-level cancellation and are not blocked by `interruptBehavior: 'block'`.
+Both methods wait for active tool cleanup, so custom tools must honor the
+request `AbortSignal` even when they block `now`-priority steering.
 
 `interruptBehavior` belongs to the `ToolConfig` accepted by `createTool()`;
 `defineTool()` / `ToolDefinition` does not expose it. Use `createTool()` with

--- a/docs/session.md
+++ b/docs/session.md
@@ -1391,7 +1391,8 @@ await session.close();
 
 调用后：
 
-- 中止正在进行的请求，并等待请求执行、模型/工具生命周期与 durable 终态收敛
+- 中止正在进行的请求，并等待请求执行与模型/工具生命周期收敛；配置
+  `durableEventStore` 时还会等待 durable 终态收敛
 - 断开所有 MCP 服务器连接
 - 触发 `SessionEnd` Hook
 - Session 永久进入关闭状态，后续 `send()` / `stream()` 会抛出错误
@@ -1412,9 +1413,9 @@ for await (const msg of session.stream()) {
 ```
 
 可以在 stream 消费回调内直接 `await session.abort()`，不会产生死锁。该 Promise
-仅在内部 Agent stream 已关闭、模型和工具生命周期清理完成、durable Request
-终态已提交且请求所有权已释放后返回。已缓冲的 stream 事件仍可继续读取，但不再
-需要通过 drain 来驱动清理。
+仅在内部 Agent stream 已关闭、模型和工具生命周期清理完成且请求所有权已释放后
+返回。配置 `durableEventStore` 时，它还会等待 durable Request 终态提交。已缓冲
+的 stream 事件仍可继续读取，但不再需要通过 drain 来驱动清理。
 
 如果 durable 终态持久化失败或写入结果未知，`abort()` 会拒绝，并通过 recovery
 fencing 阻止新 Request 启动。

--- a/docs/session.md
+++ b/docs/session.md
@@ -251,6 +251,9 @@ session.send(
 session.stream(options?: StreamOptions): AsyncGenerator<StreamMessage>
 ```
 
+每个 pending request 调用一次 `stream()`，正常情况下应消费到结束；如果消费暂停或
+提前结束，`abort()` 与 `close()` 会自行驱动取消清理，不再依赖调用方 drain。
+
 ### SendOptions
 
 ```ts
@@ -697,8 +700,8 @@ Permission 和输入应用事件，并保证：
 - 独立写入的 Request 终态通过 `causationEventId` 绑定最后一次持久化的
   Request 边界。
 - `tool_result`、`result` 或 `error` 对外可见前已提交终态。
-- pending request 的 `await session.abort()` 返回前已提交
-  `request_interrupted`。
+- pending 与 running request 的 `await session.abort()` 返回前都已提交
+  `request_interrupted`；running abort 还会等待内部执行及模型/工具生命周期清理。
 
 如果 durable 边界提交失败，Session 会 fence 当前 Recorder 并直接拒绝
 stream，不会在 Journal 刷新后伪造普通终态事件；在日志完成对账前，新请求和
@@ -1388,28 +1391,37 @@ await session.close();
 
 调用后：
 
-- 中止正在进行的请求
+- 中止正在进行的请求，并等待请求执行、模型/工具生命周期与 durable 终态收敛
 - 断开所有 MCP 服务器连接
 - 触发 `SessionEnd` Hook
 - Session 永久进入关闭状态，后续 `send()` / `stream()` 会抛出错误
+
+并发调用 `close()` 会共享同一个关闭 Promise，不会让后续调用方在 Runtime
+清理完成前提前返回。
 
 ### abort()
 
 终止当前正在进行的整个请求，不关闭会话。它与 `priority: 'now'` 不同：`abort()` 会取消所有工具，包括 `interruptBehavior: 'block'` 的工具；`now` 只中断当前步骤，并在安全点继续同一请求。
 
 ```ts
-const currentStream = session.stream();
-await session.abort();
-
-// 先排队，当前流完成清理后再消费下一请求
-await session.send('换个思路重新试试', { priority: 'later' });
-for await (const msg of currentStream) {
-  // Drain the aborted request.
-}
 for await (const msg of session.stream()) {
-  if (msg.type === 'content') process.stdout.write(msg.delta);
+  if (msg.type === 'content' && msg.delta.includes('立即停止')) {
+    await session.abort();
+  }
 }
 ```
+
+可以在 stream 消费回调内直接 `await session.abort()`，不会产生死锁。该 Promise
+仅在内部 Agent stream 已关闭、模型和工具生命周期清理完成、durable Request
+终态已提交且请求所有权已释放后返回。已缓冲的 stream 事件仍可继续读取，但不再
+需要通过 drain 来驱动清理。
+
+如果 durable 终态持久化失败或写入结果未知，`abort()` 会拒绝，并通过 recovery
+fencing 阻止新 Request 启动。
+
+JavaScript 边界上的取消是协作式的：自定义 provider 与工具必须监听
+`AbortSignal`，并在 `finally` 中释放资源；否则 Promise 会保持 pending，
+直到该操作自行结束。
 
 ### 管理待处理输入
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -420,6 +420,8 @@ const tool = createTool({
 - `block` 是默认值。工具继续完成，结果落盘后再应用 steering，适合写文件、状态变更和不可撤销的外部调用。
 - `cancel` 仅用于真正监听 `context.signal`、能安全停止并在 `finally` 中释放资源的工具。
 - Session 的显式 `abort()` 和 `close()` 属于请求级终止，不受 `block` 限制。
+  两者都会等待活动工具完成清理，因此自定义工具即使阻止 `now` 转向，也必须监听
+  request `AbortSignal`。
 
 `interruptBehavior` 属于 `createTool()` 的 `ToolConfig`，轻量
 `defineTool()` / `ToolDefinition` 不暴露该字段。需要让 Session 中的自定义

--- a/src/session/Session.ts
+++ b/src/session/Session.ts
@@ -1295,7 +1295,7 @@ class Session implements ISession {
         this.executionState.execution?.releaseBackpressure();
         return {
           alreadyClosed: true,
-          completion: this.executionState.execution?.completion ?? null,
+          execution: this.executionState.execution,
         };
       }
       let execution: SessionStreamExecution | undefined;
@@ -1326,43 +1326,45 @@ class Session implements ISession {
       };
       return {
         alreadyClosed: false,
-        completion: execution?.completion ?? null,
+        execution,
       };
     });
-    if (closeState.alreadyClosed) {
-      if (closeState.completion) {
-        await closeState.completion;
-      }
-      if (recordDurableClose) {
-        await this.closeDurableSession();
-      }
-      return;
-    }
 
     const closeErrors: unknown[] = [];
-    if (closeState.completion) {
+    if (closeState.execution) {
       try {
-        await closeState.completion;
+        await closeState.execution.completion;
       } catch (error) {
         closeErrors.push(error);
       }
+      await this.inputMutex.runExclusive(() => {
+        if (
+          this.executionState.phase === 'closed'
+          && this.executionState.execution === closeState.execution
+        ) {
+          this.executionState = { phase: 'closed' };
+        }
+      });
     }
-    this.cleanupHandle?.unregister();
-    this.cleanupHandle = null;
-    this.agent = null;
-    this.initialized = false;
-    const runtime = this.runtime;
-    this.runtime = null;
-    if (runtime) {
-      try {
-        await runtime.getHookRuntime().runSessionEnd({ reason: 'other' });
-      } catch (error) {
-        closeErrors.push(error);
-      }
-      try {
-        await runtime.close();
-      } catch (error) {
-        closeErrors.push(error);
+
+    if (!closeState.alreadyClosed) {
+      this.cleanupHandle?.unregister();
+      this.cleanupHandle = null;
+      this.agent = null;
+      this.initialized = false;
+      const runtime = this.runtime;
+      this.runtime = null;
+      if (runtime) {
+        try {
+          await runtime.getHookRuntime().runSessionEnd({ reason: 'other' });
+        } catch (error) {
+          closeErrors.push(error);
+        }
+        try {
+          await runtime.close();
+        } catch (error) {
+          closeErrors.push(error);
+        }
       }
     }
     if (recordDurableClose) {
@@ -1372,7 +1374,9 @@ class Session implements ISession {
         closeErrors.push(error);
       }
     }
-    this.logger.debug(`[Session] Closed session ${this.sessionId}`);
+    if (!closeState.alreadyClosed) {
+      this.logger.debug(`[Session] Closed session ${this.sessionId}`);
+    }
     if (closeErrors.length === 1) {
       throw closeErrors[0];
     }

--- a/src/session/Session.ts
+++ b/src/session/Session.ts
@@ -78,6 +78,7 @@ import {
     type SessionState,
     type SessionStore,
 } from './SessionStore.js';
+import { SessionStreamChannel } from './SessionStreamChannel.js';
 import type {
     ForkSessionOptions,
     InputSubmission,
@@ -101,6 +102,12 @@ export interface ResumeOptions extends SessionOptions {
   sessionId: SessionId;
 }
 
+interface SessionStreamExecution {
+  readonly completion: Promise<void>;
+  releaseBackpressure(): void;
+  isSettled(): boolean;
+}
+
 type SessionExecutionState =
   | { phase: 'idle' }
   | {
@@ -119,14 +126,19 @@ type SessionExecutionState =
       requestId: RequestId;
       controller: ActiveRequestController;
       durableRecorder: SessionDurableRecorder | null;
+      execution: SessionStreamExecution;
     }
   | {
       phase: 'stopping';
       requestId: RequestId;
       controller: ActiveRequestController;
       durableRecorder: SessionDurableRecorder | null;
+      execution: SessionStreamExecution;
     }
-  | { phase: 'closed' };
+  | {
+      phase: 'closed';
+      execution?: SessionStreamExecution;
+    };
 
 class Session implements ISession {
   readonly sessionId: SessionId;
@@ -150,6 +162,7 @@ class Session implements ISession {
   private durableJournal: DurableSessionJournal | null = null;
   private durableAcceptedRequest: DurableRequestProjection | null = null;
   private durableClosePromise: Promise<void> | null = null;
+  private closePromise: Promise<void> | null = null;
 
   /**
    * 请求阶段状态机：
@@ -624,7 +637,65 @@ class Session implements ISession {
     });
   }
 
-  async *stream(options?: StreamOptions): AsyncGenerator<StreamMessage> {
+  stream(options?: StreamOptions): AsyncGenerator<StreamMessage> {
+    return this.consumeRequestStream(options);
+  }
+
+  private async *consumeRequestStream(
+    options?: StreamOptions,
+  ): AsyncGenerator<StreamMessage> {
+    const channel = new SessionStreamChannel<StreamMessage>(1);
+    let settled = false;
+    let resolveCompletion!: () => void;
+    let rejectCompletion!: (error: unknown) => void;
+    const completion = new Promise<void>((resolve, reject) => {
+      resolveCompletion = resolve;
+      rejectCompletion = reject;
+    });
+    // A consumer may abandon the stream after starting it. Keep the original
+    // completion Promise awaitable by abort()/close() without an unhandled
+    // rejection before either path observes it.
+    void completion.catch(() => undefined);
+    const execution: SessionStreamExecution = {
+      completion,
+      releaseBackpressure: () => channel.releaseBackpressure(),
+      isSettled: () => settled,
+    };
+    const source = this.executeStream(options, execution);
+
+    void (async () => {
+      try {
+        for await (const event of source) {
+          await channel.publish(event);
+        }
+        settled = true;
+        resolveCompletion();
+        channel.close();
+      } catch (error) {
+        settled = true;
+        rejectCompletion(error);
+        channel.fail(error);
+      }
+    })();
+
+    let consumedToEnd = false;
+    try {
+      for await (const event of channel) {
+        yield event;
+      }
+      consumedToEnd = true;
+    } finally {
+      if (!consumedToEnd && !execution.isSettled()) {
+        execution.releaseBackpressure();
+        await this.abort();
+      }
+    }
+  }
+
+  private async *executeStream(
+    options: StreamOptions | undefined,
+    execution: SessionStreamExecution,
+  ): AsyncGenerator<StreamMessage> {
     await this.ensureInitialized();
     const runtime = this.getRuntime();
 
@@ -674,6 +745,7 @@ class Session implements ISession {
         requestId,
         controller: requestController,
         durableRecorder,
+        execution,
       };
       // 提交执行后立即将初始输入移出收件箱：它已被应用，不再是待处理输入，
       // 且已通过 initialInputId 从 steering 领取中排除。若延后移除，一旦流在
@@ -734,6 +806,13 @@ class Session implements ISession {
       this.rememberTrace(trace);
       await this.notifyTraceSink(trace);
     };
+    const signal = requestController.requestSignal;
+    const releaseBackpressureOnAbort = () => execution.releaseBackpressure();
+    if (signal.aborted) {
+      releaseBackpressureOnAbort();
+    } else {
+      signal.addEventListener('abort', releaseBackpressureOnAbort, { once: true });
+    }
 
     runtime.getHookRuntime().setTraceCollector(traceRecorder);
     try {
@@ -753,15 +832,19 @@ class Session implements ISession {
       const errorMessage =
         terminalError instanceof Error ? terminalError.message : String(terminalError);
       await finishTrace('error', { error: errorMessage });
-      runtime.getHookRuntime().setTraceCollector(undefined);
-      // 初始输入已在进入 running 时移出收件箱；hook 失败时仍需与正常路径一样
-      // 释放请求资源，否则会话会永久停留在 running 且外部 AbortSignal 监听器泄漏。
-      requestController.dispose();
-      await this.finishRequest(requestId);
-      if (durableRecorder && !durableFinishCommitted) {
-        throw terminalError;
+      try {
+        if (durableRecorder && !durableFinishCommitted) {
+          throw terminalError;
+        }
+        yield { type: 'error', message: errorMessage, sessionId: this.sessionId };
+      } finally {
+        runtime.getHookRuntime().setTraceCollector(undefined);
+        signal.removeEventListener('abort', releaseBackpressureOnAbort);
+        // Keep execution ownership until the terminal event is consumed or
+        // cancellation releases output backpressure.
+        requestController.dispose();
+        await this.finishRequest(requestId);
       }
-      yield { type: 'error', message: errorMessage, sessionId: this.sessionId };
       return;
     }
 
@@ -772,8 +855,6 @@ class Session implements ISession {
       totalTokens: 0,
       maxContextTokens: 0,
     };
-
-    const signal = requestController.requestSignal;
 
     const snapshot =
       pendingSnapshot ??
@@ -814,7 +895,14 @@ class Session implements ISession {
       const toolSpans = new Map<string, string>();
 
       while (true) {
-        const { value, done } = await stream.next();
+        const next = await stream.next();
+        if (
+          signal.aborted
+          && (!next.done || next.value.error?.type !== 'aborted')
+        ) {
+          return;
+        }
+        const { value, done } = next;
         if (done) {
           loopResult = value;
           agentStreamCompleted = true;
@@ -1141,10 +1229,22 @@ class Session implements ISession {
           cleanupError = error;
         }
         try {
+          await finishTrace('aborted', {
+            reason: this.getDurableInterruptReason(requestController),
+          });
+        } catch (error) {
+          cleanupError = cleanupError
+            ? new AggregateError(
+                [cleanupError, error],
+                'Agent stream cleanup and trace finalization both failed',
+              )
+            : error;
+        }
+        try {
           if (!durableFinishAttempted) {
             await finishDurableRequest({
               status: 'interrupted',
-              reason: 'user_abort',
+              reason: this.getDurableInterruptReason(requestController),
             });
           }
         } catch (error) {
@@ -1157,6 +1257,7 @@ class Session implements ISession {
         }
       }
       runtime.getHookRuntime().setTraceCollector(undefined);
+      signal.removeEventListener('abort', releaseBackpressureOnAbort);
       requestController.dispose();
       await this.finishRequest(requestId);
       if (this.executionState.phase === 'closed') {
@@ -1168,8 +1269,18 @@ class Session implements ISession {
     }
   }
 
-  async close(): Promise<void> {
-    await this.closeInternal(true);
+  close(): Promise<void> {
+    if (this.closePromise) {
+      return this.closePromise;
+    }
+    const closePromise = this.closeInternal(true);
+    this.closePromise = closePromise;
+    void closePromise.catch(() => {
+      if (this.closePromise === closePromise) {
+        this.closePromise = null;
+      }
+    });
+    return closePromise;
   }
 
   async disposeAfterFork(): Promise<void> {
@@ -1179,13 +1290,17 @@ class Session implements ISession {
   private async closeInternal(recordDurableClose: boolean): Promise<void> {
     // 关闭时对 executionState 的读写走 inputMutex，避免与并发 send()/stream()
     // 交错（例如 send() 在 await 处让出后用 pending 覆盖 closed）。
-    const alreadyClosed = await this.inputMutex.runExclusive(async () => {
+    const closeState = await this.inputMutex.runExclusive(async () => {
       if (this.executionState.phase === 'closed') {
-        return true;
+        this.executionState.execution?.releaseBackpressure();
+        return {
+          alreadyClosed: true,
+          completion: this.executionState.execution?.completion ?? null,
+        };
       }
+      let execution: SessionStreamExecution | undefined;
       if (this.executionState.phase === 'pending') {
         const { controller, input } = this.executionState;
-        controller.abortRequest({ kind: 'session_close' });
         if (recordDurableClose) {
           const durableRecorder = await this.ensureDurableRecorder(this.executionState);
           this.executionState.durableRecorder = durableRecorder;
@@ -1194,6 +1309,7 @@ class Session implements ISession {
             reason: 'session_close',
           });
         }
+        controller.abortRequest({ kind: 'session_close' });
         controller.dispose();
         this.inputInbox.remove(input.inputId);
       } else if (
@@ -1201,15 +1317,35 @@ class Session implements ISession {
         || this.executionState.phase === 'stopping'
       ) {
         this.executionState.controller.abortRequest({ kind: 'session_close' });
+        execution = this.executionState.execution;
+        execution.releaseBackpressure();
       }
-      this.executionState = { phase: 'closed' };
-      return false;
+      this.executionState = {
+        phase: 'closed',
+        ...(execution ? { execution } : {}),
+      };
+      return {
+        alreadyClosed: false,
+        completion: execution?.completion ?? null,
+      };
     });
-    if (alreadyClosed) {
+    if (closeState.alreadyClosed) {
+      if (closeState.completion) {
+        await closeState.completion;
+      }
       if (recordDurableClose) {
         await this.closeDurableSession();
       }
       return;
+    }
+
+    const closeErrors: unknown[] = [];
+    if (closeState.completion) {
+      try {
+        await closeState.completion;
+      } catch (error) {
+        closeErrors.push(error);
+      }
     }
     this.cleanupHandle?.unregister();
     this.cleanupHandle = null;
@@ -1220,48 +1356,72 @@ class Session implements ISession {
     if (runtime) {
       try {
         await runtime.getHookRuntime().runSessionEnd({ reason: 'other' });
-      } finally {
+      } catch (error) {
+        closeErrors.push(error);
+      }
+      try {
         await runtime.close();
+      } catch (error) {
+        closeErrors.push(error);
       }
     }
     if (recordDurableClose) {
-      await this.closeDurableSession();
+      try {
+        await this.closeDurableSession();
+      } catch (error) {
+        closeErrors.push(error);
+      }
     }
     this.logger.debug(`[Session] Closed session ${this.sessionId}`);
+    if (closeErrors.length === 1) {
+      throw closeErrors[0];
+    }
+    if (closeErrors.length > 1) {
+      throw new AggregateError(closeErrors, 'Session close failed in multiple phases');
+    }
   }
 
   async abort(): Promise<void> {
-    if (this.executionState.phase === 'running') {
-      const { requestId, controller, durableRecorder } = this.executionState;
-      controller.abortRequest({ kind: 'user_abort' });
-      this.executionState = {
-        phase: 'stopping',
-        requestId,
-        controller,
-        durableRecorder,
-      };
-    } else if (this.executionState.phase === 'pending') {
-      const pendingState = this.executionState;
-      pendingState.controller.abortRequest({ kind: 'user_abort' });
-      await this.inputMutex.runExclusive(async () => {
-        if (
-          this.executionState.phase !== 'pending'
-          || this.executionState.requestId !== pendingState.requestId
-        ) {
-          return;
-        }
+    const result = await this.inputMutex.runExclusive(async () => {
+      if (this.executionState.phase === 'running') {
+        const {
+          requestId,
+          controller,
+          durableRecorder,
+          execution,
+        } = this.executionState;
+        controller.abortRequest({ kind: 'user_abort' });
+        execution.releaseBackpressure();
+        this.executionState = {
+          phase: 'stopping',
+          requestId,
+          controller,
+          durableRecorder,
+          execution,
+        };
+        return { completion: execution.completion };
+      } else if (this.executionState.phase === 'stopping') {
+        this.executionState.execution.releaseBackpressure();
+        return { completion: this.executionState.execution.completion };
+      } else if (this.executionState.phase === 'pending') {
+        const pendingState = this.executionState;
         const durableRecorder = await this.ensureDurableRecorder(pendingState);
         pendingState.durableRecorder = durableRecorder;
         await durableRecorder?.finish({
           status: 'interrupted',
           reason: 'user_abort',
         });
+        pendingState.controller.abortRequest({ kind: 'user_abort' });
         const { controller, input } = pendingState;
         controller.dispose();
         this.inputInbox.remove(input.inputId);
         this.executionState = { phase: 'idle' };
         this.scheduleNextQueuedInput();
-      });
+      }
+      return { completion: null };
+    });
+    if (result.completion) {
+      await result.completion;
     }
   }
 

--- a/src/session/SessionStreamChannel.ts
+++ b/src/session/SessionStreamChannel.ts
@@ -1,0 +1,149 @@
+/**
+ * Single-consumer channel for decoupling Session execution from stream reads.
+ *
+ * Normal publishing uses two-phase acknowledgement: the producer resumes only
+ * when the consumer asks for the next event. Cancellation can release that
+ * backpressure so cleanup is never blocked by a paused consumer.
+ */
+export class SessionStreamChannel<T> implements AsyncIterable<T> {
+  private readonly buffer: Array<{
+    value: T;
+    acknowledge: () => void;
+  }> = [];
+  private readonly producerWaiters = new Set<() => void>();
+  private readonly acknowledgementWaiters = new Set<() => void>();
+  private consumerWaiter: (() => void) | null = null;
+  private backpressureReleased = false;
+  private closed = false;
+  private failed = false;
+  private error: unknown;
+
+  constructor(private readonly capacity = 1) {
+    if (!Number.isSafeInteger(capacity) || capacity < 1) {
+      throw new RangeError('Session stream channel capacity must be a positive safe integer');
+    }
+  }
+
+  async publish(value: T): Promise<boolean> {
+    while (
+      !this.closed
+      && !this.backpressureReleased
+      && this.buffer.length >= this.capacity
+    ) {
+      await new Promise<void>((resolve) => {
+        this.producerWaiters.add(resolve);
+      });
+    }
+    if (this.closed) {
+      return false;
+    }
+    let acknowledged = false;
+    let acknowledge!: () => void;
+    const acknowledgement = new Promise<void>((resolve) => {
+      acknowledge = () => {
+        if (acknowledged) {
+          return;
+        }
+        acknowledged = true;
+        this.acknowledgementWaiters.delete(acknowledge);
+        resolve();
+      };
+    });
+    this.acknowledgementWaiters.add(acknowledge);
+    this.buffer.push({ value, acknowledge });
+    this.wakeConsumer();
+    if (!this.backpressureReleased) {
+      await acknowledgement;
+    }
+    return true;
+  }
+
+  releaseBackpressure(): void {
+    if (this.backpressureReleased) {
+      return;
+    }
+    this.backpressureReleased = true;
+    this.acknowledgeAll();
+    this.wakeProducers();
+  }
+
+  close(): void {
+    if (this.closed) {
+      return;
+    }
+    this.closed = true;
+    this.acknowledgeAll();
+    this.wakeConsumer();
+    this.wakeProducers();
+  }
+
+  fail(error: unknown): void {
+    if (this.closed) {
+      return;
+    }
+    this.failed = true;
+    this.error = error;
+    this.closed = true;
+    this.acknowledgeAll();
+    this.wakeConsumer();
+    this.wakeProducers();
+  }
+
+  async *[Symbol.asyncIterator](): AsyncIterator<T> {
+    while (true) {
+      while (this.buffer.length > 0) {
+        const item = this.buffer.shift();
+        if (!item) {
+          break;
+        }
+        this.wakeProducers();
+        let advanced = false;
+        try {
+          yield item.value;
+          advanced = true;
+        } finally {
+          if (advanced) {
+            item.acknowledge();
+          }
+        }
+      }
+      if (this.failed) {
+        throw this.error;
+      }
+      if (this.closed) {
+        return;
+      }
+      await new Promise<void>((resolve) => {
+        this.consumerWaiter = resolve;
+        if (this.buffer.length > 0 || this.closed) {
+          this.wakeConsumer();
+        }
+      });
+    }
+  }
+
+  private wakeConsumer(): void {
+    const waiter = this.consumerWaiter;
+    this.consumerWaiter = null;
+    waiter?.();
+  }
+
+  private wakeProducers(): void {
+    if (this.producerWaiters.size === 0) {
+      return;
+    }
+    const waiters = [...this.producerWaiters];
+    this.producerWaiters.clear();
+    for (const waiter of waiters) {
+      waiter();
+    }
+  }
+
+  private acknowledgeAll(): void {
+    const waiters = [...this.acknowledgementWaiters];
+    this.acknowledgementWaiters.clear();
+    for (const waiter of waiters) {
+      waiter();
+    }
+  }
+}

--- a/src/session/__tests__/SessionContext.test.ts
+++ b/src/session/__tests__/SessionContext.test.ts
@@ -550,6 +550,7 @@ describe('Session runtime context', () => {
     controller.abort();
 
     await vi.waitFor(() => expect(innerClosed).toBe(true));
+    await session.abort();
     await expect(session.send('after external abort')).resolves.toMatchObject({
       status: 'started',
     });

--- a/src/session/__tests__/SessionContext.test.ts
+++ b/src/session/__tests__/SessionContext.test.ts
@@ -5,9 +5,9 @@ import { describe, expect, it, vi } from 'vitest';
 import { PersistentStore } from '../../context/storage/PersistentStore.js';
 import type { ContentPart } from '../../services/ChatServiceInterface.js';
 import {
-  InputId,
-  RequestId,
-  SessionId,
+    InputId,
+    RequestId,
+    SessionId,
 } from '../../types/branded.js';
 import { HookEvent } from '../../types/constants.js';
 
@@ -418,7 +418,7 @@ describe('Session runtime context', () => {
     await session.close();
   });
 
-  it('keeps a queued request when an aborted stream finishes cleanup', async () => {
+  it('allows a new request after awaited abort finishes stream cleanup', async () => {
     let requestCount = 0;
     createAgent.mockResolvedValueOnce({
       async *streamChat(
@@ -471,16 +471,93 @@ describe('Session runtime context', () => {
 
     await session.abort();
     await expect(session.send('second')).resolves.toMatchObject({
-      status: 'queued',
-      priority: 'later',
+      status: 'started',
     });
 
     while (!(await stream.next()).done) {
-      // Drain the aborted request so its cleanup can complete.
+      // Drain buffered terminal events from the aborted request.
     }
 
     for await (const _event of session.stream()) {
-      // The queued request must survive cleanup of the aborted stream.
+      // The next request can execute independently of the buffered first stream.
+    }
+    await session.close();
+  });
+
+  it('can await abort from inside stream consumption without deadlocking', async () => {
+    let innerClosed = false;
+    createAgent.mockResolvedValueOnce({
+      async *streamChat(): AsyncGenerator<unknown, unknown, unknown> {
+        try {
+          yield { type: 'turn_start', turn: 1 };
+          return {
+            success: true,
+            finalMessage: 'unexpected',
+            metadata: { turnsCount: 1, toolCallsCount: 0, duration: 0 },
+          };
+        } finally {
+          innerClosed = true;
+        }
+      },
+      async setModel() {},
+    } as never);
+
+    const session = await createSession({
+      provider: { type: 'openai-compatible', apiKey: 'test-key' },
+      model: 'gpt-4o-mini',
+      persistSession: false,
+    });
+    await session.send('abort from consumer');
+
+    for await (const event of session.stream()) {
+      if (event.type === 'turn_start') {
+        await session.abort();
+      }
+    }
+
+    expect(innerClosed).toBe(true);
+    await session.close();
+  });
+
+  it('releases stream backpressure when an external AbortSignal fires', async () => {
+    let innerClosed = false;
+    createAgent.mockResolvedValueOnce({
+      async *streamChat(): AsyncGenerator<unknown, unknown, unknown> {
+        try {
+          yield { type: 'turn_start', turn: 1 };
+          return {
+            success: true,
+            finalMessage: 'unexpected',
+            metadata: { turnsCount: 1, toolCallsCount: 0, duration: 0 },
+          };
+        } finally {
+          innerClosed = true;
+        }
+      },
+      async setModel() {},
+    } as never);
+
+    const session = await createSession({
+      provider: { type: 'openai-compatible', apiKey: 'test-key' },
+      model: 'gpt-4o-mini',
+      persistSession: false,
+    });
+    const controller = new AbortController();
+    await session.send('external abort', { signal: controller.signal });
+    const stream = session.stream();
+    await stream.next();
+
+    controller.abort();
+
+    await vi.waitFor(() => expect(innerClosed).toBe(true));
+    await expect(session.send('after external abort')).resolves.toMatchObject({
+      status: 'started',
+    });
+    for await (const _event of stream) {
+      // Drain buffered terminal output from the aborted request.
+    }
+    for await (const _event of session.stream()) {
+      // Drain the next request.
     }
     await session.close();
   });

--- a/src/session/__tests__/SessionDurableEvents.test.ts
+++ b/src/session/__tests__/SessionDurableEvents.test.ts
@@ -1339,6 +1339,102 @@ describe('Session durable events', () => {
     await session.close();
   });
 
+  it('durably interrupts a running request before abort resolves without stream drain', async () => {
+    const { store } = createStore();
+    let innerClosed = false;
+    let cleanupStarted = false;
+    let releaseCleanup!: () => void;
+    const cleanupGate = new Promise<void>((resolve) => {
+      releaseCleanup = resolve;
+    });
+    streamChat = async function* interruptedByAbort(_message, _context, loopOptions) {
+      let modelRequest: ModelRequestLifecycle | undefined;
+      try {
+        yield { type: 'turn_start', turn: 1, maxTurns: 10 };
+        modelRequest = await loopOptions?.modelExecutionLifecycle?.onModelRequestStarting({
+          turn: 1,
+          model: 'test-model',
+          streaming: true,
+        });
+        yield { type: 'content_delta', delta: 'partial' };
+        return {
+          success: true,
+          finalMessage: 'unexpected',
+          metadata: { turnsCount: 1, toolCallsCount: 0, duration: 1 },
+        };
+      } finally {
+        await modelRequest?.onAborted('request_interrupted');
+        cleanupStarted = true;
+        await cleanupGate;
+        innerClosed = true;
+      }
+    };
+    const session = await createSession(options(store));
+    await session.send('abort while running');
+    const output = session.stream();
+    await output.next();
+    await output.next();
+
+    let abortResolved = false;
+    const abortPromise = session.abort().then(() => {
+      abortResolved = true;
+    });
+    await vi.waitFor(() => expect(cleanupStarted).toBe(true));
+    expect(abortResolved).toBe(false);
+    releaseCleanup();
+    await abortPromise;
+
+    expect(innerClosed).toBe(true);
+    expect(session.getDurableRecoveryPlan()?.action).toBe('none');
+    expect(
+      (await store.read(session.sessionId)).events.map((event) => event.type).slice(-3),
+    ).toEqual([
+      DurableEventType.MODEL_REQUEST_ABORTED,
+      DurableEventType.TURN_ABORTED,
+      DurableEventType.REQUEST_INTERRUPTED,
+    ]);
+    await expect(output.next()).resolves.toEqual({ value: undefined, done: true });
+    await session.close();
+  });
+
+  it('rejects abort when running-request terminal persistence fails', async () => {
+    const { store } = createStore();
+    const failingStore = new FailOnEventTypeStore(
+      store,
+      DurableEventType.REQUEST_INTERRUPTED,
+    );
+    streamChat = async function* interruptedByAbort(_message, context) {
+      yield { type: 'turn_start', turn: 1, maxTurns: 10 };
+      const signal = (context as { signal?: AbortSignal }).signal;
+      await new Promise<void>((resolve) => {
+        if (signal?.aborted) {
+          resolve();
+          return;
+        }
+        signal?.addEventListener('abort', () => resolve(), { once: true });
+      });
+      return {
+        success: false,
+        error: { type: 'aborted', message: 'aborted' },
+        metadata: { turnsCount: 1, toolCallsCount: 0, duration: 1 },
+      };
+    };
+    const session = await createSession(options(failingStore));
+    await session.send('abort with failed persistence');
+    const output = session.stream();
+    await output.next();
+
+    await expect(session.abort()).rejects.toBeInstanceOf(
+      DurableCommandOutcomeUnknownError,
+    );
+
+    expect(session.getDurableRecoveryPlan()?.action).toBe('reconcile_request_outcome');
+    await expect(output.next()).rejects.toBeInstanceOf(
+      DurableCommandOutcomeUnknownError,
+    );
+    await expect(session.close()).resolves.toBeUndefined();
+  });
+
   it('durably interrupts a pending request before cancelling its input', async () => {
     const { store } = createStore();
     const session = await createSession(options(store));
@@ -1416,7 +1512,10 @@ describe('Session durable events', () => {
     const { store } = createStore();
     const session = await createSession(options(store));
 
-    await Promise.all([session.close(), session.close()]);
+    const firstClose = session.close();
+    const secondClose = session.close();
+    expect(firstClose).toBe(secondClose);
+    await Promise.all([firstClose, secondClose]);
 
     expect(
       (await store.read(session.sessionId)).events.filter(
@@ -1427,24 +1526,34 @@ describe('Session durable events', () => {
 
   it('preserves the session-close reason when closing a running request', async () => {
     const { store } = createStore();
+    let cleanupStarted = false;
+    let releaseCleanup!: () => void;
+    const cleanupGate = new Promise<void>((resolve) => {
+      releaseCleanup = resolve;
+    });
     streamChat = async function* interruptedByClose(_message, context) {
-      yield { type: 'turn_start', turn: 1, maxTurns: 10 };
-      const signal = (context as { signal?: AbortSignal }).signal;
-      if (!signal) {
-        throw new Error('Missing request signal');
-      }
-      await new Promise<void>((resolve) => {
-        if (signal.aborted) {
-          resolve();
-          return;
+      try {
+        yield { type: 'turn_start', turn: 1, maxTurns: 10 };
+        const signal = (context as { signal?: AbortSignal }).signal;
+        if (!signal) {
+          throw new Error('Missing request signal');
         }
-        signal.addEventListener('abort', () => resolve(), { once: true });
-      });
-      return {
-        success: false,
-        error: { type: 'aborted', message: 'closed' },
-        metadata: { turnsCount: 1, toolCallsCount: 0, duration: 1 },
-      };
+        await new Promise<void>((resolve) => {
+          if (signal.aborted) {
+            resolve();
+            return;
+          }
+          signal.addEventListener('abort', () => resolve(), { once: true });
+        });
+        return {
+          success: false,
+          error: { type: 'aborted', message: 'closed' },
+          metadata: { turnsCount: 1, toolCallsCount: 0, duration: 1 },
+        };
+      } finally {
+        cleanupStarted = true;
+        await cleanupGate;
+      }
     };
     const session = await createSession(options(store));
     await session.send('close while running');
@@ -1454,16 +1563,23 @@ describe('Session durable events', () => {
       done: false,
     });
 
-    await session.close();
-    for await (const _event of output) {
-      // Drain cleanup after close.
-    }
+    let closeResolved = false;
+    const closePromise = session.close().then(() => {
+      closeResolved = true;
+    });
+    await vi.waitFor(() => expect(cleanupStarted).toBe(true));
+    expect(closeResolved).toBe(false);
+    releaseCleanup();
+    await closePromise;
 
     const events = (await store.read(session.sessionId)).events;
     expect(
       events.find((event) => event.type === DurableEventType.REQUEST_INTERRUPTED)?.data,
     ).toMatchObject({ reason: 'session_close' });
     expect(events.at(-1)?.type).toBe(DurableEventType.SESSION_CLOSED);
+    for await (const _event of output) {
+      // Drain any buffered output after close has completed durably.
+    }
   });
 
   it('accepts a queued later input durably when it becomes the next request', async () => {

--- a/src/session/__tests__/SessionDurableEvents.test.ts
+++ b/src/session/__tests__/SessionDurableEvents.test.ts
@@ -1435,6 +1435,42 @@ describe('Session durable events', () => {
     await expect(session.close()).resolves.toBeUndefined();
   });
 
+  it('allows close retry after running-request terminal persistence fails', async () => {
+    const { store } = createStore();
+    const failingStore = new FailOnEventTypeStore(
+      store,
+      DurableEventType.REQUEST_INTERRUPTED,
+    );
+    streamChat = async function* interruptedByClose(_message, context) {
+      yield { type: 'turn_start', turn: 1, maxTurns: 10 };
+      const signal = (context as { signal?: AbortSignal }).signal;
+      await new Promise<void>((resolve) => {
+        if (signal?.aborted) {
+          resolve();
+          return;
+        }
+        signal?.addEventListener('abort', () => resolve(), { once: true });
+      });
+      return {
+        success: false,
+        error: { type: 'aborted', message: 'closed' },
+        metadata: { turnsCount: 1, toolCallsCount: 0, duration: 1 },
+      };
+    };
+    const session = await createSession(options(failingStore));
+    await session.send('close with failed persistence');
+    const output = session.stream();
+    await output.next();
+
+    await expect(session.close()).rejects.toBeInstanceOf(
+      DurableCommandOutcomeUnknownError,
+    );
+    await expect(session.close()).resolves.toBeUndefined();
+    await expect(output.next()).rejects.toBeInstanceOf(
+      DurableCommandOutcomeUnknownError,
+    );
+  });
+
   it('durably interrupts a pending request before cancelling its input', async () => {
     const { store } = createStore();
     const session = await createSession(options(store));

--- a/src/session/__tests__/SessionSteeringResilience.test.ts
+++ b/src/session/__tests__/SessionSteeringResilience.test.ts
@@ -108,6 +108,30 @@ describe('Session steering resilience', () => {
     await session.close();
   });
 
+  it('closes cleanly when the consumer pauses on a setup-hook error', async () => {
+    const session = await createSession({
+      ...baseOptions(createWorkspaceRoot()),
+      hooks: {
+        [HookEvent.UserPromptSubmit]: [
+          async () => {
+            throw new Error('hook close');
+          },
+        ],
+      },
+    });
+    await session.send('fail before agent stream');
+    const output = session.stream();
+    await expect(output.next()).resolves.toMatchObject({
+      value: { type: 'error', message: 'hook close' },
+      done: false,
+    });
+
+    await session.close();
+
+    expect(session.isClosed).toBe(true);
+    await expect(output.next()).resolves.toEqual({ value: undefined, done: true });
+  });
+
   it('does not double-apply the initial input when the stream throws before the first event', async () => {
     streamChatImpl = async function* throwingStream() {
       // 在产出任何事件之前抛错，模拟 input_applied 已持久化但流随即失败。

--- a/src/session/__tests__/SessionStreamChannel.test.ts
+++ b/src/session/__tests__/SessionStreamChannel.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import { SessionStreamChannel } from '../SessionStreamChannel.js';
+
+describe('SessionStreamChannel', () => {
+  it('preserves event order', async () => {
+    const channel = new SessionStreamChannel<number>(2);
+    const producer = (async () => {
+      await channel.publish(1);
+      await channel.publish(2);
+      channel.close();
+    })();
+
+    const values: number[] = [];
+    for await (const value of channel) {
+      values.push(value);
+    }
+
+    await producer;
+    expect(values).toEqual([1, 2]);
+  });
+
+  it('waits for the consumer to advance before acknowledging an event', async () => {
+    const channel = new SessionStreamChannel<number>(1);
+    let published = false;
+    const publication = channel.publish(1).then(() => {
+      published = true;
+    });
+
+    const iterator = channel[Symbol.asyncIterator]();
+    await expect(iterator.next()).resolves.toEqual({ value: 1, done: false });
+    expect(published).toBe(false);
+
+    const completed = iterator.next();
+    await publication;
+    expect(published).toBe(true);
+    channel.close();
+    await expect(completed).resolves.toEqual({ value: undefined, done: true });
+  });
+
+  it('releases blocked producers during cancellation', async () => {
+    const channel = new SessionStreamChannel<number>(1);
+    let published = false;
+    const publication = channel.publish(1).then(() => {
+      published = true;
+    });
+    const iterator = channel[Symbol.asyncIterator]();
+    await expect(iterator.next()).resolves.toEqual({ value: 1, done: false });
+    expect(published).toBe(false);
+
+    channel.releaseBackpressure();
+    await publication;
+    expect(published).toBe(true);
+
+    channel.close();
+    await expect(iterator.next()).resolves.toEqual({ value: undefined, done: true });
+  });
+
+  it('does not acknowledge an event when the consumer returns early', async () => {
+    const channel = new SessionStreamChannel<number>();
+    let published = false;
+    const publication = channel.publish(1).then(() => {
+      published = true;
+    });
+    const iterator = channel[Symbol.asyncIterator]();
+
+    await expect(iterator.next()).resolves.toEqual({ value: 1, done: false });
+    await iterator.return?.();
+    await Promise.resolve();
+    expect(published).toBe(false);
+
+    channel.releaseBackpressure();
+    await publication;
+    expect(published).toBe(true);
+  });
+
+  it('drains buffered events before propagating producer failure', async () => {
+    const channel = new SessionStreamChannel<number>();
+    const publication = channel.publish(1);
+    channel.fail(new Error('producer failed'));
+    await publication;
+
+    const values: number[] = [];
+    await expect(async () => {
+      for await (const value of channel) {
+        values.push(value);
+      }
+    }).rejects.toThrow('producer failed');
+    expect(values).toEqual([1]);
+  });
+
+  it('rejects invalid capacities', () => {
+    expect(() => new SessionStreamChannel(0)).toThrow(RangeError);
+    expect(() => new SessionStreamChannel(1.5)).toThrow(RangeError);
+  });
+});

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -357,9 +357,9 @@ export interface ISession extends AsyncDisposable {
 
   stream(options?: StreamOptions): AsyncGenerator<StreamMessage>;
 
-  /** Close the Session after active request cleanup and durable finalization settle. */
+  /** Close after active cleanup and durable finalization when durableEventStore is configured. */
   close(): Promise<void>;
-  /** Abort the active request and resolve after cleanup and durable finalization settle. */
+  /** Abort after active cleanup and durable finalization when durableEventStore is configured. */
   abort(): Promise<void>;
 
   getDefaultContext(): RuntimeContext;

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -357,7 +357,9 @@ export interface ISession extends AsyncDisposable {
 
   stream(options?: StreamOptions): AsyncGenerator<StreamMessage>;
 
+  /** Close the Session after active request cleanup and durable finalization settle. */
   close(): Promise<void>;
+  /** Abort the active request and resolve after cleanup and durable finalization settle. */
   abort(): Promise<void>;
 
   getDefaultContext(): RuntimeContext;


### PR DESCRIPTION
## Summary
- decouple internal Request execution from public stream consumption with a bounded two-phase channel
- make `await session.abort()` wait for Agent stream cleanup, model/tool settlement, durable Request finalization, and ownership release
- make `close()` share the same barrier before Runtime/MCP cleanup and deduplicate concurrent close calls
- release output backpressure for explicit abort, close, external AbortSignal, and early consumer return
- preserve normal per-event generator backpressure and fail closed when durable terminal persistence is unknown

## Reference alignment
- Codex owns active turns as internal tasks, waits for graceful cancellation, flushes the interrupted marker, then emits the terminal abort event
- Claude Code keeps cancellation separate from consumer output transport
- Grok repairs cancellation boundaries so incomplete tool-call state does not leak into the next turn

## Verification
- `pnpm run audit:prod`
- `pnpm run lint`
- `pnpm run type-check`
- `pnpm run verify:entrypoints`
- `pnpm run docs:build`
- `pnpm run changelog:check`
- `pnpm test` (1467 passed, 62 credential-gated live tests skipped)
- regression coverage for abort-from-consumer, external signals, early return, delayed cleanup, concurrent close, and durable terminal failure


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `abort()` and `close()` now wait for active requests, model and tool cleanup, and durable finalization before completing.
  * Aborting from within stream consumption no longer risks deadlocks.
  * New requests can start immediately after an awaited abort.
  * Stream cancellation reliably releases backpressure and cleans up abandoned streams.
  * Concurrent `close()` calls share the same completion result.

* **Documentation**
  * Clarified stream consumption, cancellation behavior, cleanup requirements, and durable interruption events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->