### PR TITLE
feat(session): add controlled worker handoff

### DIFF
--- a/.changes/session-worker-handoff.json
+++ b/.changes/session-worker-handoff.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "en": "Add a controlled Session worker handoff barrier that seals background-work admission, settles local execution, preserves the unfinished durable frontier, and returns its recovery plan without closing the durable Session.",
+  "zh-CN": "新增受控 Session worker handoff 屏障：封闭后台工作准入、等待本地执行收敛、保留未完成的 durable frontier，并在不关闭 durable Session 的情况下返回恢复计划。"
+}

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ console.log(result.usage);
 
 - Session lifecycle: `createSession()`, `resumeSession()`, `forkSession()`, and `prompt()`
 - Steerable requests: durable `now`, `next`, and `later` inputs with cancellation and pending-input inspection
-- Durable recovery: cross-process-safe local journaling, safe Request/Turn rollover, explicit model/tool reconciliation, and reconnectable cursors
+- Durable recovery: cross-process-safe local journaling, controlled worker handoff, safe Request/Turn rollover, explicit model/tool reconciliation, and reconnectable cursors
 - Streaming: 17 typed events for turns, content, reasoning, tools, usage, steering, results, and errors
 - Providers: OpenAI, Anthropic, Azure OpenAI, Gemini, DeepSeek, and OpenAI-compatible APIs
 - Tools: generator-only custom tools, capability-grouped built-ins, MCP tools, and typed progress/effects

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -61,7 +61,7 @@ console.log(result.usage);
 
 - Session 生命周期：`createSession()`、`resumeSession()`、`forkSession()`、`prompt()`
 - 可转向请求：持久化的 `now`、`next`、`later` 输入，支持取消和待处理输入查询
-- Durable 恢复：跨进程安全的本地 Journal、Request/Turn rollover、显式模型/工具对账与 cursor 断线续读
+- Durable 恢复：跨进程安全的本地 Journal、受控 worker handoff、Request/Turn rollover、显式模型/工具对账与 cursor 断线续读
 - 流式事件：17 种类型化事件，覆盖轮次、内容、思维、工具、usage、转向、结果和错误
 - Provider：OpenAI、Anthropic、Azure OpenAI、Gemini、DeepSeek 和 OpenAI-compatible API
 - 工具：仅 generator 的自定义工具、按能力分组的内置工具、MCP 工具和类型化进度/副作用

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -58,6 +58,7 @@ Node-local 能力外，这些函数都从根入口导出；实际 subpath 以“
 | `SubagentExecutor` | subagents | 执行单个子 Agent |
 | `JsonlDurableEventStore` | root / local | 支持同机多进程锁的 Node.js durable event JSONL adapter |
 | `SessionInputError` | session | 输入队列容量、请求匹配或活动请求选项错误 |
+| `SessionHandoffError` | session | handoff 配置、生命周期或活动后台工作前置条件错误 |
 | `SdkError` 及派生错误 | root | 类型化 SDK 错误层级 |
 
 ## 常量 / 枚举
@@ -94,6 +95,8 @@ Node-local 能力外，这些函数都从根入口导出；实际 subpath 以“
 | `ForkOptions` | fork 选项 |
 | `ForkSessionOptions` | Session fork 选项 |
 | `ForkSessionResult` | Session fork 结果 |
+| `SessionHandoffResult` | worker handoff 完成后的 journal head 与 recovery plan |
+| `SessionHandoffErrorCode` | worker handoff 的稳定错误码 |
 
 ### Durable Events
 

--- a/docs/durable-events.md
+++ b/docs/durable-events.md
@@ -575,6 +575,23 @@ v3 batch；schema 版本只能单调升级，不能在 v3 后降回 v2，且 v2 
 伪装包含 v3 模型事件。Schema v1 不会被静默推断，需要显式迁移后才能由当前
 runtime 恢复。
 
+### 受控 worker handoff
+
+`session.suspendForHandoff()` 在恢复前提供显式的源 worker 屏障。它会封闭新的
+后台子 Agent 准入，协作取消活动执行，等待模型/工具收敛与 transcript 持久化，
+关闭本地 Runtime，并返回刷新后的 journal head 和 recovery plan。
+
+与 `abort()` 和 `close()` 不同，handoff 会保留未完成的 durable Request/Turn，
+不会写入 `turn_aborted`、`request_interrupted` 或 `session_closed`；尚未收敛的
+模型或工具边界会在方法返回前按保守语义完成记录。继任 worker 必须先按返回的
+plan 调用 `DurableSessionRecoveryCoordinator`，只在 plan 允许后调用
+`resumeSession()`。
+
+仍有后台子 Agent 或归属该 Session 的后台 shell 运行时，该屏障会在取消主
+Request 前拒绝；同时要求 durable journal 与 transcript storage 都已配置。
+handoff 只协调已知的源 worker 和继任 worker，不替代跨主机 execution lease
+或 fencing token。
+
 ## JSONL 持久化
 
 文件位于：

--- a/docs/en/api-reference.md
+++ b/docs/en/api-reference.md
@@ -33,9 +33,14 @@ Types:
 `ForkSessionResult`, `HookCallback`, `HookInput`, `HookOutput`,
 `InputSubmission`, `ISession`, `McpServerStatus`, `McpToolInfo`, `ModelInfo`,
 `PendingSessionInput`, `PromptResult`, `ProviderConfig`, `ProviderType`,
-`ResumeOptions`, `SendOptions`, `SessionOptions`, `SessionTool`, `StreamMessage`,
+`ResumeOptions`, `SendOptions`, `SessionHandoffErrorCode`,
+`SessionHandoffResult`, `SessionOptions`, `SessionTool`, `StreamMessage`,
 `StreamOptions`, `SubagentInfo`, `TokenUsage`, `ToolCallRecord`,
 `ToolDefinition`, and `ToolResult`.
+
+Errors:
+
+- `SessionHandoffError`
 
 Constants:
 

--- a/docs/en/durable-events.md
+++ b/docs/en/durable-events.md
@@ -617,6 +617,27 @@ versions may only increase: a v2 batch after v3 is corrupt, and a v2 batch
 cannot masquerade as containing v3 model events. Version 1 logs are not
 inferred silently and must be migrated before this runtime can resume them.
 
+### Controlled worker handoff
+
+`session.suspendForHandoff()` provides an explicit source-worker barrier before
+recovery. It seals new background-subagent admission, cooperatively cancels the
+active execution, waits for model/tool settlement and transcript persistence,
+closes local runtime resources, and returns the refreshed journal head and
+recovery plan.
+
+Unlike `abort()` and `close()`, handoff preserves an unfinished durable
+Request/Turn. It does not write `turn_aborted`, `request_interrupted`, or
+`session_closed`; any unfinished model or tool boundary is finalized
+conservatively before the result is returned. The replacement worker must use
+the returned plan with `DurableSessionRecoveryCoordinator` and only call
+`resumeSession()` once the plan permits it.
+
+The barrier rejects before cancelling the root Request if any background
+subagent or Session-owned background shell remains active. It also requires
+both the durable journal and transcript storage. Handoff coordinates a known
+source and successor; it does not replace a cross-host execution lease or
+fencing token.
+
 ## JSONL persistence
 
 Files are stored under:

--- a/docs/en/session.md
+++ b/docs/en/session.md
@@ -219,6 +219,45 @@ for await (const event of session.stream()) {
 
 Request failures are normally represented by stream events rather than thrown from the iteration body.
 
+## Hand off to another worker
+
+Use `suspendForHandoff()` during a controlled worker replacement:
+
+```ts
+const handoff = await session.suspendForHandoff();
+console.log(handoff.headSequence, handoff.recoveryPlan.action);
+
+interface SessionHandoffResult {
+  sessionId: SessionId;
+  headSequence: EventSequence;
+  recoveryPlan: DurableSessionRecoveryPlan;
+}
+```
+
+The method requires both `storagePath` and `durableEventStore`. It immediately
+rejects new Session operations, seals background subagent and shell admission,
+cancels local execution, waits for model/tool cleanup and transcript writes,
+then closes local runtime resources. It deliberately does not commit
+`turn_aborted`, `request_interrupted`, or `session_closed`.
+
+The returned recovery plan describes the exact durable frontier observed after
+the old worker stopped. `resume_request` can be passed directly to
+`resumeSession()`. Other actions must first be handled through
+`DurableSessionRecoveryCoordinator`; for example, `resume_turn` requires
+`prepareTurnRecovery()` before the replacement calls `resumeSession()`.
+
+Handoff fails before cancelling the root Request while a background subagent or
+Session-owned background shell is still running. Wait for or terminate that
+work, then retry. A rejected handoff after cancellation has begun leaves the
+local Session closed and must be recovered from the durable journal.
+`SessionHandoffError` exposes stable `code`, `activeSubagentIds`, and
+`activeShellIds` fields for orchestration.
+
+This API is a cooperative shutdown barrier, not a cross-host lease. Stop routing
+new work to the old worker before calling it, and use a transactional
+`DurableEventStore` with fencing when multiple hosts can execute the same
+Session.
+
 ## One-shot prompts
 
 ```ts
@@ -596,6 +635,7 @@ interface ISession extends AsyncDisposable {
   cancelInput(inputId: InputId): Promise<boolean>;
 
   abort(): Promise<void>;
+  suspendForHandoff(): Promise<SessionHandoffResult>;
   close(): Promise<void>;
   fork(options?: ForkSessionOptions): Promise<ISession>;
 

--- a/docs/session.md
+++ b/docs/session.md
@@ -1424,6 +1424,41 @@ JavaScript 边界上的取消是协作式的：自定义 provider 与工具必�
 `AbortSignal`，并在 `finally` 中释放资源；否则 Promise 会保持 pending，
 直到该操作自行结束。
 
+### suspendForHandoff()
+
+滚动部署或 worker 替换时，使用 `suspendForHandoff()` 停止当前本地执行：
+
+```ts
+const handoff = await session.suspendForHandoff();
+console.log(handoff.headSequence, handoff.recoveryPlan.action);
+
+interface SessionHandoffResult {
+  sessionId: SessionId;
+  headSequence: EventSequence;
+  recoveryPlan: DurableSessionRecoveryPlan;
+}
+```
+
+该方法要求同时配置 `storagePath` 和 `durableEventStore`。调用后会立即拒绝新的
+Session 操作，封闭后台子 Agent 与 shell 准入，取消本地执行，等待模型/工具
+清理和 transcript 写入完成，再关闭本地 Runtime。它刻意不提交 `turn_aborted`、
+`request_interrupted` 或 `session_closed`。
+
+返回的 recovery plan 对应旧 worker 停止后的精确 durable frontier。
+`resume_request` 可直接交给 `resumeSession()`；其他 action 必须先通过
+`DurableSessionRecoveryCoordinator` 处理。例如，`resume_turn` 需要先调用
+`prepareTurnRecovery()`，继任 worker 再调用 `resumeSession()`。
+
+仍有后台子 Agent 或归属该 Session 的后台 shell 运行时，handoff 会在取消主
+Request 前失败；应先等待或终止这些后台工作后重试。如果取消已经开始后 handoff
+失败，本地 Session 会保持关闭，调用方必须从 durable journal 恢复。
+`SessionHandoffError` 提供稳定的 `code`、`activeSubagentIds` 和
+`activeShellIds` 字段供调度层处理。
+
+该 API 是协作式 shutdown barrier，不是跨主机 lease。调用前必须停止向旧 worker
+路由新工作；多主机可能同时执行同一 Session 时，`DurableEventStore` 仍须提供
+transactional CAS 与 fencing。
+
 ### 管理待处理输入
 
 ```ts
@@ -1751,6 +1786,9 @@ interface ISession extends AsyncDisposable {
   /** 中止当前正在进行的请求 */
   abort(): Promise<void>;
 
+  /** 停止本地执行并保留 durable frontier，供继任 worker 恢复 */
+  suspendForHandoff(): Promise<SessionHandoffResult>;
+
   /** 获取当前默认运行时上下文 */
   getDefaultContext(): RuntimeContext;
 
@@ -1846,6 +1884,8 @@ export type {
   ForkSessionResult,
   ForkOptions,
   ResumeOptions,
+  SessionHandoffResult,
+  SessionHandoffErrorCode,
   ModelInfo,
   McpServerStatus,
   McpToolInfo,
@@ -1869,6 +1909,9 @@ export type {
   PermissionUpdate,
   AgentLogger,
 };
+
+// 错误
+export { SessionHandoffError };
 
 // 常量枚举
 export {

--- a/src/__tests__/rootExports.test.ts
+++ b/src/__tests__/rootExports.test.ts
@@ -28,6 +28,8 @@ import type {
   ISession,
   PendingSessionInput,
   RuntimePatch,
+  SessionHandoffErrorCode,
+  SessionHandoffResult,
   SessionOptions,
   SessionTool,
   ToolCatalogEntry,
@@ -73,6 +75,7 @@ import {
   JsonlDurableEventStore,
   MemoryManager,
   ModelAttemptId,
+  SessionHandoffError,
   PermissionRequestId,
   projectDurableSession,
   RequestId,
@@ -220,6 +223,16 @@ describe('root exports', () => {
       DurableEventStore | undefined
     >();
     expectTypeOf<ReturnType<ISession['abort']>>().toEqualTypeOf<Promise<void>>();
+    expectTypeOf<ReturnType<ISession['suspendForHandoff']>>().toEqualTypeOf<
+      Promise<SessionHandoffResult>
+    >();
+    expectTypeOf<SessionHandoffResult['headSequence']>().toEqualTypeOf<EventSequence>();
+    expectTypeOf<SessionHandoffErrorCode>().toEqualTypeOf<
+      | 'SESSION_HANDOFF_NOT_CONFIGURED'
+      | 'SESSION_HANDOFF_ACTIVE_WORK'
+      | 'SESSION_HANDOFF_UNAVAILABLE'
+    >();
+    expect(SessionHandoffError).toBeDefined();
     expectTypeOf<ReturnType<ISession['subscribeDurableEvents']>>().toEqualTypeOf<
       Promise<DurableEventSubscription>
     >();

--- a/src/agent/subagents/BackgroundAgentManager.ts
+++ b/src/agent/subagents/BackgroundAgentManager.ts
@@ -14,7 +14,7 @@ import { join } from 'node:path';
 import { type InternalLogger, LogCategory, NOOP_LOGGER } from '../../logging/Logger.js';
 import type { ContextSnapshot } from '../../runtime/index.js';
 import type { Message } from '../../services/ChatServiceInterface.js';
-import { AgentId } from '../../types/branded.js';
+import { AgentId, type SessionId } from '../../types/branded.js';
 import type { BladeConfig, PermissionMode } from '../../types/common.js';
 import type {
   AgentSession,
@@ -90,11 +90,16 @@ export class BackgroundAgentManager {
 
   // 运行中的 agent
   private runningAgents = new Map<AgentId, BackgroundAgentRuntime>();
+  private acceptingNewAgents = true;
 
   // 会话存储（支持注入，不再硬依赖全局 singleton）
   private sessionStore: AgentSessionStore;
 
-  constructor(sessionStore: AgentSessionStore, logger?: InternalLogger) {
+  constructor(
+    sessionStore: AgentSessionStore,
+    logger?: InternalLogger,
+    private readonly ownerSessionId?: SessionId,
+  ) {
     this.sessionStore = sessionStore;
     if (logger) {
       this.logger = logger.child(LogCategory.AGENT);
@@ -109,8 +114,12 @@ export class BackgroundAgentManager {
    * 每个 SessionRuntime 应该创建自己的 BackgroundAgentManager 实例，
    * 各自持有独立的 sessionStore，避免同进程多 runtime 共享状态。
    */
-  static create(logger: InternalLogger, sessionStore: AgentSessionStore): BackgroundAgentManager {
-    return new BackgroundAgentManager(sessionStore, logger);
+  static create(
+    logger: InternalLogger,
+    sessionStore: AgentSessionStore,
+    ownerSessionId?: SessionId,
+  ): BackgroundAgentManager {
+    return new BackgroundAgentManager(sessionStore, logger, ownerSessionId);
   }
 
   setLogger(logger: InternalLogger): void {
@@ -148,6 +157,10 @@ export class BackgroundAgentManager {
    * @returns agent ID
    */
   startBackgroundAgent(options: StartBackgroundAgentOptions): string {
+    if (!this.acceptingNewAgents) {
+      throw new Error('Background agent admission is closed for Session handoff');
+    }
+
     const {
       config,
       bladeConfig,
@@ -266,6 +279,7 @@ export class BackgroundAgentManager {
         snapshot,
         messages,
         signal: workSignal,
+        backgroundAgentManager: this,
         onProgress: (progress) => {
           this.sessionStore.updateRunningSession(agentId, { progress });
         },
@@ -563,6 +577,19 @@ export class BackgroundAgentManager {
    */
   getRunningCount(): number {
     return this.runningAgents.size;
+  }
+
+  getOwnerSessionId(): SessionId | undefined {
+    return this.ownerSessionId;
+  }
+
+  getActiveAgentIds(): readonly AgentId[] {
+    return [...this.runningAgents.keys()];
+  }
+
+  /** Prevents new background-agent work from starting in this runtime. */
+  sealForHandoff(): void {
+    this.acceptingNewAgents = false;
   }
 
   /**

--- a/src/agent/subagents/SubagentExecutor.ts
+++ b/src/agent/subagents/SubagentExecutor.ts
@@ -1,5 +1,6 @@
 import { nanoid } from 'nanoid';
 import type { BladeConfig } from '../../types/common.js';
+import type { BackgroundAgentManager } from './BackgroundAgentManager.js';
 import type { SubagentRegistry } from './SubagentRegistry.js';
 import type { SubagentConfig, SubagentContext, SubagentResult } from './types.js';
 import { runSubagent } from './runSubagent.js';
@@ -18,6 +19,7 @@ export class SubagentExecutor {
     private config: SubagentConfig,
     private bladeConfig: BladeConfig,
     private readonly subagentRegistry?: SubagentRegistry,
+    private readonly backgroundAgentManager?: BackgroundAgentManager,
   ) {}
 
   /**
@@ -34,6 +36,7 @@ export class SubagentExecutor {
         config: this.config,
         bladeConfig: this.bladeConfig,
         subagentRegistry: this.subagentRegistry,
+        backgroundAgentManager: this.backgroundAgentManager,
         prompt: context.prompt,
         agentId,
         parentSessionId: context.parentSessionId,

--- a/src/agent/subagents/__tests__/BackgroundAgentManager.test.ts
+++ b/src/agent/subagents/__tests__/BackgroundAgentManager.test.ts
@@ -98,6 +98,7 @@ describe('BackgroundAgentManager', () => {
       expect.anything(),
       expect.anything(),
       expect.objectContaining({
+        backgroundAgentManager: manager,
         defaultContext: snapshot.context,
       }),
     );
@@ -209,5 +210,50 @@ describe('BackgroundAgentManager', () => {
 
     const session = await manager.waitForCompletion(agentId, 1000);
     expect(session?.status).toBe('cancelled');
+  });
+
+  it('seals new admissions only after all background agents settle', async () => {
+    runAgenticLoop.mockImplementationOnce(
+      async (
+        _message: string,
+        _context: ChatContext,
+        options?: LoopOptions,
+      ) =>
+        await new Promise((resolve) => {
+          options?.signal?.addEventListener(
+            'abort',
+            () =>
+              resolve({
+                success: false,
+                error: { message: 'aborted' },
+                metadata: { duration: 0 },
+              }),
+            { once: true },
+          );
+        }),
+    );
+
+    const agentId = AgentId(manager.startBackgroundAgent({
+      config: subagentConfig,
+      bladeConfig,
+      description: 'Handoff blocker',
+      prompt: 'inspect',
+    }));
+
+    expect(manager.getActiveAgentIds()).toEqual([agentId]);
+    await vi.waitFor(() => expect(runAgenticLoop).toHaveBeenCalled());
+    expect(manager.killAgent(agentId)).toBe(true);
+    await manager.waitForCompletion(agentId, 1000);
+
+    expect(manager.getActiveAgentIds()).toEqual([]);
+    manager.sealForHandoff();
+    expect(() =>
+      manager.startBackgroundAgent({
+        config: subagentConfig,
+        bladeConfig,
+        description: 'Rejected after handoff seal',
+        prompt: 'inspect',
+      }),
+    ).toThrow('Background agent admission is closed for Session handoff');
   });
 });

--- a/src/agent/subagents/runSubagent.ts
+++ b/src/agent/subagents/runSubagent.ts
@@ -4,6 +4,7 @@ import type { ContextSnapshot } from '../../runtime/index.js';
 import type { Message } from '../../services/ChatServiceInterface.js';
 import { Agent } from '../Agent.js';
 import type { AgentProgress, LoopResult } from '../types.js';
+import type { BackgroundAgentManager } from './BackgroundAgentManager.js';
 import type { SubagentRegistry } from './SubagentRegistry.js';
 import type { SubagentConfig } from './types.js';
 
@@ -18,6 +19,7 @@ export interface RunSubagentOptions {
   snapshot?: ContextSnapshot;
   messages?: Message[];
   signal?: AbortSignal;
+  backgroundAgentManager?: BackgroundAgentManager;
   omitEnvironment?: boolean;
   onProgress?: (progress: AgentProgress) => void;
 }
@@ -45,6 +47,7 @@ export async function runSubagent(options: RunSubagentOptions): Promise<LoopResu
     snapshot,
     messages,
     signal,
+    backgroundAgentManager,
     omitEnvironment,
     onProgress,
   } = options;
@@ -57,6 +60,7 @@ export async function runSubagent(options: RunSubagentOptions): Promise<LoopResu
     },
     {
       subagentRegistry,
+      backgroundAgentManager,
       defaultContext: snapshot ? snapshot.context : {},
     },
   );

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -50,6 +50,7 @@ export interface AgentProgress {
 
 export interface IBackgroundAgentReader {
   getAgent(agentId: AgentId): AgentSession | undefined;
+  getOwnerSessionId?(): SessionId | undefined;
   isRunning(agentId: AgentId): boolean;
   waitForCompletion(agentId: AgentId, timeout?: number): Promise<AgentSession | undefined>;
 }

--- a/src/errors/SessionHandoffError.ts
+++ b/src/errors/SessionHandoffError.ts
@@ -1,0 +1,26 @@
+import type { AgentId } from '../types/branded.js';
+import { SdkError } from './SdkError.js';
+
+export type SessionHandoffErrorCode =
+  | 'SESSION_HANDOFF_NOT_CONFIGURED'
+  | 'SESSION_HANDOFF_ACTIVE_WORK'
+  | 'SESSION_HANDOFF_UNAVAILABLE';
+
+export class SessionHandoffError extends SdkError {
+  readonly activeSubagentIds: readonly AgentId[];
+  readonly activeShellIds: readonly string[];
+
+  constructor(
+    code: SessionHandoffErrorCode,
+    message: string,
+    options: {
+      activeSubagentIds?: readonly AgentId[];
+      activeShellIds?: readonly string[];
+      cause?: unknown;
+    } = {},
+  ) {
+    super(code, message, options.cause !== undefined ? { cause: options.cause } : undefined);
+    this.activeSubagentIds = [...(options.activeSubagentIds ?? [])];
+    this.activeShellIds = [...(options.activeShellIds ?? [])];
+  }
+}

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,6 +1,8 @@
 export { AbortError } from './AbortError.js';
 export { ConfigError } from './ConfigError.js';
 export { PermissionDeniedError } from './PermissionDeniedError.js';
+export type { SessionHandoffErrorCode } from './SessionHandoffError.js';
+export { SessionHandoffError } from './SessionHandoffError.js';
 export type { SessionInputErrorCode } from './SessionInputError.js';
 export { SessionInputError } from './SessionInputError.js';
 export type { SdkErrorOptions } from './SdkError.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,13 +10,18 @@ export type {
   SubagentSource,
 } from './agent/subagents/types.js';
 export type { TokenBudgetConfig, TokenBudgetSnapshot } from './agent/TokenBudget.js';
-export type { SdkErrorOptions, SessionInputErrorCode } from './errors/index.js';
+export type {
+  SdkErrorOptions,
+  SessionHandoffErrorCode,
+  SessionInputErrorCode,
+} from './errors/index.js';
 // --- Error hierarchy ---
 export {
   AbortError,
   ConfigError,
   PermissionDeniedError,
   SdkError,
+  SessionHandoffError,
   SessionInputError,
   ToolExecutionError,
 } from './errors/index.js';
@@ -143,6 +148,7 @@ export type {
   ProviderType,
   ResumeOptions,
   SendOptions,
+  SessionHandoffResult,
   SessionOptions,
   SessionTool,
   StreamMessage,

--- a/src/session/ActiveRequestController.ts
+++ b/src/session/ActiveRequestController.ts
@@ -10,6 +10,7 @@ import type { SessionInputInbox } from './SessionInputInbox.js';
 export type RequestAbortReason =
   | { kind: 'user_abort' }
   | { kind: 'session_close' }
+  | { kind: 'session_handoff' }
   | { kind: 'external_abort'; cause?: unknown };
 
 export class ActiveRequestController implements AgentRunControl {

--- a/src/session/Session.ts
+++ b/src/session/Session.ts
@@ -1945,7 +1945,13 @@ class Session implements ISession {
     controller: ActiveRequestController,
   ): DurableRequestInterruptReason {
     const reason = controller.requestSignal.reason as RequestAbortReason | undefined;
-    return reason?.kind === 'session_close' ? 'session_close' : 'user_abort';
+    if (reason?.kind === 'session_close') {
+      return 'session_close';
+    }
+    if (reason?.kind === 'session_handoff') {
+      return 'process_restart';
+    }
+    return 'user_abort';
   }
 
   private async finishRequest(requestId: RequestId): Promise<void> {

--- a/src/session/Session.ts
+++ b/src/session/Session.ts
@@ -2,99 +2,102 @@ import { Mutex } from 'async-mutex';
 import { nanoid } from 'nanoid';
 import { Agent } from '../agent/Agent.js';
 import {
-    type InitialInputPreparation,
-    RECONCILED_INITIAL_INPUT,
+  type InitialInputPreparation,
+  RECONCILED_INITIAL_INPUT,
 } from '../agent/InitialInputPreparation.js';
 import type {
-    ChatContext,
-    LoopResult,
-    UserMessageContent,
+  ChatContext,
+  LoopResult,
+  UserMessageContent,
 } from '../agent/types.js';
+import { SessionHandoffError } from '../errors/SessionHandoffError.js';
 import { SessionInputError } from '../errors/SessionInputError.js';
 import { type CleanupHandle, registerCleanup } from '../lifecycle/CleanupRegistry.js';
 import { createRootLogger, type InternalLogger, LogCategory } from '../logging/Logger.js';
 import { type AgentTrace, TraceRecorder } from '../observability/index.js';
 import {
-    type ContextSnapshot,
-    createContextSnapshot,
-    type RuntimeContext,
+  type ContextSnapshot,
+  createContextSnapshot,
+  type RuntimeContext,
 } from '../runtime/index.js';
 import type { ContentPart, Message } from '../services/ChatServiceInterface.js';
 import { cloneMessage } from '../services/messageUtils.js';
 import {
-    CommandId,
-    InputId,
-    RequestId,
-    SessionId,
+  CommandId,
+  type EventSequence,
+  InputId,
+  RequestId,
+  SessionId,
 } from '../types/branded.js';
 import {
-    type BladeConfig,
-    type JsonObject,
-    type JsonValue,
-    type ModelConfig,
-    PermissionMode,
-    type ProviderType,
+  type BladeConfig,
+  type JsonObject,
+  type JsonValue,
+  type ModelConfig,
+  PermissionMode,
+  type ProviderType,
 } from '../types/common.js';
 import {
-    ActiveRequestController,
-    type RequestAbortReason,
+  ActiveRequestController,
+  type RequestAbortReason,
 } from './ActiveRequestController.js';
 import {
-    parseDurableRuntimeContext,
-    parseDurableUserMessageContent,
-    serializeDurableRuntimeContext,
+  parseDurableRuntimeContext,
+  parseDurableUserMessageContent,
+  serializeDurableRuntimeContext,
 } from './DurableRequestRecovery.js';
 import {
-    DurableEventSubscription,
-    DurableEventSubscriptionError,
-    type DurableEventSubscriptionOptions,
+  DurableEventSubscription,
+  DurableEventSubscriptionError,
+  type DurableEventSubscriptionOptions,
 } from './events/DurableEventSubscription.js';
 import { DurableSessionJournal } from './events/DurableSessionJournal.js';
 import type {
-    DurableRequestProjection,
-    DurableSessionProjection,
-    DurableSessionRecoveryPlan,
+  DurableRequestProjection,
+  DurableSessionProjection,
+  DurableSessionRecoveryPlan,
 } from './events/DurableSessionProjector.js';
 import { DurableSessionRecoveryCoordinator } from './events/DurableSessionRecoveryCoordinator.js';
 import {
-    type DurableRequestFinish,
-    durableRequestFinishFromLoopResult,
-    DurableSessionRecoveryRequiredError,
-    SessionDurableRecorder,
-    SessionDurableRecorderError
+  type DurableRequestFinish,
+  durableRequestFinishFromLoopResult,
+  DurableSessionRecoveryRequiredError,
+  SessionDurableRecorder,
+  SessionDurableRecorderError
 } from './events/SessionDurableRecorder.js';
 import {
-    DurableEventType,
-    type DurableRequestInterruptReason,
+  DurableEventType,
+  type DurableRequestInterruptReason,
 } from './events/types.js';
 import {
-    SessionInputInbox,
+  SessionInputInbox,
 } from './SessionInputInbox.js';
 import { SessionRuntime } from './SessionRuntime.js';
 import {
-    JsonlSessionStore,
-    NoopSessionStore,
-    type SessionSnapshot,
-    type SessionState,
-    type SessionStore,
+  JsonlSessionStore,
+  NoopSessionStore,
+  type SessionSnapshot,
+  type SessionState,
+  type SessionStore,
 } from './SessionStore.js';
 import { SessionStreamChannel } from './SessionStreamChannel.js';
 import type {
-    ForkSessionOptions,
-    InputSubmission,
-    ISession,
-    McpServerStatus,
-    McpToolInfo,
-    ModelInfo,
-    PendingSessionInput,
-    PromptResult,
-    ProviderConfig,
-    SendOptions,
-    SessionOptions,
-    StreamMessage,
-    StreamOptions,
-    TokenUsage,
-    ToolCallRecord,
+  ForkSessionOptions,
+  InputSubmission,
+  ISession,
+  McpServerStatus,
+  McpToolInfo,
+  ModelInfo,
+  PendingSessionInput,
+  PromptResult,
+  ProviderConfig,
+  SendOptions,
+  SessionHandoffResult,
+  SessionOptions,
+  StreamMessage,
+  StreamOptions,
+  TokenUsage,
+  ToolCallRecord,
 } from './types.js';
 import { InputPriority } from './types.js';
 
@@ -104,6 +107,7 @@ export interface ResumeOptions extends SessionOptions {
 
 interface SessionStreamExecution {
   readonly completion: Promise<void>;
+  readonly startedBeforeHandoff: boolean;
   releaseBackpressure(): void;
   isSettled(): boolean;
 }
@@ -136,7 +140,15 @@ type SessionExecutionState =
       execution: SessionStreamExecution;
     }
   | {
+      phase: 'suspending';
+      requestId: RequestId;
+      controller: ActiveRequestController;
+      durableRecorder: SessionDurableRecorder;
+      execution: SessionStreamExecution;
+    }
+  | {
       phase: 'closed';
+      disposition: 'terminal' | 'detached';
       execution?: SessionStreamExecution;
     };
 
@@ -159,10 +171,13 @@ class Session implements ISession {
   private readonly traces: AgentTrace[] = [];
   private readonly inputInbox = new SessionInputInbox();
   private readonly inputMutex = new Mutex();
+  private readonly streamExecutions = new Set<SessionStreamExecution>();
   private durableJournal: DurableSessionJournal | null = null;
   private durableAcceptedRequest: DurableRequestProjection | null = null;
   private durableClosePromise: Promise<void> | null = null;
   private closePromise: Promise<void> | null = null;
+  private handoffPromise: Promise<SessionHandoffResult> | null = null;
+  private handoffRequested = false;
 
   /**
    * 请求阶段状态机：
@@ -170,7 +185,8 @@ class Session implements ISession {
    * - pending: send() 已调用，等待 stream() 消费
    * - running: stream() 正在执行
    * - stopping: 已请求中止，等待 stream() 完成清理
-   * - closed: 会话已关闭
+   * - suspending: 正在停止本地执行并保留 durable 恢复边界
+   * - closed: 本地会话已关闭
    *
    * 防止在 streaming 期间再次调用 send() 产生并发 generator 竞态。
    */
@@ -205,7 +221,11 @@ class Session implements ISession {
   }
 
   get isClosed(): boolean {
-    return this.executionState.phase === 'closed';
+    return (
+      this.handoffRequested
+      || this.executionState.phase === 'suspending'
+      || this.executionState.phase === 'closed'
+    );
   }
 
   getDefaultContext(): RuntimeContext {
@@ -248,7 +268,10 @@ class Session implements ISession {
   }
 
   async initialize(): Promise<void> {
-    if (this.executionState.phase === 'closed') {
+    if (
+      this.executionState.phase === 'suspending'
+      || this.executionState.phase === 'closed'
+    ) {
       throw new Error('Session is closed');
     }
     if (this.initialized) return;
@@ -437,7 +460,10 @@ class Session implements ISession {
     await this.ensureInitialized();
 
     return this.inputMutex.runExclusive(async () => {
-      if (this.executionState.phase === 'closed') {
+      if (
+        this.executionState.phase === 'suspending'
+        || this.executionState.phase === 'closed'
+      ) {
         throw new Error('Session is closed');
       }
 
@@ -582,6 +608,12 @@ class Session implements ISession {
     await this.ensureInitialized();
     return this.inputMutex.runExclusive(async () => {
       if (
+        this.executionState.phase === 'suspending'
+        || this.executionState.phase === 'closed'
+      ) {
+        throw new Error('Session is closed');
+      }
+      if (
         (this.executionState.phase === 'running'
           || this.executionState.phase === 'stopping')
         && this.executionState.controller.isInitialInput(inputId)
@@ -658,9 +690,15 @@ class Session implements ISession {
     void completion.catch(() => undefined);
     const execution: SessionStreamExecution = {
       completion,
+      startedBeforeHandoff: !this.handoffRequested,
       releaseBackpressure: () => channel.releaseBackpressure(),
       isSettled: () => settled,
     };
+    this.streamExecutions.add(execution);
+    void completion.then(
+      () => this.streamExecutions.delete(execution),
+      () => this.streamExecutions.delete(execution),
+    );
     const source = this.executeStream(options, execution);
 
     void (async () => {
@@ -696,7 +734,14 @@ class Session implements ISession {
     options: StreamOptions | undefined,
     execution: SessionStreamExecution,
   ): AsyncGenerator<StreamMessage> {
-    await this.ensureInitialized();
+    try {
+      await this.ensureInitialized();
+    } catch (error) {
+      if (execution.startedBeforeHandoff && this.handoffRequested) {
+        return;
+      }
+      throw error;
+    }
     const runtime = this.getRuntime();
 
     // 声明请求所有权必须原子：相位检查、pending→running 转换与初始输入移除
@@ -765,6 +810,9 @@ class Session implements ISession {
     });
 
     if (!claimed) {
+      if (execution.startedBeforeHandoff && this.handoffRequested) {
+        return;
+      }
       throw new Error('No pending message. Call send() before stream().');
     }
 
@@ -807,6 +855,8 @@ class Session implements ISession {
       await this.notifyTraceSink(trace);
     };
     const signal = requestController.requestSignal;
+    const isHandoffRequested = () =>
+      durableRecorder?.isHandoffRequested() === true;
     const releaseBackpressureOnAbort = () => execution.releaseBackpressure();
     if (signal.aborted) {
       releaseBackpressureOnAbort();
@@ -820,19 +870,27 @@ class Session implements ISession {
         message = await runtime.getHookRuntime().applyUserPromptSubmit(message);
       }
     } catch (error) {
+      const handingOff = isHandoffRequested();
       let terminalError = error;
-      try {
-        await finishDurableRequest({ status: 'failed', error });
-      } catch (durableError) {
-        terminalError = new AggregateError(
-          [error, durableError],
-          'Request setup and durable finalization both failed',
-        );
+      if (!handingOff) {
+        try {
+          await finishDurableRequest({ status: 'failed', error });
+        } catch (durableError) {
+          terminalError = new AggregateError(
+            [error, durableError],
+            'Request setup and durable finalization both failed',
+          );
+        }
       }
       const errorMessage =
         terminalError instanceof Error ? terminalError.message : String(terminalError);
-      await finishTrace('error', { error: errorMessage });
+      await finishTrace(handingOff ? 'aborted' : 'error', {
+        ...(handingOff ? { reason: 'session_handoff' } : { error: errorMessage }),
+      });
       try {
+        if (handingOff) {
+          return;
+        }
         if (durableRecorder && !durableFinishCommitted) {
           throw terminalError;
         }
@@ -896,11 +954,16 @@ class Session implements ISession {
 
       while (true) {
         const next = await stream.next();
-        if (
-          signal.aborted
-          && (!next.done || next.value.error?.type !== 'aborted')
-        ) {
-          return;
+        if (signal.aborted) {
+          const canObserveHandoffCompletion =
+            isHandoffRequested()
+            && (next.done || next.value.type === 'agent_end');
+          if (
+            !canObserveHandoffCompletion
+            && (!next.done || next.value.error?.type !== 'aborted')
+          ) {
+            return;
+          }
         }
         const { value, done } = next;
         if (done) {
@@ -1158,6 +1221,11 @@ class Session implements ISession {
       const isAborted = loopResult.error?.type === 'aborted';
       const shouldExit = loopResult.metadata?.shouldExitLoop;
 
+      if (isHandoffRequested() && !loopResult.success && !shouldExit) {
+        await finishTrace('aborted', { reason: 'session_handoff' });
+        return;
+      }
+
       if (!loopResult.success && !isAborted && !shouldExit) {
         const messageText = loopResult.error?.message || 'Unknown error';
         await finishDurableRequest({
@@ -1201,8 +1269,9 @@ class Session implements ISession {
         sessionId: this.sessionId,
       };
     } catch (error) {
+      const handingOff = isHandoffRequested();
       let terminalError = error;
-      if (!durableFinishAttempted) {
+      if (!handingOff && !durableFinishAttempted) {
         try {
           await finishDurableRequest({ status: 'failed', error });
         } catch (durableError) {
@@ -1214,7 +1283,12 @@ class Session implements ISession {
       }
       const errorMessage =
         terminalError instanceof Error ? terminalError.message : String(terminalError);
-      await finishTrace('error', { error: errorMessage });
+      await finishTrace(handingOff ? 'aborted' : 'error', {
+        ...(handingOff ? { reason: 'session_handoff' } : { error: errorMessage }),
+      });
+      if (handingOff) {
+        return;
+      }
       if (durableRecorder && !durableFinishCommitted) {
         throw terminalError;
       }
@@ -1240,27 +1314,32 @@ class Session implements ISession {
               )
             : error;
         }
-        try {
-          if (!durableFinishAttempted) {
-            await finishDurableRequest({
-              status: 'interrupted',
-              reason: this.getDurableInterruptReason(requestController),
-            });
+        if (!isHandoffRequested()) {
+          try {
+            if (!durableFinishAttempted) {
+              await finishDurableRequest({
+                status: 'interrupted',
+                reason: this.getDurableInterruptReason(requestController),
+              });
+            }
+          } catch (error) {
+            cleanupError = cleanupError
+              ? new AggregateError(
+                  [cleanupError, error],
+                  'Agent stream cleanup and durable finalization both failed',
+                )
+              : error;
           }
-        } catch (error) {
-          cleanupError = cleanupError
-            ? new AggregateError(
-                [cleanupError, error],
-                'Agent stream cleanup and durable finalization both failed',
-              )
-            : error;
         }
       }
       runtime.getHookRuntime().setTraceCollector(undefined);
       signal.removeEventListener('abort', releaseBackpressureOnAbort);
       requestController.dispose();
       await this.finishRequest(requestId);
-      if (this.executionState.phase === 'closed') {
+      if (
+        this.executionState.phase === 'closed'
+        && this.executionState.disposition === 'terminal'
+      ) {
         await this.closeDurableSession();
       }
       if (cleanupError) {
@@ -1273,7 +1352,9 @@ class Session implements ISession {
     if (this.closePromise) {
       return this.closePromise;
     }
-    const closePromise = this.closeInternal(true);
+    const closePromise = this.handoffPromise
+      ? this.handoffPromise.then(() => undefined)
+      : this.closeInternal('terminal');
     this.closePromise = closePromise;
     void closePromise.catch(() => {
       if (this.closePromise === closePromise) {
@@ -1283,11 +1364,58 @@ class Session implements ISession {
     return closePromise;
   }
 
-  async disposeAfterFork(): Promise<void> {
-    await this.closeInternal(false);
+  suspendForHandoff(): Promise<SessionHandoffResult> {
+    if (!this.options.durableEventStore) {
+      return Promise.reject(
+        new SessionHandoffError(
+          'SESSION_HANDOFF_NOT_CONFIGURED',
+          'Session handoff requires durableEventStore',
+        ),
+      );
+    }
+    if (!this.persistenceEnabled || !this.options.storagePath) {
+      return Promise.reject(
+        new SessionHandoffError(
+          'SESSION_HANDOFF_NOT_CONFIGURED',
+          'Session handoff requires persistent transcript storage',
+        ),
+      );
+    }
+    if (this.handoffPromise) {
+      return this.handoffPromise;
+    }
+    if (this.closePromise) {
+      return Promise.reject(
+        new SessionHandoffError(
+          'SESSION_HANDOFF_UNAVAILABLE',
+          'Session close has already started',
+        ),
+      );
+    }
+
+    const handoffPromise = this.suspendForHandoffInternal();
+    this.handoffRequested = true;
+    this.handoffPromise = handoffPromise;
+    void handoffPromise.catch(() => {
+      if (this.handoffPromise === handoffPromise) {
+        this.handoffPromise = null;
+        if (
+          this.executionState.phase !== 'suspending'
+          && this.executionState.phase !== 'closed'
+        ) {
+          this.handoffRequested = false;
+        }
+      }
+    });
+    return handoffPromise;
   }
 
-  private async closeInternal(recordDurableClose: boolean): Promise<void> {
+  async disposeAfterFork(): Promise<void> {
+    await this.closeInternal('detached');
+  }
+
+  private async closeInternal(disposition: 'terminal' | 'detached'): Promise<void> {
+    const recordDurableClose = disposition === 'terminal';
     // 关闭时对 executionState 的读写走 inputMutex，避免与并发 send()/stream()
     // 交错（例如 send() 在 await 处让出后用 pending 覆盖 closed）。
     const closeState = await this.inputMutex.runExclusive(async () => {
@@ -1295,6 +1423,7 @@ class Session implements ISession {
         this.executionState.execution?.releaseBackpressure();
         return {
           alreadyClosed: true,
+          disposition: this.executionState.disposition,
           execution: this.executionState.execution,
         };
       }
@@ -1315,17 +1444,22 @@ class Session implements ISession {
       } else if (
         this.executionState.phase === 'running'
         || this.executionState.phase === 'stopping'
+        || this.executionState.phase === 'suspending'
       ) {
-        this.executionState.controller.abortRequest({ kind: 'session_close' });
+        if (this.executionState.phase !== 'suspending') {
+          this.executionState.controller.abortRequest({ kind: 'session_close' });
+        }
         execution = this.executionState.execution;
         execution.releaseBackpressure();
       }
       this.executionState = {
         phase: 'closed',
+        disposition,
         ...(execution ? { execution } : {}),
       };
       return {
         alreadyClosed: false,
+        disposition,
         execution,
       };
     });
@@ -1342,32 +1476,18 @@ class Session implements ISession {
           this.executionState.phase === 'closed'
           && this.executionState.execution === closeState.execution
         ) {
-          this.executionState = { phase: 'closed' };
+          this.executionState = {
+            phase: 'closed',
+            disposition: closeState.disposition,
+          };
         }
       });
     }
 
     if (!closeState.alreadyClosed) {
-      this.cleanupHandle?.unregister();
-      this.cleanupHandle = null;
-      this.agent = null;
-      this.initialized = false;
-      const runtime = this.runtime;
-      this.runtime = null;
-      if (runtime) {
-        try {
-          await runtime.getHookRuntime().runSessionEnd({ reason: 'other' });
-        } catch (error) {
-          closeErrors.push(error);
-        }
-        try {
-          await runtime.close();
-        } catch (error) {
-          closeErrors.push(error);
-        }
-      }
+      closeErrors.push(...await this.releaseLocalRuntime());
     }
-    if (recordDurableClose) {
+    if (recordDurableClose && closeState.disposition === 'terminal') {
       try {
         await this.closeDurableSession();
       } catch (error) {
@@ -1385,7 +1505,204 @@ class Session implements ISession {
     }
   }
 
+  private async suspendForHandoffInternal(): Promise<SessionHandoffResult> {
+    if (!this.initialized) {
+      throw new SessionHandoffError(
+        'SESSION_HANDOFF_UNAVAILABLE',
+        'Session is not initialized',
+      );
+    }
+    const runtime = this.getRuntime();
+    const journal = this.durableJournal;
+    if (!journal) {
+      throw new SessionHandoffError(
+        'SESSION_HANDOFF_NOT_CONFIGURED',
+        'Session handoff requires durableEventStore',
+      );
+    }
+
+    const handoffState = await this.inputMutex.runExclusive(() => {
+      if (this.executionState.phase === 'closed') {
+        throw new SessionHandoffError(
+          'SESSION_HANDOFF_UNAVAILABLE',
+          'Session is already closed',
+        );
+      }
+      if (this.executionState.phase === 'stopping') {
+        throw new SessionHandoffError(
+          'SESSION_HANDOFF_UNAVAILABLE',
+          'Session request cancellation has already started',
+        );
+      }
+
+      const durableRecorder =
+        this.executionState.phase === 'pending'
+        || this.executionState.phase === 'running'
+          ? this.executionState.durableRecorder
+          : null;
+      if (
+        (this.executionState.phase === 'pending'
+          || this.executionState.phase === 'running')
+        && !durableRecorder
+      ) {
+        throw new SessionHandoffError(
+          'SESSION_HANDOFF_NOT_CONFIGURED',
+          'Active Session handoff requires a durable Request recorder',
+        );
+      }
+      durableRecorder?.assertHandoffReady();
+
+      const blockers = runtime.sealBackgroundWorkForHandoff();
+      if (
+        blockers.activeSubagentIds.length > 0
+        || blockers.activeShellIds.length > 0
+      ) {
+        throw new SessionHandoffError(
+          'SESSION_HANDOFF_ACTIVE_WORK',
+          'Session handoff requires all background work to settle first',
+          blockers,
+        );
+      }
+
+      if (this.executionState.phase === 'running') {
+        const { requestId, controller, execution } = this.executionState;
+        if (!durableRecorder) {
+          throw new SessionHandoffError(
+            'SESSION_HANDOFF_NOT_CONFIGURED',
+            'Running Session handoff requires a durable Request recorder',
+          );
+        }
+        durableRecorder.beginHandoff();
+        controller.abortRequest({ kind: 'session_handoff' });
+        execution.releaseBackpressure();
+        this.executionState = {
+          phase: 'suspending',
+          requestId,
+          controller,
+          durableRecorder,
+          execution,
+        };
+        const executions = [...this.streamExecutions];
+        for (const activeExecution of executions) {
+          activeExecution.releaseBackpressure();
+        }
+        return { durableRecorder, executions };
+      }
+
+      if (this.executionState.phase === 'pending') {
+        durableRecorder?.beginHandoff();
+        this.executionState.controller.abortRequest({ kind: 'session_handoff' });
+        this.executionState.controller.dispose();
+      }
+      this.executionState = {
+        phase: 'closed',
+        disposition: 'detached',
+      };
+      const executions = [...this.streamExecutions];
+      for (const activeExecution of executions) {
+        activeExecution.releaseBackpressure();
+      }
+      return {
+        durableRecorder,
+        executions,
+      };
+    });
+
+    const handoffErrors: unknown[] = [];
+    const executionResults = await Promise.allSettled(
+      handoffState.executions.map((execution) => execution.completion),
+    );
+    for (const result of executionResults) {
+      if (result.status === 'rejected') {
+        handoffErrors.push(result.reason);
+      }
+    }
+    if (handoffState.durableRecorder) {
+      try {
+        await handoffState.durableRecorder.finalizeHandoff();
+      } catch (error) {
+        handoffErrors.push(error);
+      }
+    }
+
+    await this.inputMutex.runExclusive(() => {
+      if (this.executionState.phase === 'suspending') {
+        this.executionState = {
+          phase: 'closed',
+          disposition: 'detached',
+        };
+      }
+    });
+    handoffErrors.push(...await this.releaseLocalRuntime());
+
+    let recoveryPlan: DurableSessionRecoveryPlan | null = null;
+    let headSequence: EventSequence | null = null;
+    try {
+      const projection = await journal.refresh();
+      if (projection.status !== 'open' || projection.headSequence === null) {
+        throw new SessionHandoffError(
+          'SESSION_HANDOFF_UNAVAILABLE',
+          `Durable Session ${this.sessionId} is not open after handoff`,
+        );
+      }
+      headSequence = projection.headSequence;
+      recoveryPlan = journal.getRecoveryPlan();
+    } catch (error) {
+      handoffErrors.push(error);
+    }
+
+    if (handoffErrors.length === 1) {
+      throw handoffErrors[0];
+    }
+    if (handoffErrors.length > 1) {
+      throw new AggregateError(
+        handoffErrors,
+        'Session handoff failed in multiple phases',
+      );
+    }
+    if (!recoveryPlan || headSequence === null) {
+      throw new SessionHandoffError(
+        'SESSION_HANDOFF_UNAVAILABLE',
+        'Session handoff did not produce a durable recovery frontier',
+      );
+    }
+
+    this.logger.debug(`[Session] Suspended session ${this.sessionId} for handoff`);
+    return {
+      sessionId: this.sessionId,
+      headSequence,
+      recoveryPlan,
+    };
+  }
+
+  private async releaseLocalRuntime(): Promise<unknown[]> {
+    const errors: unknown[] = [];
+    this.cleanupHandle?.unregister();
+    this.cleanupHandle = null;
+    this.agent = null;
+    this.initialized = false;
+    const runtime = this.runtime;
+    this.runtime = null;
+    if (runtime) {
+      try {
+        await runtime.getHookRuntime().runSessionEnd({ reason: 'other' });
+      } catch (error) {
+        errors.push(error);
+      }
+      try {
+        await runtime.close();
+      } catch (error) {
+        errors.push(error);
+      }
+    }
+    return errors;
+  }
+
   async abort(): Promise<void> {
+    if (this.handoffPromise) {
+      await this.handoffPromise;
+      return;
+    }
     const result = await this.inputMutex.runExclusive(async () => {
       if (this.executionState.phase === 'running') {
         const {
@@ -1405,6 +1722,9 @@ class Session implements ISession {
         };
         return { completion: execution.completion };
       } else if (this.executionState.phase === 'stopping') {
+        this.executionState.execution.releaseBackpressure();
+        return { completion: this.executionState.execution.completion };
+      } else if (this.executionState.phase === 'suspending') {
         this.executionState.execution.releaseBackpressure();
         return { completion: this.executionState.execution.completion };
       } else if (this.executionState.phase === 'pending') {
@@ -1487,7 +1807,10 @@ class Session implements ISession {
   }
 
   private async ensureInitialized(): Promise<void> {
-    if (this.executionState.phase === 'closed') {
+    if (
+      this.executionState.phase === 'suspending'
+      || this.executionState.phase === 'closed'
+    ) {
       throw new Error('Session is closed');
     }
     if (!this.initialized) {

--- a/src/session/SessionRuntime.ts
+++ b/src/session/SessionRuntime.ts
@@ -18,6 +18,7 @@ import {
 import { getSandboxExecutor } from '../sandbox/SandboxExecutor.js';
 import { getSandboxService } from '../sandbox/SandboxService.js';
 import { getBuiltinTools } from '../tools/builtin/index.js';
+import { BackgroundShellManager } from '../tools/builtin/shell/BackgroundShellManager.js';
 import { ToolCatalog } from '../tools/catalog/ToolCatalog.js';
 import { toolFromDefinition } from '../tools/core/createTool.js';
 import { ExecutionPipeline } from '../tools/execution/ExecutionPipeline.js';
@@ -26,7 +27,7 @@ import type { Tool } from '../tools/types/index.js';
 import type { BladeConfig, McpServerConfig, PermissionsConfig } from '../types/common.js';
 import type { PermissionMode } from '../types/common.js';
 import { HookEvent } from '../types/constants.js';
-import type { SessionId } from '../types/branded.js';
+import type { AgentId, SessionId } from '../types/branded.js';
 import {
   createCompositePermissionHandler,
   createPermissionHandlerFromCanUseTool,
@@ -122,7 +123,11 @@ export class SessionRuntime {
     this.mcpRegistry = new McpRegistry(this.storageRoot);
     this.subagentRegistry = new SubagentRegistry(this.rootLogger, getContextCwd(defaultContext));
     const sessionStore = AgentSessionStore.create(this.storageRoot, this.rootLogger);
-    this.backgroundAgentManager = BackgroundAgentManager.create(this.rootLogger, sessionStore);
+    this.backgroundAgentManager = BackgroundAgentManager.create(
+      this.rootLogger,
+      sessionStore,
+      this.sessionId,
+    );
     this.contextManager = new ContextManager({
       storage: {
         maxMemorySize: 1000,
@@ -181,6 +186,20 @@ export class SessionRuntime {
     return this.backgroundAgentManager;
   }
 
+  sealBackgroundWorkForHandoff(): {
+    activeSubagentIds: readonly AgentId[];
+    activeShellIds: readonly string[];
+  } {
+    const activeSubagentIds = this.backgroundAgentManager.getActiveAgentIds();
+    const shellManager = BackgroundShellManager.getInstance();
+    const activeShellIds = shellManager.getActiveProcessIds(this.sessionId);
+    if (activeSubagentIds.length === 0 && activeShellIds.length === 0) {
+      this.backgroundAgentManager.sealForHandoff();
+      shellManager.sealSessionForHandoff(this.sessionId);
+    }
+    return { activeSubagentIds, activeShellIds };
+  }
+
   getContextManager(): ContextManager {
     return this.contextManager;
   }
@@ -188,6 +207,7 @@ export class SessionRuntime {
   async initialize(): Promise<void> {
     if (this.initialized) return;
 
+    BackgroundShellManager.getInstance().openSession(this.sessionId);
     if (this.options.sandbox) {
       getSandboxExecutor(this.rootLogger);
       getSandboxService().configure(this.options.sandbox);

--- a/src/session/__tests__/SessionDurableEvents.test.ts
+++ b/src/session/__tests__/SessionDurableEvents.test.ts
@@ -8,9 +8,12 @@ import { RECONCILED_INITIAL_INPUT } from '../../agent/InitialInputPreparation.js
 import type { ModelRequestLifecycle } from '../../agent/ModelExecutionLifecycle.js';
 import type { LoopOptions, LoopResult, UserMessageContent } from '../../agent/types.js';
 import { PersistentStore } from '../../context/storage/PersistentStore.js';
+import { SessionHandoffError } from '../../errors/SessionHandoffError.js';
 import { HookRuntime } from '../../hooks/HookRuntime.js';
 import type { Message } from '../../services/ChatServiceInterface.js';
+import { BackgroundShellManager } from '../../tools/builtin/shell/BackgroundShellManager.js';
 import {
+  AgentId,
   CommandId,
   EventId,
   InputId,
@@ -1469,6 +1472,632 @@ describe('Session durable events', () => {
     await expect(output.next()).rejects.toBeInstanceOf(
       DurableCommandOutcomeUnknownError,
     );
+  });
+
+  it('hands off an idle Session without closing its durable lifecycle', async () => {
+    const { root, store } = createStore();
+    const session = await createSession({
+      ...options(store),
+      persistSession: true,
+      storagePath: root,
+    });
+
+    const handoff = await session.suspendForHandoff();
+
+    expect(handoff.recoveryPlan.action).toBe('none');
+    expect(session.isClosed).toBe(true);
+    expect((await store.read(session.sessionId)).events.map((event) => event.type)).toEqual([
+      DurableEventType.SESSION_CREATED,
+    ]);
+    const shellManager = BackgroundShellManager.getInstance();
+    expect(() =>
+      shellManager.startBackgroundProcess({
+        command: 'true',
+        sessionId: session.sessionId,
+        cwd: root,
+      }),
+    ).toThrow(/admission is closed/);
+
+    const resumed = await resumeSession({
+      ...options(store),
+      persistSession: true,
+      storagePath: root,
+      sessionId: session.sessionId,
+    });
+    expect(() =>
+      shellManager.startBackgroundProcess({
+        command: 'true',
+        sessionId: session.sessionId,
+        cwd: root,
+      }),
+    ).not.toThrow();
+    await resumed.send('continue after idle handoff');
+    for await (const _event of resumed.stream()) {
+      // Drain.
+    }
+    await resumed.close();
+  });
+
+  it('hands off a pending Request without terminalizing the durable Session', async () => {
+    const { root, store } = createStore();
+    const session = await createSession({
+      ...options(store),
+      persistSession: true,
+      storagePath: root,
+    });
+    const submission = await session.send('pending handoff');
+    if (submission.status !== 'started') {
+      throw new Error('Expected started submission');
+    }
+
+    const handoff = session.suspendForHandoff();
+    expect(session.suspendForHandoff()).toBe(handoff);
+    const result = await handoff;
+    expect(result).toMatchObject({
+      sessionId: session.sessionId,
+      recoveryPlan: {
+        action: 'resume_request',
+        requestId: submission.requestId,
+      },
+    });
+    expect(session.isClosed).toBe(true);
+
+    const eventsBeforeResume = (await store.read(session.sessionId)).events;
+    expect(result.headSequence).toBe(eventsBeforeResume.at(-1)?.sequence);
+    expect(eventsBeforeResume.at(-1)?.type).toBe(DurableEventType.REQUEST_ACCEPTED);
+    expect(eventsBeforeResume).not.toContainEqual(
+      expect.objectContaining({ type: DurableEventType.SESSION_CLOSED }),
+    );
+    await expect(session.close()).resolves.toBeUndefined();
+    await expect(session.stream().next()).rejects.toThrow('Session is closed');
+    expect((await store.read(session.sessionId)).events).toHaveLength(
+      eventsBeforeResume.length,
+    );
+
+    const resumed = await resumeSession({
+      ...options(store),
+      persistSession: true,
+      storagePath: root,
+      sessionId: session.sessionId,
+    });
+    for await (const _event of resumed.stream()) {
+      // Drain the handed-off Request.
+    }
+    await resumed.close();
+  });
+
+  it('waits for a stream pump that started before claiming its pending Request', async () => {
+    const { root, store } = createStore();
+    const session = await createSession({
+      ...options(store),
+      persistSession: true,
+      storagePath: root,
+    });
+    await session.send('pending pump handoff');
+
+    let pumpStarted = false;
+    let releasePump!: () => void;
+    const pumpGate = new Promise<void>((resolve) => {
+      releasePump = resolve;
+    });
+    (session as unknown as {
+      ensureInitialized(): Promise<void>;
+    }).ensureInitialized = async () => {
+      pumpStarted = true;
+      await pumpGate;
+    };
+
+    const output = session.stream();
+    const next = output.next();
+    await vi.waitFor(() => expect(pumpStarted).toBe(true));
+    let handoffResolved = false;
+    const handoffPromise = session.suspendForHandoff().then((result) => {
+      handoffResolved = true;
+      return result;
+    });
+
+    await Promise.resolve();
+    expect(handoffResolved).toBe(false);
+    releasePump();
+    await expect(handoffPromise).resolves.toMatchObject({
+      recoveryPlan: { action: 'resume_request' },
+    });
+    await expect(next).resolves.toEqual({ value: undefined, done: true });
+  });
+
+  it('waits for running cleanup and preserves an unfinished Turn for handoff recovery', async () => {
+    const { root, store } = createStore();
+    let firstExecution = true;
+    let cleanupStarted = false;
+    let innerClosed = false;
+    let releaseCleanup!: () => void;
+    const cleanupGate = new Promise<void>((resolve) => {
+      releaseCleanup = resolve;
+    });
+    streamChat = async function* handoffStream(_message, context, loopOptions) {
+      if (!firstExecution) {
+        yield { type: 'turn_start', turn: 1, maxTurns: 10 };
+        yield { type: 'turn_end', turn: 1, hasToolCalls: false };
+        return {
+          success: true,
+          finalMessage: 'resumed',
+          metadata: { turnsCount: 1, toolCallsCount: 0, duration: 1 },
+        };
+      }
+      firstExecution = false;
+      let modelRequest: ModelRequestLifecycle | undefined;
+      try {
+        yield { type: 'turn_start', turn: 1, maxTurns: 10 };
+        modelRequest = await loopOptions?.modelExecutionLifecycle?.onModelRequestStarting({
+          turn: 1,
+          model: 'test-model',
+          streaming: true,
+        });
+        yield { type: 'content_delta', delta: 'partial' };
+        const signal = (context as { signal?: AbortSignal }).signal;
+        await new Promise<void>((resolve) => {
+          if (signal?.aborted) {
+            resolve();
+            return;
+          }
+          signal?.addEventListener('abort', () => resolve(), { once: true });
+        });
+        return {
+          success: false,
+          error: { type: 'aborted', message: 'handed off' },
+          metadata: { turnsCount: 1, toolCallsCount: 0, duration: 1 },
+        };
+      } finally {
+        await modelRequest?.onAborted('request_interrupted');
+        cleanupStarted = true;
+        await cleanupGate;
+        innerClosed = true;
+      }
+    };
+    const session = await createSession({
+      ...options(store),
+      persistSession: true,
+      storagePath: root,
+    });
+    await session.send('running handoff');
+    const output = session.stream();
+    await output.next();
+    await output.next();
+
+    let handoffResolved = false;
+    const handoffPromise = session.suspendForHandoff().then((result) => {
+      handoffResolved = true;
+      return result;
+    });
+    const concurrentClose = session.close();
+    expect(session.close()).toBe(concurrentClose);
+    expect(session.isClosed).toBe(true);
+    await expect(session.send('racing handoff')).rejects.toThrow('Session is closed');
+    await vi.waitFor(() => expect(cleanupStarted).toBe(true));
+    expect(handoffResolved).toBe(false);
+    releaseCleanup();
+    const handoff = await handoffPromise;
+    await concurrentClose;
+
+    expect(innerClosed).toBe(true);
+    expect(session.isClosed).toBe(true);
+    expect(handoff.recoveryPlan).toMatchObject({
+      action: 'resume_turn',
+      requestId: expect.any(String),
+      turnId: expect.any(String),
+    });
+    const eventsBeforeRecovery = (await store.read(session.sessionId)).events;
+    expect(eventsBeforeRecovery.map((event) => event.type)).toEqual([
+      DurableEventType.SESSION_CREATED,
+      DurableEventType.REQUEST_ACCEPTED,
+      DurableEventType.INPUT_APPLIED,
+      DurableEventType.REQUEST_STARTED,
+      DurableEventType.TURN_STARTED,
+      DurableEventType.MODEL_REQUEST_STARTED,
+      DurableEventType.MODEL_REQUEST_ABORTED,
+    ]);
+    await expect(output.next()).resolves.toEqual({ value: undefined, done: true });
+
+    const requestId = handoff.recoveryPlan.requestId;
+    const turnId = handoff.recoveryPlan.turnId;
+    if (!requestId || !turnId) {
+      throw new Error('Expected handoff recovery identifiers');
+    }
+    const coordinator = await DurableSessionRecoveryCoordinator.open(
+      store,
+      session.sessionId,
+    );
+    await coordinator.prepareTurnRecovery({
+      commandId: CommandId('handoff-recovery-command'),
+      requestId,
+      turnId,
+      recoveryRequestId: RequestId('handoff-recovery-request'),
+      recoveryInputId: InputId('handoff-recovery-input'),
+    });
+
+    const resumed = await resumeSession({
+      ...options(store),
+      persistSession: true,
+      storagePath: root,
+      sessionId: session.sessionId,
+    });
+    for await (const _event of resumed.stream()) {
+      // Drain the recovery Request on the replacement worker.
+    }
+    expect(resumed.getDurableRecoveryPlan()?.action).toBe('none');
+    await resumed.close();
+  });
+
+  it('opens a resumable Turn when handoff lands after a completed tool round', async () => {
+    const { root, store } = createStore();
+    streamChat = async function* interTurnHandoff(_message, context, loopOptions) {
+      yield { type: 'turn_start', turn: 1, maxTurns: 10 };
+      const modelRequest = await loopOptions?.modelExecutionLifecycle?.onModelRequestStarting({
+        turn: 1,
+        model: 'test-model',
+        streaming: false,
+      });
+      if (!modelRequest?.modelAttemptId) {
+        throw new Error('Missing model request lifecycle');
+      }
+      const toolCall = {
+        id: 'handoff-tool-call',
+        type: 'function' as const,
+        function: {
+          name: 'Read',
+          arguments: '{"file_path":"/tmp/input"}',
+        },
+      };
+      await modelRequest.onCompleted({
+        content: '',
+        toolCalls: [toolCall],
+      });
+      const toolLifecycle = loopOptions?.toolExecutionLifecycle;
+      const invocation = await toolLifecycle?.onToolScheduled?.({
+        toolCallId: ToolUseId(toolCall.id),
+        toolName: toolCall.function.name,
+        modelAttemptId: modelRequest.modelAttemptId,
+        modelInput: { file_path: '/tmp/input' },
+        input: { file_path: '/tmp/input' },
+        sideEffect: 'pure',
+        interruptBehavior: 'cancel',
+      });
+      if (!invocation) {
+        throw new Error('Missing tool invocation lifecycle');
+      }
+      yield { type: 'tool_start', toolCall };
+      await invocation.onExecutionStarted?.({
+        input: { file_path: '/tmp/input' },
+        sideEffect: 'pure',
+      });
+      await toolLifecycle?.onToolSettled?.({
+        toolCallId: ToolUseId(toolCall.id),
+        toolName: toolCall.function.name,
+        result: { status: 'success', model: 'contents' },
+      });
+      yield {
+        type: 'tool_result',
+        toolCall,
+        result: { status: 'success', model: 'contents' },
+      };
+      yield { type: 'turn_end', turn: 1, hasToolCalls: true };
+
+      const signal = (context as { signal?: AbortSignal }).signal;
+      if (!signal?.aborted) {
+        throw new Error('Expected handoff to abort before the next Turn');
+      }
+      yield { type: 'agent_end' };
+      return {
+        success: false,
+        error: { type: 'aborted', message: 'handed off between Turns' },
+        metadata: { turnsCount: 1, toolCallsCount: 1, duration: 1 },
+      };
+    };
+    const session = await createSession({
+      ...options(store),
+      persistSession: true,
+      storagePath: root,
+    });
+    await session.send('read and continue');
+    const output = session.stream();
+
+    let event: Awaited<ReturnType<typeof output.next>>;
+    do {
+      event = await output.next();
+    } while (!event.done && event.value.type !== 'turn_end');
+    expect(event).toMatchObject({
+      done: false,
+      value: { type: 'turn_end', turn: 1 },
+    });
+
+    const handoff = await session.suspendForHandoff();
+
+    expect(handoff.recoveryPlan).toMatchObject({
+      action: 'resume_turn',
+      requestId: expect.any(String),
+      turnId: expect.any(String),
+    });
+    await expect(output.next()).resolves.toEqual({ value: undefined, done: true });
+    const events = (await store.read(session.sessionId)).events;
+    expect(events.slice(-2)).toEqual([
+      expect.objectContaining({
+        type: DurableEventType.TURN_COMPLETED,
+        data: { turn: 1, hasToolCalls: true },
+      }),
+      expect.objectContaining({
+        type: DurableEventType.TURN_STARTED,
+        data: { turn: 2, model: 'test-model' },
+      }),
+    ]);
+    expect(events).not.toContainEqual(
+      expect.objectContaining({ type: DurableEventType.REQUEST_INTERRUPTED }),
+    );
+  });
+
+  it('opens a resumable Turn when handoff interrupts a no-tool continuation', async () => {
+    const { root, store } = createStore();
+    streamChat = async function* noToolContinuation(_message, context, loopOptions) {
+      yield { type: 'turn_start', turn: 1, maxTurns: 10 };
+      const modelRequest = await loopOptions?.modelExecutionLifecycle?.onModelRequestStarting({
+        turn: 1,
+        model: 'test-model',
+        streaming: false,
+      });
+      if (!modelRequest) {
+        throw new Error('Missing model request lifecycle');
+      }
+      await modelRequest.onCompleted({ content: 'retry with more detail' });
+      yield { type: 'turn_end', turn: 1, hasToolCalls: false };
+
+      const signal = (context as { signal?: AbortSignal }).signal;
+      if (!signal?.aborted) {
+        throw new Error('Expected handoff to abort before the next Turn');
+      }
+      yield { type: 'agent_end' };
+      return {
+        success: false,
+        error: { type: 'aborted', message: 'handed off before retry' },
+        metadata: { turnsCount: 1, toolCallsCount: 0, duration: 1 },
+      };
+    };
+    const session = await createSession({
+      ...options(store),
+      persistSession: true,
+      storagePath: root,
+    });
+    await session.send('continue after retry');
+    const output = session.stream();
+
+    let event: Awaited<ReturnType<typeof output.next>>;
+    do {
+      event = await output.next();
+    } while (!event.done && event.value.type !== 'turn_end');
+
+    await expect(session.suspendForHandoff()).resolves.toMatchObject({
+      recoveryPlan: {
+        action: 'resume_turn',
+        requestId: expect.any(String),
+        turnId: expect.any(String),
+      },
+    });
+    await expect(output.next()).resolves.toEqual({ value: undefined, done: true });
+    expect((await store.read(session.sessionId)).events.slice(-2)).toEqual([
+      expect.objectContaining({
+        type: DurableEventType.TURN_COMPLETED,
+        data: { turn: 1, hasToolCalls: false },
+      }),
+      expect.objectContaining({
+        type: DurableEventType.TURN_STARTED,
+        data: { turn: 2, model: 'test-model' },
+      }),
+    ]);
+  });
+
+  it('commits natural completion when handoff lands after a terminal no-tool Turn', async () => {
+    const { root, store } = createStore();
+    streamChat = async function* terminalHandoff(_message, _context, loopOptions) {
+      yield { type: 'turn_start', turn: 1, maxTurns: 10 };
+      const modelRequest = await loopOptions?.modelExecutionLifecycle?.onModelRequestStarting({
+        turn: 1,
+        model: 'test-model',
+        streaming: false,
+      });
+      if (!modelRequest) {
+        throw new Error('Missing model request lifecycle');
+      }
+      await modelRequest.onCompleted({ content: 'done' });
+      yield { type: 'turn_end', turn: 1, hasToolCalls: false };
+      yield { type: 'agent_end' };
+      return {
+        success: true,
+        finalMessage: 'done',
+        metadata: { turnsCount: 1, toolCallsCount: 0, duration: 1 },
+      };
+    };
+    const session = await createSession({
+      ...options(store),
+      persistSession: true,
+      storagePath: root,
+    });
+    await session.send('finish now');
+    const output = session.stream();
+
+    let event: Awaited<ReturnType<typeof output.next>>;
+    do {
+      event = await output.next();
+    } while (!event.done && event.value.type !== 'turn_end');
+    expect(event).toMatchObject({
+      done: false,
+      value: { type: 'turn_end', turn: 1 },
+    });
+
+    await expect(session.suspendForHandoff()).resolves.toMatchObject({
+      recoveryPlan: { action: 'none' },
+    });
+    await expect(output.next()).resolves.toMatchObject({
+      done: false,
+      value: { type: 'usage' },
+    });
+    await expect(output.next()).resolves.toMatchObject({
+      done: false,
+      value: { type: 'result', content: 'done' },
+    });
+    await expect(output.next()).resolves.toEqual({ value: undefined, done: true });
+    const events = (await store.read(session.sessionId)).events;
+    expect(events.at(-1)?.type).toBe(DurableEventType.REQUEST_COMPLETED);
+    expect(
+      events.filter((entry) => entry.type === DurableEventType.TURN_STARTED),
+    ).toHaveLength(1);
+  });
+
+  it('rejects handoff unless durable journal and transcript persistence are configured', async () => {
+    const withoutJournal = await createSession({
+      provider: { type: 'openai-compatible', apiKey: 'test-key' },
+      model: 'test-model',
+      persistSession: false,
+    });
+
+    await expect(withoutJournal.suspendForHandoff()).rejects.toBeInstanceOf(
+      SessionHandoffError,
+    );
+    expect(withoutJournal.isClosed).toBe(false);
+    await withoutJournal.close();
+
+    const { store } = createStore();
+    const withoutTranscript = await createSession({
+      ...options(store),
+      persistSession: true,
+    });
+    await expect(withoutTranscript.suspendForHandoff()).rejects.toMatchObject({
+      code: 'SESSION_HANDOFF_NOT_CONFIGURED',
+    });
+    expect(withoutTranscript.isClosed).toBe(false);
+    await withoutTranscript.close();
+  });
+
+  it('does not cancel the Request when a background subagent blocks handoff', async () => {
+    const { root, store } = createStore();
+    const session = await createSession({
+      ...options(store),
+      persistSession: true,
+      storagePath: root,
+    });
+    const runtime = (session as unknown as {
+      runtime: {
+        sealBackgroundWorkForHandoff(): {
+          activeSubagentIds: readonly AgentId[];
+          activeShellIds: readonly string[];
+        };
+      };
+    }).runtime;
+    vi.spyOn(runtime, 'sealBackgroundWorkForHandoff').mockReturnValue({
+      activeSubagentIds: [AgentId('active-subagent')],
+      activeShellIds: [],
+    });
+    const submission = await session.send('keep running');
+
+    await expect(session.suspendForHandoff()).rejects.toMatchObject({
+      code: 'SESSION_HANDOFF_ACTIVE_WORK',
+      activeSubagentIds: ['active-subagent'],
+      activeShellIds: [],
+    });
+    expect(session.isClosed).toBe(false);
+    expect(session.getPendingInputs()).toContainEqual(
+      expect.objectContaining({ inputId: submission.inputId }),
+    );
+    expect((await store.read(session.sessionId)).events.at(-1)?.type).toBe(
+      DurableEventType.REQUEST_ACCEPTED,
+    );
+    await session.close();
+  });
+
+  it('does not hand off while a Session-owned background shell is still alive', async () => {
+    const { root, store } = createStore();
+    const session = await createSession({
+      ...options(store),
+      persistSession: true,
+      storagePath: root,
+    });
+    const shellManager = BackgroundShellManager.getInstance();
+    const shell = shellManager.startBackgroundProcess({
+      command: 'sleep 30',
+      sessionId: session.sessionId,
+      cwd: root,
+    });
+
+    try {
+      await expect(session.suspendForHandoff()).rejects.toMatchObject({
+        code: 'SESSION_HANDOFF_ACTIVE_WORK',
+        activeSubagentIds: [],
+        activeShellIds: [shell.id],
+      });
+      expect(session.isClosed).toBe(false);
+    } finally {
+      shellManager.kill(shell.id);
+    }
+    await vi.waitFor(
+      () => expect(shellManager.getActiveProcessIds(session.sessionId)).toEqual([]),
+      { timeout: 2_000 },
+    );
+
+    await expect(session.suspendForHandoff()).resolves.toMatchObject({
+      recoveryPlan: { action: 'none' },
+    });
+  });
+
+  it('fails handoff closed when final model lifecycle persistence is uncertain', async () => {
+    const { root, store } = createStore();
+    const failingStore = new FailOnEventTypeStore(
+      store,
+      DurableEventType.MODEL_REQUEST_ABORTED,
+    );
+    streamChat = async function* failedHandoff(_message, context, loopOptions) {
+      let modelRequest: ModelRequestLifecycle | undefined;
+      try {
+        yield { type: 'turn_start', turn: 1, maxTurns: 10 };
+        modelRequest = await loopOptions?.modelExecutionLifecycle?.onModelRequestStarting({
+          turn: 1,
+          model: 'test-model',
+          streaming: true,
+        });
+        yield { type: 'content_delta', delta: 'partial' };
+        const signal = (context as { signal?: AbortSignal }).signal;
+        await new Promise<void>((resolve) => {
+          if (signal?.aborted) {
+            resolve();
+            return;
+          }
+          signal?.addEventListener('abort', () => resolve(), { once: true });
+        });
+        return {
+          success: false,
+          error: { type: 'aborted', message: 'handed off' },
+          metadata: { turnsCount: 1, toolCallsCount: 0, duration: 1 },
+        };
+      } finally {
+        await modelRequest?.onAborted('request_interrupted');
+      }
+    };
+    const session = await createSession({
+      ...options(failingStore),
+      persistSession: true,
+      storagePath: root,
+    });
+    await session.send('failed handoff');
+    const output = session.stream();
+    await output.next();
+    await output.next();
+
+    await expect(session.suspendForHandoff()).rejects.toBeInstanceOf(
+      SessionDurableRecorderError,
+    );
+    expect(session.isClosed).toBe(true);
+    expect(session.getDurableRecoveryPlan()?.action).toBe(
+      'reconcile_model_outcome',
+    );
+    expect(
+      (await store.read(session.sessionId)).events.map((event) => event.type),
+    ).not.toContain(DurableEventType.SESSION_CLOSED);
   });
 
   it('durably interrupts a pending request before cancelling its input', async () => {

--- a/src/session/__tests__/SessionDurableEvents.test.ts
+++ b/src/session/__tests__/SessionDurableEvents.test.ts
@@ -1642,6 +1642,7 @@ describe('Session durable events', () => {
           }
           signal?.addEventListener('abort', () => resolve(), { once: true });
         });
+        yield { type: 'content_delta', delta: 'ignored after handoff' };
         return {
           success: false,
           error: { type: 'aborted', message: 'handed off' },
@@ -1658,6 +1659,7 @@ describe('Session durable events', () => {
       ...options(store),
       persistSession: true,
       storagePath: root,
+      observability: { enabled: true, capturePayloads: true },
     });
     await session.send('running handoff');
     const output = session.stream();
@@ -1696,6 +1698,17 @@ describe('Session durable events', () => {
       DurableEventType.MODEL_REQUEST_STARTED,
       DurableEventType.MODEL_REQUEST_ABORTED,
     ]);
+    expect(session.getLastTrace()).toMatchObject({
+      status: 'aborted',
+      events: expect.arrayContaining([
+        expect.objectContaining({
+          type: 'error',
+          data: {
+            reason: expect.objectContaining({ value: 'process_restart' }),
+          },
+        }),
+      ]),
+    });
     await expect(output.next()).resolves.toEqual({ value: undefined, done: true });
 
     const requestId = handoff.recoveryPlan.requestId;
@@ -1973,6 +1986,74 @@ describe('Session durable events', () => {
     });
     expect(withoutTranscript.isClosed).toBe(false);
     await withoutTranscript.close();
+  });
+
+  it('rejects handoff after Session close has started', async () => {
+    const { root, store } = createStore();
+    const session = await createSession({
+      ...options(store),
+      persistSession: true,
+      storagePath: root,
+    });
+
+    const close = session.close();
+
+    await expect(session.suspendForHandoff()).rejects.toMatchObject({
+      code: 'SESSION_HANDOFF_UNAVAILABLE',
+      message: 'Session close has already started',
+    });
+    await close;
+  });
+
+  it('rejects handoff after Request cancellation has started', async () => {
+    const { root, store } = createStore();
+    let cleanupStarted = false;
+    let releaseCleanup!: () => void;
+    const cleanupGate = new Promise<void>((resolve) => {
+      releaseCleanup = resolve;
+    });
+    streamChat = async function* stoppingRequest(_message, context) {
+      try {
+        yield { type: 'turn_start', turn: 1, maxTurns: 10 };
+        const signal = (context as { signal?: AbortSignal }).signal;
+        await new Promise<void>((resolve) => {
+          if (signal?.aborted) {
+            resolve();
+            return;
+          }
+          signal?.addEventListener('abort', () => resolve(), { once: true });
+        });
+        return {
+          success: false,
+          error: { type: 'aborted', message: 'aborted' },
+          metadata: { turnsCount: 1, toolCallsCount: 0, duration: 1 },
+        };
+      } finally {
+        cleanupStarted = true;
+        await cleanupGate;
+      }
+    };
+    const session = await createSession({
+      ...options(store),
+      persistSession: true,
+      storagePath: root,
+    });
+    await session.send('abort before handoff');
+    const output = session.stream();
+    await output.next();
+    const abort = session.abort();
+    await vi.waitFor(() => expect(cleanupStarted).toBe(true));
+
+    try {
+      await expect(session.suspendForHandoff()).rejects.toMatchObject({
+        code: 'SESSION_HANDOFF_UNAVAILABLE',
+        message: 'Session request cancellation has already started',
+      });
+    } finally {
+      releaseCleanup();
+      await abort;
+      await session.close();
+    }
   });
 
   it('does not cancel the Request when a background subagent blocks handoff', async () => {

--- a/src/session/events/SessionDurableRecorder.ts
+++ b/src/session/events/SessionDurableRecorder.ts
@@ -36,6 +36,7 @@ import { toJsonValue } from '../../utils/jsonValue.js';
 import type {
   DurableCommandCommitOptions,
   DurableCommandCommitResult,
+  DurableCommandEventDraft,
   DurableSessionJournal,
 } from './DurableSessionJournal.js';
 import type { DurableSessionRecoveryPlan } from './DurableSessionProjector.js';
@@ -140,6 +141,8 @@ export class SessionDurableRecorder implements
   private ignoredTurnEnd: number | null = null;
   private requestStarted = false;
   private requestFinished = false;
+  private handoffRequested = false;
+  private completedTurnObserved = false;
 
   constructor(
     private readonly journal: DurableSessionJournal,
@@ -151,6 +154,115 @@ export class SessionDurableRecorder implements
     if (request?.requestId === requestId && request.activeTurn === null) {
       this.lastBoundaryEventId = projection.lastEventId;
       this.requestStarted = request.status === 'running';
+    }
+  }
+
+  assertHandoffReady(): void {
+    this.assertBoundaryHealthy();
+  }
+
+  beginHandoff(): boolean {
+    this.assertBoundaryHealthy();
+    if (this.requestFinished) {
+      return false;
+    }
+    this.handoffRequested = true;
+    return true;
+  }
+
+  isHandoffRequested(): boolean {
+    return this.handoffRequested;
+  }
+
+  async finalizeHandoff(): Promise<void> {
+    this.assertBoundaryHealthy();
+    if (!this.handoffRequested || this.requestFinished) {
+      return;
+    }
+    if (!this.activeTurn) {
+      const request = this.journal.getProjection().activeRequest;
+      if (
+        this.completedTurnObserved
+        && request?.requestId === this.requestId
+        && request.status === 'running'
+        && (request.pendingInputIds ?? []).length === 0
+      ) {
+        await this.startTurn(request.lastTurn + 1);
+      }
+      return;
+    }
+
+    const turn = this.activeTurn;
+    const drafts: DurableCommandEventDraft[] = [];
+    if (this.activeModelAttempt) {
+      drafts.push({
+        type: DurableEventType.MODEL_REQUEST_ABORTED,
+        requestId: this.requestId,
+        turnId: this.activeModelAttempt.turnId,
+        modelAttemptId: this.activeModelAttempt.modelAttemptId,
+        data: { reason: 'process_restart' },
+      });
+    }
+
+    const cancelledPermissions: ActiveTool[] = [];
+    const settledTools: ActiveTool[] = [];
+    for (const tool of turn.tools.values()) {
+      if (tool.status === 'settled') {
+        continue;
+      }
+      if (tool.status === 'started') {
+        drafts.push({
+          type: DurableEventType.TOOL_OUTCOME_UNKNOWN,
+          requestId: this.requestId,
+          turnId: turn.turnId,
+          toolAttemptId: tool.toolAttemptId,
+          data: {
+            toolCallId: tool.toolCallId,
+            toolName: tool.toolName,
+            reason: 'process_restart',
+          },
+        });
+        settledTools.push(tool);
+        continue;
+      }
+      if (tool.permissionRequestId && !tool.permissionDecision) {
+        drafts.push({
+          type: DurableEventType.PERMISSION_RESOLVED,
+          requestId: this.requestId,
+          turnId: turn.turnId,
+          toolAttemptId: tool.toolAttemptId,
+          data: {
+            permissionRequestId: tool.permissionRequestId,
+            decision: 'cancel',
+            message: 'Worker handoff ended permission resolution',
+          },
+        });
+        cancelledPermissions.push(tool);
+      }
+      drafts.push({
+        type: DurableEventType.TOOL_CANCELLED,
+        requestId: this.requestId,
+        turnId: turn.turnId,
+        toolAttemptId: tool.toolAttemptId,
+        data: {
+          toolCallId: tool.toolCallId,
+          toolName: tool.toolName,
+          reason: 'process_restart',
+        },
+      });
+      settledTools.push(tool);
+    }
+
+    if (drafts.length === 0) {
+      return;
+    }
+    await this.commitAtCurrentHead(drafts);
+    this.activeModelAttempt = null;
+    for (const tool of cancelledPermissions) {
+      tool.permissionDecision = 'cancel';
+    }
+    for (const tool of settledTools) {
+      tool.status = 'settled';
     }
   }
 
@@ -205,6 +317,7 @@ export class SessionDurableRecorder implements
   async onInputApplying(
     input: { readonly inputId: InputId; readonly priority: 'now' | 'next' },
   ): Promise<void> {
+    this.assertNewWorkAllowed();
     this.assertRequestOpen();
     if (!this.requestStarted) {
       throw new SessionDurableRecorderError(`Request ${this.requestId} has not started`);
@@ -241,9 +354,15 @@ export class SessionDurableRecorder implements
     this.assertRequestOpen();
     switch (event.type) {
       case 'turn_start':
+        if (this.handoffRequested) {
+          return;
+        }
         await this.startTurn(event.turn);
         return;
       case 'turn_end':
+        if (this.handoffRequested) {
+          return;
+        }
         if (this.ignoredTurnEnd === event.turn) {
           this.ignoredTurnEnd = null;
           return;
@@ -251,6 +370,9 @@ export class SessionDurableRecorder implements
         await this.completeTurn(event.turn, event.hasToolCalls);
         return;
       case 'turn_interrupted':
+        if (this.handoffRequested) {
+          return;
+        }
         if (!await this.abortTurn(event.turn, 'request_interrupted')) {
           throw new SessionDurableRecorderError(
             `Turn ${this.activeTurn?.turnId ?? event.turn} has a tool outcome that requires reconciliation`,
@@ -284,6 +406,7 @@ export class SessionDurableRecorder implements
     readonly model: string;
     readonly streaming: boolean;
   }): Promise<ModelRequestLifecycle> {
+    this.assertNewWorkAllowed();
     const turn = this.requireTurnNumber(input.turn);
     if (this.activeModelAttempt) {
       throw new SessionDurableRecorderError(
@@ -326,6 +449,9 @@ export class SessionDurableRecorder implements
 
   async finish(finish: DurableRequestFinish): Promise<boolean> {
     this.assertRequestOpen();
+    if (this.handoffRequested && finish.status === 'interrupted') {
+      return true;
+    }
     if (this.activeTurn) {
       if (finish.status === 'completed') {
         throw new SessionDurableRecorderError(
@@ -392,6 +518,7 @@ export class SessionDurableRecorder implements
   }
 
   async onToolScheduled(event: ToolScheduledLifecycle): Promise<ToolInvocationLifecycle> {
+    this.assertNewWorkAllowed();
     const turn = this.requireActiveTurn();
     if (!event.modelAttemptId || event.modelAttemptId !== turn.modelAttemptId) {
       throw new SessionDurableRecorderError(
@@ -454,8 +581,13 @@ export class SessionDurableRecorder implements
     if (tool.status === 'settled') {
       throw new SessionDurableRecorderError(`Tool call ${event.toolCallId} was already settled`);
     }
+    if (this.handoffRequested && tool.status === 'scheduled') {
+      return;
+    }
 
-    if (event.result.status === 'success') {
+    if (this.handoffRequested && tool.status === 'started' && event.result.status === 'error') {
+      await this.recordToolOutcomeUnknown(tool, 'process_restart');
+    } else if (event.result.status === 'success') {
       if (tool.status !== 'started') {
         throw new SessionDurableRecorderError(
           `Successful tool ${event.toolCallId} never crossed the execution boundary`,
@@ -541,6 +673,7 @@ export class SessionDurableRecorder implements
       },
     ]);
     this.activeTurn = null;
+    this.completedTurnObserved = true;
   }
 
   private async abortTurn(turn: number, reason: 'request_interrupted' | 'error'): Promise<boolean> {
@@ -718,6 +851,7 @@ export class SessionDurableRecorder implements
     message: string,
     input: JsonValue,
   ): Promise<PermissionRequestId> {
+    this.assertNewWorkAllowed();
     const turn = this.requireActiveTurn();
     const permissionRequestId = PermissionRequestId(nanoid());
     await this.commit([
@@ -765,6 +899,7 @@ export class SessionDurableRecorder implements
     tool: ActiveTool,
     event: ToolExecutionStartedLifecycle,
   ): Promise<void> {
+    this.assertNewWorkAllowed();
     const turn = this.requireActiveTurn();
     await this.commit([
       {
@@ -803,10 +938,38 @@ export class SessionDurableRecorder implements
     ]);
   }
 
+  private async recordToolOutcomeUnknown(
+    tool: ActiveTool,
+    reason: 'process_restart' | 'commit_outcome_unknown',
+  ): Promise<void> {
+    const turn = this.requireActiveTurn();
+    await this.commitAtCurrentHead([
+      {
+        type: DurableEventType.TOOL_OUTCOME_UNKNOWN,
+        requestId: this.requestId,
+        turnId: turn.turnId,
+        toolAttemptId: tool.toolAttemptId,
+        data: {
+          toolCallId: tool.toolCallId,
+          toolName: tool.toolName,
+          reason,
+        },
+      },
+    ]);
+  }
+
   private assertRequestOpen(): void {
     this.assertBoundaryHealthy();
     if (this.requestFinished) {
       throw new SessionDurableRecorderError(`Request ${this.requestId} is already terminal`);
+    }
+  }
+
+  private assertNewWorkAllowed(): void {
+    if (this.handoffRequested) {
+      throw new SessionDurableRecorderError(
+        `Request ${this.requestId} is suspended for worker handoff`,
+      );
     }
   }
 

--- a/src/session/events/__tests__/SessionDurableRecorder.test.ts
+++ b/src/session/events/__tests__/SessionDurableRecorder.test.ts
@@ -767,6 +767,217 @@ describe('SessionDurableRecorder', () => {
     expect((await store.read(sessionId)).events.at(-1)?.type).toBe(DurableEventType.TOOL_STARTED);
   });
 
+  it('preserves the active Turn when a Request is suspended for handoff', async () => {
+    await recorder.recordAccepted(inputId, 'handoff');
+    await recorder.recordStarted(inputId);
+    await recorder.recordAgentEvent({
+      type: 'turn_start',
+      turn: 1,
+      maxTurns: 10,
+    });
+    await recorder.onModelRequestStarting({
+      turn: 1,
+      model: 'test-model',
+      streaming: true,
+    });
+
+    expect(recorder.beginHandoff()).toBe(true);
+    await recorder.recordAgentEvent({
+      type: 'turn_end',
+      turn: 1,
+      hasToolCalls: false,
+    });
+    await expect(
+      recorder.finish({
+        status: 'interrupted',
+        reason: 'process_restart',
+      }),
+    ).resolves.toBe(true);
+    await recorder.finalizeHandoff();
+
+    expect(journal.getRecoveryPlan()).toMatchObject({
+      action: 'resume_turn',
+      requestId,
+    });
+    expect((await store.read(sessionId)).events.map((event) => event.type).slice(-2)).toEqual([
+      DurableEventType.MODEL_REQUEST_STARTED,
+      DurableEventType.MODEL_REQUEST_ABORTED,
+    ]);
+    await expect(
+      recorder.onModelRequestStarting({
+        turn: 1,
+        model: 'test-model',
+        streaming: true,
+      }),
+    ).rejects.toThrow(/suspended for worker handoff/);
+  });
+
+  it('marks an unsettled started tool outcome unknown during handoff', async () => {
+    await recorder.recordAccepted(inputId, 'handoff tool');
+    await recorder.recordStarted(inputId);
+    await recorder.recordAgentEvent({
+      type: 'turn_start',
+      turn: 1,
+      maxTurns: 10,
+    });
+    const modelAttemptId = await recordCompletedModelTool(
+      ToolUseId('handoff-tool-call'),
+      'Write',
+      {},
+    );
+    const lifecycle = await recorder.onToolScheduled({
+      toolCallId: ToolUseId('handoff-tool-call'),
+      toolName: 'Write',
+      modelAttemptId,
+      modelInput: {},
+      input: {},
+      sideEffect: 'non_idempotent',
+      interruptBehavior: 'block',
+    });
+    await lifecycle.onExecutionStarted?.({
+      input: {},
+      sideEffect: 'non_idempotent',
+    });
+
+    recorder.beginHandoff();
+    await recorder.onToolSettled({
+      toolCallId: ToolUseId('handoff-tool-call'),
+      toolName: 'Write',
+      result: {
+        status: 'error',
+        model: 'interrupted',
+        error: {
+          type: ToolErrorType.INTERRUPTED,
+          message: 'worker handoff',
+        },
+      },
+    });
+    await recorder.finalizeHandoff();
+
+    expect(journal.getRecoveryPlan()).toMatchObject({
+      action: 'reconcile_tool_outcomes',
+      requestId,
+      unknownToolAttempts: [
+        expect.objectContaining({
+          toolCallId: 'handoff-tool-call',
+          status: 'outcome_unknown',
+        }),
+      ],
+    });
+    expect((await store.read(sessionId)).events.at(-1)?.type).toBe(
+      DurableEventType.TOOL_OUTCOME_UNKNOWN,
+    );
+  });
+
+  it('cancels scheduled tools and pending permissions without ending the handoff Turn', async () => {
+    await recorder.recordAccepted(inputId, 'handoff permission');
+    await recorder.recordStarted(inputId);
+    await recorder.recordAgentEvent({
+      type: 'turn_start',
+      turn: 1,
+      maxTurns: 10,
+    });
+    const toolCallId = ToolUseId('handoff-permission-tool');
+    const modelAttemptId = await recordCompletedModelTool(
+      toolCallId,
+      'Write',
+      {},
+    );
+    const lifecycle = await recorder.onToolScheduled({
+      toolCallId,
+      toolName: 'Write',
+      modelAttemptId,
+      modelInput: {},
+      input: {},
+      sideEffect: 'non_idempotent',
+      interruptBehavior: 'block',
+    });
+    await lifecycle.onPermissionRequested?.(
+      { message: 'Allow write?' },
+      {},
+    );
+
+    recorder.beginHandoff();
+    await recorder.onToolSettled({
+      toolCallId,
+      toolName: 'Write',
+      result: {
+        status: 'error',
+        model: 'cancelled',
+        error: {
+          type: ToolErrorType.INTERRUPTED,
+          message: 'cancelled',
+        },
+      },
+    });
+    await recorder.finalizeHandoff();
+
+    expect(journal.getRecoveryPlan()).toMatchObject({
+      action: 'resume_turn',
+      pendingPermissions: [],
+      cancelableToolAttempts: [],
+    });
+    expect((await store.read(sessionId)).events.map((event) => event.type).slice(-2)).toEqual([
+      DurableEventType.PERMISSION_RESOLVED,
+      DurableEventType.TOOL_CANCELLED,
+    ]);
+  });
+
+  it('opens a recovery Turn when handoff lands between tool-backed Turns', async () => {
+    await recorder.recordAccepted(inputId, 'continue after tool');
+    await recorder.recordStarted(inputId);
+    await recorder.recordAgentEvent({
+      type: 'turn_start',
+      turn: 1,
+      maxTurns: 10,
+    });
+    const toolCallId = ToolUseId('completed-handoff-tool');
+    const modelAttemptId = await recordCompletedModelTool(
+      toolCallId,
+      'Read',
+      {},
+    );
+    const lifecycle = await recorder.onToolScheduled({
+      toolCallId,
+      toolName: 'Read',
+      modelAttemptId,
+      modelInput: {},
+      input: {},
+      sideEffect: 'pure',
+      interruptBehavior: 'cancel',
+    });
+    await lifecycle.onExecutionStarted?.({
+      input: {},
+      sideEffect: 'pure',
+    });
+    await recorder.onToolSettled({
+      toolCallId,
+      toolName: 'Read',
+      result: {
+        status: 'success',
+        model: 'done',
+      },
+    });
+    await recorder.recordAgentEvent({
+      type: 'turn_end',
+      turn: 1,
+      hasToolCalls: true,
+    });
+
+    recorder.beginHandoff();
+    await recorder.finalizeHandoff();
+
+    expect(journal.getRecoveryPlan()).toMatchObject({
+      action: 'resume_turn',
+      requestId,
+      turnId: expect.any(String),
+    });
+    expect((await store.read(sessionId)).events.at(-1)).toMatchObject({
+      type: DurableEventType.TURN_STARTED,
+      data: { turn: 2 },
+    });
+  });
+
   it('blocks steering past a started tool with an unknown outcome', async () => {
     await recorder.recordAccepted(inputId, 'run tool');
     await recorder.recordStarted(inputId);

--- a/src/session/index.ts
+++ b/src/session/index.ts
@@ -1,4 +1,8 @@
 export { createSession, forkSession, prompt, resumeSession } from './Session.js';
 export type { ForkOptions, ResumeOptions } from './Session.js';
+export {
+  SessionHandoffError,
+  type SessionHandoffErrorCode,
+} from '../errors/SessionHandoffError.js';
 export * from './events/index.js';
 export * from './types.js';

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -22,6 +22,7 @@ import type {
   ToolResult,
 } from '../tools/types/index.js';
 import type {
+  EventSequence,
   InputId,
   RequestId,
   SessionId,
@@ -346,6 +347,12 @@ export interface ForkSessionResult {
   forkedAt?: string;
 }
 
+export interface SessionHandoffResult {
+  readonly sessionId: SessionId;
+  readonly headSequence: EventSequence;
+  readonly recoveryPlan: DurableSessionRecoveryPlan;
+}
+
 export interface ISession extends AsyncDisposable {
   readonly sessionId: SessionId;
   readonly messages: Message[];
@@ -361,6 +368,8 @@ export interface ISession extends AsyncDisposable {
   close(): Promise<void>;
   /** Abort after active cleanup and durable finalization when durableEventStore is configured. */
   abort(): Promise<void>;
+  /** Stop local execution without terminalizing the durable Session so another worker can recover it. */
+  suspendForHandoff(): Promise<SessionHandoffResult>;
 
   getDefaultContext(): RuntimeContext;
   setDefaultContext(context: RuntimeContext): void;

--- a/src/tools/builtin/shell/BackgroundShellManager.ts
+++ b/src/tools/builtin/shell/BackgroundShellManager.ts
@@ -55,6 +55,7 @@ export interface KillResult {
 export class BackgroundShellManager {
   private static instance: BackgroundShellManager | null = null;
   private processes = new Map<string, BackgroundShellProcess>();
+  private sealedSessionIds = new Set<SessionId>();
 
   static getInstance(): BackgroundShellManager {
     if (!BackgroundShellManager.instance) {
@@ -64,6 +65,10 @@ export class BackgroundShellManager {
   }
 
   startBackgroundProcess(options: StartOptions): BackgroundShellProcess {
+    if (this.sealedSessionIds.has(options.sessionId)) {
+      throw new Error(`Background shell admission is closed for Session ${options.sessionId}`);
+    }
+
     const shellId = `bash_${randomUUID()}`;
     const mergedEnv: Record<string, string> = {};
 
@@ -158,6 +163,22 @@ export class BackgroundShellManager {
     return this.processes.get(shellId);
   }
 
+  getActiveProcessIds(sessionId: SessionId): readonly string[] {
+    return [...this.processes.values()]
+      .filter((processInfo) =>
+        processInfo.sessionId === sessionId
+        && processInfo.process !== undefined)
+      .map((processInfo) => processInfo.id);
+  }
+
+  sealSessionForHandoff(sessionId: SessionId): void {
+    this.sealedSessionIds.add(sessionId);
+  }
+
+  openSession(sessionId: SessionId): void {
+    this.sealedSessionIds.delete(sessionId);
+  }
+
   kill(shellId: string): KillResult | undefined {
     const processInfo = this.processes.get(shellId);
     if (!processInfo) {
@@ -189,7 +210,6 @@ export class BackgroundShellManager {
 
     processInfo.status = 'killed';
     processInfo.endTime = Date.now();
-    processInfo.process = undefined;
 
     return {
       success: true,
@@ -219,5 +239,6 @@ export class BackgroundShellManager {
       }
     }
     this.processes.clear();
+    this.sealedSessionIds.clear();
   }
 }

--- a/src/tools/builtin/shell/__tests__/BackgroundShellManager.test.ts
+++ b/src/tools/builtin/shell/__tests__/BackgroundShellManager.test.ts
@@ -1,0 +1,101 @@
+import { tmpdir } from 'node:os';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createContextSnapshot } from '../../../../runtime/index.js';
+import { SessionId } from '../../../../types/branded.js';
+import { collectToolExecution } from '../../../types/index.js';
+import { BackgroundShellManager } from '../BackgroundShellManager.js';
+import { bashTool } from '../bash.js';
+
+describe('BackgroundShellManager handoff admission', () => {
+  const manager = BackgroundShellManager.getInstance();
+
+  beforeEach(() => {
+    manager.killAll();
+  });
+
+  afterEach(() => {
+    manager.killAll();
+  });
+
+  it('tracks live processes by Session and keeps killed processes active until exit', async () => {
+    const firstSession = SessionId('handoff-shell-session');
+    const secondSession = SessionId('other-shell-session');
+    manager.openSession(firstSession);
+    manager.openSession(secondSession);
+
+    const processInfo = manager.startBackgroundProcess({
+      command: 'sleep 30',
+      sessionId: firstSession,
+      cwd: tmpdir(),
+    });
+
+    expect(manager.getActiveProcessIds(firstSession)).toEqual([processInfo.id]);
+    expect(manager.getActiveProcessIds(secondSession)).toEqual([]);
+    manager.sealSessionForHandoff(firstSession);
+    expect(() =>
+      manager.startBackgroundProcess({
+        command: 'true',
+        sessionId: firstSession,
+        cwd: tmpdir(),
+      }),
+    ).toThrow(/admission is closed/);
+
+    expect(manager.kill(processInfo.id)).toMatchObject({
+      success: true,
+      status: 'killed',
+    });
+    expect(manager.getActiveProcessIds(firstSession)).toEqual([processInfo.id]);
+    await vi.waitFor(
+      () => expect(manager.getActiveProcessIds(firstSession)).toEqual([]),
+      { timeout: 2_000 },
+    );
+
+    expect(() =>
+      manager.startBackgroundProcess({
+        command: 'true',
+        sessionId: secondSession,
+        cwd: tmpdir(),
+      }),
+    ).not.toThrow();
+  });
+
+  it('attributes Bash background processes to the calling Session', async () => {
+    const rootSessionId = SessionId('bash-tool-root-session');
+    const childSessionId = SessionId('bash-tool-child-session');
+    manager.openSession(rootSessionId);
+    const invocation = bashTool.build({
+      command: 'sleep 30',
+      timeout: 30_000,
+      run_in_background: true,
+    });
+
+    const result = await collectToolExecution(
+      invocation.execute(new AbortController().signal, {
+        sessionId: childSessionId,
+        backgroundAgentManager: {
+          getOwnerSessionId: () => rootSessionId,
+        } as never,
+        contextSnapshot: createContextSnapshot(childSessionId, 'shell-turn', {
+          capabilities: {
+            filesystem: {
+              roots: [tmpdir()],
+              cwd: tmpdir(),
+            },
+          },
+        }),
+      }),
+    );
+
+    expect(result.status).toBe('success');
+    const [shellId] = manager.getActiveProcessIds(rootSessionId);
+    expect(shellId).toMatch(/^bash_/);
+    expect(manager.getActiveProcessIds(childSessionId)).toEqual([]);
+    if (shellId) {
+      manager.kill(shellId);
+    }
+    await vi.waitFor(
+      () => expect(manager.getActiveProcessIds(rootSessionId)).toEqual([]),
+      { timeout: 2_000 },
+    );
+  });
+});

--- a/src/tools/builtin/shell/bash.ts
+++ b/src/tools/builtin/shell/bash.ts
@@ -274,7 +274,14 @@ Before executing commands:
       }
 
       if (run_in_background) {
-        return executeInBackground(effectiveCommand, workDir, env);
+        return executeInBackground(
+          effectiveCommand,
+          workDir,
+          context.backgroundAgentManager?.getOwnerSessionId?.()
+            ?? context.sessionId
+            ?? SessionId(randomUUID()),
+          env,
+        );
       }
 
       return await executeWithTimeout(effectiveCommand, workDir, env, timeout, signal);
@@ -353,12 +360,13 @@ Before executing commands:
 function executeInBackground(
   command: string,
   cwd: string,
+  sessionId: SessionId,
   env?: Record<string, string>
 ): ToolResult {
   const manager = BackgroundShellManager.getInstance();
   const backgroundProcess = manager.startBackgroundProcess({
     command,
-    sessionId: SessionId(randomUUID()),
+    sessionId,
     cwd,
     env,
   });

--- a/src/tools/builtin/task/task.ts
+++ b/src/tools/builtin/task/task.ts
@@ -256,7 +256,12 @@ export function createTaskTool({ registry }: { registry: SubagentRegistry }) {
           };
         }
 
-        const executor = new SubagentExecutor(subagentConfig, context.bladeConfig, registry);
+        const executor = new SubagentExecutor(
+          subagentConfig,
+          context.bladeConfig,
+          registry,
+          context.backgroundAgentManager as BackgroundAgentManager | undefined,
+        );
         const subagentContext: SubagentContext = {
           prompt,
           parentSessionId: context.sessionId,

--- a/src/tools/execution/ExecutionPipeline.ts
+++ b/src/tools/execution/ExecutionPipeline.ts
@@ -554,6 +554,10 @@ export class ExecutionPipeline {
       input: structuredClone(state.params),
       sideEffect: state.resolvedBehavior?.sideEffect ?? state.tool.sideEffect,
     });
+    if (state.context.signal?.aborted) {
+      state.result = this.createAbortedResult('Task was aborted before tool execution');
+      return;
+    }
     const timeoutController = this.toolTimeoutMs ? new AbortController() : undefined;
     const executionSignal = timeoutController
       ? state.context.signal

--- a/src/tools/execution/__tests__/ExecutionPipeline.test.ts
+++ b/src/tools/execution/__tests__/ExecutionPipeline.test.ts
@@ -1202,6 +1202,59 @@ describe('ExecutionPipeline', () => {
     expect(executeSpy).not.toHaveBeenCalled();
   });
 
+  it('blocks the side effect when cancellation wins during the execution-start boundary', async () => {
+    const registry = new ToolRegistry();
+    const boundary = deferred();
+    const boundaryStarted = deferred();
+    const executeSpy = vi.fn(() => completeToolExecution({
+      status: 'success',
+      model: 'unexpected',
+    }));
+    registerTool(
+      registry,
+      createTool({
+        name: 'CancelledBoundaryTool',
+        displayName: 'Cancelled Boundary Tool',
+        kind: ToolKind.Execute,
+        sideEffect: 'non_idempotent',
+        description: { short: 'Cancellation boundary tool' },
+        schema: z.object({}),
+        execute: executeSpy,
+      }),
+    );
+    const pipeline = new ExecutionPipeline(registry, {
+      permissionMode: PermissionMode.YOLO,
+    });
+    const controller = new AbortController();
+    const resultPromise = executePipeline(
+      pipeline,
+      'CancelledBoundaryTool',
+      {},
+      {
+        permissionMode: PermissionMode.YOLO,
+        signal: controller.signal,
+        toolInvocationLifecycle: {
+          onExecutionStarted: async () => {
+            boundaryStarted.resolve();
+            await boundary.promise;
+          },
+        },
+      },
+    );
+
+    await boundaryStarted.promise;
+    controller.abort();
+    boundary.resolve();
+
+    await expect(resultPromise).resolves.toMatchObject({
+      status: 'error',
+      error: {
+        message: 'Task was aborted before tool execution',
+      },
+    });
+    expect(executeSpy).not.toHaveBeenCalled();
+  });
+
   it('blocks the side effect when permission resolution cannot be persisted', async () => {
     const registry = new ToolRegistry();
     const executeSpy = vi.fn(() => completeToolExecution({


### PR DESCRIPTION
## Summary

- add `session.suspendForHandoff()` as an awaitable source-worker shutdown barrier that preserves the unfinished durable frontier
- seal nested background-agent and Session-owned background-shell admission before cancelling local execution
- conservatively settle active model/tool attempts and synthesize a recovery Turn when handoff lands between completed and next Turns
- export stable handoff result/error contracts and document the recovery workflow in English and Chinese

## Safety properties

- does not emit `turn_aborted`, `request_interrupted`, or `session_closed` for an unfinished handoff
- waits for all started stream pumps and local cleanup before returning the refreshed journal head and recovery plan
- marks started tool outcomes unknown when completion cannot be trusted
- rejects before root cancellation while background work is active
- remains a cooperative source-worker barrier; cross-host execution still requires transactional CAS/fencing

## Validation

- `pnpm run lint`
- `pnpm run type-check`
- `pnpm exec vitest run --reporter=json --outputFile=/tmp/blade-agent-sdk-vitest-final.json` (532 suites, 1487 passed, 62 skipped, 0 failed)
- `pnpm run verify:entrypoints`
- `pnpm run docs:build`
- `pnpm run changelog:check -- --base origin/main`
- `pnpm run audit:prod`

## Release

The bilingual `feature` fragment requests `5.1.0`, keeping the release within the 5.x line.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added controlled session worker handoff via `suspendForHandoff()`.
  * Handoff stops new background work, settles local execution, preserves unfinished durable work, and returns a recovery plan.
  * Added typed handoff results and errors, including active-work details.
  * Background agents and shell processes are tracked and blocked during handoff.
* **Bug Fixes**
  * Prevented cancelled tools from starting execution.
* **Documentation**
  * Added English and Chinese documentation covering handoff behavior, recovery, prerequisites, and limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->