### PR TITLE
fix(ci): migrate workflows to Node 24 actions

### DIFF
--- a/.changes/github-actions-node24.json
+++ b/.changes/github-actions-node24.json
@@ -1,0 +1,5 @@
+{
+  "type": "fix",
+  "en": "Upgrade CI, release, and documentation workflows to Node.js 24-backed GitHub Actions.",
+  "zh-CN": "升级 CI、发布与文档工作流使用的 GitHub Actions，统一迁移到 Node.js 24 runtime。"
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,10 @@ jobs:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
@@ -77,10 +77,10 @@ jobs:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
           cache: 'pnpm'

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -24,15 +24,15 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: '22'
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
       - run: pnpm run docs:build
-      - uses: actions/configure-pages@v4
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/configure-pages@v6
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: docs/.vitepress/dist
 
@@ -45,4 +45,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,10 +28,10 @@ jobs:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '22.14'
           cache: 'pnpm'

--- a/scripts/__tests__/node-version-policy.test.ts
+++ b/scripts/__tests__/node-version-policy.test.ts
@@ -1,8 +1,22 @@
-import { readFileSync } from 'node:fs';
+import { readFileSync, readdirSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 import { parse } from 'yaml';
+
+function collectActionReferences(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value.flatMap(collectActionReferences);
+  }
+  if (!value || typeof value !== 'object') {
+    return [];
+  }
+  return Object.entries(value).flatMap(([key, nested]) =>
+    key === 'uses' && typeof nested === 'string'
+      ? [nested]
+      : collectActionReferences(nested),
+  );
+}
 
 describe('Node.js version policy', () => {
   it('runs CI verification only on the supported Node.js release line', () => {
@@ -17,5 +31,25 @@ describe('Node.js version policy', () => {
     const packageJson = JSON.parse(readFileSync(resolve('package.json'), 'utf8'));
 
     expect(packageJson.engines.node).toBe('>=22.14.0');
+  });
+
+  it('uses Node.js 24-backed GitHub Action majors in every workflow', () => {
+    const workflowDirectory = resolve('.github/workflows');
+    const actionReferences = readdirSync(workflowDirectory)
+      .filter((name) => name.endsWith('.yml') || name.endsWith('.yaml'))
+      .flatMap((name) =>
+        collectActionReferences(
+          parse(readFileSync(resolve(workflowDirectory, name), 'utf8')),
+        ),
+      );
+
+    expect([...new Set(actionReferences)].sort()).toEqual([
+      'actions/checkout@v5',
+      'actions/configure-pages@v6',
+      'actions/deploy-pages@v5',
+      'actions/setup-node@v7',
+      'actions/upload-pages-artifact@v5',
+      'pnpm/action-setup@v6',
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

- upgrade `actions/setup-node` from v4 to v7 and `pnpm/action-setup` from v4 to v6 in CI, release, and docs workflows
- upgrade Pages actions to `configure-pages@v6`, `upload-pages-artifact@v5`, and `deploy-pages@v5`
- add a repository-wide policy test that recursively inventories every workflow `uses` reference and rejects deprecated or unapproved action majors

## Evidence

The previous main workflows emitted GitHub's Node.js 20 action runtime deprecation warning. The selected action majors are current stable releases and use Node.js 24 directly, or compose the current Node.js 24-backed artifact action.

## Validation

- `actionlint`
- `pnpm exec vitest run scripts/__tests__/node-version-policy.test.ts scripts/__tests__/semantic-release-config.test.ts`
- full suite: 532 suites, 1490 passed, 62 skipped, 0 failed
- `pnpm run type-check`
- `pnpm run lint`
- `pnpm run verify:entrypoints`
- `pnpm run docs:build`
- `pnpm run changelog:check -- --base origin/main`
- `pnpm run audit:prod`

## Release

The bilingual `fix` fragment requests a patch release within the 5.x line.
