### PR TITLE
feat(session): add durable execution leases

### DIFF
--- a/.changes/durable-execution-leases.json
+++ b/.changes/durable-execution-leases.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "en": "Add Store-backed Session execution leases with automatic heartbeats, sticky monotonic fencing, atomic Journal append validation, descendant cancellation, and controlled close or handoff release.",
+  "zh-CN": "新增 Store-backed Session 执行租约：支持自动 heartbeat、粘性单调 fencing、Journal append 原子校验、子执行取消及 close/handoff 受控释放。"
+}

--- a/.changes/durable-execution-leases.json
+++ b/.changes/durable-execution-leases.json
@@ -1,5 +1,5 @@
 {
   "type": "feature",
-  "en": "Add Store-backed Session execution leases with automatic heartbeats, sticky monotonic fencing, atomic Journal append validation, descendant cancellation, and controlled close or handoff release.",
-  "zh-CN": "新增 Store-backed Session 执行租约：支持自动 heartbeat、粘性单调 fencing、Journal append 原子校验、子执行取消及 close/handoff 受控释放。"
+  "en": "Add Store-backed Session execution leases with automatic heartbeats, sticky monotonic fencing, atomic Journal, transcript, and subagent-state guards, process-tree cancellation, and controlled close or handoff release.",
+  "zh-CN": "新增 Store-backed Session 执行租约：支持自动 heartbeat、粘性单调 fencing、Journal、transcript 与 subagent 状态原子保护、进程树取消及 close/handoff 受控释放。"
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,4 +95,5 @@ jobs:
           src/session/events/__tests__/JsonlDurableEventStore.test.ts
           src/session/events/__tests__/JsonlDurableEventStoreCompromise.test.ts
           src/session/events/__tests__/JsonlDurableEventStoreUnavailableLock.test.ts
+          src/agent/subagents/__tests__/AgentSessionStore.test.ts
           src/tools/builtin/shell/__tests__/BackgroundShellManager.test.ts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,3 +95,4 @@ jobs:
           src/session/events/__tests__/JsonlDurableEventStore.test.ts
           src/session/events/__tests__/JsonlDurableEventStoreCompromise.test.ts
           src/session/events/__tests__/JsonlDurableEventStoreUnavailableLock.test.ts
+          src/tools/builtin/shell/__tests__/BackgroundShellManager.test.ts

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ console.log(result.usage);
 
 - Session lifecycle: `createSession()`, `resumeSession()`, `forkSession()`, and `prompt()`
 - Steerable requests: durable `now`, `next`, and `later` inputs with cancellation and pending-input inspection
-- Durable recovery: cross-process-safe local journaling, controlled worker handoff, safe Request/Turn rollover, explicit model/tool reconciliation, and reconnectable cursors
+- Durable recovery: lease-fenced execution ownership, controlled worker handoff, safe Request/Turn rollover, explicit model/tool reconciliation, and reconnectable cursors
 - Streaming: 17 typed events for turns, content, reasoning, tools, usage, steering, results, and errors
 - Providers: OpenAI, Anthropic, Azure OpenAI, Gemini, DeepSeek, and OpenAI-compatible APIs
 - Tools: generator-only custom tools, capability-grouped built-ins, MCP tools, and typed progress/effects

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -61,7 +61,7 @@ console.log(result.usage);
 
 - Session 生命周期：`createSession()`、`resumeSession()`、`forkSession()`、`prompt()`
 - 可转向请求：持久化的 `now`、`next`、`later` 输入，支持取消和待处理输入查询
-- Durable 恢复：跨进程安全的本地 Journal、受控 worker handoff、Request/Turn rollover、显式模型/工具对账与 cursor 断线续读
+- Durable 恢复：带 fencing 的执行租约、受控 worker handoff、Request/Turn rollover、显式模型/工具对账与 cursor 断线续读
 - 流式事件：17 种类型化事件，覆盖轮次、内容、思维、工具、usage、转向、结果和错误
 - Provider：OpenAI、Anthropic、Azure OpenAI、Gemini、DeepSeek 和 OpenAI-compatible API
 - 工具：仅 generator 的自定义工具、按能力分组的内置工具、MCP 工具和类型化进度/副作用

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -106,7 +106,7 @@ Node-local 能力外，这些函数都从根入口导出；实际 subpath 以“
 | 导出 | 说明 |
 |------|------|
 | `DurableEventStore` | append/read/head 的持久化接口 |
-| `DurableExecutionLeaseStore` | 粘性 `requiresExecutionLease`、原子 acquire/renew/release/assert 与 fenced append 接口 |
+| `DurableExecutionLeaseStore` | 粘性 `requiresExecutionLease`、原子 acquire/renew/release/assert、`withExecutionLease` 与 fenced append 接口 |
 | `DurableExecutionLeaseOptions` | Session lease 的 owner、TTL、heartbeat 和可选 lease ID |
 | `DurableExecutionLeaseSnapshot` / `DurableExecutionFence` | 当前租约快照及传递给 Store/工具的 fence |
 | `DurableExecutionLeaseErrorCode` | lease 配置、冲突、缺少 fence、失租、损坏与写入错误码 |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -56,7 +56,9 @@ Node-local 能力外，这些函数都从根入口导出；实际 subpath 以“
 | `MemoryManager` | memory | memory 编排层 |
 | `SubagentRegistry` | subagents | 注册和发现子 Agent |
 | `SubagentExecutor` | subagents | 执行单个子 Agent |
+| `DurableExecutionLease` | durable events | 自动 heartbeat 的 Store-backed execution lease handle |
 | `JsonlDurableEventStore` | root / local | 支持同机多进程锁的 Node.js durable event JSONL adapter |
+| `DurableExecutionLeaseError` | durable events | lease 冲突、失租、缺少 fence 或状态损坏错误 |
 | `SessionInputError` | session | 输入队列容量、请求匹配或活动请求选项错误 |
 | `SessionHandoffError` | session | handoff 配置、生命周期或活动后台工作前置条件错误 |
 | `SdkError` 及派生错误 | root | 类型化 SDK 错误层级 |
@@ -88,6 +90,7 @@ Node-local 能力外，这些函数都从根入口导出；实际 subpath 以“
 | `InputId` / `RequestId` / `SessionId` | 输入、活动请求与会话的 branded identifiers |
 | `EventId` / `EventSequence` | durable event 标识与 Session 内单调序列 |
 | `CommandId` / `TurnId` / `ModelAttemptId` / `ToolAttemptId` / `PermissionRequestId` | durable command、turn、模型尝试、工具尝试与权限请求标识 |
+| `WorkerId` / `ExecutionLeaseId` / `FencingToken` | worker、租约和单调 fence 的 branded identifiers |
 | `StreamOptions` | stream() 选项 |
 | `StreamMessage` | Session 流式消息联合类型 |
 | `PromptResult` | prompt() 返回结果 |
@@ -103,6 +106,10 @@ Node-local 能力外，这些函数都从根入口导出；实际 subpath 以“
 | 导出 | 说明 |
 |------|------|
 | `DurableEventStore` | append/read/head 的持久化接口 |
+| `DurableExecutionLeaseStore` | 粘性 `requiresExecutionLease`、原子 acquire/renew/release/assert 与 fenced append 接口 |
+| `DurableExecutionLeaseOptions` | Session lease 的 owner、TTL、heartbeat 和可选 lease ID |
+| `DurableExecutionLeaseSnapshot` / `DurableExecutionFence` | 当前租约快照及传递给 Store/工具的 fence |
+| `DurableExecutionLeaseErrorCode` | lease 配置、冲突、缺少 fence、失租、损坏与写入错误码 |
 | `DurableEventSubscription` | 支持 replay/caught-up/live 阶段的可重连事件流 |
 | `durableEventCursor` / `parseDurableEventCursor` | 创建和严格解析版本化恢复 cursor |
 | `DurableSessionJournal` / `DurableSessionJournalOptions` | command-oriented 串行提交、CAS 重试与对账层 |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -57,6 +57,9 @@ Node-local 能力外，这些函数都从根入口导出；实际 subpath 以“
 | `SubagentRegistry` | subagents | 注册和发现子 Agent |
 | `SubagentExecutor` | subagents | 执行单个子 Agent |
 | `DurableExecutionLease` | durable events | 自动 heartbeat 的 Store-backed execution lease handle |
+| `executionFence` | durable events | 从 lease snapshot 提取不可变的下游 fence |
+| `isDurableExecutionLeaseStore` | durable events | 检查 Store 是否实现完整 execution lease 协议 |
+| `DURABLE_EXECUTION_LEASE_FORMAT` | durable events | lease sidecar 的持久化格式标识 |
 | `JsonlDurableEventStore` | root / local | 支持同机多进程锁的 Node.js durable event JSONL adapter |
 | `DurableExecutionLeaseError` | durable events | lease 冲突、失租、缺少 fence 或状态损坏错误 |
 | `SessionInputError` | session | 输入队列容量、请求匹配或活动请求选项错误 |

--- a/docs/durable-events.md
+++ b/docs/durable-events.md
@@ -597,16 +597,21 @@ const journal = await DurableSessionJournal.open(store, sessionId, {
 要求是粘性的：Store 一旦为 Session 创建过 lease 状态，即使当前 lease 已过期或
 释放，后续 append 和 Journal/Recovery Coordinator open 仍必须携带新的活动
 lease。`requiresExecutionLease()` 用于入口处提前检测；append 内的事务校验才是
-最终权威边界。
+最终权威边界。短时内部持久化可通过 `withExecutionLease()` 在同一所有权锁内
+执行，避免 transcript 写入与 lease 接管交错；不要用它包裹模型或工具等长耗时
+外部 I/O。
 
 进程内 lease handle 会自动 heartbeat。任何续租或校验失败都会中止
 `lease.signal` 并保持 fail-closed。配置 `SessionOptions.executionLease` 后，
 Session 会集成该 handle：模型调用与工具副作用在 I/O 前立即校验所有权，Journal
-commit 携带 fence；失租时本地执行关闭，但不会写入伪造的 durable 终态。
+commit 携带 fence，subagent 状态与 output 写入也在同一所有权边界内执行；失租
+时本地执行关闭，但不会写入伪造的 durable 终态。
 
 fence 保护 SDK 生命周期提交。工具修改其他共享资源时，还必须让下游比较
 `ExecutionContext.executionFence.fencingToken`；通用 SDK 无法强制 fence
-已经启动且下游不校验 token 的操作。
+已经启动且下游不校验 token 的操作。SDK 会在当前 worker 内终止受管 shell 的
+完整进程组并等待退出，但它不是跨进程 supervisor，不能替代共享资源上的 token
+校验。
 
 ### 受控 worker handoff
 

--- a/docs/durable-events.md
+++ b/docs/durable-events.md
@@ -575,6 +575,39 @@ v3 batch；schema 版本只能单调升级，不能在 v3 后降回 v2，且 v2 
 伪装包含 v3 模型事件。Schema v1 不会被静默推断，需要显式迁移后才能由当前
 runtime 恢复。
 
+### 执行租约与 fencing
+
+`DurableExecutionLease` 在 Journal CAS 之上提供 opt-in worker 所有权：
+
+```ts
+const lease = await DurableExecutionLease.acquire(store, sessionId, {
+  ownerId: WorkerId('worker-a'),
+  ttlMs: 30_000,
+  heartbeatIntervalMs: 10_000,
+});
+const journal = await DurableSessionJournal.open(store, sessionId, {
+  executionLease: lease,
+});
+```
+
+支持租约的 Store 实现 `DurableExecutionLeaseStore`。获取、续租、释放和
+`append(..., { executionFence })` 必须通过同一个事务边界串行化。接管会递增
+`FencingToken`；stale writer 收到 `DURABLE_EXECUTION_LEASE_LOST`，活动租约
+期间未携带 fence 的 append 收到 `DURABLE_EXECUTION_LEASE_REQUIRED`。fencing
+要求是粘性的：Store 一旦为 Session 创建过 lease 状态，即使当前 lease 已过期或
+释放，后续 append 和 Journal/Recovery Coordinator open 仍必须携带新的活动
+lease。`requiresExecutionLease()` 用于入口处提前检测；append 内的事务校验才是
+最终权威边界。
+
+进程内 lease handle 会自动 heartbeat。任何续租或校验失败都会中止
+`lease.signal` 并保持 fail-closed。配置 `SessionOptions.executionLease` 后，
+Session 会集成该 handle：模型调用与工具副作用在 I/O 前立即校验所有权，Journal
+commit 携带 fence；失租时本地执行关闭，但不会写入伪造的 durable 终态。
+
+fence 保护 SDK 生命周期提交。工具修改其他共享资源时，还必须让下游比较
+`ExecutionContext.executionFence.fencingToken`；通用 SDK 无法强制 fence
+已经启动且下游不校验 token 的操作。
+
 ### 受控 worker handoff
 
 `session.suspendForHandoff()` 在恢复前提供显式的源 worker 屏障。它会封闭新的
@@ -589,8 +622,9 @@ plan 调用 `DurableSessionRecoveryCoordinator`，只在 plan 允许后调用
 
 仍有后台子 Agent 或归属该 Session 的后台 shell 运行时，该屏障会在取消主
 Request 前拒绝；同时要求 durable journal 与 transcript storage 都已配置。
-handoff 只协调已知的源 worker 和继任 worker，不替代跨主机 execution lease
-或 fencing token。
+未配置 `executionLease` 时，handoff 只协调已知的源 worker 和继任 worker。
+配置后，源 worker 会持有租约直到清理完成，并在返回前释放，继任 worker 随后可
+获取下一个 token。
 
 ## JSONL 持久化
 
@@ -598,6 +632,7 @@ handoff 只协调已知的源 worker 和继任 worker，不替代跨主机 execu
 
 ```text
 {storageRoot}/durable-events/{base64url(sessionId)}.jsonl
+{storageRoot}/durable-events/{base64url(sessionId)}.lease.json
 ```
 
 每行是一个完整 append batch，而不是单个事件。该布局保证进程在写入中途崩溃
@@ -626,17 +661,19 @@ addon 无法加载或平台不支持 advisory lock 时，Store 以
 Windows 的 x64/arm64；Alpine/musl 及其他目标不受 `JsonlDurableEventStore`
 支持。
 
-事件文件使用 `0600` 权限，Session ID 经过 base64url 编码，不会成为文件路径。
+事件文件与 lease sidecar 使用 `0600` 权限，Session ID 经过 base64url 编码，
+不会成为文件路径。
 事件会保存原始请求输入、完整模型响应、工具输入和模型侧工具结果；调用方必须将
 Store 视为敏感数据存储，并自行配置加密、保留期限和访问控制。
 
 ## 一致性边界
 
 `JsonlDurableEventStore` 保证同一主机上多个 Node.js 进程针对同一 Session 的
-互斥读写和原子 compare-and-append。该保证要求本地文件系统正确实现 advisory
-lock；它不适用于 NFS 等共享网络文件系统，也不提供跨主机 execution lease。
-多副本服务仍应实现 `DurableEventStore` 接口，并使用数据库事务、CAS 或带
-fencing token 的 lease 保证单写者；不能依赖未提供 fencing 的超时 lease。
+互斥读写、原子 compare-and-append，以及带单调 fencing token 的执行租约。租约
+状态和 event append 共用同一把 Session 锁。该保证要求本地文件系统正确实现
+advisory lock，不适用于 NFS 等共享网络文件系统。多副本服务必须实现
+`DurableExecutionLeaseStore`，并通过数据库事务让每次 append 与 fence 校验
+保持原子；不能依赖未提供 fencing 的超时 lease。
 
 `DURABLE_EVENT_WRITE_FAILED` 不代表 batch 一定没有写入：底层写入成功后
 `fsync`、解锁或关闭锁文件失败时，提交结果都可能未知。调用方重试前必须重新
@@ -655,6 +692,10 @@ Store 不持久化 token delta、工具 progress 等高频 UI 事件。只有会
 | `DurableSessionJournalError` | command 输入、Store page 或 commit 返回值违反契约 |
 | `DurableEventSubscriptionError` | 订阅配置、cursor 锚点或 Store page 不满足续读契约 |
 | `DurableSessionRecoveryRequiredError` | Session 存在未完成工作，必须先执行恢复或对账 |
+| `DurableExecutionLeaseError` | lease 获取、heartbeat、所有权或持久化状态失败 |
+| `DURABLE_EXECUTION_LEASE_CONFLICT` | 另一个未过期的 worker lease 正持有 Session |
+| `DURABLE_EXECUTION_LEASE_REQUIRED` | 活动 lease 存在，但 append 未携带对应 fence |
+| `DURABLE_EXECUTION_LEASE_LOST` | lease 已过期、释放或被更高 token 替换 |
 | `SessionDurableRecorderError` | Session runtime 观察到非法 durable 生命周期状态 |
 | `DurableEventProjectionError` | schema、事件顺序或关联关系不满足生命周期约束 |
 | `DurableEventSequenceConflictError` | compare-and-append 前置条件失败 |

--- a/docs/en/api-reference.md
+++ b/docs/en/api-reference.md
@@ -55,6 +55,9 @@ Constants:
 - `ModelAttemptId`
 - `ToolAttemptId`
 - `PermissionRequestId`
+- `WorkerId`
+- `ExecutionLeaseId`
+- `FencingToken`
 - `AgentId`
 - `MessageId`
 - `ToolUseId`
@@ -65,6 +68,11 @@ These ID exports are branded identifiers, not arbitrary strings.
 
 Runtime:
 
+- `DurableExecutionLease`
+- `DurableExecutionLeaseError`
+- `executionFence`
+- `isDurableExecutionLeaseStore`
+- `DURABLE_EXECUTION_LEASE_FORMAT`
 - `JsonlDurableEventStore`
 - `DurableEventSubscription`
 - `durableEventCursor`
@@ -85,6 +93,11 @@ Runtime:
 
 Types and errors:
 
+- `DurableExecutionLeaseOptions`
+- `DurableExecutionLeaseStore`
+- `DurableExecutionLeaseSnapshot`
+- `DurableExecutionFence`
+- `DurableExecutionLeaseErrorCode`
 - `DurableEventStore`
 - `JsonlDurableEventStoreOptions`
 - `DurableEventCursor`

--- a/docs/en/durable-events.md
+++ b/docs/en/durable-events.md
@@ -641,17 +641,24 @@ once a Store creates lease state for a Session, every later append and
 Journal/Recovery Coordinator open requires a new active lease even after the
 previous lease expires or is released. `requiresExecutionLease()` provides an
 early entry-point check; the transactional append check remains authoritative.
+Short internal persistence operations can use `withExecutionLease()` to run
+under the same ownership lock and avoid racing transcript writes with takeover.
+Do not hold this boundary around long-running model or tool I/O.
 
 The process-local lease handle heartbeats automatically. Any renewal or
 validation failure aborts `lease.signal` and remains fail-closed. Session
 integrates this handle when `SessionOptions.executionLease` is configured:
 model calls and tool side effects validate ownership immediately before I/O,
-Journal commits carry the fence, and lease loss closes local execution without
-writing a false durable terminal event.
+Journal commits carry the fence, and subagent state and output writes run under
+the same ownership boundary. Lease loss closes local execution without writing
+a false durable terminal event.
 
 The fence protects SDK lifecycle commits. External resources modified by a tool
 must also compare `ExecutionContext.executionFence.fencingToken`; otherwise an
 already-started operation cannot be forcibly fenced by a generic SDK.
+Within the current worker, the SDK terminates a managed shell's complete process
+group and waits for it to exit. It is not a cross-process supervisor or a
+substitute for downstream token validation.
 
 ### Controlled worker handoff
 

--- a/docs/en/durable-events.md
+++ b/docs/en/durable-events.md
@@ -617,6 +617,42 @@ versions may only increase: a v2 batch after v3 is corrupt, and a v2 batch
 cannot masquerade as containing v3 model events. Version 1 logs are not
 inferred silently and must be migrated before this runtime can resume them.
 
+### Execution leases and fencing
+
+`DurableExecutionLease` adds opt-in worker ownership on top of Journal CAS:
+
+```ts
+const lease = await DurableExecutionLease.acquire(store, sessionId, {
+  ownerId: WorkerId('worker-a'),
+  ttlMs: 30_000,
+  heartbeatIntervalMs: 10_000,
+});
+const journal = await DurableSessionJournal.open(store, sessionId, {
+  executionLease: lease,
+});
+```
+
+A lease-capable Store implements `DurableExecutionLeaseStore`. Acquisition,
+renewal, release, and `append(..., { executionFence })` must serialize through
+the same transactional boundary. A takeover increments `FencingToken`; a stale
+writer receives `DURABLE_EXECUTION_LEASE_LOST`, while an unfenced append during
+an active lease receives `DURABLE_EXECUTION_LEASE_REQUIRED`. Fencing is sticky:
+once a Store creates lease state for a Session, every later append and
+Journal/Recovery Coordinator open requires a new active lease even after the
+previous lease expires or is released. `requiresExecutionLease()` provides an
+early entry-point check; the transactional append check remains authoritative.
+
+The process-local lease handle heartbeats automatically. Any renewal or
+validation failure aborts `lease.signal` and remains fail-closed. Session
+integrates this handle when `SessionOptions.executionLease` is configured:
+model calls and tool side effects validate ownership immediately before I/O,
+Journal commits carry the fence, and lease loss closes local execution without
+writing a false durable terminal event.
+
+The fence protects SDK lifecycle commits. External resources modified by a tool
+must also compare `ExecutionContext.executionFence.fencingToken`; otherwise an
+already-started operation cannot be forcibly fenced by a generic SDK.
+
 ### Controlled worker handoff
 
 `session.suspendForHandoff()` provides an explicit source-worker barrier before
@@ -634,9 +670,10 @@ the returned plan with `DurableSessionRecoveryCoordinator` and only call
 
 The barrier rejects before cancelling the root Request if any background
 subagent or Session-owned background shell remains active. It also requires
-both the durable journal and transcript storage. Handoff coordinates a known
-source and successor; it does not replace a cross-host execution lease or
-fencing token.
+both the durable journal and transcript storage. Without `executionLease`,
+handoff only coordinates a known source and successor. With it, the source
+retains ownership through cleanup and releases the lease before returning, so
+the successor can acquire the next token.
 
 ## JSONL persistence
 
@@ -644,6 +681,7 @@ Files are stored under:
 
 ```text
 {storageRoot}/durable-events/{base64url(sessionId)}.jsonl
+{storageRoot}/durable-events/{base64url(sessionId)}.lease.json
 ```
 
 Each line is a complete append batch rather than one event. If the process
@@ -679,21 +717,22 @@ does not support advisory locking, the Store fails closed with
 Linux, and Windows on x64/arm64. `JsonlDurableEventStore` does not support
 Alpine/musl or other targets.
 
-Event files use mode `0600`. Session IDs are base64url encoded and cannot
-become filesystem paths.
+Event files and lease sidecars use mode `0600`. Session IDs are base64url
+encoded and cannot become filesystem paths.
 Events contain raw request inputs, complete model responses, tool inputs, and
 model-facing tool results. Treat the Store as sensitive data and configure
 encryption, retention, and access control at the deployment boundary.
 
 ## Consistency boundary
 
-`JsonlDurableEventStore` provides mutually exclusive reads and atomic
-compare-and-append across Node.js processes on the same host. This guarantee
-requires a local filesystem with working advisory locks; it does not apply to
-shared network filesystems such as NFS and does not provide a cross-host
-execution lease. Replicated services must still implement `DurableEventStore`
-with database transactions, CAS, or a lease carrying a fencing token. An
-unfenced timeout-based lease is not sufficient.
+`JsonlDurableEventStore` provides mutually exclusive reads, atomic
+compare-and-append, and execution leases with monotonic fencing tokens across
+Node.js processes on the same host. Lease state and event appends share the
+same Session lock. This guarantee requires a local filesystem with working
+advisory locks and does not apply to shared network filesystems such as NFS.
+Replicated services must implement `DurableExecutionLeaseStore` using database
+transactions that atomically validate the fence with each append. An unfenced
+timeout-based lease is not sufficient.
 
 `DURABLE_EVENT_WRITE_FAILED` does not prove that a batch was not written. The
 outcome can be unknown when `fsync`, unlocking, or closing the lock file fails
@@ -714,6 +753,10 @@ journal.
 | `DurableSessionJournalError` | Command input, Store page, or commit result violates its contract. |
 | `DurableEventSubscriptionError` | Subscription options, cursor anchors, or Store pages violate the replay contract. |
 | `DurableSessionRecoveryRequiredError` | The Session has unfinished work that requires recovery or reconciliation. |
+| `DurableExecutionLeaseError` | Lease acquisition, heartbeat, ownership, or persisted lease state failed. |
+| `DURABLE_EXECUTION_LEASE_CONFLICT` | Another unexpired worker lease owns the Session. |
+| `DURABLE_EXECUTION_LEASE_REQUIRED` | An active lease exists but the append did not carry its fence. |
+| `DURABLE_EXECUTION_LEASE_LOST` | The lease expired, was released, or was replaced by a higher token. |
 | `SessionDurableRecorderError` | Session runtime observed an invalid durable lifecycle state. |
 | `DurableEventProjectionError` | Schema, ordering, or correlation violates lifecycle invariants. |
 | `DurableEventSequenceConflictError` | Compare-and-append precondition failed. |

--- a/docs/en/session.md
+++ b/docs/en/session.md
@@ -253,10 +253,88 @@ local Session closed and must be recovered from the durable journal.
 `SessionHandoffError` exposes stable `code`, `activeSubagentIds`, and
 `activeShellIds` fields for orchestration.
 
-This API is a cooperative shutdown barrier, not a cross-host lease. Stop routing
-new work to the old worker before calling it, and use a transactional
-`DurableEventStore` with fencing when multiple hosts can execute the same
-Session.
+Without `executionLease`, this API remains a cooperative shutdown barrier:
+stop routing new work to the old worker before calling it. With a lease-capable
+`DurableEventStore`, handoff keeps the current lease until execution, transcript
+writes, and journal finalization settle, then releases it before returning.
+The successor acquires a higher fencing token when it calls `resumeSession()`.
+
+## Fence execution across workers
+
+Configure `executionLease` when more than one worker can open the same durable
+Session:
+
+```ts
+import {
+  JsonlDurableEventStore,
+  WorkerId,
+  createSession,
+} from '@blade-ai/agent-sdk';
+
+const eventStore = new JsonlDurableEventStore('/var/lib/my-agent');
+const session = await createSession({
+  provider,
+  model,
+  storagePath: '/var/lib/my-agent',
+  durableEventStore: eventStore,
+  executionLease: {
+    ownerId: WorkerId(process.env.HOSTNAME ?? `worker-${process.pid}`),
+    ttlMs: 30_000,
+    heartbeatIntervalMs: 10_000,
+  },
+});
+```
+
+Session acquisition is fail-closed. A second live worker receives
+`DURABLE_EXECUTION_LEASE_CONFLICT`. Each successful takeover increments a
+monotonic `FencingToken`; every Journal commit validates the active lease in
+the same Store transaction as its append. The Session heartbeat stops admitting
+new work and aborts the root execution, foreground/background subagents, and
+Session-owned shells when ownership cannot be renewed.
+
+Once a Session enables an execution lease, its fencing requirement is
+permanent. After the old lease expires or is released, `resumeSession()` without
+`executionLease` still fails with `DURABLE_EXECUTION_LEASE_REQUIRED`; the
+successor must first acquire a lease with a higher token. Normal `close()` waits
+for background agents and Session-owned shells to stop before it commits the
+durable close and releases the lease.
+
+`session.getExecutionLease()` returns the current lease snapshot. Tools receive
+the immutable `{ leaseId, fencingToken }` as
+`ExecutionContext.executionFence`. A tool that writes another shared system
+must pass this fence to that system and have it reject older tokens. The SDK can
+prevent stale Journal commits and new model/tool starts, but a generic
+downstream service cannot be hard-fenced unless it validates the token.
+
+`JsonlDurableEventStore` implements this protocol for Node.js processes sharing
+one supported local filesystem. It is not a cross-host store. Cross-host
+deployments must implement `DurableExecutionLeaseStore` so lease mutation and
+`append(..., { executionFence })` validation occur in the same database
+transaction.
+
+Recovery mutations can hold the same lease guard:
+
+```ts
+import {
+  DurableExecutionLease,
+  DurableSessionRecoveryCoordinator,
+  WorkerId,
+} from '@blade-ai/agent-sdk';
+
+const lease = await DurableExecutionLease.acquire(eventStore, sessionId, {
+  ownerId: WorkerId('recovery-worker'),
+});
+try {
+  const coordinator = await DurableSessionRecoveryCoordinator.open(
+    eventStore,
+    sessionId,
+    { executionLease: lease },
+  );
+  // Reconcile or prepare recovery while the fence remains active.
+} finally {
+  await lease.release();
+}
+```
 
 ## One-shot prompts
 
@@ -617,6 +695,7 @@ Payload capture is opt-in because prompts and tool data may be sensitive.
 | `storagePath` | `string` | Enables JSONL persistence |
 | `persistSession` | `boolean` | Disable persistence explicitly |
 | `durableEventStore` | `DurableEventStore` | Opt-in durable execution journal |
+| `executionLease` | `DurableExecutionLeaseOptions` | Opt-in worker ownership, heartbeat, and fencing |
 | `outputFormat` | `OutputFormat` | Structured output schema |
 | `sandbox` | `SandboxSettings` | Bash sandbox settings |
 | `observability` | `ObservabilityOptions` | Trace collection |
@@ -656,6 +735,7 @@ interface ISession extends AsyncDisposable {
   getTraces(): AgentTrace[];
   getDurableProjection(): DurableSessionProjection | null;
   getDurableRecoveryPlan(): DurableSessionRecoveryPlan | null;
+  getExecutionLease(): DurableExecutionLeaseSnapshot | null;
   subscribeDurableEvents(
     options?: DurableEventSubscriptionOptions,
   ): Promise<DurableEventSubscription>;

--- a/docs/en/session.md
+++ b/docs/en/session.md
@@ -288,16 +288,24 @@ const session = await createSession({
 Session acquisition is fail-closed. A second live worker receives
 `DURABLE_EXECUTION_LEASE_CONFLICT`. Each successful takeover increments a
 monotonic `FencingToken`; every Journal commit validates the active lease in
-the same Store transaction as its append. The Session heartbeat stops admitting
-new work and aborts the root execution, foreground/background subagents, and
-Session-owned shells when ownership cannot be renewed.
+the same Store transaction as its append. Short SDK-owned transcript writes are
+serialized against takeover through `withExecutionLease()`. Background-subagent
+state and output writes carry and validate the same fence. The Session heartbeat
+stops admitting new work and aborts the root execution, foreground/background
+subagents, and complete process groups for Session-owned shells when ownership
+cannot be renewed.
 
 Once a Session enables an execution lease, its fencing requirement is
 permanent. After the old lease expires or is released, `resumeSession()` without
 `executionLease` still fails with `DURABLE_EXECUTION_LEASE_REQUIRED`; the
 successor must first acquire a lease with a higher token. Normal `close()` waits
 for background agents and Session-owned shells to stop before it commits the
-durable close and releases the lease.
+durable close and releases the lease. If runtime cleanup fails, it retains the
+lease and allows the caller to retry `close()`.
+
+Normally omit `leaseId` so the SDK generates a random ID for each worker
+execution. Reusing the same `ownerId + leaseId` is treated as an idempotent
+retry of one acquisition; concurrent workers must never share that identity.
 
 `session.getExecutionLease()` returns the current lease snapshot. Tools receive
 the immutable `{ leaseId, fencingToken }` as

--- a/docs/en/session.md
+++ b/docs/en/session.md
@@ -315,10 +315,10 @@ prevent stale Journal commits and new model/tool starts, but a generic
 downstream service cannot be hard-fenced unless it validates the token.
 
 `JsonlDurableEventStore` implements this protocol for Node.js processes sharing
-one supported local filesystem. It is not a cross-host store. Cross-host
-deployments must implement `DurableExecutionLeaseStore` so lease mutation and
-`append(..., { executionFence })` validation occur in the same database
-transaction.
+one supported local filesystem. It is not a cross-host store. Lease-enabled
+cross-host Sessions must implement `DurableExecutionLeaseStore` so lease
+mutation and `append(..., { executionFence })` validation occur in the same
+database transaction.
 
 Recovery mutations can hold the same lease guard:
 

--- a/docs/session.md
+++ b/docs/session.md
@@ -1455,9 +1455,82 @@ Request 前失败；应先等待或终止这些后台工作后重试。如果取
 `SessionHandoffError` 提供稳定的 `code`、`activeSubagentIds` 和
 `activeShellIds` 字段供调度层处理。
 
-该 API 是协作式 shutdown barrier，不是跨主机 lease。调用前必须停止向旧 worker
-路由新工作；多主机可能同时执行同一 Session 时，`DurableEventStore` 仍须提供
-transactional CAS 与 fencing。
+未配置 `executionLease` 时，该 API 仍只是协作式 shutdown barrier；调用前必须
+停止向旧 worker 路由新工作。配置支持租约的 `DurableEventStore` 后，handoff
+会在执行、transcript 写入及 journal 收敛期间继续持有当前租约，并在返回前释放；
+继任 worker 调用 `resumeSession()` 时会取得更高的 fencing token。
+
+## 跨 worker 执行 fencing
+
+当多个 worker 可能打开同一个 durable Session 时，配置 `executionLease`：
+
+```ts
+import {
+  JsonlDurableEventStore,
+  WorkerId,
+  createSession,
+} from '@blade-ai/agent-sdk';
+
+const eventStore = new JsonlDurableEventStore('/var/lib/my-agent');
+const session = await createSession({
+  provider,
+  model,
+  storagePath: '/var/lib/my-agent',
+  durableEventStore: eventStore,
+  executionLease: {
+    ownerId: WorkerId(process.env.HOSTNAME ?? `worker-${process.pid}`),
+    ttlMs: 30_000,
+    heartbeatIntervalMs: 10_000,
+  },
+});
+```
+
+Session 获取租约时保持 fail-closed。第二个存活 worker 会收到
+`DURABLE_EXECUTION_LEASE_CONFLICT`。每次成功接管都会递增单调
+`FencingToken`；Journal 的每次 commit 都在 Store 的同一事务中校验活动租约和
+event append。heartbeat 无法续租时，Session 会停止接收新工作，并取消根执行、
+前台/后台子 Agent 及归属该 Session 的后台 shell。
+
+Session 一旦启用过 execution lease，fencing 要求会永久保留。旧租约过期或释放
+后，未配置 `executionLease` 的 `resumeSession()` 仍会收到
+`DURABLE_EXECUTION_LEASE_REQUIRED`；继任 worker 必须先获取更高 token 的 lease。
+正常 `close()` 会先取消并等待后台 Agent、终止 Session shell，再提交 durable
+关闭并释放 lease。
+
+`session.getExecutionLease()` 返回当前租约快照。工具会通过
+`ExecutionContext.executionFence` 收到不可变的 `{ leaseId, fencingToken }`。
+工具若写入其他共享系统，必须把该 fence 传给下游，并由下游拒绝更旧的 token。
+SDK 可以阻止 stale journal commit 和新的模型/工具起点，但通用外部服务只有主动
+校验 token 才能获得 hard fencing。
+
+`JsonlDurableEventStore` 只为共享同一受支持本地文件系统的 Node.js 进程实现该
+协议，并不是跨主机 Store。跨主机部署必须实现
+`DurableExecutionLeaseStore`，并在同一个数据库事务中完成租约变更和
+`append(..., { executionFence })` 校验。
+
+恢复操作也可以持有相同的 lease guard：
+
+```ts
+import {
+  DurableExecutionLease,
+  DurableSessionRecoveryCoordinator,
+  WorkerId,
+} from '@blade-ai/agent-sdk';
+
+const lease = await DurableExecutionLease.acquire(eventStore, sessionId, {
+  ownerId: WorkerId('recovery-worker'),
+});
+try {
+  const coordinator = await DurableSessionRecoveryCoordinator.open(
+    eventStore,
+    sessionId,
+    { executionLease: lease },
+  );
+  // 在 fence 有效期间执行对账或准备恢复。
+} finally {
+  await lease.release();
+}
+```
 
 ### 管理待处理输入
 
@@ -1666,6 +1739,7 @@ async function analyzeCodeManual() {
 | `storagePath`     | `string`                                                | —  | —           | 会话存储根路径；未设置时使用内存存储                              |
 | `persistSession`  | `boolean`                                               | —  | `true`      | 有 `storagePath` 时是否启用消息历史持久化                         |
 | `durableEventStore` | `DurableEventStore`                                  | —  | —           | opt-in durable 执行事件 Store                                 |
+| `executionLease` | `DurableExecutionLeaseOptions`                         | —  | —           | opt-in worker 所有权、heartbeat 与 fencing                     |
 | `outputFormat`    | `OutputFormat`                                          | —  | —           | 结构化 JSON Schema 输出格式                              |
 | `sandbox`         | `SandboxSettings`                                       | —  | —           | 命令执行沙箱设置                                          |
 | `observability`   | `ObservabilityOptions`                                  | —  | —           | Trace 收集、payload 捕获与 sink 配置                         |
@@ -1830,6 +1904,7 @@ interface ISession extends AsyncDisposable {
   getTraces(): AgentTrace[];
   getDurableProjection(): DurableSessionProjection | null;
   getDurableRecoveryPlan(): DurableSessionRecoveryPlan | null;
+  getExecutionLease(): DurableExecutionLeaseSnapshot | null;
   subscribeDurableEvents(
     options?: DurableEventSubscriptionOptions,
   ): Promise<DurableEventSubscription>;

--- a/docs/session.md
+++ b/docs/session.md
@@ -1511,7 +1511,7 @@ SDK 可以阻止 stale journal commit 和新的模型/工具起点，但通用�
 校验 token 才能获得 hard fencing。
 
 `JsonlDurableEventStore` 只为共享同一受支持本地文件系统的 Node.js 进程实现该
-协议，并不是跨主机 Store。跨主机部署必须实现
+协议，并不是跨主机 Store。启用 execution lease 的跨主机 Session 必须实现
 `DurableExecutionLeaseStore`，并在同一个数据库事务中完成租约变更和
 `append(..., { executionFence })` 校验。
 
@@ -1941,7 +1941,13 @@ function prompt(
 
 ```ts
 // 函数
-export { createSession, resumeSession, forkSession, prompt };
+export {
+  createSession,
+  resumeSession,
+  forkSession,
+  prompt,
+  DurableExecutionLease,
+};
 
 // 类型
 export type {
@@ -1968,6 +1974,14 @@ export type {
   ResumeOptions,
   SessionHandoffResult,
   SessionHandoffErrorCode,
+  DurableExecutionLeaseOptions,
+  DurableExecutionLeaseSnapshot,
+  DurableExecutionLeaseStore,
+  DurableExecutionFence,
+  DurableExecutionLeaseErrorCode,
+  WorkerId,
+  ExecutionLeaseId,
+  FencingToken,
   ModelInfo,
   McpServerStatus,
   McpToolInfo,

--- a/docs/session.md
+++ b/docs/session.md
@@ -1488,14 +1488,21 @@ const session = await createSession({
 Session 获取租约时保持 fail-closed。第二个存活 worker 会收到
 `DURABLE_EXECUTION_LEASE_CONFLICT`。每次成功接管都会递增单调
 `FencingToken`；Journal 的每次 commit 都在 Store 的同一事务中校验活动租约和
-event append。heartbeat 无法续租时，Session 会停止接收新工作，并取消根执行、
-前台/后台子 Agent 及归属该 Session 的后台 shell。
+event append；SDK 自身的短时 transcript 写入通过 `withExecutionLease()` 与接管
+串行化，后台子 Agent 的状态与 output 写入也会携带并校验 fence。heartbeat
+无法续租时，Session 会停止接收新工作，并取消根执行、前台/后台子 Agent 及归属
+该 Session 的后台 shell 完整进程组。
 
 Session 一旦启用过 execution lease，fencing 要求会永久保留。旧租约过期或释放
 后，未配置 `executionLease` 的 `resumeSession()` 仍会收到
 `DURABLE_EXECUTION_LEASE_REQUIRED`；继任 worker 必须先获取更高 token 的 lease。
 正常 `close()` 会先取消并等待后台 Agent、终止 Session shell，再提交 durable
-关闭并释放 lease。
+关闭并释放 lease；如果 Runtime 清理失败，则保留 lease，并允许调用方重试
+`close()`。
+
+通常应省略 `leaseId` 让 SDK 为每次 worker 执行生成随机 ID。显式复用同一
+`ownerId + leaseId` 被视为同一次 acquire 的幂等重试；不得由两个并发 worker
+共享这组身份。
 
 `session.getExecutionLease()` 返回当前租约快照。工具会通过
 `ExecutionContext.executionFence` 收到不可变的 `{ leaseId, fencingToken }`。

--- a/src/__tests__/rootExports.test.ts
+++ b/src/__tests__/rootExports.test.ts
@@ -9,11 +9,15 @@ import type {
   DurableEventStore,
   DurableEventSubscriptionMessage,
   DurableEventSubscriptionOptions,
+  DurableExecutionFence,
+  DurableExecutionLeaseOptions,
+  DurableExecutionLeaseSnapshot,
+  DurableExecutionLeaseStore,
   DurableModelAttemptProjection,
   DurableModelOutcomeReconciliationCommand,
-  DurableRequestRecoveryOrigin,
-  DurableRequestRecoveryKind,
   DurableRequestOutcomeReconciliationCommand,
+  DurableRequestRecoveryKind,
+  DurableRequestRecoveryOrigin,
   DurableRequestRolloverCommand,
   DurableRequestRolloverResult,
   DurableSessionCommand,
@@ -24,6 +28,7 @@ import type {
   DurableToolStartCommand,
   DurableTurnRecoveryCommand,
   DurableTurnRecoveryResult,
+  ExecutionContext,
   InputSubmission,
   ISession,
   PendingSessionInput,
@@ -56,11 +61,14 @@ import {
   createMemoryWriteTool,
   DURABLE_EVENT_CURSOR_VERSION,
   DURABLE_EVENT_SCHEMA_VERSION,
+  DURABLE_EXECUTION_LEASE_FORMAT,
   DurableCommandConflictError,
   DurableCommandOutcomeUnknownError,
   DurableEventSubscription,
   DurableEventSubscriptionError,
   DurableEventType,
+  DurableExecutionLease,
+  DurableExecutionLeaseError,
   DurableSessionJournal,
   DurableSessionProjector,
   DurableSessionRecoveryCoordinator,
@@ -69,17 +77,19 @@ import {
   durableEventCursor,
   EventId,
   EventSequence,
+  ExecutionLeaseId,
+  FencingToken,
   FileSystemMemoryStore,
   InputId,
   InputPriority,
   JsonlDurableEventStore,
   MemoryManager,
   ModelAttemptId,
-  SessionHandoffError,
   PermissionRequestId,
   projectDurableSession,
   RequestId,
   SessionDurableRecorderError,
+  SessionHandoffError,
   SessionInputError,
   SubagentExecutor,
   SubagentRegistry,
@@ -88,6 +98,7 @@ import {
   ToolErrorType,
   ToolSideEffect,
   TurnId,
+  WorkerId,
 } from '../index.js';
 
 describe('root exports', () => {
@@ -124,6 +135,12 @@ describe('root exports', () => {
     expect(PermissionRequestId('permission-1')).toBe('permission-1');
     expect(DurableCommandConflictError).toBeDefined();
     expect(DurableCommandOutcomeUnknownError).toBeDefined();
+    expect(DurableExecutionLease.acquire).toBeTypeOf('function');
+    expect(DurableExecutionLeaseError).toBeDefined();
+    expect(DURABLE_EXECUTION_LEASE_FORMAT).toBe('blade.durable-execution-lease');
+    expect(ExecutionLeaseId('lease-1')).toBe('lease-1');
+    expect(FencingToken(1)).toBe(1);
+    expect(WorkerId('worker-1')).toBe('worker-1');
     expect(DurableSessionJournal.open).toBeTypeOf('function');
     expect(DurableSessionProjector).toBeDefined();
     expect(DurableSessionRecoveryCoordinator.open).toBeTypeOf('function');
@@ -189,15 +206,15 @@ describe('root exports', () => {
     expectTypeOf<DurableModelAttemptProjection['modelAttemptId']>().toEqualTypeOf<
       ReturnType<typeof ModelAttemptId>
     >();
-    expectTypeOf<
-      DurableModelOutcomeReconciliationCommand['modelAttemptId']
-    >().toEqualTypeOf<ReturnType<typeof ModelAttemptId>>();
+    expectTypeOf<DurableModelOutcomeReconciliationCommand['modelAttemptId']>().toEqualTypeOf<
+      ReturnType<typeof ModelAttemptId>
+    >();
     expectTypeOf<DurableRequestRolloverCommand['inputId']>().toEqualTypeOf<InputId>();
     expectTypeOf<DurableRequestRolloverCommand['sourceLastTurn']>().toEqualTypeOf<number>();
     expectTypeOf<DurableRequestRolloverCommand['recoveryTurnId']>().toEqualTypeOf<TurnId>();
-    expectTypeOf<
-      DurableRequestRolloverCommand['preparation']['appliedInputIds']
-    >().toEqualTypeOf<readonly InputId[]>();
+    expectTypeOf<DurableRequestRolloverCommand['preparation']['appliedInputIds']>().toEqualTypeOf<
+      readonly InputId[]
+    >();
     expectTypeOf<DurableRequestRolloverResult['recoveryRequestId']>().toEqualTypeOf<RequestId>();
     expectTypeOf<DurableSessionProjection['reconciledInputIds']>().toEqualTypeOf<
       readonly InputId[] | undefined
@@ -219,9 +236,28 @@ describe('root exports', () => {
       EventSequence | null | undefined
     >();
     expectTypeOf<DurableEventStore['append']>().toBeFunction();
+    expectTypeOf<DurableExecutionLeaseStore['acquireExecutionLease']>().toBeFunction();
+    expectTypeOf<DurableExecutionFence['fencingToken']>().toEqualTypeOf<
+      ReturnType<typeof FencingToken>
+    >();
+    expectTypeOf<DurableExecutionLeaseSnapshot['ownerId']>().toEqualTypeOf<
+      ReturnType<typeof WorkerId>
+    >();
+    expectTypeOf<DurableExecutionLeaseOptions['leaseId']>().toEqualTypeOf<
+      ReturnType<typeof ExecutionLeaseId> | undefined
+    >();
     expectTypeOf<SessionOptions['durableEventStore']>().toEqualTypeOf<
       DurableEventStore | undefined
     >();
+    expectTypeOf<SessionOptions['executionLease']>().toEqualTypeOf<
+      DurableExecutionLeaseOptions | undefined
+    >();
+    expectTypeOf<ExecutionContext['executionFence']>().toEqualTypeOf<
+      DurableExecutionFence | undefined
+    >();
+    expectTypeOf<
+      ReturnType<ISession['getExecutionLease']>
+    >().toEqualTypeOf<DurableExecutionLeaseSnapshot | null>();
     expectTypeOf<ReturnType<ISession['abort']>>().toEqualTypeOf<Promise<void>>();
     expectTypeOf<ReturnType<ISession['suspendForHandoff']>>().toEqualTypeOf<
       Promise<SessionHandoffResult>

--- a/src/__tests__/rootExports.test.ts
+++ b/src/__tests__/rootExports.test.ts
@@ -136,6 +136,7 @@ describe('root exports', () => {
     expect(DurableCommandConflictError).toBeDefined();
     expect(DurableCommandOutcomeUnknownError).toBeDefined();
     expect(DurableExecutionLease.acquire).toBeTypeOf('function');
+    expect(DurableExecutionLease.prototype.runFenced).toBeTypeOf('function');
     expect(DurableExecutionLeaseError).toBeDefined();
     expect(DURABLE_EXECUTION_LEASE_FORMAT).toBe('blade.durable-execution-lease');
     expect(ExecutionLeaseId('lease-1')).toBe('lease-1');
@@ -237,6 +238,7 @@ describe('root exports', () => {
     >();
     expectTypeOf<DurableEventStore['append']>().toBeFunction();
     expectTypeOf<DurableExecutionLeaseStore['acquireExecutionLease']>().toBeFunction();
+    expectTypeOf<DurableExecutionLeaseStore['withExecutionLease']>().toBeFunction();
     expectTypeOf<DurableExecutionFence['fencingToken']>().toEqualTypeOf<
       ReturnType<typeof FencingToken>
     >();

--- a/src/agent/Agent.ts
+++ b/src/agent/Agent.ts
@@ -279,6 +279,8 @@ export class Agent {
       systemPrompt: context.systemPrompt,
       subagentInfo: context.subagentInfo,
       backgroundAgentManager: context.backgroundAgentManager,
+      executionFence: context.executionFence,
+      assertExecutionLease: context.assertExecutionLease,
     });
 
     return await this.loopRunner.runLoop(message, chatContext, options);

--- a/src/agent/Agent.ts
+++ b/src/agent/Agent.ts
@@ -281,6 +281,7 @@ export class Agent {
       backgroundAgentManager: context.backgroundAgentManager,
       executionFence: context.executionFence,
       assertExecutionLease: context.assertExecutionLease,
+      runWithExecutionLease: context.runWithExecutionLease,
     });
 
     return await this.loopRunner.runLoop(message, chatContext, options);

--- a/src/agent/CompactionHandler.ts
+++ b/src/agent/CompactionHandler.ts
@@ -5,6 +5,10 @@ import { TokenCounter } from '../context/TokenCounter.js';
 import { type InternalLogger, LogCategory, NOOP_LOGGER } from '../logging/Logger.js';
 import type { IChatService } from '../services/ChatServiceInterface.js';
 import { cloneMessage } from '../services/messageUtils.js';
+import {
+  isExecutionLeaseFailure,
+  runWithExecutionLeaseBoundary,
+} from '../session/events/DurableExecutionLeaseStore.js';
 import type { SessionId } from '../types/branded.js';
 import type { CompactingEvent } from './AgentEvent.js';
 import type { ConversationState } from './state/ConversationState.js';
@@ -15,36 +19,6 @@ export interface CompactionRuntimeContext {
   signal?: AbortSignal;
   assertExecutionLease?: () => Promise<void>;
   runWithExecutionLease?: <T>(operation: () => Promise<T>) => Promise<T>;
-}
-
-function isExecutionLeaseFailure(error: unknown): boolean {
-  return (
-    typeof error === 'object' &&
-    error !== null &&
-    'code' in error &&
-    typeof error.code === 'string' &&
-    error.code.startsWith('DURABLE_EXECUTION_LEASE_')
-  );
-}
-
-async function runFencedPersistence<T>(
-  runtimeCtx: CompactionRuntimeContext,
-  operation: () => Promise<T>,
-): Promise<T> {
-  runtimeCtx.signal?.throwIfAborted();
-  if (runtimeCtx.runWithExecutionLease) {
-    const result = await runtimeCtx.runWithExecutionLease(async () => {
-      runtimeCtx.signal?.throwIfAborted();
-      return operation();
-    });
-    runtimeCtx.signal?.throwIfAborted();
-    return result;
-  }
-  await runtimeCtx.assertExecutionLease?.();
-  const result = await operation();
-  runtimeCtx.signal?.throwIfAborted();
-  await runtimeCtx.assertExecutionLease?.();
-  return result;
 }
 
 export class CompactionHandler {
@@ -175,7 +149,7 @@ export class CompactionHandler {
         try {
           const contextMgr = this.getContextManager();
           if (contextMgr && runtimeCtx.sessionId) {
-            await runFencedPersistence(
+            await runWithExecutionLeaseBoundary(
               runtimeCtx,
               () => contextMgr.saveCompaction(
                 runtimeCtx.sessionId,
@@ -304,7 +278,7 @@ export class CompactionHandler {
       try {
         const contextMgr = this.getContextManager();
         if (contextMgr && runtimeCtx.sessionId) {
-          await runFencedPersistence(
+          await runWithExecutionLeaseBoundary(
             runtimeCtx,
             () => contextMgr.saveCompaction(
               runtimeCtx.sessionId,

--- a/src/agent/CompactionHandler.ts
+++ b/src/agent/CompactionHandler.ts
@@ -12,6 +12,8 @@ import type { ConversationState } from './state/ConversationState.js';
 export interface CompactionRuntimeContext {
   sessionId: SessionId;
   projectDir?: string;
+  signal?: AbortSignal;
+  assertExecutionLease?: () => Promise<void>;
 }
 
 export class CompactionHandler {
@@ -107,6 +109,7 @@ export class CompactionHandler {
 
       yield { type: 'compacting', isCompacting: true };
 
+      await runtimeCtx.assertExecutionLease?.();
       try {
         const result = await CompactionService.compact(convState.getContextMessages(), {
           trigger: 'auto',
@@ -118,6 +121,7 @@ export class CompactionHandler {
           customHeaders: chatConfig.customHeaders,
           actualPreTokens: actualPromptTokens,
           projectDir: runtimeCtx.projectDir,
+          signal: runtimeCtx.signal,
         });
 
         if (result.success) {
@@ -181,6 +185,7 @@ export class CompactionHandler {
     runtimeCtx: CompactionRuntimeContext,
   ): AsyncGenerator<CompactingEvent, boolean> {
     this.logger.warn('[Agent] 反应式压缩触发 (context length error)');
+    await runtimeCtx.assertExecutionLease?.();
     yield { type: 'compacting', isCompacting: true };
     const originalMessages = convState.getContextMessages().map(cloneMessage);
     let workingMessages = originalMessages.map(cloneMessage);
@@ -238,6 +243,7 @@ export class CompactionHandler {
         baseURL: chatConfig.baseUrl,
         customHeaders: chatConfig.customHeaders,
         projectDir: runtimeCtx.projectDir,
+        signal: runtimeCtx.signal,
       });
 
       convState.replaceContent(result.compactedMessages);

--- a/src/agent/CompactionHandler.ts
+++ b/src/agent/CompactionHandler.ts
@@ -14,6 +14,37 @@ export interface CompactionRuntimeContext {
   projectDir?: string;
   signal?: AbortSignal;
   assertExecutionLease?: () => Promise<void>;
+  runWithExecutionLease?: <T>(operation: () => Promise<T>) => Promise<T>;
+}
+
+function isExecutionLeaseFailure(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    typeof error.code === 'string' &&
+    error.code.startsWith('DURABLE_EXECUTION_LEASE_')
+  );
+}
+
+async function runFencedPersistence<T>(
+  runtimeCtx: CompactionRuntimeContext,
+  operation: () => Promise<T>,
+): Promise<T> {
+  runtimeCtx.signal?.throwIfAborted();
+  if (runtimeCtx.runWithExecutionLease) {
+    const result = await runtimeCtx.runWithExecutionLease(async () => {
+      runtimeCtx.signal?.throwIfAborted();
+      return operation();
+    });
+    runtimeCtx.signal?.throwIfAborted();
+    return result;
+  }
+  await runtimeCtx.assertExecutionLease?.();
+  const result = await operation();
+  runtimeCtx.signal?.throwIfAborted();
+  await runtimeCtx.assertExecutionLease?.();
+  return result;
 }
 
 export class CompactionHandler {
@@ -122,7 +153,10 @@ export class CompactionHandler {
           actualPreTokens: actualPromptTokens,
           projectDir: runtimeCtx.projectDir,
           signal: runtimeCtx.signal,
+          assertExecutionLease: runtimeCtx.assertExecutionLease,
         });
+        runtimeCtx.signal?.throwIfAborted();
+        await runtimeCtx.assertExecutionLease?.();
 
         if (result.success) {
           convState.replaceContent(result.compactedMessages);
@@ -141,20 +175,29 @@ export class CompactionHandler {
         try {
           const contextMgr = this.getContextManager();
           if (contextMgr && runtimeCtx.sessionId) {
-            await contextMgr.saveCompaction(
-              runtimeCtx.sessionId,
-              result.summary,
-              {
-                trigger: 'auto',
-                preTokens: result.preTokens,
-                postTokens: result.postTokens,
-                filesIncluded: result.filesIncluded,
-              },
-              null
+            await runFencedPersistence(
+              runtimeCtx,
+              () => contextMgr.saveCompaction(
+                runtimeCtx.sessionId,
+                result.summary,
+                {
+                  trigger: 'auto',
+                  preTokens: result.preTokens,
+                  postTokens: result.postTokens,
+                  filesIncluded: result.filesIncluded,
+                },
+                null,
+              ),
             );
             this.logger.debug(`[Agent] [轮次 ${currentTurn}] 压缩数据已保存到 JSONL`);
           }
         } catch (saveError) {
+          if (
+            runtimeCtx.signal?.aborted ||
+            isExecutionLeaseFailure(saveError)
+          ) {
+            throw saveError;
+          }
           this.logger.warn(`[Agent] [轮次 ${currentTurn}] 保存压缩数据失败:`, saveError);
         }
 
@@ -162,6 +205,12 @@ export class CompactionHandler {
 
         return true;
       } catch (error) {
+        if (
+          runtimeCtx.signal?.aborted ||
+          isExecutionLeaseFailure(error)
+        ) {
+          throw error;
+        }
         yield { type: 'compacting', isCompacting: false };
 
         this.logger.error(`[Agent] [轮次 ${currentTurn}] 压缩失败，继续执行`, error);
@@ -244,7 +293,10 @@ export class CompactionHandler {
         customHeaders: chatConfig.customHeaders,
         projectDir: runtimeCtx.projectDir,
         signal: runtimeCtx.signal,
+        assertExecutionLease: runtimeCtx.assertExecutionLease,
       });
+      runtimeCtx.signal?.throwIfAborted();
+      await runtimeCtx.assertExecutionLease?.();
 
       convState.replaceContent(result.compactedMessages);
 
@@ -252,25 +304,40 @@ export class CompactionHandler {
       try {
         const contextMgr = this.getContextManager();
         if (contextMgr && runtimeCtx.sessionId) {
-          await contextMgr.saveCompaction(
-            runtimeCtx.sessionId,
-            result.summary,
-            {
-              trigger: 'auto',
-              preTokens: result.preTokens,
-              postTokens: result.postTokens,
-              filesIncluded: result.filesIncluded,
-            },
-            null,
+          await runFencedPersistence(
+            runtimeCtx,
+            () => contextMgr.saveCompaction(
+              runtimeCtx.sessionId,
+              result.summary,
+              {
+                trigger: 'auto',
+                preTokens: result.preTokens,
+                postTokens: result.postTokens,
+                filesIncluded: result.filesIncluded,
+              },
+              null,
+            ),
           );
         }
       } catch (saveError) {
+        if (
+          runtimeCtx.signal?.aborted ||
+          isExecutionLeaseFailure(saveError)
+        ) {
+          throw saveError;
+        }
         this.logger.warn('[Agent] 保存反应式压缩数据失败:', saveError);
       }
 
       yield { type: 'compacting', isCompacting: false };
       return true;
     } catch (error) {
+      if (
+        runtimeCtx.signal?.aborted ||
+        isExecutionLeaseFailure(error)
+      ) {
+        throw error;
+      }
       // Fallback: emergency truncation
       this.logger.error('[Agent] 反应式压缩失败，使用紧急截断:', error);
       const recentMessages = originalMessages.slice(-40);

--- a/src/agent/LoopHookBuilder.ts
+++ b/src/agent/LoopHookBuilder.ts
@@ -12,6 +12,10 @@ import { SdkError } from '../errors/SdkError.js';
 import type { HookRuntime } from '../hooks/HookRuntime.js';
 import type { InternalLogger } from '../logging/Logger.js';
 import type { Message } from '../services/ChatServiceInterface.js';
+import {
+  isExecutionLeaseFailure,
+  runWithExecutionLeaseBoundary,
+} from '../session/events/DurableExecutionLeaseStore.js';
 import type { ExecutionPipeline } from '../tools/execution/ExecutionPipeline.js';
 import type { ToolEffect } from '../tools/types/index.js';
 import type { SessionId } from '../types/branded.js';
@@ -23,19 +27,9 @@ import type { RuntimePatchManager } from './RuntimePatchManager.js';
 import type { LoopState } from './state/LoopState.js';
 import type { TokenBudget } from './TokenBudget.js';
 import type {
-    ChatContext,
-    LoopOptions,
+  ChatContext,
+  LoopOptions,
 } from './types.js';
-
-function isExecutionLeaseFailure(error: unknown): boolean {
-  return (
-    typeof error === 'object'
-    && error !== null
-    && 'code' in error
-    && typeof error.code === 'string'
-    && error.code.startsWith('DURABLE_EXECUTION_LEASE_')
-  );
-}
 
 export interface LoopHookBuilderDeps {
   context: ChatContext;
@@ -71,21 +65,14 @@ async function persistToJsonl<T>(
     signal?.throwIfAborted();
     const contextMgr = modelManager.getContextManager();
     if (contextMgr && sessionId) {
-      const persist = async (): Promise<T> => {
-        signal?.throwIfAborted();
-        const result = await callback(contextMgr, sessionId);
-        signal?.throwIfAborted();
-        return result;
-      };
-      if (runWithExecutionLease) {
-        const result = await runWithExecutionLease(persist);
-        signal?.throwIfAborted();
-        return result;
-      }
-      await assertExecutionLease?.();
-      const result = await persist();
-      await assertExecutionLease?.();
-      return result;
+      return runWithExecutionLeaseBoundary(
+        {
+          signal,
+          assertExecutionLease,
+          runWithExecutionLease,
+        },
+        () => callback(contextMgr, sessionId),
+      );
     }
   } catch (error) {
     if (signal?.aborted || isExecutionLeaseFailure(error)) {
@@ -368,7 +355,10 @@ export function buildLoopConfig(deps: LoopHookBuilderDeps): AgentLoopConfig {
               lastActivity: toolCall.function.name,
               updatedAt: Date.now(),
             });
-          } catch {
+          } catch (error) {
+            if (isExecutionLeaseFailure(error)) {
+              throw error;
+            }
             // 忽略回调异常
           }
         }

--- a/src/agent/LoopHookBuilder.ts
+++ b/src/agent/LoopHookBuilder.ts
@@ -133,6 +133,8 @@ export function buildLoopConfig(deps: LoopHookBuilderDeps): AgentLoopConfig {
         const runtimeCtx: CompactionRuntimeContext = {
           sessionId: context.sessionId,
           projectDir: context.snapshot?.cwd ?? defaultProjectPath,
+          signal: context.signal,
+          assertExecutionLease: context.assertExecutionLease,
         };
         const compactionStream = compactionHandler.checkAndCompactInLoop(
           loopState.conversationState, runtimeCtx, ctx.turn, ctx.lastPromptTokens,
@@ -143,6 +145,7 @@ export function buildLoopConfig(deps: LoopHookBuilderDeps): AgentLoopConfig {
       onTurnLimitReached: options?.onTurnLimitReached,
 
       async onTurnLimitCompact(_ctx) {
+        await context.assertExecutionLease?.();
         try {
           const cs = loopState.getChatService().getConfig();
           const compactResult = await CompactionService.compact(
@@ -156,6 +159,7 @@ export function buildLoopConfig(deps: LoopHookBuilderDeps): AgentLoopConfig {
               baseURL: cs.baseUrl,
               customHeaders: cs.customHeaders,
               projectDir: context.snapshot?.cwd ?? defaultProjectPath,
+              signal: context.signal,
             },
           );
           const continueMessage: Message = {
@@ -329,6 +333,8 @@ export function buildLoopConfig(deps: LoopHookBuilderDeps): AgentLoopConfig {
             const runtimeCtx: CompactionRuntimeContext = {
               sessionId: context.sessionId,
               projectDir: context.snapshot?.cwd ?? defaultProjectPath,
+              signal: context.signal,
+              assertExecutionLease: context.assertExecutionLease,
             };
             const compactStream = compactionHandler?.reactiveCompact(loopState.conversationState, runtimeCtx);
             if (!compactStream) return false;

--- a/src/agent/LoopHookBuilder.ts
+++ b/src/agent/LoopHookBuilder.ts
@@ -27,6 +27,16 @@ import type {
     LoopOptions,
 } from './types.js';
 
+function isExecutionLeaseFailure(error: unknown): boolean {
+  return (
+    typeof error === 'object'
+    && error !== null
+    && 'code' in error
+    && typeof error.code === 'string'
+    && error.code.startsWith('DURABLE_EXECUTION_LEASE_')
+  );
+}
+
 export interface LoopHookBuilderDeps {
   context: ChatContext;
   options: LoopOptions | undefined;
@@ -48,20 +58,42 @@ export interface LoopHookBuilderDeps {
 }
 
 // ===== JSONL 持久化辅助 =====
-async function persistToJsonl(
+async function persistToJsonl<T>(
   modelManager: ModelManager,
   sessionId: SessionId | undefined,
   logger: InternalLogger,
-  callback: (contextManager: ContextManager, sessionId: SessionId) => Promise<void>,
-): Promise<void> {
+  callback: (contextManager: ContextManager, sessionId: SessionId) => Promise<T>,
+  assertExecutionLease?: () => Promise<void>,
+  signal?: AbortSignal,
+  runWithExecutionLease?: <T>(operation: () => Promise<T>) => Promise<T>,
+): Promise<T | undefined> {
   try {
+    signal?.throwIfAborted();
     const contextMgr = modelManager.getContextManager();
     if (contextMgr && sessionId) {
-      await callback(contextMgr, sessionId);
+      const persist = async (): Promise<T> => {
+        signal?.throwIfAborted();
+        const result = await callback(contextMgr, sessionId);
+        signal?.throwIfAborted();
+        return result;
+      };
+      if (runWithExecutionLease) {
+        const result = await runWithExecutionLease(persist);
+        signal?.throwIfAborted();
+        return result;
+      }
+      await assertExecutionLease?.();
+      const result = await persist();
+      await assertExecutionLease?.();
+      return result;
     }
   } catch (error) {
+    if (signal?.aborted || isExecutionLeaseFailure(error)) {
+      throw error;
+    }
     logger.warn('[LoopHookBuilder] JSONL persistence failed:', error);
   }
+  return undefined;
 }
 
 // ===== Main builder =====
@@ -100,17 +132,25 @@ export function buildLoopConfig(deps: LoopHookBuilderDeps): AgentLoopConfig {
         const content = options?.prepareInput
           ? await options.prepareInput(hookContent)
           : hookContent;
-        const contextMgr = modelManager.getContextManager();
-        const messageId = contextMgr && context.sessionId
-          ? await contextMgr.saveAppliedInputMessage(
-              context.sessionId,
+        context.signal?.throwIfAborted();
+        await context.assertExecutionLease?.();
+        const messageId = await persistToJsonl(
+          modelManager,
+          context.sessionId,
+          logger,
+          (contextMgr, sessionId) =>
+            contextMgr.saveAppliedInputMessage(
+              sessionId,
               input.inputId,
               runControl.requestId,
               content,
               getLastUuid(),
               context.subagentInfo,
-            )
-          : undefined;
+            ),
+          context.assertExecutionLease,
+          context.signal,
+          context.runWithExecutionLease,
+        );
         if (messageId) {
           setLastUuid(messageId);
         }
@@ -135,6 +175,7 @@ export function buildLoopConfig(deps: LoopHookBuilderDeps): AgentLoopConfig {
           projectDir: context.snapshot?.cwd ?? defaultProjectPath,
           signal: context.signal,
           assertExecutionLease: context.assertExecutionLease,
+          runWithExecutionLease: context.runWithExecutionLease,
         };
         const compactionStream = compactionHandler.checkAndCompactInLoop(
           loopState.conversationState, runtimeCtx, ctx.turn, ctx.lastPromptTokens,
@@ -160,8 +201,11 @@ export function buildLoopConfig(deps: LoopHookBuilderDeps): AgentLoopConfig {
               customHeaders: cs.customHeaders,
               projectDir: context.snapshot?.cwd ?? defaultProjectPath,
               signal: context.signal,
+              assertExecutionLease: context.assertExecutionLease,
             },
           );
+          context.signal?.throwIfAborted();
+          await context.assertExecutionLease?.();
           const continueMessage: Message = {
             role: 'user',
             content: 'This session is being continued from a previous conversation. '
@@ -170,14 +214,22 @@ export function buildLoopConfig(deps: LoopHookBuilderDeps): AgentLoopConfig {
               + 'Continue with the last task that you were asked to work on.',
           };
 
-          await persistToJsonl(modelManager, context.sessionId, logger, async (contextMgr, sessionId) => {
-            await contextMgr.saveCompaction(
-              sessionId, compactResult.summary,
-              { trigger: 'auto', preTokens: compactResult.preTokens,
-                postTokens: compactResult.postTokens, filesIncluded: compactResult.filesIncluded },
-              null,
-            );
-          });
+          await persistToJsonl(
+            modelManager,
+            context.sessionId,
+            logger,
+            async (contextMgr, sessionId) => {
+              await contextMgr.saveCompaction(
+                sessionId, compactResult.summary,
+                { trigger: 'auto', preTokens: compactResult.preTokens,
+                  postTokens: compactResult.postTokens, filesIncluded: compactResult.filesIncluded },
+                null,
+              );
+            },
+            context.assertExecutionLease,
+            context.signal,
+            context.runWithExecutionLease,
+          );
 
           return {
             success: true,
@@ -185,6 +237,12 @@ export function buildLoopConfig(deps: LoopHookBuilderDeps): AgentLoopConfig {
             continueMessage,
           };
         } catch (compactError) {
+          if (
+            context.signal?.aborted
+            || isExecutionLeaseFailure(compactError)
+          ) {
+            throw compactError;
+          }
           logger.error('[LoopHookBuilder] 压缩失败，使用降级策略:', compactError);
           const recentMessages = loopState.conversationState.getContextMessages().slice(-80);
           return { success: true, compactedMessages: recentMessages };
@@ -205,60 +263,76 @@ export function buildLoopConfig(deps: LoopHookBuilderDeps): AgentLoopConfig {
           .flatMap((effect) => effect.messages);
         pendingInjectedMessages.push(...injectedMessages);
 
-        await persistToJsonl(modelManager, context.sessionId, logger, async (contextMgr, sessionId) => {
-          const metadata = result.metadata;
-          const isSubagentStatus = (v: unknown): v is 'running' | 'completed' | 'failed' | 'cancelled' =>
-            v === 'running' || v === 'completed' || v === 'failed' || v === 'cancelled';
-          const subagentStatus = isSubagentStatus(metadata?.subagentStatus)
-            ? metadata.subagentStatus : 'completed';
-          const subagentRef = metadata && typeof metadata.subagentSessionId === 'string'
-            ? {
-                subagentSessionId: metadata.subagentSessionId,
-                subagentType: typeof metadata.subagentType === 'string'
-                  ? metadata.subagentType : toolCall.function.name,
-                subagentStatus,
-                subagentSummary: typeof metadata.subagentSummary === 'string'
-                  ? metadata.subagentSummary : undefined,
-              }
-            : undefined;
-          const uuid = await contextMgr.saveToolResult(
-            sessionId, toolCall.id, toolCall.function.name,
-            result.status === 'success' ? result.model : null,
-            getLastUuid(), result.status === 'success' ? undefined : result.error.message,
-            context.subagentInfo, subagentRef,
-          );
-          setLastUuid(uuid);
-        });
+        await persistToJsonl(
+          modelManager,
+          context.sessionId,
+          logger,
+          async (contextMgr, sessionId) => {
+            const metadata = result.metadata;
+            const isSubagentStatus = (v: unknown): v is 'running' | 'completed' | 'failed' | 'cancelled' =>
+              v === 'running' || v === 'completed' || v === 'failed' || v === 'cancelled';
+            const subagentStatus = isSubagentStatus(metadata?.subagentStatus)
+              ? metadata.subagentStatus : 'completed';
+            const subagentRef = metadata && typeof metadata.subagentSessionId === 'string'
+              ? {
+                  subagentSessionId: metadata.subagentSessionId,
+                  subagentType: typeof metadata.subagentType === 'string'
+                    ? metadata.subagentType : toolCall.function.name,
+                  subagentStatus,
+                  subagentSummary: typeof metadata.subagentSummary === 'string'
+                    ? metadata.subagentSummary : undefined,
+                }
+              : undefined;
+            const uuid = await contextMgr.saveToolResult(
+              sessionId, toolCall.id, toolCall.function.name,
+              result.status === 'success' ? result.model : null,
+              getLastUuid(), result.status === 'success' ? undefined : result.error.message,
+              context.subagentInfo, subagentRef,
+            );
+            setLastUuid(uuid);
+          },
+          context.assertExecutionLease,
+          context.signal,
+          context.runWithExecutionLease,
+        );
 
         pendingToolResultCount = Math.max(0, pendingToolResultCount - 1);
         if (pendingToolResultCount === 0 && pendingInjectedMessages.length > 0) {
           const messagesToPersist = pendingInjectedMessages;
           pendingInjectedMessages = [];
-          await persistToJsonl(modelManager, context.sessionId, logger, async (contextMgr, sessionId) => {
-            for (const injectedMessage of messagesToPersist) {
-              const customMeta = (() => {
-                const isRec = (v: unknown): v is Record<string, unknown> =>
-                  typeof v === 'object' && v !== null && !Array.isArray(v);
-                const base = isRec(injectedMessage.metadata)
-                  ? { ...injectedMessage.metadata }
-                  : {};
-                if (injectedMessage.role === 'system') {
-                  base._systemSource = 'tool_injection';
-                }
-                return Object.keys(base).length > 0 ? base : undefined;
-              })();
+          await persistToJsonl(
+            modelManager,
+            context.sessionId,
+            logger,
+            async (contextMgr, sessionId) => {
+              for (const injectedMessage of messagesToPersist) {
+                const customMeta = (() => {
+                  const isRec = (v: unknown): v is Record<string, unknown> =>
+                    typeof v === 'object' && v !== null && !Array.isArray(v);
+                  const base = isRec(injectedMessage.metadata)
+                    ? { ...injectedMessage.metadata }
+                    : {};
+                  if (injectedMessage.role === 'system') {
+                    base._systemSource = 'tool_injection';
+                  }
+                  return Object.keys(base).length > 0 ? base : undefined;
+                })();
 
-              const injectedUuid = await contextMgr.saveMessage(
-                sessionId,
-                injectedMessage.role,
-                injectedMessage.content,
-                getLastUuid(),
-                customMeta ? { customMetadata: customMeta } : undefined,
-                context.subagentInfo,
-              );
-              setLastUuid(injectedUuid);
-            }
-          });
+                const injectedUuid = await contextMgr.saveMessage(
+                  sessionId,
+                  injectedMessage.role,
+                  injectedMessage.content,
+                  getLastUuid(),
+                  customMeta ? { customMetadata: customMeta } : undefined,
+                  context.subagentInfo,
+                );
+                setLastUuid(injectedUuid);
+              }
+            },
+            context.assertExecutionLease,
+            context.signal,
+            context.runWithExecutionLease,
+          );
         }
 
         for (const effect of effects) {
@@ -288,7 +362,7 @@ export function buildLoopConfig(deps: LoopHookBuilderDeps): AgentLoopConfig {
         if (options?.onProgress) {
           progressToolUseCount++;
           try {
-            options.onProgress({
+            await options.onProgress({
               toolUseCount: progressToolUseCount,
               tokenCount: 0,
               lastActivity: toolCall.function.name,
@@ -306,23 +380,35 @@ export function buildLoopConfig(deps: LoopHookBuilderDeps): AgentLoopConfig {
         pendingToolResultCount = ctx.toolCalls?.length ?? 0;
         pendingInjectedMessages = [];
         currentAssistantMessageId = null;
-        await persistToJsonl(modelManager, context.sessionId, logger, async (contextMgr, sessionId) => {
-          if (ctx.content.trim() !== '' || ctx.reasoningContent || (ctx.toolCalls?.length ?? 0) > 0) {
-            const uuid = await contextMgr.saveMessage(
-              sessionId,
-              'assistant',
-              ctx.content,
-              getLastUuid(),
-              {
-                reasoningContent: ctx.reasoningContent,
-                toolCalls: ctx.toolCalls,
-              },
-              context.subagentInfo,
-            );
-            setLastUuid(uuid);
-            currentAssistantMessageId = uuid;
-          }
-        });
+        await persistToJsonl(
+          modelManager,
+          context.sessionId,
+          logger,
+          async (contextMgr, sessionId) => {
+            if (
+              ctx.content.trim() !== ''
+              || ctx.reasoningContent
+              || (ctx.toolCalls?.length ?? 0) > 0
+            ) {
+              const uuid = await contextMgr.saveMessage(
+                sessionId,
+                'assistant',
+                ctx.content,
+                getLastUuid(),
+                {
+                  reasoningContent: ctx.reasoningContent,
+                  toolCalls: ctx.toolCalls,
+                },
+                context.subagentInfo,
+              );
+              setLastUuid(uuid);
+              currentAssistantMessageId = uuid;
+            }
+          },
+          context.assertExecutionLease,
+          context.signal,
+          context.runWithExecutionLease,
+        );
       },
 
     },
@@ -335,6 +421,7 @@ export function buildLoopConfig(deps: LoopHookBuilderDeps): AgentLoopConfig {
               projectDir: context.snapshot?.cwd ?? defaultProjectPath,
               signal: context.signal,
               assertExecutionLease: context.assertExecutionLease,
+              runWithExecutionLease: context.runWithExecutionLease,
             };
             const compactStream = compactionHandler?.reactiveCompact(loopState.conversationState, runtimeCtx);
             if (!compactStream) return false;

--- a/src/agent/LoopRunner.ts
+++ b/src/agent/LoopRunner.ts
@@ -375,6 +375,8 @@ export class LoopRunner {
         confirmationHandler: context.confirmationHandler,
         bladeConfig: this.config,
         backgroundAgentManager: context.backgroundAgentManager,
+        executionFence: context.executionFence,
+        assertExecutionLease: context.assertExecutionLease,
         toolCatalog: catalog instanceof ToolCatalog
           ? catalog
           : undefined,

--- a/src/agent/LoopRunner.ts
+++ b/src/agent/LoopRunner.ts
@@ -14,6 +14,10 @@ import type { HookRuntime } from '../hooks/HookRuntime.js';
 import { type InternalLogger, LogCategory, NOOP_LOGGER } from '../logging/Logger.js';
 import { buildSystemPrompt } from '../prompts/index.js';
 import type { Message } from '../services/ChatServiceInterface.js';
+import {
+  isExecutionLeaseFailure,
+  runWithExecutionLeaseBoundary,
+} from '../session/events/DurableExecutionLeaseStore.js';
 import type { SkillActivationContext } from '../skills/index.js';
 import { injectSkillsMetadata } from '../skills/index.js';
 import { ToolCatalog } from '../tools/catalog/index.js';
@@ -51,36 +55,6 @@ function hasPersistableUserContent(message: UserMessageContent): boolean {
   }
 
   return message.some((part) => part.type === 'image_url' || part.text.trim() !== '');
-}
-
-function isExecutionLeaseFailure(error: unknown): boolean {
-  return (
-    typeof error === 'object'
-    && error !== null
-    && 'code' in error
-    && typeof error.code === 'string'
-    && error.code.startsWith('DURABLE_EXECUTION_LEASE_')
-  );
-}
-
-async function runFencedTranscriptWrite<T>(
-  context: ChatContext,
-  operation: () => Promise<T>,
-): Promise<T> {
-  context.signal?.throwIfAborted();
-  if (context.runWithExecutionLease) {
-    const result = await context.runWithExecutionLease(async () => {
-      context.signal?.throwIfAborted();
-      return operation();
-    });
-    context.signal?.throwIfAborted();
-    return result;
-  }
-  await context.assertExecutionLease?.();
-  const result = await operation();
-  context.signal?.throwIfAborted();
-  await context.assertExecutionLease?.();
-  return result;
 }
 
 export class LoopRunner {
@@ -200,7 +174,7 @@ export class LoopRunner {
       const sessionId = context.sessionId;
       const inputApplication = options.inputApplication;
       try {
-        lastMessageUuid = await runFencedTranscriptWrite(
+        lastMessageUuid = await runWithExecutionLeaseBoundary(
           context,
           () => contextMgr.saveAppliedInputMessage(
             sessionId,
@@ -222,7 +196,7 @@ export class LoopRunner {
       try {
         if (contextMgr && context.sessionId && hasPersistableUserContent(message)) {
           const sessionId = context.sessionId;
-          lastMessageUuid = await runFencedTranscriptWrite(
+          lastMessageUuid = await runWithExecutionLeaseBoundary(
             context,
             () => contextMgr.saveMessage(
               sessionId,
@@ -287,6 +261,12 @@ export class LoopRunner {
       syncContextMessages(context, loopState.conversationState);
       return result;
     } catch (error) {
+      if (isExecutionLeaseFailure(error)) {
+        throw error;
+      }
+      if (isExecutionLeaseFailure(context.signal?.reason)) {
+        throw context.signal.reason;
+      }
       if (error instanceof Error &&
         (error.name === 'AbortError' || error.message.includes('aborted'))) {
         return {

--- a/src/agent/LoopRunner.ts
+++ b/src/agent/LoopRunner.ts
@@ -53,6 +53,36 @@ function hasPersistableUserContent(message: UserMessageContent): boolean {
   return message.some((part) => part.type === 'image_url' || part.text.trim() !== '');
 }
 
+function isExecutionLeaseFailure(error: unknown): boolean {
+  return (
+    typeof error === 'object'
+    && error !== null
+    && 'code' in error
+    && typeof error.code === 'string'
+    && error.code.startsWith('DURABLE_EXECUTION_LEASE_')
+  );
+}
+
+async function runFencedTranscriptWrite<T>(
+  context: ChatContext,
+  operation: () => Promise<T>,
+): Promise<T> {
+  context.signal?.throwIfAborted();
+  if (context.runWithExecutionLease) {
+    const result = await context.runWithExecutionLease(async () => {
+      context.signal?.throwIfAborted();
+      return operation();
+    });
+    context.signal?.throwIfAborted();
+    return result;
+  }
+  await context.assertExecutionLease?.();
+  const result = await operation();
+  context.signal?.throwIfAborted();
+  await context.assertExecutionLease?.();
+  return result;
+}
+
 export class LoopRunner {
   readonly runtimePatchManager: RuntimePatchManager;
   private readonly logger: InternalLogger;
@@ -167,27 +197,47 @@ export class LoopRunner {
     let lastMessageUuid: string | null = null;
     const contextMgr = this.modelManager.getContextManager();
     if (contextMgr && context.sessionId && options?.inputApplication) {
+      const sessionId = context.sessionId;
+      const inputApplication = options.inputApplication;
       try {
-        lastMessageUuid = await contextMgr.saveAppliedInputMessage(
-          context.sessionId,
-          options.inputApplication.inputId,
-          options.inputApplication.requestId,
-          message,
-          null,
-          context.subagentInfo,
+        lastMessageUuid = await runFencedTranscriptWrite(
+          context,
+          () => contextMgr.saveAppliedInputMessage(
+            sessionId,
+            inputApplication.inputId,
+            inputApplication.requestId,
+            message,
+            null,
+            context.subagentInfo,
+          ),
         );
       } catch (error) {
+        if (context.signal?.aborted || isExecutionLeaseFailure(error)) {
+          throw error;
+        }
         // 与其他消息写入保持一致的 best-effort 策略：持久化失败不应中断请求。
         this.logger.warn('[LoopRunner] 保存已应用输入消息失败:', error);
       }
     } else {
       try {
         if (contextMgr && context.sessionId && hasPersistableUserContent(message)) {
-          lastMessageUuid = await contextMgr.saveMessage(
-            context.sessionId, 'user', message, null, undefined, context.subagentInfo
+          const sessionId = context.sessionId;
+          lastMessageUuid = await runFencedTranscriptWrite(
+            context,
+            () => contextMgr.saveMessage(
+              sessionId,
+              'user',
+              message,
+              null,
+              undefined,
+              context.subagentInfo,
+            ),
           );
         }
       } catch (error) {
+        if (context.signal?.aborted || isExecutionLeaseFailure(error)) {
+          throw error;
+        }
         this.logger.warn('[LoopRunner] 保存用户消息失败:', error);
       }
     }
@@ -377,6 +427,7 @@ export class LoopRunner {
         backgroundAgentManager: context.backgroundAgentManager,
         executionFence: context.executionFence,
         assertExecutionLease: context.assertExecutionLease,
+        runWithExecutionLease: context.runWithExecutionLease,
         toolCatalog: catalog instanceof ToolCatalog
           ? catalog
           : undefined,

--- a/src/agent/__tests__/AgentLoop.test.ts
+++ b/src/agent/__tests__/AgentLoop.test.ts
@@ -207,6 +207,37 @@ async function collectEvents(
 
 describe('agentLoop', () => {
   describe('basic flow', () => {
+    it('checks the execution lease after persisting model start and before provider I/O', async () => {
+      const chatService = createMockChatService([{ content: 'must not run' }]);
+      const onModelRequestStarting = vi.fn(async () => ({
+        onCompleted: vi.fn(async () => {}),
+        onFailed: vi.fn(async () => {}),
+        onAborted: vi.fn(async () => {}),
+      }));
+      const assertExecutionLease = vi.fn(async () => {
+        throw new Error('execution lease lost');
+      });
+      const config = baseConfig({
+        modelExecutionLifecycle: { onModelRequestStarting },
+        turnState: {
+          chatService,
+          executionContext: {
+            sessionId: SessionId('fenced-model-session'),
+            userId: 'test-user',
+            assertExecutionLease,
+          },
+        },
+      });
+
+      await expect(collectEvents(agentLoop(config))).rejects.toThrow(
+        'execution lease lost',
+      );
+
+      expect(onModelRequestStarting).toHaveBeenCalledOnce();
+      expect(assertExecutionLease).toHaveBeenCalledOnce();
+      expect(chatService.chat).not.toHaveBeenCalled();
+    });
+
     it('settles the durable model lifecycle around a successful provider call', async () => {
       const onCompleted = vi.fn(async () => {});
       const onFailed = vi.fn(async () => {});

--- a/src/agent/__tests__/CompactionHandler.test.ts
+++ b/src/agent/__tests__/CompactionHandler.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Message } from '../../services/ChatServiceInterface.js';
+import { DurableExecutionLeaseError } from '../../session/events/DurableExecutionLeaseStore.js';
 import { SessionId } from '../../types/branded.js';
 import { ConversationState } from '../state/ConversationState.js';
 
@@ -117,6 +118,59 @@ describe('CompactionHandler', () => {
     await expect(stream.next()).rejects.toThrow('execution lease lost');
     expect(assertExecutionLease).toHaveBeenCalledOnce();
     expect(mockCompact).not.toHaveBeenCalled();
+  });
+
+  it('discards a compaction result when execution ownership changes during provider I/O', async () => {
+    const handler = new CompactionHandler(
+      () => ({
+        getConfig: () => ({
+          model: 'gpt-4o-mini',
+          provider: 'openai-compatible' as const,
+          maxContextTokens: 1000,
+          maxOutputTokens: 200,
+          apiKey: 'test-key',
+          baseUrl: 'https://example.com',
+        }),
+      }) as never,
+      () => undefined,
+    );
+    const originalMessages = [
+      { role: 'user', content: 'context that must remain unchanged' },
+      { role: 'assistant', content: 'continue' },
+    ] satisfies Message[];
+    const currentMessage = originalMessages.at(-1);
+    if (!currentMessage) {
+      throw new Error('Expected a current compaction message');
+    }
+    const convState = new ConversationState(
+      null,
+      originalMessages.slice(0, -1),
+      currentMessage,
+    );
+    const leaseLost = new DurableExecutionLeaseError(
+      'DURABLE_EXECUTION_LEASE_LOST',
+      'execution ownership changed',
+    );
+    const assertExecutionLease = vi.fn()
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(leaseLost);
+    const stream = handler.checkAndCompactInLoop(
+      convState,
+      {
+        sessionId: SessionId('mid-compaction-loss-session'),
+        assertExecutionLease,
+      },
+      2,
+      700,
+    );
+
+    await expect(stream.next()).resolves.toMatchObject({
+      value: { type: 'compacting', isCompacting: true },
+      done: false,
+    });
+    await expect(stream.next()).rejects.toBe(leaseLost);
+    expect(mockCompact).toHaveBeenCalledOnce();
+    expect(convState.getContextMessages()).toEqual(originalMessages);
   });
 
   it('falls back from the original messages when reactive compaction fails after microcompact', async () => {

--- a/src/agent/__tests__/CompactionHandler.test.ts
+++ b/src/agent/__tests__/CompactionHandler.test.ts
@@ -78,6 +78,47 @@ describe('CompactionHandler', () => {
     );
   });
 
+  it('checks execution ownership before compaction provider I/O', async () => {
+    const handler = new CompactionHandler(
+      () => ({
+        getConfig: () => ({
+          model: 'gpt-4o-mini',
+          provider: 'openai-compatible' as const,
+          maxContextTokens: 1000,
+          maxOutputTokens: 200,
+          apiKey: 'test-key',
+          baseUrl: 'https://example.com',
+        }),
+      }) as never,
+      () => undefined,
+    );
+    const convState = new ConversationState(
+      null,
+      [{ role: 'user', content: 'context that requires compaction' }],
+      { role: 'assistant', content: 'continue' },
+    );
+    const assertExecutionLease = vi.fn(async () => {
+      throw new Error('execution lease lost');
+    });
+    const stream = handler.checkAndCompactInLoop(
+      convState,
+      {
+        sessionId: SessionId('fenced-compaction-session'),
+        assertExecutionLease,
+      },
+      2,
+      700,
+    );
+
+    await expect(stream.next()).resolves.toMatchObject({
+      value: { type: 'compacting', isCompacting: true },
+      done: false,
+    });
+    await expect(stream.next()).rejects.toThrow('execution lease lost');
+    expect(assertExecutionLease).toHaveBeenCalledOnce();
+    expect(mockCompact).not.toHaveBeenCalled();
+  });
+
   it('falls back from the original messages when reactive compaction fails after microcompact', async () => {
     mockCompact.mockRejectedValueOnce(new Error('compaction failed'));
 
@@ -101,8 +142,12 @@ describe('CompactionHandler', () => {
       { role: 'tool', tool_call_id: 'call-2', content: 'b'.repeat(3800) },
     ] satisfies Message[];
     const convState = new ConversationState(null, originalMessages.slice(0, -1), originalMessages[originalMessages.length - 1]);
+    const controller = new AbortController();
 
-    const stream = handler.reactiveCompact(convState, { sessionId: SessionId('session-1') });
+    const stream = handler.reactiveCompact(convState, {
+      sessionId: SessionId('session-1'),
+      signal: controller.signal,
+    });
     let didCompact = false;
     while (true) {
       const { value, done } = await stream.next();
@@ -118,5 +163,9 @@ describe('CompactionHandler', () => {
     // The fallback uses originalMessages.slice(-40), so content should still be original (not microcompacted)
     expect(updatedCtx[1]).toEqual(originalMessages[1]);
     expect(updatedCtx[1]?.content).not.toContain('[Microcompact]');
+    expect(mockCompact).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ signal: controller.signal }),
+    );
   });
 });

--- a/src/agent/__tests__/LoopRunner.test.ts
+++ b/src/agent/__tests__/LoopRunner.test.ts
@@ -247,6 +247,29 @@ describe('LoopRunner', () => {
       expect(mm._contextMgr.saveMessage).toHaveBeenCalled();
     });
 
+    it('fences the initial transcript write before model execution', async () => {
+      const mm = createMockModelManager();
+      const pipeline = createMockPipeline();
+      const runner = new LoopRunner(baseConfig, baseOptions, mm, pipeline);
+      const leaseError = Object.assign(new Error('execution lease lost'), {
+        code: 'DURABLE_EXECUTION_LEASE_LOST',
+      });
+      const runWithExecutionLease = vi.fn(async () => {
+        throw leaseError;
+      });
+
+      await expect(
+        runner.runLoop(
+          'Test message',
+          createContext({ runWithExecutionLease }),
+        ),
+      ).rejects.toBe(leaseError);
+
+      expect(runWithExecutionLease).toHaveBeenCalledOnce();
+      expect(mm._contextMgr.saveMessage).not.toHaveBeenCalled();
+      expect(mm._chat).not.toHaveBeenCalled();
+    });
+
     it('persists streaming tool turns in provider-compatible order', async () => {
       const workspaceRoot = mkdtempSync(join(tmpdir(), 'loop-runner-persistence-'));
       const sessionId = SessionId('streaming-tool-session');

--- a/src/agent/__tests__/LoopRunner.test.ts
+++ b/src/agent/__tests__/LoopRunner.test.ts
@@ -10,6 +10,7 @@ import type { RuntimeContextPatch } from '../../runtime/RuntimeContextPatch.js';
 import type { RuntimePatch } from '../../runtime/RuntimePatch.js';
 import type { Message } from '../../services/ChatServiceInterface.js';
 import { ActiveRequestController } from '../../session/ActiveRequestController.js';
+import { DurableExecutionLeaseError } from '../../session/events/DurableExecutionLeaseStore.js';
 import { SessionInputInbox } from '../../session/SessionInputInbox.js';
 import { JsonlSessionStore } from '../../session/SessionStore.js';
 import { ToolCatalog } from '../../tools/catalog/ToolCatalog.js';
@@ -268,6 +269,40 @@ describe('LoopRunner', () => {
       expect(runWithExecutionLease).toHaveBeenCalledOnce();
       expect(mm._contextMgr.saveMessage).not.toHaveBeenCalled();
       expect(mm._chat).not.toHaveBeenCalled();
+    });
+
+    it('propagates execution lease loss from progress persistence', async () => {
+      const mm = createMockModelManager();
+      mm._chat
+        .mockResolvedValueOnce({
+          content: '',
+          toolCalls: [{
+            id: 'lease-progress-tool',
+            type: 'function',
+            function: { name: 'Read', arguments: '{}' },
+          }],
+          usage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 },
+        })
+        .mockResolvedValueOnce({
+          content: 'unexpected',
+          toolCalls: [],
+          usage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 },
+        });
+      const pipeline = createMockPipeline();
+      const runner = new LoopRunner(baseConfig, baseOptions, mm, pipeline);
+      const leaseError = new DurableExecutionLeaseError(
+        'DURABLE_EXECUTION_LEASE_LOST',
+        'worker is stale',
+      );
+
+      await expect(
+        runner.runLoop('Run a tool', createContext(), {
+          onProgress: async () => {
+            throw leaseError;
+          },
+        }),
+      ).rejects.toBe(leaseError);
+      expect(mm._chat).toHaveBeenCalledOnce();
     });
 
     it('persists streaming tool turns in provider-compatible order', async () => {

--- a/src/agent/loop/__tests__/executeToolCalls.test.ts
+++ b/src/agent/loop/__tests__/executeToolCalls.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { createContextSnapshot } from '../../../runtime/index.js';
+import { DurableExecutionLeaseError } from '../../../session/events/DurableExecutionLeaseStore.js';
 import { completeToolExecution, type ExecutionContext } from '../../../tools/types/index.js';
 import { ModelAttemptId, SessionId } from '../../../types/branded.js';
 import type { JsonObject } from '../../../types/common.js';
@@ -202,6 +203,47 @@ describe('executeToolCalls', () => {
     expect(outcome.result.status).toBe('error');
     expect(outcome.result.model).toContain('Tool execution failed:');
     expect(outcome.result.model).toContain('JSON');
+  });
+
+  it('propagates execution lease failures instead of creating a tool result', async () => {
+    const leaseError = new DurableExecutionLeaseError(
+      'DURABLE_EXECUTION_LEASE_LOST',
+      'worker is stale',
+    );
+    const onToolSettled = vi.fn(async () => {});
+
+    await expect(
+      executeToolCalls({
+        plan: {
+          mode: 'serial',
+          calls: [
+            {
+              id: 'tool-stale-worker',
+              type: 'function',
+              function: {
+                name: 'Write',
+                arguments: '{}',
+              },
+            },
+          ],
+        },
+        executionPipeline: {
+          // biome-ignore lint/correctness/useYield: generator fails before producing output
+          execute: vi.fn(async function* () {
+            throw leaseError;
+          }),
+          getRegistry: () => ({
+            get: () => undefined,
+          }),
+        } as never,
+        executionContext: {
+          sessionId: SessionId('session-stale-worker'),
+          userId: 'user-1',
+          lifecycle: { onToolSettled },
+        },
+      }),
+    ).rejects.toBe(leaseError);
+    expect(onToolSettled).not.toHaveBeenCalled();
   });
 
   it('emits a unified ready-progress-message-effect-result-completed update sequence for each tool call', async () => {

--- a/src/agent/loop/runToolCall.ts
+++ b/src/agent/loop/runToolCall.ts
@@ -1,6 +1,9 @@
 import { type InternalLogger, LogCategory, NOOP_LOGGER } from '../../logging/Logger.js';
 import type { ContextSnapshot } from '../../runtime/index.js';
-import type { DurableExecutionFence } from '../../session/events/DurableExecutionLeaseStore.js';
+import {
+  type DurableExecutionFence,
+  isExecutionLeaseFailure,
+} from '../../session/events/DurableExecutionLeaseStore.js';
 import type { ToolCatalog } from '../../tools/catalog/index.js';
 import type { ExecutionPipeline } from '../../tools/execution/ExecutionPipeline.js';
 import type { ToolRegistry } from '../../tools/registry/ToolRegistry.js';
@@ -261,6 +264,9 @@ export async function runToolCall(input: RunToolCallInput): Promise<ToolExecutio
 
     outcome = { toolCall: input.toolCall, result, effects, toolUseUuid };
   } catch (error) {
+    if (isExecutionLeaseFailure(error)) {
+      throw error;
+    }
     logger.error(`Tool execution failed for ${input.toolCall.function.name}:`, error);
     outcome = buildFailedOutcome(input.toolCall, error, interruptBehavior, input.steeringSignal);
   }

--- a/src/agent/loop/runToolCall.ts
+++ b/src/agent/loop/runToolCall.ts
@@ -1,5 +1,6 @@
 import { type InternalLogger, LogCategory, NOOP_LOGGER } from '../../logging/Logger.js';
 import type { ContextSnapshot } from '../../runtime/index.js';
+import type { DurableExecutionFence } from '../../session/events/DurableExecutionLeaseStore.js';
 import type { ToolCatalog } from '../../tools/catalog/index.js';
 import type { ExecutionPipeline } from '../../tools/execution/ExecutionPipeline.js';
 import type { ToolRegistry } from '../../tools/registry/ToolRegistry.js';
@@ -80,6 +81,8 @@ export interface ToolExecutionContext {
   confirmationHandler?: ConfirmationHandler;
   bladeConfig?: BladeConfig;
   backgroundAgentManager?: IBackgroundAgentManager;
+  executionFence?: DurableExecutionFence;
+  assertExecutionLease?: () => Promise<void>;
   toolCatalog?: ToolCatalog;
   toolRegistry?: ToolRegistry;
   discoveredTools?: string[];
@@ -207,6 +210,8 @@ export async function runToolCall(input: RunToolCallInput): Promise<ToolExecutio
         confirmationHandler: input.executionContext.confirmationHandler,
         bladeConfig: input.executionContext.bladeConfig,
         backgroundAgentManager: input.executionContext.backgroundAgentManager,
+        executionFence: input.executionContext.executionFence,
+        assertExecutionLease: input.executionContext.assertExecutionLease,
         toolCatalog: input.executionContext.toolCatalog,
         toolRegistry: input.executionContext.toolRegistry,
         discoveredTools: input.executionContext.discoveredTools,

--- a/src/agent/loop/runToolCall.ts
+++ b/src/agent/loop/runToolCall.ts
@@ -83,6 +83,7 @@ export interface ToolExecutionContext {
   backgroundAgentManager?: IBackgroundAgentManager;
   executionFence?: DurableExecutionFence;
   assertExecutionLease?: () => Promise<void>;
+  runWithExecutionLease?: <T>(operation: () => Promise<T>) => Promise<T>;
   toolCatalog?: ToolCatalog;
   toolRegistry?: ToolRegistry;
   discoveredTools?: string[];
@@ -212,6 +213,7 @@ export async function runToolCall(input: RunToolCallInput): Promise<ToolExecutio
         backgroundAgentManager: input.executionContext.backgroundAgentManager,
         executionFence: input.executionContext.executionFence,
         assertExecutionLease: input.executionContext.assertExecutionLease,
+        runWithExecutionLease: input.executionContext.runWithExecutionLease,
         toolCatalog: input.executionContext.toolCatalog,
         toolRegistry: input.executionContext.toolRegistry,
         discoveredTools: input.executionContext.discoveredTools,

--- a/src/agent/loop/runTurn.ts
+++ b/src/agent/loop/runTurn.ts
@@ -99,6 +99,7 @@ export async function* runTurn(
     model: turnChatService.getConfig().model,
     streaming: streaming === true,
   });
+  await turnState.executionContext.assertExecutionLease?.();
 
   let settlementAttempted = false;
   const settleCompleted = async (response: ChatResponse): Promise<void> => {

--- a/src/agent/state/TurnState.ts
+++ b/src/agent/state/TurnState.ts
@@ -37,6 +37,7 @@ export interface LoopExecutionContext {
   backgroundAgentManager?: IBackgroundAgentManager;
   executionFence?: DurableExecutionFence;
   assertExecutionLease?: () => Promise<void>;
+  runWithExecutionLease?: <T>(operation: () => Promise<T>) => Promise<T>;
   toolRegistry?: ToolRegistry;
   toolCatalog?: ToolCatalog;
   discoveredTools?: string[];

--- a/src/agent/state/TurnState.ts
+++ b/src/agent/state/TurnState.ts
@@ -1,6 +1,7 @@
 import type { JSONSchema7 } from 'json-schema';
 import type { ContextSnapshot } from '../../runtime/index.js';
 import type { IChatService, Message } from '../../services/ChatServiceInterface.js';
+import type { DurableExecutionFence } from '../../session/events/DurableExecutionLeaseStore.js';
 import type { ToolCatalog } from '../../tools/catalog/index.js';
 import type { ToolRegistry } from '../../tools/registry/ToolRegistry.js';
 import type {
@@ -34,6 +35,8 @@ export interface LoopExecutionContext {
   confirmationHandler?: ConfirmationHandler;
   bladeConfig?: BladeConfig;
   backgroundAgentManager?: IBackgroundAgentManager;
+  executionFence?: DurableExecutionFence;
+  assertExecutionLease?: () => Promise<void>;
   toolRegistry?: ToolRegistry;
   toolCatalog?: ToolCatalog;
   discoveredTools?: string[];

--- a/src/agent/subagents/AgentSessionStore.ts
+++ b/src/agent/subagents/AgentSessionStore.ts
@@ -8,13 +8,20 @@
  */
 
 import fs from 'node:fs';
+import { unlink } from 'node:fs/promises';
 import path from 'node:path';
 import writeFileAtomic from 'write-file-atomic';
 import { type InternalLogger, LogCategory, NOOP_LOGGER } from '../../logging/Logger.js';
 import type { Message } from '../../services/ChatServiceInterface.js';
 import type { DurableExecutionFence } from '../../session/events/DurableExecutionLeaseStore.js';
 import { AgentId } from '../../types/branded.js';
+import {
+  syncParentDirectory,
+  withAdvisoryFileLock,
+} from '../../utils/advisoryFileLock.js';
 import type { AgentProgress } from '../types.js';
+
+const AGENT_SESSION_LOCK_TIMEOUT_MS = 10_000;
 
 /**
  * Agent 会话状态
@@ -139,17 +146,22 @@ export class AgentSessionStore {
   /**
    * 保存会话
    */
-  saveSession(session: AgentSession): boolean {
-    const current = this.loadSessionFromDisk(session.id);
-    if (current && !this.canReplaceExecution(current.executionFence, session.executionFence)) {
-      return false;
-    }
+  async saveSession(session: AgentSession): Promise<boolean> {
+    return this.runWithSessionLock(session.id, 'write', async () => {
+      const current = this.loadSessionFromDisk(session.id);
+      if (
+        current &&
+        !this.canReplaceExecution(current.executionFence, session.executionFence)
+      ) {
+        return false;
+      }
 
-    this.writeSession(session);
-    return true;
+      await this.writeSession(session);
+      return true;
+    });
   }
 
-  private writeSession(session: AgentSession): void {
+  private async writeSession(session: AgentSession): Promise<void> {
     const filePath = this.getSessionPath(session.id);
     if (!filePath) {
       this.cache.set(session.id, session);
@@ -159,18 +171,13 @@ export class AgentSessionStore {
     try {
       const data = JSON.stringify(session, null, 2);
       const created = !fs.existsSync(filePath);
-      writeFileAtomic.sync(filePath, data, {
+      await writeFileAtomic(filePath, data, {
         encoding: 'utf8',
         fsync: true,
         mode: 0o600,
       });
-      if (created && process.platform !== 'win32' && this.sessionsDir) {
-        const directory = fs.openSync(this.sessionsDir, 'r');
-        try {
-          fs.fsyncSync(directory);
-        } finally {
-          fs.closeSync(directory);
-        }
+      if (created) {
+        await syncParentDirectory(filePath);
       }
       this.cache.set(session.id, session);
       this.logger.debug(`Session saved: ${session.id}`);
@@ -217,38 +224,40 @@ export class AgentSessionStore {
   /**
    * 更新会话状态
    */
-  updateSession(
+  async updateSession(
     agentId: AgentId,
     updates: Partial<AgentSession>,
     expectedExecutionFence?: DurableExecutionFence,
-  ): AgentSession | undefined {
-    const session = this.loadSessionFromDisk(agentId);
-    if (
-      !session ||
-      !this.sameExecutionFence(session.executionFence, expectedExecutionFence)
-    ) {
-      return undefined;
-    }
+  ): Promise<AgentSession | undefined> {
+    return this.runWithSessionLock(agentId, 'write', async () => {
+      const session = this.loadSessionFromDisk(agentId);
+      if (
+        !session ||
+        !this.sameExecutionFence(session.executionFence, expectedExecutionFence)
+      ) {
+        return undefined;
+      }
 
-    const updatedSession: AgentSession = {
-      ...session,
-      ...updates,
-      executionFence: session.executionFence,
-      lastActiveAt: Date.now(),
-    };
+      const updatedSession: AgentSession = {
+        ...session,
+        ...updates,
+        executionFence: session.executionFence,
+        lastActiveAt: Date.now(),
+      };
 
-    this.writeSession(updatedSession);
-    return updatedSession;
+      await this.writeSession(updatedSession);
+      return updatedSession;
+    });
   }
 
   /**
    * 追加消息到会话
    */
-  appendMessages(
+  async appendMessages(
     agentId: AgentId,
     messages: Message[],
     expectedExecutionFence?: DurableExecutionFence,
-  ): AgentSession | undefined {
+  ): Promise<AgentSession | undefined> {
     const session = this.loadSession(agentId);
     if (!session) {
       return undefined;
@@ -263,31 +272,40 @@ export class AgentSessionStore {
    * 更新运行中会话的可变字段（消息、进度）。
    * 仅允许在 status === 'running' 时更新，避免终端状态后写入陈旧数据。
    */
-  updateRunningSession(
+  async updateRunningSession(
     agentId: AgentId,
     updates: { messages?: Message[]; progress?: AgentProgress },
     expectedExecutionFence?: DurableExecutionFence,
-  ): AgentSession | undefined {
-    const session = this.loadSessionFromDisk(agentId);
-    if (
-      !session ||
-      session.status !== 'running' ||
-      !this.sameExecutionFence(session.executionFence, expectedExecutionFence)
-    ) {
-      return undefined;
-    }
-    return this.updateSession(agentId, updates, expectedExecutionFence);
+  ): Promise<AgentSession | undefined> {
+    return this.runWithSessionLock(agentId, 'write', async () => {
+      const session = this.loadSessionFromDisk(agentId);
+      if (
+        !session ||
+        session.status !== 'running' ||
+        !this.sameExecutionFence(session.executionFence, expectedExecutionFence)
+      ) {
+        return undefined;
+      }
+      const updatedSession: AgentSession = {
+        ...session,
+        ...updates,
+        executionFence: session.executionFence,
+        lastActiveAt: Date.now(),
+      };
+      await this.writeSession(updatedSession);
+      return updatedSession;
+    });
   }
 
   /**
    * 标记会话完成（成功或失败）。
    */
-  markCompleted(
+  async markCompleted(
     agentId: AgentId,
     result: { success: boolean; message: string; error?: string },
     stats?: AgentSession['stats'],
     expectedExecutionFence?: DurableExecutionFence,
-  ): AgentSession | undefined {
+  ): Promise<AgentSession | undefined> {
     return this.updateSession(agentId, {
       status: result.success ? 'completed' : 'failed',
       result,
@@ -300,12 +318,12 @@ export class AgentSessionStore {
   /**
    * 标记会话已取消。
    */
-  markCancelled(
+  async markCancelled(
     agentId: AgentId,
     result?: { success: false; message: string; error?: string },
     stats?: AgentSession['stats'],
     expectedExecutionFence?: DurableExecutionFence,
-  ): AgentSession | undefined {
+  ): Promise<AgentSession | undefined> {
     return this.updateSession(agentId, {
       status: 'cancelled',
       result: result ?? { success: false, message: '' },
@@ -318,24 +336,22 @@ export class AgentSessionStore {
   /**
    * 删除会话
    */
-  deleteSession(
+  async deleteSession(
     agentId: AgentId,
     expectedExecutionFence?: DurableExecutionFence,
-  ): boolean {
+  ): Promise<boolean> {
     try {
-      const session = this.loadSessionFromDisk(agentId);
-      if (
-        session &&
-        !this.sameExecutionFence(session.executionFence, expectedExecutionFence)
-      ) {
-        return false;
-      }
-      const filePath = this.getSessionPath(agentId);
-      if (filePath && fs.existsSync(filePath)) {
-        fs.unlinkSync(filePath);
-      }
-      this.cache.delete(agentId);
-      return true;
+      return await this.runWithSessionLock(agentId, 'write', async () => {
+        const session = this.loadSessionFromDisk(agentId);
+        if (
+          session &&
+          !this.sameExecutionFence(session.executionFence, expectedExecutionFence)
+        ) {
+          return false;
+        }
+        await this.deleteSessionFile(agentId);
+        return true;
+      });
     } catch (error) {
       this.logger.warn(`Failed to delete session ${agentId}:`, error);
       return false;
@@ -384,7 +400,9 @@ export class AgentSessionStore {
    * 清理过期会话
    * @param maxAgeMs 最大保留时间（毫秒），默认 7 天
    */
-  cleanupExpiredSessions(maxAgeMs: number = 7 * 24 * 60 * 60 * 1000): number {
+  async cleanupExpiredSessions(
+    maxAgeMs: number = 7 * 24 * 60 * 60 * 1000,
+  ): Promise<number> {
     const now = Date.now();
     const sessions = this.listSessions();
     let cleaned = 0;
@@ -395,7 +413,7 @@ export class AgentSessionStore {
 
       const age = now - session.lastActiveAt;
       if (age > maxAgeMs) {
-        if (this.deleteSession(session.id)) {
+        if (await this.deleteTerminalSession(session.id)) {
           cleaned++;
         }
       }
@@ -413,6 +431,77 @@ export class AgentSessionStore {
    */
   clearCache(): void {
     this.cache.clear();
+  }
+
+  private async deleteTerminalSession(agentId: AgentId): Promise<boolean> {
+    return this.runWithSessionLock(agentId, 'write', async () => {
+      const session = this.loadSessionFromDisk(agentId);
+      if (!session || session.status === 'running') {
+        return false;
+      }
+      await this.deleteSessionFile(agentId);
+      return true;
+    });
+  }
+
+  private async deleteSessionFile(agentId: AgentId): Promise<void> {
+    const filePath = this.getSessionPath(agentId);
+    if (filePath) {
+      try {
+        await unlink(filePath);
+      } catch (error) {
+        if (
+          !(
+            typeof error === 'object' &&
+            error !== null &&
+            'code' in error &&
+            error.code === 'ENOENT'
+          )
+        ) {
+          throw error;
+        }
+      }
+    }
+    this.cache.delete(agentId);
+  }
+
+  private runWithSessionLock<T>(
+    agentId: AgentId,
+    operation: 'read' | 'write',
+    callback: () => Promise<T>,
+  ): Promise<T> {
+    const filePath = this.getSessionPath(agentId);
+    if (!filePath) {
+      return callback();
+    }
+    return withAdvisoryFileLock(
+      filePath,
+      {
+        timeoutMs: AGENT_SESSION_LOCK_TIMEOUT_MS,
+        errors: {
+          prepare: (cause) => this.storageError(agentId, operation, cause),
+          initialize: (cause) => this.storageError(agentId, operation, cause),
+          acquire: (cause) => this.storageError(agentId, operation, cause),
+          timeout: () =>
+            new Error(
+              `Timed out acquiring the background agent ${operation} lock for ${agentId}`,
+            ),
+          release: (cause) => this.storageError(agentId, operation, cause),
+        },
+      },
+      callback,
+    );
+  }
+
+  private storageError(
+    agentId: AgentId,
+    operation: 'read' | 'write',
+    cause: unknown,
+  ): Error {
+    return new Error(
+      `Failed to ${operation} background agent session ${agentId}`,
+      { cause },
+    );
   }
 
   private canReplaceExecution(

--- a/src/agent/subagents/AgentSessionStore.ts
+++ b/src/agent/subagents/AgentSessionStore.ts
@@ -9,8 +9,10 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+import writeFileAtomic from 'write-file-atomic';
 import { type InternalLogger, LogCategory, NOOP_LOGGER } from '../../logging/Logger.js';
 import type { Message } from '../../services/ChatServiceInterface.js';
+import type { DurableExecutionFence } from '../../session/events/DurableExecutionLeaseStore.js';
 import { AgentId } from '../../types/branded.js';
 import type { AgentProgress } from '../types.js';
 
@@ -72,6 +74,9 @@ export interface AgentSession {
 
   /** 运行时进度（仅在 status === 'running' 时持续更新） */
   progress?: AgentProgress;
+
+  /** Root Session ownership that is allowed to mutate this execution. */
+  executionFence?: DurableExecutionFence;
 }
 
 /**
@@ -134,19 +139,44 @@ export class AgentSessionStore {
   /**
    * 保存会话
    */
-  saveSession(session: AgentSession): void {
-    // 更新缓存
-    this.cache.set(session.id, session);
+  saveSession(session: AgentSession): boolean {
+    const current = this.loadSessionFromDisk(session.id);
+    if (current && !this.canReplaceExecution(current.executionFence, session.executionFence)) {
+      return false;
+    }
 
+    this.writeSession(session);
+    return true;
+  }
+
+  private writeSession(session: AgentSession): void {
     const filePath = this.getSessionPath(session.id);
-    if (!filePath) return;
+    if (!filePath) {
+      this.cache.set(session.id, session);
+      return;
+    }
 
     try {
       const data = JSON.stringify(session, null, 2);
-      fs.writeFileSync(filePath, data, 'utf-8');
+      const created = !fs.existsSync(filePath);
+      writeFileAtomic.sync(filePath, data, {
+        encoding: 'utf8',
+        fsync: true,
+        mode: 0o600,
+      });
+      if (created && process.platform !== 'win32' && this.sessionsDir) {
+        const directory = fs.openSync(this.sessionsDir, 'r');
+        try {
+          fs.fsyncSync(directory);
+        } finally {
+          fs.closeSync(directory);
+        }
+      }
+      this.cache.set(session.id, session);
       this.logger.debug(`Session saved: ${session.id}`);
     } catch (error) {
       this.logger.warn(`Failed to save session ${session.id}:`, error);
+      throw error;
     }
   }
 
@@ -154,14 +184,18 @@ export class AgentSessionStore {
    * 加载会话
    */
   loadSession(agentId: AgentId): AgentSession | undefined {
-    // 先检查缓存
-    if (this.cache.has(agentId)) {
+    if (!this.sessionsDir && this.cache.has(agentId)) {
       return this.cache.get(agentId);
     }
 
-    const filePath = this.getSessionPath(agentId);
-    if (!filePath) return undefined;
+    return this.loadSessionFromDisk(agentId);
+  }
 
+  private loadSessionFromDisk(agentId: AgentId): AgentSession | undefined {
+    const filePath = this.getSessionPath(agentId);
+    if (!filePath) {
+      return this.cache.get(agentId);
+    }
     try {
       if (!fs.existsSync(filePath)) {
         return undefined;
@@ -185,27 +219,36 @@ export class AgentSessionStore {
    */
   updateSession(
     agentId: AgentId,
-    updates: Partial<AgentSession>
+    updates: Partial<AgentSession>,
+    expectedExecutionFence?: DurableExecutionFence,
   ): AgentSession | undefined {
-    const session = this.loadSession(agentId);
-    if (!session) {
+    const session = this.loadSessionFromDisk(agentId);
+    if (
+      !session ||
+      !this.sameExecutionFence(session.executionFence, expectedExecutionFence)
+    ) {
       return undefined;
     }
 
     const updatedSession: AgentSession = {
       ...session,
       ...updates,
+      executionFence: session.executionFence,
       lastActiveAt: Date.now(),
     };
 
-    this.saveSession(updatedSession);
+    this.writeSession(updatedSession);
     return updatedSession;
   }
 
   /**
    * 追加消息到会话
    */
-  appendMessages(agentId: AgentId, messages: Message[]): AgentSession | undefined {
+  appendMessages(
+    agentId: AgentId,
+    messages: Message[],
+    expectedExecutionFence?: DurableExecutionFence,
+  ): AgentSession | undefined {
     const session = this.loadSession(agentId);
     if (!session) {
       return undefined;
@@ -213,7 +256,7 @@ export class AgentSessionStore {
 
     return this.updateSession(agentId, {
       messages: [...session.messages, ...messages],
-    });
+    }, expectedExecutionFence);
   }
 
   /**
@@ -223,12 +266,17 @@ export class AgentSessionStore {
   updateRunningSession(
     agentId: AgentId,
     updates: { messages?: Message[]; progress?: AgentProgress },
+    expectedExecutionFence?: DurableExecutionFence,
   ): AgentSession | undefined {
-    const session = this.loadSession(agentId);
-    if (!session || session.status !== 'running') {
+    const session = this.loadSessionFromDisk(agentId);
+    if (
+      !session ||
+      session.status !== 'running' ||
+      !this.sameExecutionFence(session.executionFence, expectedExecutionFence)
+    ) {
       return undefined;
     }
-    return this.updateSession(agentId, updates);
+    return this.updateSession(agentId, updates, expectedExecutionFence);
   }
 
   /**
@@ -237,7 +285,8 @@ export class AgentSessionStore {
   markCompleted(
     agentId: AgentId,
     result: { success: boolean; message: string; error?: string },
-    stats?: AgentSession['stats']
+    stats?: AgentSession['stats'],
+    expectedExecutionFence?: DurableExecutionFence,
   ): AgentSession | undefined {
     return this.updateSession(agentId, {
       status: result.success ? 'completed' : 'failed',
@@ -245,7 +294,7 @@ export class AgentSessionStore {
       stats,
       completedAt: Date.now(),
       progress: undefined,
-    });
+    }, expectedExecutionFence);
   }
 
   /**
@@ -255,6 +304,7 @@ export class AgentSessionStore {
     agentId: AgentId,
     result?: { success: false; message: string; error?: string },
     stats?: AgentSession['stats'],
+    expectedExecutionFence?: DurableExecutionFence,
   ): AgentSession | undefined {
     return this.updateSession(agentId, {
       status: 'cancelled',
@@ -262,14 +312,24 @@ export class AgentSessionStore {
       stats,
       completedAt: Date.now(),
       progress: undefined,
-    });
+    }, expectedExecutionFence);
   }
 
   /**
    * 删除会话
    */
-  deleteSession(agentId: AgentId): boolean {
+  deleteSession(
+    agentId: AgentId,
+    expectedExecutionFence?: DurableExecutionFence,
+  ): boolean {
     try {
+      const session = this.loadSessionFromDisk(agentId);
+      if (
+        session &&
+        !this.sameExecutionFence(session.executionFence, expectedExecutionFence)
+      ) {
+        return false;
+      }
       const filePath = this.getSessionPath(agentId);
       if (filePath && fs.existsSync(filePath)) {
         fs.unlinkSync(filePath);
@@ -353,5 +413,34 @@ export class AgentSessionStore {
    */
   clearCache(): void {
     this.cache.clear();
+  }
+
+  private canReplaceExecution(
+    current: DurableExecutionFence | undefined,
+    next: DurableExecutionFence | undefined,
+  ): boolean {
+    if (!current) {
+      return true;
+    }
+    if (!next) {
+      return false;
+    }
+    if (this.sameExecutionFence(current, next)) {
+      return true;
+    }
+    return next.fencingToken > current.fencingToken;
+  }
+
+  private sameExecutionFence(
+    left: DurableExecutionFence | undefined,
+    right: DurableExecutionFence | undefined,
+  ): boolean {
+    if (!left || !right) {
+      return left === right;
+    }
+    return (
+      left.leaseId === right.leaseId &&
+      left.fencingToken === right.fencingToken
+    );
   }
 }

--- a/src/agent/subagents/BackgroundAgentManager.ts
+++ b/src/agent/subagents/BackgroundAgentManager.ts
@@ -8,9 +8,9 @@
  */
 
 import { nanoid } from 'nanoid';
-import { writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import writeFileAtomic from 'write-file-atomic';
 import { type InternalLogger, LogCategory, NOOP_LOGGER } from '../../logging/Logger.js';
 import type { ContextSnapshot } from '../../runtime/index.js';
 import type { Message } from '../../services/ChatServiceInterface.js';
@@ -46,6 +46,12 @@ interface BackgroundAgentRuntime {
 
   /** 待注入的消息队列（SendMessage 使用） */
   pendingMessages: string[];
+
+  /** Durable ownership used to fence every persisted mutation. */
+  executionFence?: DurableExecutionFence;
+
+  /** Store transaction that excludes root Session lease takeover. */
+  runWithExecutionLease?: <T>(operation: () => Promise<T>) => Promise<T>;
 }
 
 /**
@@ -87,6 +93,9 @@ export interface StartBackgroundAgentOptions {
 
   /** @internal Validates root Session ownership before a side effect. */
   assertExecutionLease?: () => Promise<void>;
+
+  /** @internal Serializes short transcript writes against lease takeover. */
+  runWithExecutionLease?: <T>(operation: () => Promise<T>) => Promise<T>;
 }
 
 /**
@@ -163,7 +172,7 @@ export class BackgroundAgentManager {
    * 启动后台 Agent
    * @returns agent ID
    */
-  startBackgroundAgent(options: StartBackgroundAgentOptions): string {
+  async startBackgroundAgent(options: StartBackgroundAgentOptions): Promise<string> {
     if (!this.acceptingNewAgents) {
       throw new Error('Background agent admission is closed for Session handoff');
     }
@@ -181,13 +190,14 @@ export class BackgroundAgentManager {
       snapshot,
       executionFence,
       assertExecutionLease,
+      runWithExecutionLease,
     } = options;
 
     // 生成或使用已有的 agent ID
     const id = agentId || AgentId(nanoid());
 
     // 创建输出文件路径
-    const outputFile = join(tmpdir(), `blade-agent-${id}.output`);
+    const outputFile = join(tmpdir(), `blade-agent-${nanoid()}.output`);
 
     // 拆分生命周期取消和当前工作取消
     const lifecycleController = new AbortController();
@@ -214,26 +224,41 @@ export class BackgroundAgentManager {
       lastActiveAt: Date.now(),
       parentSessionId,
       outputFile,
+      executionFence,
     };
 
-    // 保存会话
-    this.sessionStore.saveSession(session);
+    await this.runOwnedPersistence(
+      executionFence,
+      runWithExecutionLease,
+      async () => {
+        if (!this.sessionStore.saveSession(session)) {
+          throw new Error(`Execution fence rejected background agent ${id} creation`);
+        }
+      },
+    );
+    await assertExecutionLease?.();
+    if (!this.acceptingNewAgents) {
+      throw new Error('Background agent admission closed during ownership validation');
+    }
 
     const startTime = Date.now();
-    const promise = this.executeAgent(
-      id,
-      config,
-      bladeConfig,
-      subagentRegistry,
-      prompt,
-      parentSessionId,
-      permissionMode,
-      lifecycleController.signal,
-      workController.signal,
-      existingMessages,
-      snapshot,
-      executionFence,
-      assertExecutionLease,
+    const promise = Promise.resolve().then(() =>
+      this.executeAgent(
+        id,
+        config,
+        bladeConfig,
+        subagentRegistry,
+        prompt,
+        parentSessionId,
+        permissionMode,
+        lifecycleController.signal,
+        workController.signal,
+        existingMessages,
+        snapshot,
+        executionFence,
+        assertExecutionLease,
+        runWithExecutionLease,
+      ),
     );
 
     // 记录运行时信息
@@ -244,11 +269,15 @@ export class BackgroundAgentManager {
       workController,
       startTime,
       pendingMessages: [],
+      executionFence,
+      runWithExecutionLease,
     });
 
     // 执行完成后清理
     promise.finally(() => {
-      this.runningAgents.delete(id);
+      if (this.runningAgents.get(id)?.promise === promise) {
+        this.runningAgents.delete(id);
+      }
     });
 
     this.logger.info(`Background agent started: ${id} (${config.name})`);
@@ -272,6 +301,7 @@ export class BackgroundAgentManager {
     snapshot?: ContextSnapshot,
     executionFence?: DurableExecutionFence,
     assertExecutionLease?: () => Promise<void>,
+    runWithExecutionLease?: <T>(operation: () => Promise<T>) => Promise<T>,
   ): Promise<SubagentResult> {
     const startTime = Date.now();
 
@@ -295,20 +325,29 @@ export class BackgroundAgentManager {
         backgroundAgentManager: this,
         executionFence,
         assertExecutionLease,
-        onProgress: (progress) => {
-          this.sessionStore.updateRunningSession(agentId, { progress });
+        runWithExecutionLease,
+        onProgress: async (progress) => {
+          await this.runOwnedPersistence(
+            executionFence,
+            runWithExecutionLease,
+            async () => {
+              if (
+                !this.sessionStore.updateRunningSession(
+                  agentId,
+                  { progress },
+                  executionFence,
+                )
+              ) {
+                throw new Error(
+                  `Execution fence rejected background agent ${agentId} progress`,
+                );
+              }
+            },
+          );
         },
       });
 
-      this.sessionStore.updateRunningSession(agentId, {
-        messages,
-      });
-
       const duration = Date.now() - startTime;
-      const wasCancelled =
-        lifecycleSignal.aborted ||
-        workSignal.aborted ||
-        this.sessionStore.loadSession(agentId)?.status === 'cancelled';
       const result: SubagentResult = loopResult.success
         ? {
             success: true,
@@ -328,80 +367,135 @@ export class BackgroundAgentManager {
             stats: { duration },
           };
 
-      if (wasCancelled && !result.success) {
-        this.sessionStore.markCancelled(
-          agentId,
-          {
-            success: false,
-            message: result.message,
-            error: result.error,
-          },
-          result.stats,
-        );
-      } else {
-        this.sessionStore.markCompleted(
-          agentId,
-          {
-            success: result.success,
-            message: result.message,
-            error: result.error,
-          },
-          result.stats
-        );
-      }
-
-      // Write output to file for streaming access
-      const session = this.sessionStore.loadSession(agentId);
-      if (session?.outputFile) {
-        const output = JSON.stringify(
-          { status: wasCancelled ? 'cancelled' : result.success ? 'completed' : 'failed', result },
-          null,
-          2,
-        );
-        await writeFile(session.outputFile, output, 'utf-8').catch(() => {/* ignore write errors */});
-      }
+      await this.runOwnedPersistence(
+        executionFence,
+        runWithExecutionLease,
+        async () => {
+          this.sessionStore.updateRunningSession(
+            agentId,
+            { messages },
+            executionFence,
+          );
+          const wasCancelled =
+            lifecycleSignal.aborted ||
+            workSignal.aborted ||
+            this.sessionStore.loadSession(agentId)?.status === 'cancelled';
+          const updated = wasCancelled && !result.success
+            ? this.sessionStore.markCancelled(
+                agentId,
+                {
+                  success: false,
+                  message: result.message,
+                  error: result.error,
+                },
+                result.stats,
+                executionFence,
+              )
+            : this.sessionStore.markCompleted(
+                agentId,
+                {
+                  success: result.success,
+                  message: result.message,
+                  error: result.error,
+                },
+                result.stats,
+                executionFence,
+              );
+          if (!updated) {
+            throw new Error(
+              `Execution fence rejected background agent ${agentId} completion`,
+            );
+          }
+          if (updated.outputFile) {
+            const output = JSON.stringify(
+              {
+                status: wasCancelled
+                  ? 'cancelled'
+                  : result.success
+                    ? 'completed'
+                    : 'failed',
+                result,
+              },
+              null,
+              2,
+            );
+            await writeFileAtomic(
+              updated.outputFile,
+              output,
+              {
+                encoding: 'utf8',
+                fsync: true,
+                mode: 0o600,
+              },
+            ).catch((outputError: unknown) => {
+              this.logger.warn(
+                `Failed to persist background agent ${agentId} output`,
+                outputError,
+              );
+            });
+          }
+        },
+      );
 
       this.logger.info(`Background agent completed: ${agentId} (success=${result.success})`);
       return result;
     } catch (error) {
       const duration = Date.now() - startTime;
       const errorMessage = error instanceof Error ? error.message : String(error);
-      const wasCancelled =
-        lifecycleSignal.aborted ||
-        workSignal.aborted ||
-        this.sessionStore.loadSession(agentId)?.status === 'cancelled';
-
-      if (wasCancelled) {
-        this.sessionStore.markCancelled(
-          agentId,
-          {
-            success: false,
-            message: '',
-            error: errorMessage,
-          },
-          { duration },
-        );
-      } else {
-        this.sessionStore.markCompleted(
-          agentId,
-          {
-            success: false,
-            message: '',
-            error: errorMessage,
-          },
-          { duration }
-        );
-      }
-
-      this.logger.warn(`Background agent failed: ${agentId}`, error);
-
-      return {
+      const failure: SubagentResult = {
         success: false,
         message: '',
         agentId,
         error: errorMessage,
         stats: { duration },
       };
+
+      try {
+        await this.runOwnedPersistence(
+          executionFence,
+          runWithExecutionLease,
+          async () => {
+            const wasCancelled =
+              lifecycleSignal.aborted ||
+              workSignal.aborted ||
+              this.sessionStore.loadSession(agentId)?.status === 'cancelled';
+            const updated = wasCancelled
+              ? this.sessionStore.markCancelled(
+                  agentId,
+                  {
+                    success: false,
+                    message: '',
+                    error: errorMessage,
+                  },
+                  { duration },
+                  executionFence,
+                )
+              : this.sessionStore.markCompleted(
+                  agentId,
+                  {
+                    success: false,
+                    message: '',
+                    error: errorMessage,
+                  },
+                  { duration },
+                  executionFence,
+                );
+            if (!updated) {
+              throw new Error(
+                `Execution fence rejected background agent ${agentId} failure`,
+              );
+            }
+          },
+        );
+      } catch (persistenceError) {
+        this.logger.warn(
+          `Background agent ${agentId} failure could not be persisted`,
+          persistenceError,
+        );
+      }
+
+      this.logger.warn(`Background agent failed: ${agentId}`, error);
+      return failure;
     }
   }
 
@@ -465,7 +559,7 @@ export class BackgroundAgentManager {
    * @param bladeConfig BladeConfig 配置
    * @returns 新的 agent ID（如果创建了新 agent）或原 ID（如果继续执行）
    */
-  resumeAgent(
+  async resumeAgent(
     agentId: AgentId,
     newPrompt: string,
     config: SubagentConfig,
@@ -476,7 +570,8 @@ export class BackgroundAgentManager {
     description?: string,
     executionFence?: DurableExecutionFence,
     assertExecutionLease?: () => Promise<void>,
-  ): string | undefined {
+    runWithExecutionLease?: <T>(operation: () => Promise<T>) => Promise<T>,
+  ): Promise<string | undefined> {
     const session = this.sessionStore.loadSession(agentId);
 
     if (!session) {
@@ -501,20 +596,23 @@ export class BackgroundAgentManager {
       existingMessages: session.messages,
       executionFence,
       assertExecutionLease,
+      runWithExecutionLease,
     });
   }
 
   /**
    * 取消/终止 Agent
    */
-  killAgent(agentId: AgentId): boolean {
+  async killAgent(agentId: AgentId): Promise<boolean> {
     const runtime = this.runningAgents.get(agentId);
 
     if (!runtime) {
       // 不在运行中
       const session = this.sessionStore.loadSession(agentId);
       if (session && session.status === 'running') {
-        // 更新状态为已取消
+        if (session.executionFence) {
+          return false;
+        }
         this.sessionStore.markCancelled(agentId);
       }
       return false;
@@ -523,8 +621,24 @@ export class BackgroundAgentManager {
     // 发送取消信号
     runtime.lifecycleController.abort();
 
-    // 更新状态
-    this.sessionStore.markCancelled(agentId);
+    await this.runOwnedPersistence(
+      runtime.executionFence,
+      runtime.runWithExecutionLease,
+      async () => {
+        if (
+          !this.sessionStore.markCancelled(
+            agentId,
+            undefined,
+            undefined,
+            runtime.executionFence,
+          )
+        ) {
+          throw new Error(
+            `Execution fence rejected background agent ${agentId} cancellation`,
+          );
+        }
+      },
+    );
 
     this.logger.info(`Background agent cancelled: ${agentId}`);
     return true;
@@ -616,7 +730,7 @@ export class BackgroundAgentManager {
     this.sealForHandoff();
     const agentIds = this.getActiveAgentIds();
     for (const agentId of agentIds) {
-      this.killAgent(agentId);
+      this.runningAgents.get(agentId)?.lifecycleController.abort();
     }
     return agentIds;
   }
@@ -634,8 +748,8 @@ export class BackgroundAgentManager {
    * 终止所有运行中的 Agent
    */
   killAll(): void {
-    for (const [agentId] of this.runningAgents) {
-      this.killAgent(agentId);
+    for (const runtime of this.runningAgents.values()) {
+      runtime.lifecycleController.abort();
     }
   }
 
@@ -644,5 +758,18 @@ export class BackgroundAgentManager {
    */
   cleanupExpiredSessions(maxAgeMs?: number): number {
     return this.sessionStore.cleanupExpiredSessions(maxAgeMs);
+  }
+
+  private async runOwnedPersistence<T>(
+    executionFence: DurableExecutionFence | undefined,
+    runWithExecutionLease: (<R>(operation: () => Promise<R>) => Promise<R>) | undefined,
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    if (executionFence && !runWithExecutionLease) {
+      throw new Error('Fenced background agents require a lease persistence boundary');
+    }
+    return runWithExecutionLease
+      ? runWithExecutionLease(operation)
+      : operation();
   }
 }

--- a/src/agent/subagents/BackgroundAgentManager.ts
+++ b/src/agent/subagents/BackgroundAgentManager.ts
@@ -14,7 +14,10 @@ import writeFileAtomic from 'write-file-atomic';
 import { type InternalLogger, LogCategory, NOOP_LOGGER } from '../../logging/Logger.js';
 import type { ContextSnapshot } from '../../runtime/index.js';
 import type { Message } from '../../services/ChatServiceInterface.js';
-import type { DurableExecutionFence } from '../../session/events/DurableExecutionLeaseStore.js';
+import {
+  type DurableExecutionFence,
+  DurableExecutionLeaseError,
+} from '../../session/events/DurableExecutionLeaseStore.js';
 import { AgentId, type SessionId } from '../../types/branded.js';
 import type { BladeConfig, PermissionMode } from '../../types/common.js';
 import type {
@@ -24,6 +27,8 @@ import type {
 import { runSubagent } from './runSubagent.js';
 import type { SubagentRegistry } from './SubagentRegistry.js';
 import type { SubagentConfig, SubagentResult } from './types.js';
+
+const DEFAULT_BACKGROUND_AGENT_SHUTDOWN_TIMEOUT_MS = 30_000;
 
 /**
  * 后台 Agent 运行时信息
@@ -121,7 +126,9 @@ export class BackgroundAgentManager {
       this.logger = logger.child(LogCategory.AGENT);
       this.sessionStore.setLogger(logger);
     }
-    this.cleanupOrphanedSessions();
+    void this.cleanupOrphanedSessions().catch((error: unknown) => {
+      this.logger.warn('Failed to clean up orphaned agent sessions', error);
+    });
   }
 
   /**
@@ -143,7 +150,7 @@ export class BackgroundAgentManager {
     this.sessionStore.setLogger(logger);
   }
 
-  private cleanupOrphanedSessions(): void {
+  private async cleanupOrphanedSessions(): Promise<void> {
     const sessions = this.sessionStore.listSessions();
     const now = Date.now();
     const maxOrphanAge = 30 * 60 * 1000;
@@ -155,7 +162,7 @@ export class BackgroundAgentManager {
 
         if (!isInMemory || age > maxOrphanAge) {
           this.logger.warn(`Cleaning up orphaned agent session: ${session.id}`);
-          this.sessionStore.markCompleted(
+          await this.sessionStore.markCompleted(
             session.id,
             {
               success: false,
@@ -174,6 +181,13 @@ export class BackgroundAgentManager {
    */
   async startBackgroundAgent(options: StartBackgroundAgentOptions): Promise<string> {
     if (!this.acceptingNewAgents) {
+      if (options.executionFence) {
+        throw this.executionFenceError(
+          options.agentId,
+          options.executionFence,
+          'admission is closed',
+        );
+      }
       throw new Error('Background agent admission is closed for Session handoff');
     }
 
@@ -231,13 +245,20 @@ export class BackgroundAgentManager {
       executionFence,
       runWithExecutionLease,
       async () => {
-        if (!this.sessionStore.saveSession(session)) {
-          throw new Error(`Execution fence rejected background agent ${id} creation`);
+        if (!(await this.sessionStore.saveSession(session))) {
+          throw this.executionFenceError(id, executionFence, 'creation was rejected');
         }
       },
     );
     await assertExecutionLease?.();
     if (!this.acceptingNewAgents) {
+      if (executionFence) {
+        throw this.executionFenceError(
+          id,
+          executionFence,
+          'admission closed during ownership validation',
+        );
+      }
       throw new Error('Background agent admission closed during ownership validation');
     }
 
@@ -332,14 +353,16 @@ export class BackgroundAgentManager {
             runWithExecutionLease,
             async () => {
               if (
-                !this.sessionStore.updateRunningSession(
+                !(await this.sessionStore.updateRunningSession(
                   agentId,
                   { progress },
                   executionFence,
-                )
+                ))
               ) {
-                throw new Error(
-                  `Execution fence rejected background agent ${agentId} progress`,
+                throw this.executionFenceError(
+                  agentId,
+                  executionFence,
+                  'progress was rejected',
                 );
               }
             },
@@ -371,7 +394,7 @@ export class BackgroundAgentManager {
         executionFence,
         runWithExecutionLease,
         async () => {
-          this.sessionStore.updateRunningSession(
+          await this.sessionStore.updateRunningSession(
             agentId,
             { messages },
             executionFence,
@@ -381,7 +404,7 @@ export class BackgroundAgentManager {
             workSignal.aborted ||
             this.sessionStore.loadSession(agentId)?.status === 'cancelled';
           const updated = wasCancelled && !result.success
-            ? this.sessionStore.markCancelled(
+            ? await this.sessionStore.markCancelled(
                 agentId,
                 {
                   success: false,
@@ -391,7 +414,7 @@ export class BackgroundAgentManager {
                 result.stats,
                 executionFence,
               )
-            : this.sessionStore.markCompleted(
+            : await this.sessionStore.markCompleted(
                 agentId,
                 {
                   success: result.success,
@@ -402,8 +425,10 @@ export class BackgroundAgentManager {
                 executionFence,
               );
           if (!updated) {
-            throw new Error(
-              `Execution fence rejected background agent ${agentId} completion`,
+            throw this.executionFenceError(
+              agentId,
+              executionFence,
+              'completion was rejected',
             );
           }
           if (updated.outputFile) {
@@ -460,7 +485,7 @@ export class BackgroundAgentManager {
               workSignal.aborted ||
               this.sessionStore.loadSession(agentId)?.status === 'cancelled';
             const updated = wasCancelled
-              ? this.sessionStore.markCancelled(
+              ? await this.sessionStore.markCancelled(
                   agentId,
                   {
                     success: false,
@@ -470,7 +495,7 @@ export class BackgroundAgentManager {
                   { duration },
                   executionFence,
                 )
-              : this.sessionStore.markCompleted(
+              : await this.sessionStore.markCompleted(
                   agentId,
                   {
                     success: false,
@@ -481,8 +506,10 @@ export class BackgroundAgentManager {
                   executionFence,
                 );
             if (!updated) {
-              throw new Error(
-                `Execution fence rejected background agent ${agentId} failure`,
+              throw this.executionFenceError(
+                agentId,
+                executionFence,
+                'failure was rejected',
               );
             }
           },
@@ -532,11 +559,12 @@ export class BackgroundAgentManager {
 
     // 等待执行完成或超时
     if (timeout > 0) {
-      const timeoutPromise = new Promise<'timeout'>((resolve) =>
-        setTimeout(() => resolve('timeout'), timeout)
-      );
-
-      const result = await Promise.race([runtime.promise, timeoutPromise]);
+      let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+      const timeoutPromise = new Promise<'timeout'>((resolve) => {
+        timeoutHandle = setTimeout(() => resolve('timeout'), timeout);
+      });
+      const result = await Promise.race([runtime.promise, timeoutPromise])
+        .finally(() => clearTimeout(timeoutHandle));
 
       if (result === 'timeout') {
         // 返回当前状态（仍在运行）
@@ -613,7 +641,7 @@ export class BackgroundAgentManager {
         if (session.executionFence) {
           return false;
         }
-        this.sessionStore.markCancelled(agentId);
+        await this.sessionStore.markCancelled(agentId);
       }
       return false;
     }
@@ -626,15 +654,17 @@ export class BackgroundAgentManager {
       runtime.runWithExecutionLease,
       async () => {
         if (
-          !this.sessionStore.markCancelled(
+          !(await this.sessionStore.markCancelled(
             agentId,
             undefined,
             undefined,
             runtime.executionFence,
-          )
+          ))
         ) {
-          throw new Error(
-            `Execution fence rejected background agent ${agentId} cancellation`,
+          throw this.executionFenceError(
+            agentId,
+            runtime.executionFence,
+            'cancellation was rejected',
           );
         }
       },
@@ -736,11 +766,24 @@ export class BackgroundAgentManager {
   }
 
   /** Cancels all descendants and waits until their execution promises settle. */
-  async sealCancelAndWait(): Promise<readonly AgentId[]> {
+  async sealCancelAndWait(
+    timeoutMs = DEFAULT_BACKGROUND_AGENT_SHUTDOWN_TIMEOUT_MS,
+  ): Promise<readonly AgentId[]> {
+    if (!Number.isSafeInteger(timeoutMs) || timeoutMs < 0) {
+      throw new Error('Background agent shutdown timeout must be non-negative');
+    }
     const agentIds = this.sealAndCancelAll();
     await Promise.all(
-      agentIds.map((agentId) => this.waitForCompletion(agentId, 0)),
+      agentIds.map((agentId) => this.waitForCompletion(agentId, timeoutMs)),
     );
+    const unsettledAgentIds = agentIds.filter((agentId) =>
+      this.runningAgents.has(agentId),
+    );
+    if (unsettledAgentIds.length > 0) {
+      throw new Error(
+        `Timed out waiting for background agents to stop: ${unsettledAgentIds.join(', ')}`,
+      );
+    }
     return agentIds;
   }
 
@@ -756,7 +799,7 @@ export class BackgroundAgentManager {
   /**
    * 清理过期会话
    */
-  cleanupExpiredSessions(maxAgeMs?: number): number {
+  cleanupExpiredSessions(maxAgeMs?: number): Promise<number> {
     return this.sessionStore.cleanupExpiredSessions(maxAgeMs);
   }
 
@@ -766,10 +809,34 @@ export class BackgroundAgentManager {
     operation: () => Promise<T>,
   ): Promise<T> {
     if (executionFence && !runWithExecutionLease) {
-      throw new Error('Fenced background agents require a lease persistence boundary');
+      throw new DurableExecutionLeaseError(
+        'DURABLE_EXECUTION_LEASE_INVALID',
+        'Fenced background agents require a lease persistence boundary',
+        {
+          sessionId: this.ownerSessionId,
+          leaseId: executionFence.leaseId,
+          fencingToken: executionFence.fencingToken,
+        },
+      );
     }
     return runWithExecutionLease
       ? runWithExecutionLease(operation)
       : operation();
+  }
+
+  private executionFenceError(
+    agentId: AgentId | undefined,
+    executionFence: DurableExecutionFence | undefined,
+    detail: string,
+  ): DurableExecutionLeaseError {
+    return new DurableExecutionLeaseError(
+      'DURABLE_EXECUTION_LEASE_LOST',
+      `Execution fence for background agent ${agentId ?? 'unknown'} ${detail}`,
+      {
+        sessionId: this.ownerSessionId,
+        leaseId: executionFence?.leaseId,
+        fencingToken: executionFence?.fencingToken,
+      },
+    );
   }
 }

--- a/src/agent/subagents/BackgroundAgentManager.ts
+++ b/src/agent/subagents/BackgroundAgentManager.ts
@@ -14,6 +14,7 @@ import { join } from 'node:path';
 import { type InternalLogger, LogCategory, NOOP_LOGGER } from '../../logging/Logger.js';
 import type { ContextSnapshot } from '../../runtime/index.js';
 import type { Message } from '../../services/ChatServiceInterface.js';
+import type { DurableExecutionFence } from '../../session/events/DurableExecutionLeaseStore.js';
 import { AgentId, type SessionId } from '../../types/branded.js';
 import type { BladeConfig, PermissionMode } from '../../types/common.js';
 import type {
@@ -80,6 +81,12 @@ export interface StartBackgroundAgentOptions {
 
   /** 父 turn 的 context snapshot（如果存在则继承） */
   snapshot?: ContextSnapshot;
+
+  /** Root Session execution fence propagated to nested work. */
+  executionFence?: DurableExecutionFence;
+
+  /** @internal Validates root Session ownership before a side effect. */
+  assertExecutionLease?: () => Promise<void>;
 }
 
 /**
@@ -172,6 +179,8 @@ export class BackgroundAgentManager {
       agentId,
       existingMessages,
       snapshot,
+      executionFence,
+      assertExecutionLease,
     } = options;
 
     // 生成或使用已有的 agent ID
@@ -223,6 +232,8 @@ export class BackgroundAgentManager {
       workController.signal,
       existingMessages,
       snapshot,
+      executionFence,
+      assertExecutionLease,
     );
 
     // 记录运行时信息
@@ -259,6 +270,8 @@ export class BackgroundAgentManager {
     workSignal: AbortSignal,
     existingMessages?: Message[],
     snapshot?: ContextSnapshot,
+    executionFence?: DurableExecutionFence,
+    assertExecutionLease?: () => Promise<void>,
   ): Promise<SubagentResult> {
     const startTime = Date.now();
 
@@ -280,6 +293,8 @@ export class BackgroundAgentManager {
         messages,
         signal: workSignal,
         backgroundAgentManager: this,
+        executionFence,
+        assertExecutionLease,
         onProgress: (progress) => {
           this.sessionStore.updateRunningSession(agentId, { progress });
         },
@@ -459,6 +474,8 @@ export class BackgroundAgentManager {
     permissionMode?: PermissionMode,
     subagentRegistry?: SubagentRegistry,
     description?: string,
+    executionFence?: DurableExecutionFence,
+    assertExecutionLease?: () => Promise<void>,
   ): string | undefined {
     const session = this.sessionStore.loadSession(agentId);
 
@@ -482,6 +499,8 @@ export class BackgroundAgentManager {
       permissionMode,
       agentId,
       existingMessages: session.messages,
+      executionFence,
+      assertExecutionLease,
     });
   }
 
@@ -590,6 +609,25 @@ export class BackgroundAgentManager {
   /** Prevents new background-agent work from starting in this runtime. */
   sealForHandoff(): void {
     this.acceptingNewAgents = false;
+  }
+
+  /** Prevents new work and cancels every active descendant after lease loss. */
+  sealAndCancelAll(): readonly AgentId[] {
+    this.sealForHandoff();
+    const agentIds = this.getActiveAgentIds();
+    for (const agentId of agentIds) {
+      this.killAgent(agentId);
+    }
+    return agentIds;
+  }
+
+  /** Cancels all descendants and waits until their execution promises settle. */
+  async sealCancelAndWait(): Promise<readonly AgentId[]> {
+    const agentIds = this.sealAndCancelAll();
+    await Promise.all(
+      agentIds.map((agentId) => this.waitForCompletion(agentId, 0)),
+    );
+    return agentIds;
   }
 
   /**

--- a/src/agent/subagents/BackgroundAgentManager.ts
+++ b/src/agent/subagents/BackgroundAgentManager.ts
@@ -156,7 +156,7 @@ export class BackgroundAgentManager {
     const maxOrphanAge = 30 * 60 * 1000;
 
     for (const session of sessions) {
-      if (session.status === 'running') {
+      if (session.status === 'running' && !session.executionFence) {
         const isInMemory = this.runningAgents.has(session.id);
         const age = now - session.lastActiveAt;
 

--- a/src/agent/subagents/SubagentExecutor.ts
+++ b/src/agent/subagents/SubagentExecutor.ts
@@ -1,9 +1,9 @@
 import { nanoid } from 'nanoid';
 import type { BladeConfig } from '../../types/common.js';
 import type { BackgroundAgentManager } from './BackgroundAgentManager.js';
+import { runSubagent } from './runSubagent.js';
 import type { SubagentRegistry } from './SubagentRegistry.js';
 import type { SubagentConfig, SubagentContext, SubagentResult } from './types.js';
-import { runSubagent } from './runSubagent.js';
 
 /**
  * Subagent 执行器
@@ -42,6 +42,9 @@ export class SubagentExecutor {
         parentSessionId: context.parentSessionId,
         permissionMode: context.permissionMode,
         snapshot: context.snapshot,
+        signal: context.signal,
+        executionFence: context.executionFence,
+        assertExecutionLease: context.assertExecutionLease,
         omitEnvironment: context.omitEnvironment ?? this.config.omitEnvironment,
       });
 

--- a/src/agent/subagents/SubagentExecutor.ts
+++ b/src/agent/subagents/SubagentExecutor.ts
@@ -45,6 +45,7 @@ export class SubagentExecutor {
         signal: context.signal,
         executionFence: context.executionFence,
         assertExecutionLease: context.assertExecutionLease,
+        runWithExecutionLease: context.runWithExecutionLease,
         omitEnvironment: context.omitEnvironment ?? this.config.omitEnvironment,
       });
 

--- a/src/agent/subagents/__tests__/AgentSessionStore.test.ts
+++ b/src/agent/subagents/__tests__/AgentSessionStore.test.ts
@@ -49,7 +49,7 @@ describe('AgentSessionStore', () => {
     const fakeHome = await createTempDir('blade-agent-home-');
 
     const store = AgentSessionStore.create();
-    store.saveSession(createSession('agent-memory'));
+    await store.saveSession(createSession('agent-memory'));
 
     expect(store.loadSession(AgentId('agent-memory'))?.id).toBe('agent-memory');
     expect(store.listSessions().map((session) => session.id)).toEqual(['agent-memory']);
@@ -60,7 +60,7 @@ describe('AgentSessionStore', () => {
     const storageRoot = await createTempDir('blade-agent-storage-');
 
     const store = AgentSessionStore.create(storageRoot);
-    store.saveSession(createSession('agent/unsafe:id'));
+    await store.saveSession(createSession('agent/unsafe:id'));
 
     const sessionPath = join(storageRoot, 'agents', 'sessions', 'agent_unsafe_id.json');
     expect(await pathExists(sessionPath)).toBe(true);
@@ -83,28 +83,82 @@ describe('AgentSessionStore', () => {
       fencingToken: FencingToken(2),
     };
 
-    expect(store.saveSession({
+    await expect(store.saveSession({
       ...createSession(agentId),
       executionFence: staleFence,
-    })).toBe(true);
-    expect(store.saveSession({
+    })).resolves.toBe(true);
+    await expect(store.saveSession({
       ...createSession(agentId),
       description: 'Successor execution',
       executionFence: successorFence,
-    })).toBe(true);
+    })).resolves.toBe(true);
 
-    expect(
+    await expect(
       store.markCancelled(agentId, undefined, undefined, staleFence),
-    ).toBeUndefined();
-    expect(store.saveSession({
+    ).resolves.toBeUndefined();
+    await expect(store.saveSession({
       ...createSession(agentId),
       description: 'Stale replacement',
       executionFence: staleFence,
-    })).toBe(false);
+    })).resolves.toBe(false);
     expect(store.loadSession(agentId)).toMatchObject({
       description: 'Successor execution',
       status: 'running',
       executionFence: successorFence,
+    });
+    await expect(store.deleteSession(agentId)).resolves.toBe(false);
+
+    await expect(
+      store.markCompleted(
+        agentId,
+        { success: true, message: 'done' },
+        undefined,
+        successorFence,
+      ),
+    ).resolves.toMatchObject({ status: 'completed' });
+    await new Promise<void>((resolve) => setTimeout(resolve, 2));
+    await expect(store.cleanupExpiredSessions(0)).resolves.toBe(1);
+    expect(store.loadSession(agentId)).toBeUndefined();
+  });
+
+  it('serializes fencing-token takeovers across Store instances', async () => {
+    const storageRoot = await createTempDir('blade-agent-fence-race-');
+    const firstStore = AgentSessionStore.create(storageRoot);
+    const secondStore = AgentSessionStore.create(storageRoot);
+    const agentId = AgentId('agent-fence-race');
+    await firstStore.saveSession({
+      ...createSession(agentId),
+      executionFence: {
+        leaseId: ExecutionLeaseId('lease-1'),
+        fencingToken: FencingToken(1),
+      },
+    });
+
+    await Promise.all([
+      firstStore.saveSession({
+        ...createSession(agentId),
+        description: 'token 2',
+        executionFence: {
+          leaseId: ExecutionLeaseId('lease-2'),
+          fencingToken: FencingToken(2),
+        },
+      }),
+      secondStore.saveSession({
+        ...createSession(agentId),
+        description: 'token 3',
+        executionFence: {
+          leaseId: ExecutionLeaseId('lease-3'),
+          fencingToken: FencingToken(3),
+        },
+      }),
+    ]);
+
+    expect(firstStore.loadSession(agentId)).toMatchObject({
+      description: 'token 3',
+      executionFence: {
+        leaseId: 'lease-3',
+        fencingToken: 3,
+      },
     });
   });
 });

--- a/src/agent/subagents/__tests__/AgentSessionStore.test.ts
+++ b/src/agent/subagents/__tests__/AgentSessionStore.test.ts
@@ -3,7 +3,11 @@ import { access, mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
-import { AgentId } from '../../../types/branded.js';
+import {
+  AgentId,
+  ExecutionLeaseId,
+  FencingToken,
+} from '../../../types/branded.js';
 import { type AgentSession, AgentSessionStore } from '../AgentSessionStore.js';
 
 const tempDirs: string[] = [];
@@ -63,6 +67,44 @@ describe('AgentSessionStore', () => {
     expect(JSON.parse(await readFile(sessionPath, 'utf8'))).toMatchObject({
       id: 'agent/unsafe:id',
       subagentType: 'research',
+    });
+  });
+
+  it('rejects stale subagent writers after a fencing-token takeover', async () => {
+    const storageRoot = await createTempDir('blade-agent-fenced-storage-');
+    const store = AgentSessionStore.create(storageRoot);
+    const agentId = AgentId('agent-fenced');
+    const staleFence = {
+      leaseId: ExecutionLeaseId('lease-stale'),
+      fencingToken: FencingToken(1),
+    };
+    const successorFence = {
+      leaseId: ExecutionLeaseId('lease-successor'),
+      fencingToken: FencingToken(2),
+    };
+
+    expect(store.saveSession({
+      ...createSession(agentId),
+      executionFence: staleFence,
+    })).toBe(true);
+    expect(store.saveSession({
+      ...createSession(agentId),
+      description: 'Successor execution',
+      executionFence: successorFence,
+    })).toBe(true);
+
+    expect(
+      store.markCancelled(agentId, undefined, undefined, staleFence),
+    ).toBeUndefined();
+    expect(store.saveSession({
+      ...createSession(agentId),
+      description: 'Stale replacement',
+      executionFence: staleFence,
+    })).toBe(false);
+    expect(store.loadSession(agentId)).toMatchObject({
+      description: 'Successor execution',
+      status: 'running',
+      executionFence: successorFence,
     });
   });
 });

--- a/src/agent/subagents/__tests__/BackgroundAgentManager.test.ts
+++ b/src/agent/subagents/__tests__/BackgroundAgentManager.test.ts
@@ -256,4 +256,45 @@ describe('BackgroundAgentManager', () => {
       }),
     ).toThrow('Background agent admission is closed for Session handoff');
   });
+
+  it('seals admission and cancels every running agent after ownership loss', async () => {
+    runAgenticLoop.mockImplementationOnce(
+      async (
+        _message: string,
+        _context: ChatContext,
+        options?: LoopOptions,
+      ) =>
+        await new Promise((resolve) => {
+          options?.signal?.addEventListener(
+            'abort',
+            () =>
+              resolve({
+                success: false,
+                error: { message: 'ownership lost' },
+                metadata: { duration: 0 },
+              }),
+            { once: true },
+          );
+        }),
+    );
+    const agentId = AgentId(manager.startBackgroundAgent({
+      config: subagentConfig,
+      bladeConfig,
+      description: 'Lease-owned work',
+      prompt: 'inspect',
+    }));
+    await vi.waitFor(() => expect(runAgenticLoop).toHaveBeenCalled());
+
+    await expect(manager.sealCancelAndWait()).resolves.toEqual([agentId]);
+    expect(manager.getAgent(agentId)?.status).toBe('cancelled');
+    expect(manager.getActiveAgentIds()).toEqual([]);
+    expect(() =>
+      manager.startBackgroundAgent({
+        config: subagentConfig,
+        bladeConfig,
+        description: 'Rejected after ownership loss',
+        prompt: 'inspect',
+      }),
+    ).toThrow('Background agent admission is closed');
+  });
 });

--- a/src/agent/subagents/__tests__/BackgroundAgentManager.test.ts
+++ b/src/agent/subagents/__tests__/BackgroundAgentManager.test.ts
@@ -307,6 +307,31 @@ describe('BackgroundAgentManager', () => {
     ).rejects.toThrow('Background agent admission is closed');
   });
 
+  it('fails cleanup closed when a background agent misses the shutdown deadline', async () => {
+    let finishExecution: (() => void) | undefined;
+    runAgenticLoop.mockImplementationOnce(async () => {
+      await new Promise<void>((resolve) => {
+        finishExecution = resolve;
+      });
+      return { success: false, error: { message: 'cancelled late' } };
+    });
+    const agentId = AgentId(await manager.startBackgroundAgent({
+      config: subagentConfig,
+      bladeConfig,
+      description: 'Unresponsive work',
+      prompt: 'inspect',
+    }));
+    await vi.waitFor(() => expect(runAgenticLoop).toHaveBeenCalled());
+
+    await expect(manager.sealCancelAndWait(10)).rejects.toThrow(
+      `Timed out waiting for background agents to stop: ${agentId}`,
+    );
+    expect(manager.getActiveAgentIds()).toEqual([agentId]);
+
+    finishExecution?.();
+    await manager.waitForCompletion(agentId, 0);
+  });
+
   it('prevents a stale owner from overwriting successor state or output', async () => {
     const store = AgentSessionStore.create();
     const oldManager = BackgroundAgentManager.create(

--- a/src/agent/subagents/__tests__/BackgroundAgentManager.test.ts
+++ b/src/agent/subagents/__tests__/BackgroundAgentManager.test.ts
@@ -1,7 +1,14 @@
+import { access, readFile, rm } from 'node:fs/promises';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { NOOP_LOGGER } from '../../../logging/Logger.js';
 import { createContextSnapshot } from '../../../runtime/index.js';
-import { AgentId, SessionId } from '../../../types/branded.js';
+import { DurableExecutionLeaseError } from '../../../session/events/DurableExecutionLeaseStore.js';
+import {
+    AgentId,
+    ExecutionLeaseId,
+    FencingToken,
+    SessionId,
+} from '../../../types/branded.js';
 import type { ChatContext, LoopOptions } from '../../types.js';
 import { AgentSessionStore } from '../AgentSessionStore.js';
 
@@ -84,7 +91,7 @@ describe('BackgroundAgentManager', () => {
       },
     });
 
-    const agentId = AgentId(manager.startBackgroundAgent({
+    const agentId = AgentId(await manager.startBackgroundAgent({
       config: subagentConfig,
       bladeConfig,
       description: 'Inspect repo',
@@ -105,7 +112,7 @@ describe('BackgroundAgentManager', () => {
   });
 
   it('updates the session description when resuming with a new description', async () => {
-    const agentId = AgentId(manager.startBackgroundAgent({
+    const agentId = AgentId(await manager.startBackgroundAgent({
       config: subagentConfig,
       bladeConfig,
       description: 'Original description',
@@ -114,7 +121,7 @@ describe('BackgroundAgentManager', () => {
 
     await manager.waitForCompletion(agentId, 1000);
 
-    const resumedId = manager.resumeAgent(
+    const resumedId = await manager.resumeAgent(
       agentId,
       'follow up',
       subagentConfig,
@@ -152,7 +159,7 @@ describe('BackgroundAgentManager', () => {
         }),
     );
 
-    const agentId = AgentId(manager.startBackgroundAgent({
+    const agentId = AgentId(await manager.startBackgroundAgent({
       config: subagentConfig,
       bladeConfig,
       description: 'Long running task',
@@ -171,7 +178,8 @@ describe('BackgroundAgentManager', () => {
     expect(runtime?.workController).toBeInstanceOf(AbortController);
     expect(runtime?.lifecycleController).not.toBe(runtime?.workController);
 
-    manager.killAgent(agentId);
+    await vi.waitFor(() => expect(runAgenticLoop).toHaveBeenCalled());
+    await manager.killAgent(agentId);
 
     expect(runtime?.lifecycleController.signal.aborted).toBe(true);
     expect(runtime?.workController.signal.aborted).toBe(true);
@@ -199,14 +207,15 @@ describe('BackgroundAgentManager', () => {
         }),
     );
 
-    const agentId = AgentId(manager.startBackgroundAgent({
+    const agentId = AgentId(await manager.startBackgroundAgent({
       config: subagentConfig,
       bladeConfig,
       description: 'Long running task',
       prompt: 'inspect',
     }));
 
-    expect(manager.killAgent(agentId)).toBe(true);
+    await vi.waitFor(() => expect(runAgenticLoop).toHaveBeenCalled());
+    await expect(manager.killAgent(agentId)).resolves.toBe(true);
 
     const session = await manager.waitForCompletion(agentId, 1000);
     expect(session?.status).toBe('cancelled');
@@ -233,7 +242,7 @@ describe('BackgroundAgentManager', () => {
         }),
     );
 
-    const agentId = AgentId(manager.startBackgroundAgent({
+    const agentId = AgentId(await manager.startBackgroundAgent({
       config: subagentConfig,
       bladeConfig,
       description: 'Handoff blocker',
@@ -242,19 +251,19 @@ describe('BackgroundAgentManager', () => {
 
     expect(manager.getActiveAgentIds()).toEqual([agentId]);
     await vi.waitFor(() => expect(runAgenticLoop).toHaveBeenCalled());
-    expect(manager.killAgent(agentId)).toBe(true);
+    await expect(manager.killAgent(agentId)).resolves.toBe(true);
     await manager.waitForCompletion(agentId, 1000);
 
     expect(manager.getActiveAgentIds()).toEqual([]);
     manager.sealForHandoff();
-    expect(() =>
+    await expect(
       manager.startBackgroundAgent({
         config: subagentConfig,
         bladeConfig,
         description: 'Rejected after handoff seal',
         prompt: 'inspect',
       }),
-    ).toThrow('Background agent admission is closed for Session handoff');
+    ).rejects.toThrow('Background agent admission is closed for Session handoff');
   });
 
   it('seals admission and cancels every running agent after ownership loss', async () => {
@@ -277,7 +286,7 @@ describe('BackgroundAgentManager', () => {
           );
         }),
     );
-    const agentId = AgentId(manager.startBackgroundAgent({
+    const agentId = AgentId(await manager.startBackgroundAgent({
       config: subagentConfig,
       bladeConfig,
       description: 'Lease-owned work',
@@ -288,13 +297,124 @@ describe('BackgroundAgentManager', () => {
     await expect(manager.sealCancelAndWait()).resolves.toEqual([agentId]);
     expect(manager.getAgent(agentId)?.status).toBe('cancelled');
     expect(manager.getActiveAgentIds()).toEqual([]);
-    expect(() =>
+    await expect(
       manager.startBackgroundAgent({
         config: subagentConfig,
         bladeConfig,
         description: 'Rejected after ownership loss',
         prompt: 'inspect',
       }),
-    ).toThrow('Background agent admission is closed');
+    ).rejects.toThrow('Background agent admission is closed');
+  });
+
+  it('prevents a stale owner from overwriting successor state or output', async () => {
+    const store = AgentSessionStore.create();
+    const oldManager = BackgroundAgentManager.create(
+      NOOP_LOGGER,
+      store,
+      SessionId('root-session'),
+    );
+    const successorManager = BackgroundAgentManager.create(
+      NOOP_LOGGER,
+      store,
+      SessionId('root-session'),
+    );
+    const agentId = AgentId('shared-agent');
+    const staleFence = {
+      leaseId: ExecutionLeaseId('stale-lease'),
+      fencingToken: FencingToken(1),
+    };
+    const successorFence = {
+      leaseId: ExecutionLeaseId('successor-lease'),
+      fencingToken: FencingToken(2),
+    };
+    let activeToken = 1;
+    const boundary = (token: number) =>
+      async <T>(operation: () => Promise<T>): Promise<T> => {
+        if (activeToken !== token) {
+          throw new DurableExecutionLeaseError(
+            'DURABLE_EXECUTION_LEASE_LOST',
+            `Execution token ${token} is stale`,
+          );
+        }
+        return operation();
+      };
+    let finishOld: (() => void) | undefined;
+    let finishSuccessor: (() => void) | undefined;
+    runAgenticLoop
+      .mockImplementationOnce(async () => {
+        await new Promise<void>((resolve) => {
+          finishOld = resolve;
+        });
+        return { success: true, finalMessage: 'stale result' };
+      })
+      .mockImplementationOnce(async () => {
+        await new Promise<void>((resolve) => {
+          finishSuccessor = resolve;
+        });
+        return { success: true, finalMessage: 'successor result' };
+      });
+
+    await oldManager.startBackgroundAgent({
+      config: subagentConfig,
+      bladeConfig,
+      description: 'Stale execution',
+      prompt: 'inspect',
+      agentId,
+      executionFence: staleFence,
+      assertExecutionLease: async () => {
+        await boundary(1)(async () => {});
+      },
+      runWithExecutionLease: boundary(1),
+    });
+    await vi.waitFor(() => expect(runAgenticLoop).toHaveBeenCalledTimes(1));
+    const staleOutputFile = store.loadSession(agentId)?.outputFile;
+
+    activeToken = 2;
+    await successorManager.startBackgroundAgent({
+      config: subagentConfig,
+      bladeConfig,
+      description: 'Successor execution',
+      prompt: 'continue',
+      agentId,
+      executionFence: successorFence,
+      assertExecutionLease: async () => {
+        await boundary(2)(async () => {});
+      },
+      runWithExecutionLease: boundary(2),
+    });
+    await vi.waitFor(() => expect(runAgenticLoop).toHaveBeenCalledTimes(2));
+    const successorOutputFile = store.loadSession(agentId)?.outputFile;
+    expect(successorOutputFile).not.toBe(staleOutputFile);
+
+    finishOld?.();
+    await oldManager.waitForCompletion(agentId, 0);
+    expect(store.loadSession(agentId)).toMatchObject({
+      description: 'Successor execution',
+      status: 'running',
+      executionFence: successorFence,
+      outputFile: successorOutputFile,
+    });
+    if (staleOutputFile) {
+      await expect(access(staleOutputFile)).rejects.toThrow();
+    }
+
+    finishSuccessor?.();
+    await successorManager.waitForCompletion(agentId, 0);
+    expect(store.loadSession(agentId)).toMatchObject({
+      status: 'completed',
+      result: {
+        success: true,
+        message: 'successor result',
+      },
+      executionFence: successorFence,
+      outputFile: successorOutputFile,
+    });
+    if (successorOutputFile) {
+      await expect(readFile(successorOutputFile, 'utf8')).resolves.toContain(
+        'successor result',
+      );
+      await rm(successorOutputFile, { force: true });
+    }
   });
 });

--- a/src/agent/subagents/__tests__/SubagentExecutor.test.ts
+++ b/src/agent/subagents/__tests__/SubagentExecutor.test.ts
@@ -59,6 +59,9 @@ describe('SubagentExecutor', () => {
     );
     const controller = new AbortController();
     const assertExecutionLease = vi.fn(async () => {});
+    const runWithExecutionLease = async <T>(
+      operation: () => Promise<T>,
+    ): Promise<T> => operation();
 
     await executor.execute({
       prompt: 'inspect',
@@ -70,6 +73,7 @@ describe('SubagentExecutor', () => {
         fencingToken: FencingToken(7),
       },
       assertExecutionLease,
+      runWithExecutionLease,
     });
 
     expect(createAgent).toHaveBeenCalledWith(
@@ -88,6 +92,7 @@ describe('SubagentExecutor', () => {
           fencingToken: 7,
         },
         assertExecutionLease,
+        runWithExecutionLease,
       }),
       expect.objectContaining({
         signal: controller.signal,

--- a/src/agent/subagents/__tests__/SubagentExecutor.test.ts
+++ b/src/agent/subagents/__tests__/SubagentExecutor.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { createContextSnapshot } from '../../../runtime/index.js';
-import { SessionId } from '../../../types/branded.js';
+import { ExecutionLeaseId, FencingToken, SessionId } from '../../../types/branded.js';
 
 const runAgenticLoop = vi.fn(async () => ({
   success: true,
@@ -57,11 +57,19 @@ describe('SubagentExecutor', () => {
         currentModelId: 'default',
       },
     );
+    const controller = new AbortController();
+    const assertExecutionLease = vi.fn(async () => {});
 
     await executor.execute({
       prompt: 'inspect',
       parentSessionId: 'parent-session',
       snapshot,
+      signal: controller.signal,
+      executionFence: {
+        leaseId: ExecutionLeaseId('lease-1'),
+        fencingToken: FencingToken(7),
+      },
+      assertExecutionLease,
     });
 
     expect(createAgent).toHaveBeenCalledWith(
@@ -75,6 +83,14 @@ describe('SubagentExecutor', () => {
       'inspect',
       expect.objectContaining({
         snapshot,
+        executionFence: {
+          leaseId: 'lease-1',
+          fencingToken: 7,
+        },
+        assertExecutionLease,
+      }),
+      expect.objectContaining({
+        signal: controller.signal,
       }),
     );
   });

--- a/src/agent/subagents/runSubagent.ts
+++ b/src/agent/subagents/runSubagent.ts
@@ -25,7 +25,7 @@ export interface RunSubagentOptions {
   assertExecutionLease?: () => Promise<void>;
   runWithExecutionLease?: <T>(operation: () => Promise<T>) => Promise<T>;
   omitEnvironment?: boolean;
-  onProgress?: (progress: AgentProgress) => void;
+  onProgress?: (progress: AgentProgress) => void | Promise<void>;
 }
 
 function resolveModelId(config: SubagentConfig): string | undefined {

--- a/src/agent/subagents/runSubagent.ts
+++ b/src/agent/subagents/runSubagent.ts
@@ -23,6 +23,7 @@ export interface RunSubagentOptions {
   backgroundAgentManager?: BackgroundAgentManager;
   executionFence?: DurableExecutionFence;
   assertExecutionLease?: () => Promise<void>;
+  runWithExecutionLease?: <T>(operation: () => Promise<T>) => Promise<T>;
   omitEnvironment?: boolean;
   onProgress?: (progress: AgentProgress) => void;
 }
@@ -53,6 +54,7 @@ export async function runSubagent(options: RunSubagentOptions): Promise<LoopResu
     backgroundAgentManager,
     executionFence,
     assertExecutionLease,
+    runWithExecutionLease,
     omitEnvironment,
     onProgress,
   } = options;
@@ -92,6 +94,7 @@ export async function runSubagent(options: RunSubagentOptions): Promise<LoopResu
     omitEnvironment,
     executionFence,
     assertExecutionLease,
+    runWithExecutionLease,
   };
 
   return loopOptions

--- a/src/agent/subagents/runSubagent.ts
+++ b/src/agent/subagents/runSubagent.ts
@@ -2,6 +2,7 @@ import { SessionId } from '../../types/branded.js';
 import type { BladeConfig, PermissionMode } from '../../types/common.js';
 import type { ContextSnapshot } from '../../runtime/index.js';
 import type { Message } from '../../services/ChatServiceInterface.js';
+import type { DurableExecutionFence } from '../../session/events/DurableExecutionLeaseStore.js';
 import { Agent } from '../Agent.js';
 import type { AgentProgress, LoopResult } from '../types.js';
 import type { BackgroundAgentManager } from './BackgroundAgentManager.js';
@@ -20,6 +21,8 @@ export interface RunSubagentOptions {
   messages?: Message[];
   signal?: AbortSignal;
   backgroundAgentManager?: BackgroundAgentManager;
+  executionFence?: DurableExecutionFence;
+  assertExecutionLease?: () => Promise<void>;
   omitEnvironment?: boolean;
   onProgress?: (progress: AgentProgress) => void;
 }
@@ -48,6 +51,8 @@ export async function runSubagent(options: RunSubagentOptions): Promise<LoopResu
     messages,
     signal,
     backgroundAgentManager,
+    executionFence,
+    assertExecutionLease,
     omitEnvironment,
     onProgress,
   } = options;
@@ -85,6 +90,8 @@ export async function runSubagent(options: RunSubagentOptions): Promise<LoopResu
       isSidechain: true,
     },
     omitEnvironment,
+    executionFence,
+    assertExecutionLease,
   };
 
   return loopOptions

--- a/src/agent/subagents/types.ts
+++ b/src/agent/subagents/types.ts
@@ -113,6 +113,7 @@ export interface SubagentContext {
   omitEnvironment?: boolean;
   executionFence?: DurableExecutionFence;
   assertExecutionLease?: () => Promise<void>;
+  runWithExecutionLease?: <T>(operation: () => Promise<T>) => Promise<T>;
 }
 
 /**

--- a/src/agent/subagents/types.ts
+++ b/src/agent/subagents/types.ts
@@ -1,4 +1,5 @@
 import type { ContextSnapshot } from '../../runtime/index.js';
+import type { DurableExecutionFence } from '../../session/events/DurableExecutionLeaseStore.js';
 import { PermissionMode } from '../../types/common.js';
 
 /**
@@ -25,7 +26,7 @@ export type ClaudeCodePermissionMode =
  * - ignore → DEFAULT (忽略，使用默认)
  */
 export function mapClaudeCodePermissionMode(
-  mode: ClaudeCodePermissionMode | undefined
+  mode: ClaudeCodePermissionMode | undefined,
 ): PermissionMode {
   switch (mode) {
     case 'default':
@@ -57,12 +58,7 @@ export type SubagentColor =
   | 'pink'
   | 'cyan';
 
-export type SubagentSource =
-  | 'builtin'
-  | 'user'
-  | 'project'
-  | 'session'
-  | `plugin:${string}`;
+export type SubagentSource = 'builtin' | 'user' | 'project' | 'session' | `plugin:${string}`;
 
 /**
  * Subagent 配置
@@ -113,7 +109,10 @@ export interface SubagentContext {
   permissionMode?: PermissionMode;
   subagentSessionId?: string;
   snapshot?: ContextSnapshot;
+  signal?: AbortSignal;
   omitEnvironment?: boolean;
+  executionFence?: DurableExecutionFence;
+  assertExecutionLease?: () => Promise<void>;
 }
 
 /**

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -57,10 +57,14 @@ export interface IBackgroundAgentReader {
 }
 
 export interface IBackgroundAgentController {
-  killAgent(agentId: AgentId): boolean;
+  killAgent(agentId: AgentId): Promise<boolean>;
   cancelCurrentWork(agentId: AgentId): boolean;
-  startBackgroundAgent(options: StartBackgroundAgentOptions): string;
-  resumeAgent(agentId: AgentId, newPrompt: string, ...args: unknown[]): string | undefined;
+  startBackgroundAgent(options: StartBackgroundAgentOptions): Promise<string>;
+  resumeAgent(
+    agentId: AgentId,
+    newPrompt: string,
+    ...args: unknown[]
+  ): Promise<string | undefined>;
   sendMessage(agentId: AgentId, message: string): boolean;
 }
 
@@ -99,6 +103,8 @@ export interface ChatContext {
   executionFence?: DurableExecutionFence;
   /** @internal Validates execution ownership immediately before a model or tool side effect. */
   assertExecutionLease?: () => Promise<void>;
+  /** @internal Serializes a short persistence operation against lease takeover. */
+  runWithExecutionLease?: <T>(operation: () => Promise<T>) => Promise<T>;
 }
 
 /**
@@ -160,7 +166,7 @@ export interface LoopOptions {
   initialInputPreparation?: InitialInputPreparation;
   onTurnLimitReached?: (data: { turnsCount: number }) => Promise<TurnLimitResponse>;
   /** 进度回调，每次 tool call 完成后触发 */
-  onProgress?: (progress: AgentProgress) => void;
+  onProgress?: (progress: AgentProgress) => void | Promise<void>;
 }
 
 /**

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -4,6 +4,7 @@
 
 import type { ContextSnapshot } from '../runtime/index.js';
 import type { ContentPart, Message } from '../services/ChatServiceInterface.js';
+import type { DurableExecutionFence } from '../session/events/DurableExecutionLeaseStore.js';
 import type { ToolCatalogSourcePolicy } from '../tools/catalog/index.js';
 import type { ConfirmationHandler, ToolExecutionLifecycle } from '../tools/types/ExecutionTypes.js';
 import type { AgentId, InputId, RequestId, SessionId } from '../types/branded.js';
@@ -95,6 +96,9 @@ export interface ChatContext {
   subagentInfo?: SubagentInfoForContext; // 子代理信息（用于 JSONL 写入）
   omitEnvironment?: boolean;
   backgroundAgentManager?: IBackgroundAgentManager;
+  executionFence?: DurableExecutionFence;
+  /** @internal Validates execution ownership immediately before a model or tool side effect. */
+  assertExecutionLease?: () => Promise<void>;
 }
 
 /**

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -21,8 +21,8 @@ export type {
   ToolEffect,
   ToolEffectYield,
   ToolExecution,
-  ToolExecutionStartedLifecycle,
   ToolExecutionLifecycle,
+  ToolExecutionStartedLifecycle,
   ToolInvocationLifecycle,
   ToolMessage,
   ToolModelContent,
@@ -39,6 +39,8 @@ export {
   completeToolExecution,
   EventId,
   EventSequence,
+  ExecutionLeaseId,
+  FencingToken,
   HookEvent,
   InputId,
   InputPriority,
@@ -55,6 +57,7 @@ export {
   ToolSideEffect,
   ToolUseId,
   TurnId,
+  WorkerId,
 } from '../core/index.js';
 export * from '../session/events/core.js';
 

--- a/src/context/CompactionService.ts
+++ b/src/context/CompactionService.ts
@@ -10,6 +10,7 @@ import {
     createChatServiceAsync,
     type Message,
 } from '../services/ChatServiceInterface.js';
+import { isExecutionLeaseFailure } from '../session/events/DurableExecutionLeaseStore.js';
 import { SessionId } from '../types/branded.js';
 import { PermissionMode, type ProviderType } from '../types/common.js';
 import { FileAnalyzer, type FileContent } from './FileAnalyzer.js';
@@ -84,16 +85,6 @@ const RETAIN_PERCENT = 0.2;
 
 /** 降级时保留比例（30%） */
 const FALLBACK_RETAIN_PERCENT = 0.3;
-
-function isExecutionLeaseFailure(error: unknown): boolean {
-  return (
-    typeof error === 'object'
-    && error !== null
-    && 'code' in error
-    && typeof error.code === 'string'
-    && error.code.startsWith('DURABLE_EXECUTION_LEASE_')
-  );
-}
 
 /**
  * 保留最近的消息窗口，并过滤掉 tool_call_id 不在保留窗口内的孤儿 tool 消息。

--- a/src/context/CompactionService.ts
+++ b/src/context/CompactionService.ts
@@ -48,6 +48,8 @@ export interface CompactionOptions {
   projectDir?: string;
   /** Cancels the compaction provider request with its owning execution. */
   signal?: AbortSignal;
+  /** @internal Validates execution ownership around compaction side effects. */
+  assertExecutionLease?: () => Promise<void>;
 }
 
 /**
@@ -82,6 +84,16 @@ const RETAIN_PERCENT = 0.2;
 
 /** 降级时保留比例（30%） */
 const FALLBACK_RETAIN_PERCENT = 0.3;
+
+function isExecutionLeaseFailure(error: unknown): boolean {
+  return (
+    typeof error === 'object'
+    && error !== null
+    && 'code' in error
+    && typeof error.code === 'string'
+    && error.code.startsWith('DURABLE_EXECUTION_LEASE_')
+  );
+}
 
 /**
  * 保留最近的消息窗口，并过滤掉 tool_call_id 不在保留窗口内的孤儿 tool 消息。
@@ -122,6 +134,8 @@ export async function compact(
   messages: Message[],
   options: CompactionOptions
 ): Promise<CompactionResult> {
+  options.signal?.throwIfAborted();
+  await options.assertExecutionLease?.();
   const preTokens =
     options.actualPreTokens ?? TokenCounter.countTokens(messages, options.modelName);
   const tokenSource = options.actualPreTokens
@@ -142,7 +156,10 @@ export async function compact(
       options.projectDir,
       options.sessionId || SessionId('unknown'),
       options.permissionMode || PermissionMode.DEFAULT,
+      options.signal,
     );
+    options.signal?.throwIfAborted();
+    await options.assertExecutionLease?.();
 
     if (preCompactResult.blockCompaction) {
       console.log(
@@ -170,7 +187,10 @@ export async function compact(
       permissionMode: options.permissionMode || PermissionMode.DEFAULT,
       messagesBefore: messages.length,
       tokensBefore: preTokens,
+      abortSignal: options.signal,
     });
+    options.signal?.throwIfAborted();
+    await options.assertExecutionLease?.();
 
     if (hookResult.blockCompaction) {
       console.log(
@@ -195,6 +215,9 @@ export async function compact(
       );
     }
     } catch (hookError) {
+      if (options.signal?.aborted || isExecutionLeaseFailure(hookError)) {
+        throw hookError;
+      }
       console.warn('[CompactionService] Compaction hook execution failed:', hookError);
     }
   }
@@ -210,7 +233,11 @@ export async function compact(
     const fileContents = await FileAnalyzer.readFilesContent(filePaths);
     console.log('[CompactionService] 成功读取文件:', fileContents.length);
 
+    options.signal?.throwIfAborted();
+    await options.assertExecutionLease?.();
     const summary = await generateSummary(messages, fileContents, options);
+    options.signal?.throwIfAborted();
+    await options.assertExecutionLease?.();
     console.log('[CompactionService] 生成总结，长度:', summary.length);
 
     const retainCount = Math.ceil(messages.length * RETAIN_PERCENT);
@@ -243,6 +270,8 @@ export async function compact(
 
     if (options.projectDir) {
       try {
+        options.signal?.throwIfAborted();
+        await options.assertExecutionLease?.();
         const postHookManager = HookManager.getInstance();
         const postHookResult = await postHookManager.executePostCompactHooks(
           {
@@ -256,15 +285,22 @@ export async function compact(
           options.projectDir,
           options.sessionId || SessionId('unknown'),
           options.permissionMode || PermissionMode.DEFAULT,
+          options.signal,
         );
+        options.signal?.throwIfAborted();
+        await options.assertExecutionLease?.();
         if (postHookResult.warning) {
           console.warn(`[CompactionService] PostCompact hook warning: ${postHookResult.warning}`);
         }
       } catch (hookError) {
+        if (options.signal?.aborted || isExecutionLeaseFailure(hookError)) {
+          throw hookError;
+        }
         console.warn('[CompactionService] PostCompact hook execution failed:', hookError);
       }
     }
 
+    options.signal?.throwIfAborted();
     return {
       success: true,
       summary,
@@ -276,6 +312,10 @@ export async function compact(
       summaryMessage,
     };
   } catch (error) {
+    options.signal?.throwIfAborted();
+    if (isExecutionLeaseFailure(error)) {
+      throw error;
+    }
     console.error('[CompactionService] 压缩失败，使用降级策略', error);
     return fallbackCompact(messages, options, preTokens, error);
   }

--- a/src/context/CompactionService.ts
+++ b/src/context/CompactionService.ts
@@ -46,6 +46,8 @@ export interface CompactionOptions {
   permissionMode?: PermissionMode;
   /** 当前 turn 的项目目录（用于 hooks） */
   projectDir?: string;
+  /** Cancels the compaction provider request with its owning execution. */
+  signal?: AbortSignal;
 }
 
 /**
@@ -317,7 +319,8 @@ async function generateSummary(
   }, NOOP_LOGGER);
 
   const response = await chatService.sideQuery(
-    [{ role: 'user', content: prompt }]
+    [{ role: 'user', content: prompt }],
+    options.signal,
   );
 
   const content = response.content || '';

--- a/src/context/__tests__/CompactionService.test.ts
+++ b/src/context/__tests__/CompactionService.test.ts
@@ -60,6 +60,26 @@ describe('CompactionService', () => {
     expect(mockChat).not.toHaveBeenCalled();
   });
 
+  it('does not convert an aborted provider request into fallback compaction', async () => {
+    const controller = new AbortController();
+    const abortError = new Error('execution ownership lost');
+    mockSideQuery.mockImplementationOnce(async () => {
+      controller.abort(abortError);
+      throw abortError;
+    });
+
+    await expect(
+      compact([{ role: 'user', content: 'hello' }], {
+        trigger: 'auto',
+        modelName: 'gpt-5',
+        maxContextTokens: 128000,
+        apiKey: 'test-key',
+        baseURL: 'https://api.openai.com/v1',
+        signal: controller.signal,
+      }),
+    ).rejects.toBe(abortError);
+  });
+
   it('retainRecentMessages drops orphan tool results outside the retained window', () => {
     const messages: Message[] = [
       { role: 'assistant', content: 'a', tool_calls: [{ id: 'tc-keep', type: 'function', function: { name: 'x', arguments: '{}' } }] },

--- a/src/context/__tests__/CompactionService.test.ts
+++ b/src/context/__tests__/CompactionService.test.ts
@@ -34,6 +34,7 @@ describe('CompactionService', () => {
 
   it('uses the native openai provider for official OpenAI compaction requests', async () => {
     const messages: Message[] = [{ role: 'user', content: 'hello' }];
+    const controller = new AbortController();
 
     await compact(messages, {
       trigger: 'manual',
@@ -41,6 +42,7 @@ describe('CompactionService', () => {
       maxContextTokens: 128000,
       apiKey: 'test-key',
       baseURL: 'https://api.openai.com/v1',
+      signal: controller.signal,
     });
 
     expect(mockCreateChatServiceAsync).toHaveBeenCalledWith(
@@ -51,7 +53,10 @@ describe('CompactionService', () => {
       }),
       expect.anything(),
     );
-    expect(mockSideQuery).toHaveBeenCalledTimes(1);
+    expect(mockSideQuery).toHaveBeenCalledWith(
+      expect.anything(),
+      controller.signal,
+    );
     expect(mockChat).not.toHaveBeenCalled();
   });
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -46,8 +46,8 @@ export type {
   ToolEffectYield,
   ToolError,
   ToolExecution,
-  ToolExecutionStartedLifecycle,
   ToolExecutionLifecycle,
+  ToolExecutionStartedLifecycle,
   ToolExposureConfig,
   ToolExposureMode,
   ToolInvocationLifecycle,
@@ -71,6 +71,8 @@ export {
   CommandId,
   EventId,
   EventSequence,
+  ExecutionLeaseId,
+  FencingToken,
   InputId,
   ModelAttemptId,
   PermissionRequestId,
@@ -79,6 +81,7 @@ export {
   ToolAttemptId,
   ToolUseId,
   TurnId,
+  WorkerId,
 } from '../types/branded.js';
 export type {
   JsonObject,

--- a/src/index.ts
+++ b/src/index.ts
@@ -192,8 +192,8 @@ export type {
   ToolEffectYield,
   ToolError,
   ToolExecution,
-  ToolExecutionStartedLifecycle,
   ToolExecutionLifecycle,
+  ToolExecutionStartedLifecycle,
   ToolExposureConfig,
   ToolExposureMode,
   ToolInvocationLifecycle,
@@ -217,6 +217,8 @@ export {
   CommandId,
   EventId,
   EventSequence,
+  ExecutionLeaseId,
+  FencingToken,
   InputId,
   MessageId,
   ModelAttemptId,
@@ -226,6 +228,7 @@ export {
   ToolAttemptId,
   ToolUseId,
   TurnId,
+  WorkerId,
 } from './types/branded.js';
 // --- Constants & types ---
 export type {

--- a/src/session/ActiveRequestController.ts
+++ b/src/session/ActiveRequestController.ts
@@ -11,6 +11,7 @@ export type RequestAbortReason =
   | { kind: 'user_abort' }
   | { kind: 'session_close' }
   | { kind: 'session_handoff' }
+  | { kind: 'execution_lease_lost'; cause: unknown }
   | { kind: 'external_abort'; cause?: unknown };
 
 export class ActiveRequestController implements AgentRunControl {

--- a/src/session/Session.ts
+++ b/src/session/Session.ts
@@ -5,11 +5,7 @@ import {
   type InitialInputPreparation,
   RECONCILED_INITIAL_INPUT,
 } from '../agent/InitialInputPreparation.js';
-import type {
-  ChatContext,
-  LoopResult,
-  UserMessageContent,
-} from '../agent/types.js';
+import type { ChatContext, LoopResult, UserMessageContent } from '../agent/types.js';
 import { SessionHandoffError } from '../errors/SessionHandoffError.js';
 import { SessionInputError } from '../errors/SessionInputError.js';
 import { type CleanupHandle, registerCleanup } from '../lifecycle/CleanupRegistry.js';
@@ -22,13 +18,7 @@ import {
 } from '../runtime/index.js';
 import type { ContentPart, Message } from '../services/ChatServiceInterface.js';
 import { cloneMessage } from '../services/messageUtils.js';
-import {
-  CommandId,
-  type EventSequence,
-  InputId,
-  RequestId,
-  SessionId,
-} from '../types/branded.js';
+import { CommandId, type EventSequence, InputId, RequestId, SessionId } from '../types/branded.js';
 import {
   type BladeConfig,
   type JsonObject,
@@ -37,10 +27,7 @@ import {
   PermissionMode,
   type ProviderType,
 } from '../types/common.js';
-import {
-  ActiveRequestController,
-  type RequestAbortReason,
-} from './ActiveRequestController.js';
+import { ActiveRequestController, type RequestAbortReason } from './ActiveRequestController.js';
 import {
   parseDurableRuntimeContext,
   parseDurableUserMessageContent,
@@ -51,6 +38,11 @@ import {
   DurableEventSubscriptionError,
   type DurableEventSubscriptionOptions,
 } from './events/DurableEventSubscription.js';
+import { DurableExecutionLease } from './events/DurableExecutionLease.js';
+import {
+  DurableExecutionLeaseError,
+  type DurableExecutionLease as DurableExecutionLeaseSnapshot,
+} from './events/DurableExecutionLeaseStore.js';
 import { DurableSessionJournal } from './events/DurableSessionJournal.js';
 import type {
   DurableRequestProjection,
@@ -63,15 +55,10 @@ import {
   durableRequestFinishFromLoopResult,
   DurableSessionRecoveryRequiredError,
   SessionDurableRecorder,
-  SessionDurableRecorderError
+  SessionDurableRecorderError,
 } from './events/SessionDurableRecorder.js';
-import {
-  DurableEventType,
-  type DurableRequestInterruptReason,
-} from './events/types.js';
-import {
-  SessionInputInbox,
-} from './SessionInputInbox.js';
+import { DurableEventType, type DurableRequestInterruptReason } from './events/types.js';
+import { SessionInputInbox } from './SessionInputInbox.js';
 import { SessionRuntime } from './SessionRuntime.js';
 import {
   JsonlSessionStore,
@@ -175,6 +162,9 @@ class Session implements ISession {
   private durableJournal: DurableSessionJournal | null = null;
   private durableAcceptedRequest: DurableRequestProjection | null = null;
   private durableClosePromise: Promise<void> | null = null;
+  private executionLease: DurableExecutionLease | null = null;
+  private executionLeaseFailure: DurableExecutionLeaseError | null = null;
+  private executionLeaseLossCleanup: (() => void) | null = null;
   private closePromise: Promise<void> | null = null;
   private handoffPromise: Promise<SessionHandoffResult> | null = null;
   private handoffRequested = false;
@@ -222,9 +212,10 @@ class Session implements ISession {
 
   get isClosed(): boolean {
     return (
-      this.handoffRequested
-      || this.executionState.phase === 'suspending'
-      || this.executionState.phase === 'closed'
+      this.executionLeaseFailure !== null ||
+      this.handoffRequested ||
+      this.executionState.phase === 'suspending' ||
+      this.executionState.phase === 'closed'
     );
   }
 
@@ -252,6 +243,10 @@ class Session implements ISession {
     return this.durableJournal?.getRecoveryPlan() ?? null;
   }
 
+  getExecutionLease(): DurableExecutionLeaseSnapshot | null {
+    return this.executionLease?.snapshot ?? null;
+  }
+
   /** Replays persisted lifecycle events, then follows newly committed events. */
   async subscribeDurableEvents(
     options: DurableEventSubscriptionOptions = {},
@@ -268,55 +263,85 @@ class Session implements ISession {
   }
 
   async initialize(): Promise<void> {
+    if (this.executionLeaseFailure) {
+      throw this.executionLeaseFailure;
+    }
     if (
-      this.executionState.phase === 'suspending'
-      || this.executionState.phase === 'closed'
+      this.handoffRequested ||
+      this.executionState.phase === 'suspending' ||
+      this.executionState.phase === 'closed'
     ) {
       throw new Error('Session is closed');
     }
     if (this.initialized) return;
 
-    await this.initializeDurableJournal();
-    const config = this.buildBladeConfig();
-    this.runtime = new SessionRuntime(
-      this.sessionId,
-      this.options,
-      config,
-      this.permissionMode,
-      this.defaultContext,
-      this.rootLogger,
-    );
-    await this.runtime.initialize();
-    if (this.isResumeSession) {
-      await this.runtime.ensureSessionLoaded();
-    } else {
-      await this.runtime.ensureSessionCreated();
+    await this.initializeExecutionLease();
+    try {
+      await this.initializeDurableJournal();
+      const config = this.buildBladeConfig();
+      this.runtime = new SessionRuntime(
+        this.sessionId,
+        this.options,
+        config,
+        this.permissionMode,
+        this.defaultContext,
+        this.rootLogger,
+      );
+      await this.runtime.initialize();
+      if (this.isResumeSession) {
+        await this.runtime.ensureSessionLoaded();
+      } else {
+        await this.runtime.ensureSessionCreated();
+      }
+
+      this.agent = await Agent.create(
+        config,
+        {
+          permissionMode: this.permissionMode,
+          systemPrompt: this.options.systemPrompt,
+          maxTurns: this.maxTurns,
+          permissionHandler: this.options.permissionHandler,
+          canUseTool: this.options.canUseTool,
+          toolSourcePolicy: this.options.toolSourcePolicy,
+          outputFormat: this.options.outputFormat,
+          sandbox: this.options.sandbox,
+          tokenBudget: this.options.tokenBudget,
+        },
+        this.runtime.getAgentRuntimeDeps(),
+      );
+
+      this.executionLeaseLossCleanup =
+        this.executionLease?.onLost((error) => {
+          this.handleExecutionLeaseLoss(error);
+        }) ?? null;
+      await this.executionLease?.assertActive();
+      await this.runtime.getHookRuntime().runSessionStart({
+        isResume: this.isResumeSession,
+        resumeSessionId: this.isResumeSession ? this.sessionId : undefined,
+      });
+      await this.executionLease?.assertActive();
+      if (this.executionLeaseFailure) {
+        throw this.executionLeaseFailure;
+      }
+      this.initialized = true;
+      this.cleanupHandle = registerCleanup(() => this.close());
+
+      this.logger.debug(`[Session] Initialized session ${this.sessionId}`);
+    } catch (error) {
+      const cleanupErrors = await this.releaseLocalRuntime();
+      try {
+        await this.releaseExecutionLease();
+      } catch (leaseError) {
+        cleanupErrors.push(leaseError);
+      }
+      if (cleanupErrors.length > 0) {
+        throw new AggregateError(
+          [error, ...cleanupErrors],
+          `Session ${this.sessionId} initialization failed during cleanup`,
+        );
+      }
+      throw error;
     }
-
-    this.agent = await Agent.create(
-      config,
-      {
-        permissionMode: this.permissionMode,
-        systemPrompt: this.options.systemPrompt,
-        maxTurns: this.maxTurns,
-        permissionHandler: this.options.permissionHandler,
-        canUseTool: this.options.canUseTool,
-        toolSourcePolicy: this.options.toolSourcePolicy,
-        outputFormat: this.options.outputFormat,
-        sandbox: this.options.sandbox,
-        tokenBudget: this.options.tokenBudget,
-      },
-      this.runtime.getAgentRuntimeDeps(),
-    );
-
-    this.initialized = true;
-    this.cleanupHandle = registerCleanup(() => this.close());
-    await this.runtime.getHookRuntime().runSessionStart({
-      isResume: this.isResumeSession,
-      resumeSessionId: this.isResumeSession ? this.sessionId : undefined,
-    });
-
-    this.logger.debug(`[Session] Initialized session ${this.sessionId}`);
   }
 
   async loadHistory(): Promise<void> {
@@ -333,16 +358,14 @@ class Session implements ISession {
       throw error;
     }
     const durableProjection = this.durableJournal?.getProjection();
-    const reconciledHistoryInputIds = new Set<string>(
-      durableProjection?.reconciledInputIds ?? [],
-    );
+    const reconciledHistoryInputIds = new Set<string>(durableProjection?.reconciledInputIds ?? []);
     this._messages = (state?.messages ?? []).filter((message) => {
       const metadata = message.metadata;
       const messageInputId =
-        typeof metadata === 'object'
-        && metadata !== null
-        && !Array.isArray(metadata)
-        && typeof metadata.inputId === 'string'
+        typeof metadata === 'object' &&
+        metadata !== null &&
+        !Array.isArray(metadata) &&
+        typeof metadata.inputId === 'string'
           ? metadata.inputId
           : null;
       return messageInputId === null || !reconciledHistoryInputIds.has(messageInputId);
@@ -453,17 +476,14 @@ class Session implements ISession {
     return urls[type] || '';
   }
 
-  async send(
-    message: UserMessageContent,
-    options?: SendOptions,
-  ): Promise<InputSubmission> {
+  async send(message: UserMessageContent, options?: SendOptions): Promise<InputSubmission> {
     await this.ensureInitialized();
 
     return this.inputMutex.runExclusive(async () => {
-      if (
-        this.executionState.phase === 'suspending'
-        || this.executionState.phase === 'closed'
-      ) {
+      if (this.executionLeaseFailure) {
+        throw this.executionLeaseFailure;
+      }
+      if (this.executionState.phase === 'suspending' || this.executionState.phase === 'closed') {
         throw new Error('Session is closed');
       }
 
@@ -531,20 +551,16 @@ class Session implements ISession {
       let priority = options?.priority ?? InputPriority.NEXT;
       const activeRequestId = this.executionState.requestId;
       const activeController = this.executionState.controller;
-      if (
-        options?.expectedRequestId
-        && options.expectedRequestId !== activeRequestId
-      ) {
+      if (options?.expectedRequestId && options.expectedRequestId !== activeRequestId) {
         throw new SessionInputError(
           'SESSION_REQUEST_MISMATCH',
           `Expected request "${options.expectedRequestId}" but "${activeRequestId}" is active`,
         );
       }
       let canSteerCurrentRequest =
-        priority !== InputPriority.LATER
-        && this.executionState.phase !== 'stopping'
-        && (this.executionState.phase !== 'running'
-          || !this.executionState.controller.isSealed);
+        priority !== InputPriority.LATER &&
+        this.executionState.phase !== 'stopping' &&
+        (this.executionState.phase !== 'running' || !this.executionState.controller.isSealed);
       if (!canSteerCurrentRequest) {
         priority = InputPriority.LATER;
       }
@@ -553,19 +569,16 @@ class Session implements ISession {
         inputId,
         content: message,
         priority,
-        targetRequestId: canSteerCurrentRequest
-          ? activeRequestId
-          : undefined,
+        targetRequestId: canSteerCurrentRequest ? activeRequestId : undefined,
         acceptedAt: Date.now(),
       };
       this.inputInbox.reserve(input);
       try {
         await this.persistInput(input);
         const requestStillAcceptsSteering =
-          (this.executionState.phase === 'pending'
-            || this.executionState.phase === 'running')
-          && this.executionState.requestId === activeRequestId
-          && !activeController.isSealed;
+          (this.executionState.phase === 'pending' || this.executionState.phase === 'running') &&
+          this.executionState.requestId === activeRequestId &&
+          !activeController.isSealed;
         if (canSteerCurrentRequest && !requestStillAcceptsSteering) {
           canSteerCurrentRequest = false;
           priority = InputPriority.LATER;
@@ -573,9 +586,9 @@ class Session implements ISession {
         }
         this.inputInbox.markCommitted(inputId);
         if (
-          canSteerCurrentRequest
-          && priority === InputPriority.NOW
-          && this.executionState.phase === 'running'
+          canSteerCurrentRequest &&
+          priority === InputPriority.NOW &&
+          this.executionState.phase === 'running'
         ) {
           activeController.interruptStep(inputId);
         }
@@ -588,9 +601,7 @@ class Session implements ISession {
             status: 'steered',
             inputId,
             requestId: activeRequestId,
-            priority: priority === InputPriority.NOW
-              ? InputPriority.NOW
-              : InputPriority.NEXT,
+            priority: priority === InputPriority.NOW ? InputPriority.NOW : InputPriority.NEXT,
           }
         : {
             status: 'queued',
@@ -607,16 +618,15 @@ class Session implements ISession {
   async cancelInput(inputId: InputId): Promise<boolean> {
     await this.ensureInitialized();
     return this.inputMutex.runExclusive(async () => {
-      if (
-        this.executionState.phase === 'suspending'
-        || this.executionState.phase === 'closed'
-      ) {
+      if (this.executionLeaseFailure) {
+        throw this.executionLeaseFailure;
+      }
+      if (this.executionState.phase === 'suspending' || this.executionState.phase === 'closed') {
         throw new Error('Session is closed');
       }
       if (
-        (this.executionState.phase === 'running'
-          || this.executionState.phase === 'stopping')
-        && this.executionState.controller.isInitialInput(inputId)
+        (this.executionState.phase === 'running' || this.executionState.phase === 'stopping') &&
+        this.executionState.controller.isInitialInput(inputId)
       ) {
         return false;
       }
@@ -626,8 +636,7 @@ class Session implements ISession {
       }
 
       const pendingState =
-        this.executionState.phase === 'pending'
-        && this.executionState.input.inputId === inputId
+        this.executionState.phase === 'pending' && this.executionState.input.inputId === inputId
           ? this.executionState
           : null;
       let durablyInterrupted = false;
@@ -643,11 +652,9 @@ class Session implements ISession {
         }
       }
       try {
-        await this.getRuntime().getContextManager().saveInputCancelled(
-          this.sessionId,
-          inputId,
-          'cancelled_by_user',
-        );
+        await this.getRuntime()
+          .getContextManager()
+          .saveInputCancelled(this.sessionId, inputId, 'cancelled_by_user');
       } catch (error) {
         if (!durablyInterrupted) {
           this.inputInbox.releaseClaim(inputId);
@@ -673,9 +680,7 @@ class Session implements ISession {
     return this.consumeRequestStream(options);
   }
 
-  private async *consumeRequestStream(
-    options?: StreamOptions,
-  ): AsyncGenerator<StreamMessage> {
+  private async *consumeRequestStream(options?: StreamOptions): AsyncGenerator<StreamMessage> {
     const channel = new SessionStreamChannel<StreamMessage>(1);
     let settled = false;
     let resolveCompletion!: () => void;
@@ -748,6 +753,9 @@ class Session implements ISession {
     // 需在 inputMutex 内一次完成，避免与 send()/cancelInput()/finishRequest()
     // 对 executionState 的并发读写交错。
     const claimed = await this.inputMutex.runExclusive(async () => {
+      if (this.executionLeaseFailure) {
+        throw this.executionLeaseFailure;
+      }
       if (this.executionState.phase !== 'pending') {
         return null;
       }
@@ -762,8 +770,9 @@ class Session implements ISession {
         initialInputPreparation,
       } = this.executionState;
       const requestController = this.executionState.controller;
-      const durableRecorder = pendingDurableRecorder
-        ?? (this.durableJournal
+      const durableRecorder =
+        pendingDurableRecorder ??
+        (this.durableJournal
           ? new SessionDurableRecorder(this.durableJournal, requestId, this.options.model)
           : null);
       try {
@@ -834,7 +843,7 @@ class Session implements ISession {
         return;
       }
       durableFinishAttempted = true;
-      if (!await durableRecorder.finish(finish)) {
+      if (!(await durableRecorder.finish(finish))) {
         throw new SessionDurableRecorderError(
           `Request ${requestId} has a tool outcome that requires reconciliation`,
         );
@@ -855,8 +864,7 @@ class Session implements ISession {
       await this.notifyTraceSink(trace);
     };
     const signal = requestController.requestSignal;
-    const isHandoffRequested = () =>
-      durableRecorder?.isHandoffRequested() === true;
+    const isHandoffRequested = () => durableRecorder?.isHandoffRequested() === true;
     const releaseBackpressureOnAbort = () => execution.releaseBackpressure();
     if (signal.aborted) {
       releaseBackpressureOnAbort();
@@ -871,8 +879,9 @@ class Session implements ISession {
       }
     } catch (error) {
       const handingOff = isHandoffRequested();
+      const leaseFailure = this.executionLeaseFailure;
       let terminalError = error;
-      if (!handingOff) {
+      if (!handingOff && !leaseFailure) {
         try {
           await finishDurableRequest({ status: 'failed', error });
         } catch (durableError) {
@@ -884,12 +893,19 @@ class Session implements ISession {
       }
       const errorMessage =
         terminalError instanceof Error ? terminalError.message : String(terminalError);
-      await finishTrace(handingOff ? 'aborted' : 'error', {
-        ...(handingOff ? { reason: 'session_handoff' } : { error: errorMessage }),
+      await finishTrace(handingOff || leaseFailure ? 'aborted' : 'error', {
+        ...(handingOff
+          ? { reason: 'session_handoff' }
+          : leaseFailure
+            ? { reason: 'process_restart' }
+            : { error: errorMessage }),
       });
       try {
         if (handingOff) {
           return;
+        }
+        if (leaseFailure) {
+          throw leaseFailure;
         }
         if (durableRecorder && !durableFinishCommitted) {
           throw terminalError;
@@ -918,6 +934,7 @@ class Session implements ISession {
       pendingSnapshot ??
       createContextSnapshot(this.sessionId, nanoid(), this.defaultContext, sendOptions?.context);
     runtime.prepareTurn(snapshot);
+    const executionLease = this.executionLease;
 
     const context: ChatContext = {
       messages: this._messages,
@@ -926,6 +943,8 @@ class Session implements ISession {
       snapshot,
       signal,
       permissionMode: this.permissionMode,
+      executionFence: executionLease?.fence,
+      assertExecutionLease: executionLease ? () => executionLease.assertActive() : undefined,
       backgroundAgentManager: runtime.getBackgroundAgentManager(),
     };
 
@@ -941,9 +960,7 @@ class Session implements ISession {
       modelExecutionLifecycle: durableRecorder ?? undefined,
       toolExecutionLifecycle: durableRecorder ?? undefined,
       initialInputPreparation:
-        initialInputPreparation === RECONCILED_INITIAL_INPUT
-          ? RECONCILED_INITIAL_INPUT
-          : undefined,
+        initialInputPreparation === RECONCILED_INITIAL_INPUT ? RECONCILED_INITIAL_INPUT : undefined,
     });
     let agentStreamCompleted = false;
 
@@ -954,13 +971,15 @@ class Session implements ISession {
 
       while (true) {
         const next = await stream.next();
+        if (this.executionLeaseFailure) {
+          throw this.executionLeaseFailure;
+        }
         if (signal.aborted) {
           const canObserveHandoffCompletion =
-            isHandoffRequested()
-            && (next.done || next.value.type === 'agent_end');
+            isHandoffRequested() && (next.done || next.value.type === 'agent_end');
           if (
-            !canObserveHandoffCompletion
-            && (!next.done || next.value.error?.type !== 'aborted')
+            !canObserveHandoffCompletion &&
+            (!next.done || next.value.error?.type !== 'aborted')
           ) {
             return;
           }
@@ -1270,8 +1289,9 @@ class Session implements ISession {
       };
     } catch (error) {
       const handingOff = isHandoffRequested();
+      const leaseFailure = this.executionLeaseFailure;
       let terminalError = error;
-      if (!handingOff && !durableFinishAttempted) {
+      if (!handingOff && !leaseFailure && !durableFinishAttempted) {
         try {
           await finishDurableRequest({ status: 'failed', error });
         } catch (durableError) {
@@ -1283,11 +1303,18 @@ class Session implements ISession {
       }
       const errorMessage =
         terminalError instanceof Error ? terminalError.message : String(terminalError);
-      await finishTrace(handingOff ? 'aborted' : 'error', {
-        ...(handingOff ? { reason: 'session_handoff' } : { error: errorMessage }),
+      await finishTrace(handingOff || leaseFailure ? 'aborted' : 'error', {
+        ...(handingOff
+          ? { reason: 'session_handoff' }
+          : leaseFailure
+            ? { reason: 'process_restart' }
+            : { error: errorMessage }),
       });
       if (handingOff) {
         return;
+      }
+      if (leaseFailure) {
+        throw leaseFailure;
       }
       if (durableRecorder && !durableFinishCommitted) {
         throw terminalError;
@@ -1314,7 +1341,7 @@ class Session implements ISession {
               )
             : error;
         }
-        if (!isHandoffRequested()) {
+        if (!isHandoffRequested() && !this.executionLeaseFailure) {
           try {
             if (!durableFinishAttempted) {
               await finishDurableRequest({
@@ -1337,8 +1364,8 @@ class Session implements ISession {
       requestController.dispose();
       await this.finishRequest(requestId);
       if (
-        this.executionState.phase === 'closed'
-        && this.executionState.disposition === 'terminal'
+        this.executionState.phase === 'closed' &&
+        this.executionState.disposition === 'terminal'
       ) {
         await this.closeDurableSession();
       }
@@ -1365,6 +1392,9 @@ class Session implements ISession {
   }
 
   suspendForHandoff(): Promise<SessionHandoffResult> {
+    if (this.executionLeaseFailure) {
+      return Promise.reject(this.executionLeaseFailure);
+    }
     if (!this.options.durableEventStore) {
       return Promise.reject(
         new SessionHandoffError(
@@ -1386,10 +1416,7 @@ class Session implements ISession {
     }
     if (this.closePromise) {
       return Promise.reject(
-        new SessionHandoffError(
-          'SESSION_HANDOFF_UNAVAILABLE',
-          'Session close has already started',
-        ),
+        new SessionHandoffError('SESSION_HANDOFF_UNAVAILABLE', 'Session close has already started'),
       );
     }
 
@@ -1399,10 +1426,7 @@ class Session implements ISession {
     void handoffPromise.catch(() => {
       if (this.handoffPromise === handoffPromise) {
         this.handoffPromise = null;
-        if (
-          this.executionState.phase !== 'suspending'
-          && this.executionState.phase !== 'closed'
-        ) {
+        if (this.executionState.phase !== 'suspending' && this.executionState.phase !== 'closed') {
           this.handoffRequested = false;
         }
       }
@@ -1414,7 +1438,10 @@ class Session implements ISession {
     await this.closeInternal('detached');
   }
 
-  private async closeInternal(disposition: 'terminal' | 'detached'): Promise<void> {
+  private async closeInternal(
+    disposition: 'terminal' | 'detached',
+    abortReason: RequestAbortReason = { kind: 'session_close' },
+  ): Promise<void> {
     const recordDurableClose = disposition === 'terminal';
     // 关闭时对 executionState 的读写走 inputMutex，避免与并发 send()/stream()
     // 交错（例如 send() 在 await 处让出后用 pending 覆盖 closed）。
@@ -1438,16 +1465,16 @@ class Session implements ISession {
             reason: 'session_close',
           });
         }
-        controller.abortRequest({ kind: 'session_close' });
+        controller.abortRequest(abortReason);
         controller.dispose();
         this.inputInbox.remove(input.inputId);
       } else if (
-        this.executionState.phase === 'running'
-        || this.executionState.phase === 'stopping'
-        || this.executionState.phase === 'suspending'
+        this.executionState.phase === 'running' ||
+        this.executionState.phase === 'stopping' ||
+        this.executionState.phase === 'suspending'
       ) {
         if (this.executionState.phase !== 'suspending') {
-          this.executionState.controller.abortRequest({ kind: 'session_close' });
+          this.executionState.controller.abortRequest(abortReason);
         }
         execution = this.executionState.execution;
         execution.releaseBackpressure();
@@ -1473,8 +1500,8 @@ class Session implements ISession {
       }
       await this.inputMutex.runExclusive(() => {
         if (
-          this.executionState.phase === 'closed'
-          && this.executionState.execution === closeState.execution
+          this.executionState.phase === 'closed' &&
+          this.executionState.execution === closeState.execution
         ) {
           this.executionState = {
             phase: 'closed',
@@ -1485,7 +1512,7 @@ class Session implements ISession {
     }
 
     if (!closeState.alreadyClosed) {
-      closeErrors.push(...await this.releaseLocalRuntime());
+      closeErrors.push(...(await this.releaseLocalRuntime()));
     }
     if (recordDurableClose && closeState.disposition === 'terminal') {
       try {
@@ -1493,6 +1520,11 @@ class Session implements ISession {
       } catch (error) {
         closeErrors.push(error);
       }
+    }
+    try {
+      await this.releaseExecutionLease();
+    } catch (error) {
+      closeErrors.push(error);
     }
     if (!closeState.alreadyClosed) {
       this.logger.debug(`[Session] Closed session ${this.sessionId}`);
@@ -1507,10 +1539,7 @@ class Session implements ISession {
 
   private async suspendForHandoffInternal(): Promise<SessionHandoffResult> {
     if (!this.initialized) {
-      throw new SessionHandoffError(
-        'SESSION_HANDOFF_UNAVAILABLE',
-        'Session is not initialized',
-      );
+      throw new SessionHandoffError('SESSION_HANDOFF_UNAVAILABLE', 'Session is not initialized');
     }
     const runtime = this.getRuntime();
     const journal = this.durableJournal;
@@ -1523,10 +1552,7 @@ class Session implements ISession {
 
     const handoffState = await this.inputMutex.runExclusive(() => {
       if (this.executionState.phase === 'closed') {
-        throw new SessionHandoffError(
-          'SESSION_HANDOFF_UNAVAILABLE',
-          'Session is already closed',
-        );
+        throw new SessionHandoffError('SESSION_HANDOFF_UNAVAILABLE', 'Session is already closed');
       }
       if (this.executionState.phase === 'stopping') {
         throw new SessionHandoffError(
@@ -1536,14 +1562,12 @@ class Session implements ISession {
       }
 
       const durableRecorder =
-        this.executionState.phase === 'pending'
-        || this.executionState.phase === 'running'
+        this.executionState.phase === 'pending' || this.executionState.phase === 'running'
           ? this.executionState.durableRecorder
           : null;
       if (
-        (this.executionState.phase === 'pending'
-          || this.executionState.phase === 'running')
-        && !durableRecorder
+        (this.executionState.phase === 'pending' || this.executionState.phase === 'running') &&
+        !durableRecorder
       ) {
         throw new SessionHandoffError(
           'SESSION_HANDOFF_NOT_CONFIGURED',
@@ -1552,11 +1576,10 @@ class Session implements ISession {
       }
       durableRecorder?.assertHandoffReady();
 
-      const blockers = runtime.sealBackgroundWorkForHandoff();
-      if (
-        blockers.activeSubagentIds.length > 0
-        || blockers.activeShellIds.length > 0
-      ) {
+      const blockers = runtime.sealBackgroundWorkForHandoff(
+        this.executionLease?.fence,
+      );
+      if (blockers.activeSubagentIds.length > 0 || blockers.activeShellIds.length > 0) {
         throw new SessionHandoffError(
           'SESSION_HANDOFF_ACTIVE_WORK',
           'Session handoff requires all background work to settle first',
@@ -1633,7 +1656,7 @@ class Session implements ISession {
         };
       }
     });
-    handoffErrors.push(...await this.releaseLocalRuntime());
+    handoffErrors.push(...(await this.releaseLocalRuntime()));
 
     let recoveryPlan: DurableSessionRecoveryPlan | null = null;
     let headSequence: EventSequence | null = null;
@@ -1650,15 +1673,17 @@ class Session implements ISession {
     } catch (error) {
       handoffErrors.push(error);
     }
+    try {
+      await this.releaseExecutionLease();
+    } catch (error) {
+      handoffErrors.push(error);
+    }
 
     if (handoffErrors.length === 1) {
       throw handoffErrors[0];
     }
     if (handoffErrors.length > 1) {
-      throw new AggregateError(
-        handoffErrors,
-        'Session handoff failed in multiple phases',
-      );
+      throw new AggregateError(handoffErrors, 'Session handoff failed in multiple phases');
     }
     if (!recoveryPlan || headSequence === null) {
       throw new SessionHandoffError(
@@ -1682,6 +1707,7 @@ class Session implements ISession {
     this.agent = null;
     this.initialized = false;
     const runtime = this.runtime;
+    const executionFence = this.executionLease?.fence;
     this.runtime = null;
     if (runtime) {
       try {
@@ -1690,12 +1716,70 @@ class Session implements ISession {
         errors.push(error);
       }
       try {
-        await runtime.close();
+        await runtime.close(executionFence);
       } catch (error) {
         errors.push(error);
       }
     }
     return errors;
+  }
+
+  private async initializeExecutionLease(): Promise<void> {
+    const options = this.options.executionLease;
+    if (!options || this.executionLease) {
+      return;
+    }
+    if (!this.persistenceEnabled || !this.options.storagePath) {
+      throw new DurableExecutionLeaseError(
+        'DURABLE_EXECUTION_LEASE_INVALID',
+        'Session execution leases require persistent transcript storage',
+        { sessionId: this.sessionId },
+      );
+    }
+    const store = this.options.durableEventStore;
+    if (!store) {
+      throw new DurableExecutionLeaseError(
+        'DURABLE_EXECUTION_LEASE_NOT_SUPPORTED',
+        'Session execution leases require durableEventStore',
+        { sessionId: this.sessionId },
+      );
+    }
+    this.executionLease = await DurableExecutionLease.acquire(store, this.sessionId, options);
+  }
+
+  private async releaseExecutionLease(): Promise<void> {
+    this.executionLeaseLossCleanup?.();
+    this.executionLeaseLossCleanup = null;
+    const lease = this.executionLease;
+    await lease?.release();
+    if (this.executionLease === lease) {
+      this.executionLease = null;
+    }
+  }
+
+  private handleExecutionLeaseLoss(error: DurableExecutionLeaseError): void {
+    if (this.executionLeaseFailure) {
+      return;
+    }
+    this.executionLeaseFailure = error;
+    if (!this.initialized || this.handoffPromise || this.closePromise) {
+      return;
+    }
+
+    const executionFence = this.executionLease?.fence;
+    if (executionFence) {
+      this.runtime?.stopBackgroundWorkAfterLeaseLoss(executionFence);
+    }
+    const cleanup = this.closeInternal('detached', {
+      kind: 'execution_lease_lost',
+      cause: error,
+    }).catch((cleanupError: unknown) => {
+      this.logger.error(
+        `[Session] Failed to clean up after execution lease loss for ${this.sessionId}`,
+        cleanupError,
+      );
+    });
+    this.closePromise = cleanup;
   }
 
   async abort(): Promise<void> {
@@ -1705,12 +1789,7 @@ class Session implements ISession {
     }
     const result = await this.inputMutex.runExclusive(async () => {
       if (this.executionState.phase === 'running') {
-        const {
-          requestId,
-          controller,
-          durableRecorder,
-          execution,
-        } = this.executionState;
+        const { requestId, controller, durableRecorder, execution } = this.executionState;
         controller.abortRequest({ kind: 'user_abort' });
         execution.releaseBackpressure();
         this.executionState = {
@@ -1807,15 +1886,21 @@ class Session implements ISession {
   }
 
   private async ensureInitialized(): Promise<void> {
+    if (this.executionLeaseFailure) {
+      throw this.executionLeaseFailure;
+    }
     if (
-      this.executionState.phase === 'suspending'
-      || this.executionState.phase === 'closed'
+      this.handoffRequested ||
+      this.executionState.phase === 'suspending' ||
+      this.executionState.phase === 'closed'
     ) {
       throw new Error('Session is closed');
     }
     if (!this.initialized) {
       await this.initialize();
+      return;
     }
+    await this.executionLease?.assertActive();
   }
 
   private getAgent(): Agent {
@@ -1841,7 +1926,9 @@ class Session implements ISession {
       return;
     }
 
-    const journal = await DurableSessionJournal.open(eventStore, this.sessionId);
+    const journal = await DurableSessionJournal.open(eventStore, this.sessionId, {
+      ...(this.executionLease ? { executionLease: this.executionLease } : {}),
+    });
     const projection = journal.getProjection();
     if (projection.status === 'empty') {
       await journal.commit({
@@ -1862,14 +1949,10 @@ class Session implements ISession {
       return;
     }
     if (!this.isResumeSession) {
-      throw new SessionDurableRecorderError(
-        `Durable Session ${this.sessionId} already exists`,
-      );
+      throw new SessionDurableRecorderError(`Durable Session ${this.sessionId} already exists`);
     }
     if (projection.status === 'closed') {
-      throw new SessionDurableRecorderError(
-        `Durable Session ${this.sessionId} is closed`,
-      );
+      throw new SessionDurableRecorderError(`Durable Session ${this.sessionId} is closed`);
     }
     const resumeDecision = new DurableSessionRecoveryCoordinator(journal).planResume();
     if (resumeDecision.action === 'recovery_required') {
@@ -1914,15 +1997,17 @@ class Session implements ISession {
     if (projection.status !== 'open' || projection.activeRequest) {
       return;
     }
-    const closePromise = journal.commit({
-      commandId: CommandId(nanoid()),
-      events: [
-        {
-          type: DurableEventType.SESSION_CLOSED,
-          data: { reason: 'shutdown' },
-        },
-      ],
-    }).then(() => undefined);
+    const closePromise = journal
+      .commit({
+        commandId: CommandId(nanoid()),
+        events: [
+          {
+            type: DurableEventType.SESSION_CLOSED,
+            data: { reason: 'shutdown' },
+          },
+        ],
+      })
+      .then(() => undefined);
     this.durableClosePromise = closePromise;
     try {
       await closePromise;
@@ -1951,15 +2036,17 @@ class Session implements ISession {
     if (reason?.kind === 'session_handoff') {
       return 'process_restart';
     }
+    if (reason?.kind === 'execution_lease_lost') {
+      return 'process_restart';
+    }
     return 'user_abort';
   }
 
   private async finishRequest(requestId: RequestId): Promise<void> {
     await this.inputMutex.runExclusive(() => {
       if (
-        (this.executionState.phase !== 'running'
-          && this.executionState.phase !== 'stopping')
-        || this.executionState.requestId !== requestId
+        (this.executionState.phase !== 'running' && this.executionState.phase !== 'stopping') ||
+        this.executionState.requestId !== requestId
       ) {
         return;
       }
@@ -1992,12 +2079,9 @@ class Session implements ISession {
       options: options || null,
       durableRecorder,
       initialInputPreparation,
-      snapshot: snapshot ?? createContextSnapshot(
-        this.sessionId,
-        nanoid(),
-        this.defaultContext,
-        options?.context,
-      ),
+      snapshot:
+        snapshot ??
+        createContextSnapshot(this.sessionId, nanoid(), this.defaultContext, options?.context),
     };
   }
 
@@ -2043,9 +2127,7 @@ class Session implements ISession {
       sendOptions,
       recorder,
       snapshot,
-      request.recoveryKind === 'pre_turn_request'
-        ? RECONCILED_INITIAL_INPUT
-        : undefined,
+      request.recoveryKind === 'pre_turn_request' ? RECONCILED_INITIAL_INPUT : undefined,
     );
     this.durableAcceptedRequest = null;
   }
@@ -2054,10 +2136,7 @@ class Session implements ISession {
     if (this.executionState.phase !== 'idle') {
       return;
     }
-    if (
-      this.durableJournal
-      && this.durableJournal.getRecoveryPlan().action !== 'none'
-    ) {
+    if (this.durableJournal && this.durableJournal.getRecoveryPlan().action !== 'none') {
       return;
     }
     const requestId = RequestId(nanoid());
@@ -2069,16 +2148,15 @@ class Session implements ISession {
   }
 
   private async persistInput(input: PendingSessionInput): Promise<void> {
-    await this.getRuntime().getContextManager().saveInputEnqueued(
-      this.sessionId,
-      {
+    await this.getRuntime()
+      .getContextManager()
+      .saveInputEnqueued(this.sessionId, {
         inputId: input.inputId,
         content: input.content as JsonValue,
         priority: input.priority,
         targetRequestId: input.targetRequestId,
         acceptedAt: input.acceptedAt,
-      },
-    );
+      });
   }
 
   private safeParseJson(str: string): JsonValue {

--- a/src/session/Session.ts
+++ b/src/session/Session.ts
@@ -165,6 +165,7 @@ class Session implements ISession {
   private executionLease: DurableExecutionLease | null = null;
   private executionLeaseFailure: DurableExecutionLeaseError | null = null;
   private executionLeaseLossCleanup: (() => void) | null = null;
+  private runtimeEndAttempted = false;
   private closePromise: Promise<void> | null = null;
   private handoffPromise: Promise<SessionHandoffResult> | null = null;
   private handoffRequested = false;
@@ -289,9 +290,9 @@ class Session implements ISession {
       );
       await this.runtime.initialize();
       if (this.isResumeSession) {
-        await this.runtime.ensureSessionLoaded();
+        await this.runWithExecutionLease(() => this.getRuntime().ensureSessionLoaded());
       } else {
-        await this.runtime.ensureSessionCreated();
+        await this.runWithExecutionLease(() => this.getRuntime().ensureSessionCreated());
       }
 
       this.agent = await Agent.create(
@@ -329,10 +330,15 @@ class Session implements ISession {
       this.logger.debug(`[Session] Initialized session ${this.sessionId}`);
     } catch (error) {
       const cleanupErrors = await this.releaseLocalRuntime();
-      try {
-        await this.releaseExecutionLease();
-      } catch (leaseError) {
-        cleanupErrors.push(leaseError);
+      if (cleanupErrors.length === 0) {
+        try {
+          await this.releaseExecutionLease();
+        } catch (leaseError) {
+          this.executionLease?.abandon(leaseError);
+          cleanupErrors.push(leaseError);
+        }
+      } else {
+        this.executionLease?.abandon(error);
       }
       if (cleanupErrors.length > 0) {
         throw new AggregateError(
@@ -652,9 +658,11 @@ class Session implements ISession {
         }
       }
       try {
-        await this.getRuntime()
-          .getContextManager()
-          .saveInputCancelled(this.sessionId, inputId, 'cancelled_by_user');
+        await this.runWithExecutionLease(() =>
+          this.getRuntime()
+            .getContextManager()
+            .saveInputCancelled(this.sessionId, inputId, 'cancelled_by_user'),
+        );
       } catch (error) {
         if (!durablyInterrupted) {
           this.inputInbox.releaseClaim(inputId);
@@ -945,6 +953,9 @@ class Session implements ISession {
       permissionMode: this.permissionMode,
       executionFence: executionLease?.fence,
       assertExecutionLease: executionLease ? () => executionLease.assertActive() : undefined,
+      runWithExecutionLease: executionLease
+        ? (operation) => executionLease.runFenced(operation)
+        : undefined,
       backgroundAgentManager: runtime.getBackgroundAgentManager(),
     };
 
@@ -1511,7 +1522,7 @@ class Session implements ISession {
       });
     }
 
-    if (!closeState.alreadyClosed) {
+    if (this.runtime) {
       closeErrors.push(...(await this.releaseLocalRuntime()));
     }
     if (recordDurableClose && closeState.disposition === 'terminal') {
@@ -1521,10 +1532,15 @@ class Session implements ISession {
         closeErrors.push(error);
       }
     }
-    try {
-      await this.releaseExecutionLease();
-    } catch (error) {
-      closeErrors.push(error);
+    if (
+      !this.runtime &&
+      (closeErrors.length === 0 || this.executionLeaseFailure)
+    ) {
+      try {
+        await this.releaseExecutionLease();
+      } catch (error) {
+        closeErrors.push(error);
+      }
     }
     if (!closeState.alreadyClosed) {
       this.logger.debug(`[Session] Closed session ${this.sessionId}`);
@@ -1673,10 +1689,15 @@ class Session implements ISession {
     } catch (error) {
       handoffErrors.push(error);
     }
-    try {
-      await this.releaseExecutionLease();
-    } catch (error) {
-      handoffErrors.push(error);
+    if (
+      !this.runtime &&
+      (handoffErrors.length === 0 || this.executionLeaseFailure)
+    ) {
+      try {
+        await this.releaseExecutionLease();
+      } catch (error) {
+        handoffErrors.push(error);
+      }
     }
 
     if (handoffErrors.length === 1) {
@@ -1708,17 +1729,28 @@ class Session implements ISession {
     this.initialized = false;
     const runtime = this.runtime;
     const executionFence = this.executionLease?.fence;
-    this.runtime = null;
     if (runtime) {
-      try {
-        await runtime.getHookRuntime().runSessionEnd({ reason: 'other' });
-      } catch (error) {
-        errors.push(error);
+      let runtimeClosed = false;
+      if (!this.runtimeEndAttempted) {
+        try {
+          await runtime.getHookRuntime().runSessionEnd({ reason: 'other' });
+          this.runtimeEndAttempted = true;
+        } catch (error) {
+          errors.push(error);
+        }
       }
       try {
         await runtime.close(executionFence);
+        runtimeClosed = true;
       } catch (error) {
         errors.push(error);
+      }
+      if (
+        this.runtimeEndAttempted &&
+        runtimeClosed &&
+        this.runtime === runtime
+      ) {
+        this.runtime = null;
       }
     }
     return errors;
@@ -1747,12 +1779,18 @@ class Session implements ISession {
     this.executionLease = await DurableExecutionLease.acquire(store, this.sessionId, options);
   }
 
+  private runWithExecutionLease<T>(operation: () => Promise<T>): Promise<T> {
+    return this.executionLease
+      ? this.executionLease.runFenced(operation)
+      : operation();
+  }
+
   private async releaseExecutionLease(): Promise<void> {
-    this.executionLeaseLossCleanup?.();
-    this.executionLeaseLossCleanup = null;
     const lease = this.executionLease;
     await lease?.release();
     if (this.executionLease === lease) {
+      this.executionLeaseLossCleanup?.();
+      this.executionLeaseLossCleanup = null;
       this.executionLease = null;
     }
   }
@@ -1762,24 +1800,45 @@ class Session implements ISession {
       return;
     }
     this.executionLeaseFailure = error;
-    if (!this.initialized || this.handoffPromise || this.closePromise) {
-      return;
+    const state = this.executionState;
+    if (state.phase === 'pending') {
+      state.controller.abortRequest({
+        kind: 'execution_lease_lost',
+        cause: error,
+      });
+    } else if (
+      state.phase === 'running' ||
+      state.phase === 'stopping' ||
+      state.phase === 'suspending'
+    ) {
+      state.controller.abortRequest({
+        kind: 'execution_lease_lost',
+        cause: error,
+      });
+      state.execution.releaseBackpressure();
     }
-
     const executionFence = this.executionLease?.fence;
     if (executionFence) {
       this.runtime?.stopBackgroundWorkAfterLeaseLoss(executionFence);
     }
+    if (!this.initialized || this.handoffPromise || this.closePromise) {
+      return;
+    }
+
     const cleanup = this.closeInternal('detached', {
       kind: 'execution_lease_lost',
       cause: error,
-    }).catch((cleanupError: unknown) => {
+    });
+    this.closePromise = cleanup;
+    void cleanup.catch((cleanupError: unknown) => {
       this.logger.error(
         `[Session] Failed to clean up after execution lease loss for ${this.sessionId}`,
         cleanupError,
       );
+      if (this.closePromise === cleanup) {
+        this.closePromise = null;
+      }
     });
-    this.closePromise = cleanup;
   }
 
   async abort(): Promise<void> {
@@ -2148,15 +2207,17 @@ class Session implements ISession {
   }
 
   private async persistInput(input: PendingSessionInput): Promise<void> {
-    await this.getRuntime()
-      .getContextManager()
-      .saveInputEnqueued(this.sessionId, {
-        inputId: input.inputId,
-        content: input.content as JsonValue,
-        priority: input.priority,
-        targetRequestId: input.targetRequestId,
-        acceptedAt: input.acceptedAt,
-      });
+    await this.runWithExecutionLease(() =>
+      this.getRuntime()
+        .getContextManager()
+        .saveInputEnqueued(this.sessionId, {
+          inputId: input.inputId,
+          content: input.content as JsonValue,
+          priority: input.priority,
+          targetRequestId: input.targetRequestId,
+          acceptedAt: input.acceptedAt,
+        }),
+    );
   }
 
   private safeParseJson(str: string): JsonValue {
@@ -2202,9 +2263,11 @@ class Session implements ISession {
   async fork(options?: ForkSessionOptions): Promise<ISession> {
     await this.ensureInitialized();
     const snapshot = this.persistenceEnabled
-      ? await this.store.forkState(this.sessionId, {
-          messageId: options?.messageId,
-        })
+      ? await this.runWithExecutionLease(() =>
+          this.store.forkState(this.sessionId, {
+            messageId: options?.messageId,
+          }),
+        )
       : this.createSnapshotFromMessages(options?.messageId);
 
     const forkedSession = new Session(

--- a/src/session/SessionRuntime.ts
+++ b/src/session/SessionRuntime.ts
@@ -17,6 +17,7 @@ import {
 } from '../runtime/index.js';
 import { getSandboxExecutor } from '../sandbox/SandboxExecutor.js';
 import { getSandboxService } from '../sandbox/SandboxService.js';
+import type { DurableExecutionFence } from './events/DurableExecutionLeaseStore.js';
 import { getBuiltinTools } from '../tools/builtin/index.js';
 import { BackgroundShellManager } from '../tools/builtin/shell/BackgroundShellManager.js';
 import { ToolCatalog } from '../tools/catalog/ToolCatalog.js';
@@ -186,18 +187,33 @@ export class SessionRuntime {
     return this.backgroundAgentManager;
   }
 
-  sealBackgroundWorkForHandoff(): {
+  sealBackgroundWorkForHandoff(executionFence?: DurableExecutionFence): {
     activeSubagentIds: readonly AgentId[];
     activeShellIds: readonly string[];
   } {
     const activeSubagentIds = this.backgroundAgentManager.getActiveAgentIds();
     const shellManager = BackgroundShellManager.getInstance();
-    const activeShellIds = shellManager.getActiveProcessIds(this.sessionId);
+    const activeShellIds = shellManager.getActiveProcessIds(
+      this.sessionId,
+      executionFence,
+    );
     if (activeSubagentIds.length === 0 && activeShellIds.length === 0) {
       this.backgroundAgentManager.sealForHandoff();
-      shellManager.sealSessionForHandoff(this.sessionId);
+      if (executionFence) {
+        shellManager.sealExecutionFence(this.sessionId, executionFence);
+      } else {
+        shellManager.sealSessionForHandoff(this.sessionId);
+      }
     }
     return { activeSubagentIds, activeShellIds };
+  }
+
+  stopBackgroundWorkAfterLeaseLoss(executionFence: DurableExecutionFence): void {
+    this.backgroundAgentManager.sealAndCancelAll();
+    BackgroundShellManager.getInstance().killExecutionFence(
+      this.sessionId,
+      executionFence,
+    );
   }
 
   getContextManager(): ContextManager {
@@ -244,8 +260,28 @@ export class SessionRuntime {
     });
   }
 
-  async close(): Promise<void> {
-    await this.mcpRegistry.disconnectAll();
+  async close(executionFence?: DurableExecutionFence): Promise<void> {
+    const shellManager = BackgroundShellManager.getInstance();
+    const shutdownResults = await Promise.allSettled([
+      this.backgroundAgentManager.sealCancelAndWait(),
+      executionFence
+        ? shellManager.terminateExecutionFence(this.sessionId, executionFence)
+        : shellManager.terminateSession(this.sessionId),
+    ]);
+    const errors = shutdownResults.flatMap((result) =>
+      result.status === 'rejected' ? [result.reason] : [],
+    );
+    try {
+      await this.mcpRegistry.disconnectAll();
+    } catch (error) {
+      errors.push(error);
+    }
+    if (errors.length === 1) {
+      throw errors[0];
+    }
+    if (errors.length > 1) {
+      throw new AggregateError(errors, `Session runtime ${this.sessionId} close failed`);
+    }
   }
 
   async mcpServerStatus(): Promise<McpServerStatus[]> {

--- a/src/session/__tests__/SessionDurableEvents.test.ts
+++ b/src/session/__tests__/SessionDurableEvents.test.ts
@@ -16,6 +16,7 @@ import {
   AgentId,
   CommandId,
   EventId,
+  ExecutionLeaseId,
   InputId,
   ModelAttemptId,
   RequestId,
@@ -23,6 +24,7 @@ import {
   ToolAttemptId,
   ToolUseId,
   TurnId,
+  WorkerId,
 } from '../../types/branded.js';
 import type { JsonValue } from '../../types/common.js';
 import { type DurableEventStore, DurableEventStoreError } from '../events/DurableEventStore.js';
@@ -30,6 +32,7 @@ import {
   DurableEventSubscriptionError,
   type DurableEventSubscriptionMessage,
 } from '../events/DurableEventSubscription.js';
+import { DurableExecutionLeaseError } from '../events/DurableExecutionLeaseStore.js';
 import {
   DurableCommandOutcomeUnknownError,
   DurableSessionJournal,
@@ -120,9 +123,7 @@ class InjectInputBeforeTurnStore implements DurableEventStore {
     options?: DurableEventAppendOptions,
   ): Promise<DurableEventAppendResult> {
     if (!this.injected) {
-      const turnStarted = events.find(
-        (event) => event.type === DurableEventType.TURN_STARTED,
-      );
+      const turnStarted = events.find((event) => event.type === DurableEventType.TURN_STARTED);
       if (turnStarted?.type === DurableEventType.TURN_STARTED) {
         this.injected = true;
         await this.delegate.append(
@@ -182,6 +183,7 @@ function options(store: DurableEventStore) {
 
 afterEach(async () => {
   vi.restoreAllMocks();
+  BackgroundShellManager.getInstance().killAll();
   streamChat = async function* defaultStream() {
     yield { type: 'turn_start', turn: 1, maxTurns: 10 };
     yield { type: 'turn_end', turn: 1, hasToolCalls: false };
@@ -275,9 +277,7 @@ describe('Session durable events', () => {
       DurableEventType.REQUEST_COMPLETED,
     ]);
     expect(
-      events.find(
-        (event) => event.type === DurableEventType.MODEL_REQUEST_COMPLETED,
-      )?.data,
+      events.find((event) => event.type === DurableEventType.MODEL_REQUEST_COMPLETED)?.data,
     ).toEqual({
       response: {
         content: 'durable response',
@@ -330,9 +330,7 @@ describe('Session durable events', () => {
     }
 
     expect(steering.status).toBe('steered');
-    expect(streamEvents).not.toContainEqual(
-      expect.objectContaining({ type: 'error' }),
-    );
+    expect(streamEvents).not.toContainEqual(expect.objectContaining({ type: 'error' }));
     expect(durableEventsBeforePreparation).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -344,8 +342,7 @@ describe('Session durable events', () => {
     expect(
       (await store.read(session.sessionId)).events.filter(
         (event) =>
-          event.type === DurableEventType.INPUT_APPLIED
-          && event.data.inputId === steering.inputId,
+          event.type === DurableEventType.INPUT_APPLIED && event.data.inputId === steering.inputId,
       ),
     ).toHaveLength(1);
     await session.close();
@@ -692,10 +689,10 @@ describe('Session durable events', () => {
     expect(
       events.some(
         (event) =>
-          event.type === DurableEventType.TURN_STARTED
-          || event.type === DurableEventType.REQUEST_COMPLETED
-          || event.type === DurableEventType.REQUEST_FAILED
-          || event.type === DurableEventType.REQUEST_INTERRUPTED,
+          event.type === DurableEventType.TURN_STARTED ||
+          event.type === DurableEventType.REQUEST_COMPLETED ||
+          event.type === DurableEventType.REQUEST_FAILED ||
+          event.type === DurableEventType.REQUEST_INTERRUPTED,
       ),
     ).toBe(false);
     expect(session.getDurableRecoveryPlan()).toMatchObject({
@@ -1402,10 +1399,7 @@ describe('Session durable events', () => {
 
   it('rejects abort when running-request terminal persistence fails', async () => {
     const { store } = createStore();
-    const failingStore = new FailOnEventTypeStore(
-      store,
-      DurableEventType.REQUEST_INTERRUPTED,
-    );
+    const failingStore = new FailOnEventTypeStore(store, DurableEventType.REQUEST_INTERRUPTED);
     streamChat = async function* interruptedByAbort(_message, context) {
       yield { type: 'turn_start', turn: 1, maxTurns: 10 };
       const signal = (context as { signal?: AbortSignal }).signal;
@@ -1427,23 +1421,16 @@ describe('Session durable events', () => {
     const output = session.stream();
     await output.next();
 
-    await expect(session.abort()).rejects.toBeInstanceOf(
-      DurableCommandOutcomeUnknownError,
-    );
+    await expect(session.abort()).rejects.toBeInstanceOf(DurableCommandOutcomeUnknownError);
 
     expect(session.getDurableRecoveryPlan()?.action).toBe('reconcile_request_outcome');
-    await expect(output.next()).rejects.toBeInstanceOf(
-      DurableCommandOutcomeUnknownError,
-    );
+    await expect(output.next()).rejects.toBeInstanceOf(DurableCommandOutcomeUnknownError);
     await expect(session.close()).resolves.toBeUndefined();
   });
 
   it('allows close retry after running-request terminal persistence fails', async () => {
     const { store } = createStore();
-    const failingStore = new FailOnEventTypeStore(
-      store,
-      DurableEventType.REQUEST_INTERRUPTED,
-    );
+    const failingStore = new FailOnEventTypeStore(store, DurableEventType.REQUEST_INTERRUPTED);
     streamChat = async function* interruptedByClose(_message, context) {
       yield { type: 'turn_start', turn: 1, maxTurns: 10 };
       const signal = (context as { signal?: AbortSignal }).signal;
@@ -1465,13 +1452,9 @@ describe('Session durable events', () => {
     const output = session.stream();
     await output.next();
 
-    await expect(session.close()).rejects.toBeInstanceOf(
-      DurableCommandOutcomeUnknownError,
-    );
+    await expect(session.close()).rejects.toBeInstanceOf(DurableCommandOutcomeUnknownError);
     await expect(session.close()).resolves.toBeUndefined();
-    await expect(output.next()).rejects.toBeInstanceOf(
-      DurableCommandOutcomeUnknownError,
-    );
+    await expect(output.next()).rejects.toBeInstanceOf(DurableCommandOutcomeUnknownError);
   });
 
   it('hands off an idle Session without closing its durable lifecycle', async () => {
@@ -1518,6 +1501,312 @@ describe('Session durable events', () => {
     await resumed.close();
   });
 
+  it('transfers a fenced execution lease only after handoff completes', async () => {
+    const { root, store } = createStore();
+    const first = await createSession({
+      ...options(store),
+      persistSession: true,
+      storagePath: root,
+      executionLease: {
+        ownerId: WorkerId('worker-first'),
+        leaseId: ExecutionLeaseId('lease-first'),
+        ttlMs: 10_000,
+        heartbeatIntervalMs: 5_000,
+      },
+    });
+    expect(first.getExecutionLease()).toMatchObject({
+      sessionId: first.sessionId,
+      ownerId: 'worker-first',
+      leaseId: 'lease-first',
+      fencingToken: 1,
+    });
+
+    await expect(
+      resumeSession({
+        ...options(store),
+        persistSession: true,
+        storagePath: root,
+        sessionId: first.sessionId,
+        executionLease: {
+          ownerId: WorkerId('worker-second'),
+          leaseId: ExecutionLeaseId('lease-second'),
+          ttlMs: 10_000,
+          heartbeatIntervalMs: 5_000,
+        },
+      }),
+    ).rejects.toMatchObject({
+      code: 'DURABLE_EXECUTION_LEASE_CONFLICT',
+    });
+
+    const submission = await first.send('continue on the replacement worker');
+    if (submission.status !== 'started') {
+      throw new Error('Expected the first leased Request to start');
+    }
+    const handoff = await first.suspendForHandoff();
+    expect(handoff.recoveryPlan).toMatchObject({
+      action: 'resume_request',
+      requestId: submission.requestId,
+    });
+    expect(first.getExecutionLease()).toBeNull();
+
+    await expect(
+      resumeSession({
+        ...options(store),
+        persistSession: true,
+        storagePath: root,
+        sessionId: first.sessionId,
+      }),
+    ).rejects.toMatchObject({
+      code: 'DURABLE_EXECUTION_LEASE_REQUIRED',
+      sessionId: first.sessionId,
+    });
+
+    const second = await resumeSession({
+      ...options(store),
+      persistSession: true,
+      storagePath: root,
+      sessionId: first.sessionId,
+      executionLease: {
+        ownerId: WorkerId('worker-second'),
+        leaseId: ExecutionLeaseId('lease-second'),
+        ttlMs: 10_000,
+        heartbeatIntervalMs: 5_000,
+      },
+    });
+    expect(second.getExecutionLease()).toMatchObject({
+      ownerId: 'worker-second',
+      leaseId: 'lease-second',
+      fencingToken: 2,
+    });
+    for await (const _event of second.stream()) {
+      // Drain the handed-off Request.
+    }
+    await second.close();
+  });
+
+  it('fails closed and stops publishing when the execution lease is lost', async () => {
+    const { root } = createStore();
+    let now = Date.parse('2026-08-22T12:00:00.000Z');
+    const store = new JsonlDurableEventStore(root, {
+      clock: () => new Date(now),
+    });
+    streamChat = async function* leaseLossStream(_message, context, loopOptions) {
+      yield { type: 'turn_start', turn: 1, maxTurns: 10 };
+      await loopOptions?.modelExecutionLifecycle?.onModelRequestStarting({
+        turn: 1,
+        model: 'test-model',
+        streaming: true,
+      });
+      yield { type: 'content_delta', delta: 'before lease loss' };
+      const signal = (context as { signal?: AbortSignal }).signal;
+      await new Promise<void>((resolve) => {
+        if (signal?.aborted) {
+          resolve();
+          return;
+        }
+        signal?.addEventListener('abort', () => resolve(), { once: true });
+      });
+      return {
+        success: false,
+        error: { type: 'aborted', message: 'lease lost' },
+        metadata: { turnsCount: 1, toolCallsCount: 0, duration: 1 },
+      };
+    };
+    const session = await createSession({
+      ...options(store),
+      persistSession: true,
+      storagePath: root,
+      executionLease: {
+        ownerId: WorkerId('worker-first'),
+        leaseId: ExecutionLeaseId('lease-first'),
+        ttlMs: 60_000,
+        heartbeatIntervalMs: 30_000,
+      },
+    });
+    const firstLease = session.getExecutionLease();
+    if (!firstLease) {
+      throw new Error('Expected an active execution lease');
+    }
+    const runtime = (
+      session as unknown as {
+        runtime: {
+          getBackgroundAgentManager(): {
+            sealAndCancelAll(): readonly AgentId[];
+          };
+        } | null;
+      }
+    ).runtime;
+    if (!runtime) {
+      throw new Error('Expected an initialized Session runtime');
+    }
+    const cancelBackgroundAgents = vi.spyOn(
+      runtime.getBackgroundAgentManager(),
+      'sealAndCancelAll',
+    );
+    const shellManager = BackgroundShellManager.getInstance();
+    const backgroundShell = shellManager.startBackgroundProcess({
+      command: 'sleep 30',
+      sessionId: session.sessionId,
+      cwd: root,
+      executionFence: firstLease,
+    });
+    await session.send('wait for lease loss');
+    const output = session.stream();
+    await output.next();
+    await output.next();
+    now += 60_001;
+    const replacementLease = await store.acquireExecutionLease(session.sessionId, {
+      ownerId: WorkerId('worker-second'),
+      leaseId: ExecutionLeaseId('lease-second'),
+      ttlMs: 10_000,
+    });
+
+    await expect(session.send('reject stale worker input')).rejects.toMatchObject({
+      code: 'DURABLE_EXECUTION_LEASE_LOST',
+    });
+    await expect(output.next()).rejects.toBeInstanceOf(DurableExecutionLeaseError);
+    expect(cancelBackgroundAgents).toHaveBeenCalled();
+    await vi.waitFor(
+      () => expect(shellManager.getActiveProcessIds(session.sessionId)).toEqual([]),
+      { timeout: 2_000 },
+    );
+    expect(shellManager.consumeOutput(backgroundShell.id)?.status).toMatch(/^(killed|exited)$/);
+    await expect(session.close()).resolves.toBeUndefined();
+    expect(session.isClosed).toBe(true);
+    expect(session.getExecutionLease()).toBeNull();
+    expect(session.getDurableRecoveryPlan()?.action).toBe('reconcile_model_outcome');
+    const eventTypes = (await store.read(session.sessionId)).events.map((entry) => entry.type);
+    expect(eventTypes).not.toContain(DurableEventType.REQUEST_INTERRUPTED);
+    expect(eventTypes).not.toContain(DurableEventType.SESSION_CLOSED);
+    await expect(
+      store.append(
+        session.sessionId,
+        [
+          {
+            type: DurableEventType.MODEL_REQUEST_ABORTED,
+            requestId: RequestId('stale-request'),
+            turnId: TurnId('stale-turn'),
+            modelAttemptId: ModelAttemptId('stale-model'),
+            data: { reason: 'process_restart' },
+          },
+        ],
+        { executionFence: firstLease },
+      ),
+    ).rejects.toMatchObject({
+      code: 'DURABLE_EXECUTION_LEASE_LOST',
+    });
+    await store.releaseExecutionLease(replacementLease);
+  });
+
+  it('rejects execution lease configuration without persistent durable storage', async () => {
+    await expect(
+      createSession({
+        provider: { type: 'openai-compatible', apiKey: 'test-key' },
+        model: 'test-model',
+        persistSession: false,
+        executionLease: {
+          ownerId: WorkerId('worker-without-store'),
+        },
+      }),
+    ).rejects.toMatchObject({
+      code: 'DURABLE_EXECUTION_LEASE_INVALID',
+    });
+  });
+
+  it('retains the lease handle so close can retry a failed release', async () => {
+    const { root, store } = createStore();
+    const session = await createSession({
+      ...options(store),
+      persistSession: true,
+      storagePath: root,
+      executionLease: {
+        ownerId: WorkerId('worker-release-retry'),
+        ttlMs: 10_000,
+        heartbeatIntervalMs: 5_000,
+      },
+    });
+    const release = vi.spyOn(store, 'releaseExecutionLease');
+    release.mockRejectedValueOnce(new Error('transient release failure'));
+
+    await expect(session.close()).rejects.toMatchObject({
+      code: 'DURABLE_EXECUTION_LEASE_LOST',
+    });
+    expect(session.getExecutionLease()).not.toBeNull();
+
+    await expect(session.close()).resolves.toBeUndefined();
+    expect(release).toHaveBeenCalledTimes(2);
+    expect(session.getExecutionLease()).toBeNull();
+  });
+
+  it('waits for Session-owned shells before releasing execution ownership', async () => {
+    const { root, store } = createStore();
+    const session = await createSession({
+      ...options(store),
+      persistSession: true,
+      storagePath: root,
+      executionLease: {
+        ownerId: WorkerId('worker-close-shell'),
+        ttlMs: 10_000,
+        heartbeatIntervalMs: 5_000,
+      },
+    });
+    const shellManager = BackgroundShellManager.getInstance();
+    const executionFence = session.getExecutionLease();
+    if (!executionFence) {
+      throw new Error('Expected an active execution lease');
+    }
+    shellManager.startBackgroundProcess({
+      command: 'sleep 30',
+      sessionId: session.sessionId,
+      cwd: root,
+      executionFence,
+    });
+    const originalRelease = store.releaseExecutionLease.bind(store);
+    const release = vi.spyOn(store, 'releaseExecutionLease').mockImplementation(async (lease) => {
+      expect(shellManager.getActiveProcessIds(session.sessionId)).toEqual([]);
+      await originalRelease(lease);
+    });
+
+    await session.close();
+
+    expect(release).toHaveBeenCalledOnce();
+    expect(session.getExecutionLease()).toBeNull();
+  });
+
+  it('releases ownership when the final initialization fence check fails', async () => {
+    const { root, store } = createStore();
+    const assertExecutionLease = vi.spyOn(store, 'assertExecutionLease');
+    const releaseExecutionLease = vi.spyOn(store, 'releaseExecutionLease');
+    const originalAssert = assertExecutionLease.getMockImplementation();
+    let assertionCount = 0;
+    assertExecutionLease.mockImplementation(async (lease) => {
+      assertionCount += 1;
+      if (assertionCount === 3) {
+        throw new DurableExecutionLeaseError(
+          'DURABLE_EXECUTION_LEASE_LOST',
+          'ownership changed during initialization',
+        );
+      }
+      await originalAssert?.(lease);
+    });
+
+    await expect(
+      createSession({
+        ...options(store),
+        persistSession: true,
+        storagePath: root,
+        executionLease: {
+          ownerId: WorkerId('worker-initialization-loss'),
+          ttlMs: 10_000,
+          heartbeatIntervalMs: 5_000,
+        },
+      }),
+    ).rejects.toMatchObject({
+      code: 'DURABLE_EXECUTION_LEASE_LOST',
+    });
+    expect(releaseExecutionLease).toHaveBeenCalledOnce();
+  });
+
   it('hands off a pending Request without terminalizing the durable Session', async () => {
     const { root, store } = createStore();
     const session = await createSession({
@@ -1550,9 +1839,7 @@ describe('Session durable events', () => {
     );
     await expect(session.close()).resolves.toBeUndefined();
     await expect(session.stream().next()).rejects.toThrow('Session is closed');
-    expect((await store.read(session.sessionId)).events).toHaveLength(
-      eventsBeforeResume.length,
-    );
+    expect((await store.read(session.sessionId)).events).toHaveLength(eventsBeforeResume.length);
 
     const resumed = await resumeSession({
       ...options(store),
@@ -1580,9 +1867,11 @@ describe('Session durable events', () => {
     const pumpGate = new Promise<void>((resolve) => {
       releasePump = resolve;
     });
-    (session as unknown as {
-      ensureInitialized(): Promise<void>;
-    }).ensureInitialized = async () => {
+    (
+      session as unknown as {
+        ensureInitialized(): Promise<void>;
+      }
+    ).ensureInitialized = async () => {
       pumpStarted = true;
       await pumpGate;
     };
@@ -1716,10 +2005,7 @@ describe('Session durable events', () => {
     if (!requestId || !turnId) {
       throw new Error('Expected handoff recovery identifiers');
     }
-    const coordinator = await DurableSessionRecoveryCoordinator.open(
-      store,
-      session.sessionId,
-    );
+    const coordinator = await DurableSessionRecoveryCoordinator.open(store, session.sessionId);
     await coordinator.prepareTurnRecovery({
       commandId: CommandId('handoff-recovery-command'),
       requestId,
@@ -1958,9 +2244,7 @@ describe('Session durable events', () => {
     await expect(output.next()).resolves.toEqual({ value: undefined, done: true });
     const events = (await store.read(session.sessionId)).events;
     expect(events.at(-1)?.type).toBe(DurableEventType.REQUEST_COMPLETED);
-    expect(
-      events.filter((entry) => entry.type === DurableEventType.TURN_STARTED),
-    ).toHaveLength(1);
+    expect(events.filter((entry) => entry.type === DurableEventType.TURN_STARTED)).toHaveLength(1);
   });
 
   it('rejects handoff unless durable journal and transcript persistence are configured', async () => {
@@ -1970,9 +2254,7 @@ describe('Session durable events', () => {
       persistSession: false,
     });
 
-    await expect(withoutJournal.suspendForHandoff()).rejects.toBeInstanceOf(
-      SessionHandoffError,
-    );
+    await expect(withoutJournal.suspendForHandoff()).rejects.toBeInstanceOf(SessionHandoffError);
     expect(withoutJournal.isClosed).toBe(false);
     await withoutJournal.close();
 
@@ -2063,14 +2345,16 @@ describe('Session durable events', () => {
       persistSession: true,
       storagePath: root,
     });
-    const runtime = (session as unknown as {
-      runtime: {
-        sealBackgroundWorkForHandoff(): {
-          activeSubagentIds: readonly AgentId[];
-          activeShellIds: readonly string[];
+    const runtime = (
+      session as unknown as {
+        runtime: {
+          sealBackgroundWorkForHandoff(): {
+            activeSubagentIds: readonly AgentId[];
+            activeShellIds: readonly string[];
+          };
         };
-      };
-    }).runtime;
+      }
+    ).runtime;
     vi.spyOn(runtime, 'sealBackgroundWorkForHandoff').mockReturnValue({
       activeSubagentIds: [AgentId('active-subagent')],
       activeShellIds: [],
@@ -2128,10 +2412,7 @@ describe('Session durable events', () => {
 
   it('fails handoff closed when final model lifecycle persistence is uncertain', async () => {
     const { root, store } = createStore();
-    const failingStore = new FailOnEventTypeStore(
-      store,
-      DurableEventType.MODEL_REQUEST_ABORTED,
-    );
+    const failingStore = new FailOnEventTypeStore(store, DurableEventType.MODEL_REQUEST_ABORTED);
     streamChat = async function* failedHandoff(_message, context, loopOptions) {
       let modelRequest: ModelRequestLifecycle | undefined;
       try {
@@ -2169,16 +2450,12 @@ describe('Session durable events', () => {
     await output.next();
     await output.next();
 
-    await expect(session.suspendForHandoff()).rejects.toBeInstanceOf(
-      SessionDurableRecorderError,
-    );
+    await expect(session.suspendForHandoff()).rejects.toBeInstanceOf(SessionDurableRecorderError);
     expect(session.isClosed).toBe(true);
-    expect(session.getDurableRecoveryPlan()?.action).toBe(
-      'reconcile_model_outcome',
+    expect(session.getDurableRecoveryPlan()?.action).toBe('reconcile_model_outcome');
+    expect((await store.read(session.sessionId)).events.map((event) => event.type)).not.toContain(
+      DurableEventType.SESSION_CLOSED,
     );
-    expect(
-      (await store.read(session.sessionId)).events.map((event) => event.type),
-    ).not.toContain(DurableEventType.SESSION_CLOSED);
   });
 
   it('durably interrupts a pending request before cancelling its input', async () => {

--- a/src/session/__tests__/SessionDurableEvents.test.ts
+++ b/src/session/__tests__/SessionDurableEvents.test.ts
@@ -79,6 +79,7 @@ vi.mock('../../agent/Agent.js', () => ({
 }));
 
 const { createSession, forkSession, resumeSession } = await import('../Session.js');
+const { SessionRuntime } = await import('../SessionRuntime.js');
 
 class FailOnEventTypeStore implements DurableEventStore {
   constructor(
@@ -1590,6 +1591,7 @@ describe('Session durable events', () => {
     const store = new JsonlDurableEventStore(root, {
       clock: () => new Date(now),
     });
+    let requestSignal: AbortSignal | undefined;
     streamChat = async function* leaseLossStream(_message, context, loopOptions) {
       yield { type: 'turn_start', turn: 1, maxTurns: 10 };
       await loopOptions?.modelExecutionLifecycle?.onModelRequestStarting({
@@ -1599,6 +1601,7 @@ describe('Session durable events', () => {
       });
       yield { type: 'content_delta', delta: 'before lease loss' };
       const signal = (context as { signal?: AbortSignal }).signal;
+      requestSignal = signal;
       await new Promise<void>((resolve) => {
         if (signal?.aborted) {
           resolve();
@@ -1654,6 +1657,26 @@ describe('Session durable events', () => {
     const output = session.stream();
     await output.next();
     await output.next();
+    let releaseInputMutex: (() => void) | undefined;
+    let markInputMutexHeld: (() => void) | undefined;
+    const inputMutexHeld = new Promise<void>((resolve) => {
+      markInputMutexHeld = resolve;
+    });
+    const inputMutexGate = new Promise<void>((resolve) => {
+      releaseInputMutex = resolve;
+    });
+    const inputMutex = (
+      session as unknown as {
+        inputMutex: {
+          runExclusive<T>(operation: () => Promise<T>): Promise<T>;
+        };
+      }
+    ).inputMutex;
+    const blockedOperation = inputMutex.runExclusive(async () => {
+      markInputMutexHeld?.();
+      await inputMutexGate;
+    });
+    await inputMutexHeld;
     now += 60_001;
     const replacementLease = await store.acquireExecutionLease(session.sessionId, {
       ownerId: WorkerId('worker-second'),
@@ -1661,9 +1684,20 @@ describe('Session durable events', () => {
       ttlMs: 10_000,
     });
 
-    await expect(session.send('reject stale worker input')).rejects.toMatchObject({
+    const localLease = (
+      session as unknown as {
+        executionLease: { assertActive(): Promise<void> } | null;
+      }
+    ).executionLease;
+    if (!localLease) {
+      throw new Error('Expected a local execution lease handle');
+    }
+    await expect(localLease.assertActive()).rejects.toMatchObject({
       code: 'DURABLE_EXECUTION_LEASE_LOST',
     });
+    expect(requestSignal?.aborted).toBe(true);
+    releaseInputMutex?.();
+    await blockedOperation;
     await expect(output.next()).rejects.toBeInstanceOf(DurableExecutionLeaseError);
     expect(cancelBackgroundAgents).toHaveBeenCalled();
     await vi.waitFor(
@@ -1738,6 +1772,120 @@ describe('Session durable events', () => {
     expect(session.getExecutionLease()).toBeNull();
   });
 
+  it('does not release ownership until runtime cleanup succeeds', async () => {
+    const { root, store } = createStore();
+    const session = await createSession({
+      ...options(store),
+      persistSession: true,
+      storagePath: root,
+      executionLease: {
+        ownerId: WorkerId('worker-runtime-close-retry'),
+        ttlMs: 10_000,
+        heartbeatIntervalMs: 5_000,
+      },
+    });
+    const runtime = (
+      session as unknown as {
+        runtime: { close(): Promise<void> } | null;
+      }
+    ).runtime;
+    if (!runtime) {
+      throw new Error('Expected an initialized Session runtime');
+    }
+    const originalClose = runtime.close.bind(runtime);
+    const runtimeClose = vi.spyOn(runtime, 'close')
+      .mockRejectedValueOnce(new Error('runtime cleanup failed'))
+      .mockImplementation(originalClose);
+    const release = vi.spyOn(store, 'releaseExecutionLease');
+
+    await expect(session.close()).rejects.toThrow('runtime cleanup failed');
+    expect(release).not.toHaveBeenCalled();
+    expect(session.getExecutionLease()).not.toBeNull();
+
+    await expect(session.close()).resolves.toBeUndefined();
+    expect(runtimeClose).toHaveBeenCalledTimes(2);
+    expect(release).toHaveBeenCalledOnce();
+    expect(session.getExecutionLease()).toBeNull();
+  });
+
+  it('retries a failed SessionEnd hook before releasing ownership', async () => {
+    const { root, store } = createStore();
+    const session = await createSession({
+      ...options(store),
+      persistSession: true,
+      storagePath: root,
+      executionLease: {
+        ownerId: WorkerId('worker-session-end-retry'),
+        ttlMs: 10_000,
+        heartbeatIntervalMs: 5_000,
+      },
+    });
+    const runtime = (
+      session as unknown as {
+        runtime: {
+          getHookRuntime(): {
+            runSessionEnd(input: { reason: 'other' }): Promise<void>;
+          };
+        } | null;
+      }
+    ).runtime;
+    if (!runtime) {
+      throw new Error('Expected an initialized Session runtime');
+    }
+    const hookRuntime = runtime.getHookRuntime();
+    const originalSessionEnd = hookRuntime.runSessionEnd.bind(hookRuntime);
+    const sessionEnd = vi.spyOn(hookRuntime, 'runSessionEnd')
+      .mockRejectedValueOnce(new Error('SessionEnd cleanup failed'))
+      .mockImplementation(originalSessionEnd);
+    const release = vi.spyOn(store, 'releaseExecutionLease');
+
+    await expect(session.close()).rejects.toThrow('SessionEnd cleanup failed');
+    expect(release).not.toHaveBeenCalled();
+    expect(session.getExecutionLease()).not.toBeNull();
+
+    await expect(session.close()).resolves.toBeUndefined();
+    expect(sessionEnd).toHaveBeenCalledTimes(2);
+    expect(release).toHaveBeenCalledOnce();
+    expect(session.getExecutionLease()).toBeNull();
+  });
+
+  it('does not release handoff ownership until runtime cleanup succeeds', async () => {
+    const { root, store } = createStore();
+    const session = await createSession({
+      ...options(store),
+      persistSession: true,
+      storagePath: root,
+      executionLease: {
+        ownerId: WorkerId('worker-handoff-cleanup-retry'),
+        ttlMs: 10_000,
+        heartbeatIntervalMs: 5_000,
+      },
+    });
+    const runtime = (
+      session as unknown as {
+        runtime: { close(): Promise<void> } | null;
+      }
+    ).runtime;
+    if (!runtime) {
+      throw new Error('Expected an initialized Session runtime');
+    }
+    const originalClose = runtime.close.bind(runtime);
+    vi.spyOn(runtime, 'close')
+      .mockRejectedValueOnce(new Error('handoff runtime cleanup failed'))
+      .mockImplementation(originalClose);
+    const release = vi.spyOn(store, 'releaseExecutionLease');
+
+    await expect(session.suspendForHandoff()).rejects.toThrow(
+      'handoff runtime cleanup failed',
+    );
+    expect(release).not.toHaveBeenCalled();
+    expect(session.getExecutionLease()).not.toBeNull();
+
+    await expect(session.close()).resolves.toBeUndefined();
+    expect(release).toHaveBeenCalledOnce();
+    expect(session.getExecutionLease()).toBeNull();
+  });
+
   it('waits for Session-owned shells before releasing execution ownership', async () => {
     const { root, store } = createStore();
     const session = await createSession({
@@ -1805,6 +1953,59 @@ describe('Session durable events', () => {
       code: 'DURABLE_EXECUTION_LEASE_LOST',
     });
     expect(releaseExecutionLease).toHaveBeenCalledOnce();
+  });
+
+  it('abandons initialization ownership when runtime cleanup cannot finish', async () => {
+    const { root } = createStore();
+    let now = Date.parse('2026-08-22T12:00:00.000Z');
+    const store = new JsonlDurableEventStore(root, {
+      clock: () => new Date(now),
+    });
+    const acquire = vi.spyOn(store, 'acquireExecutionLease');
+    const renew = vi.spyOn(store, 'renewExecutionLease');
+    const release = vi.spyOn(store, 'releaseExecutionLease');
+    vi.spyOn(SessionRuntime.prototype, 'close').mockRejectedValueOnce(
+      new Error('runtime initialization cleanup failed'),
+    );
+    createAgent.mockRejectedValueOnce(new Error('agent initialization failed'));
+    await expect(
+      createSession({
+        ...options(store),
+        persistSession: true,
+        storagePath: root,
+        executionLease: {
+          ownerId: WorkerId('worker-abandoned-initialization'),
+          ttlMs: 100,
+          heartbeatIntervalMs: 20,
+        },
+      }),
+    ).rejects.toBeInstanceOf(AggregateError);
+    const sessionId = acquire.mock.calls[0]?.[0];
+    if (!sessionId) {
+      throw new Error('Expected initialization to acquire a Session lease');
+    }
+    expect(release).not.toHaveBeenCalled();
+    const renewCallsAfterAbandon = renew.mock.calls.length;
+    await new Promise<void>((resolve) => setTimeout(resolve, 40));
+    expect(renew).toHaveBeenCalledTimes(renewCallsAfterAbandon);
+    await expect(
+      store.acquireExecutionLease(sessionId, {
+        ownerId: WorkerId('worker-before-expiry'),
+        leaseId: ExecutionLeaseId('lease-before-expiry'),
+        ttlMs: 100,
+      }),
+    ).rejects.toMatchObject({
+      code: 'DURABLE_EXECUTION_LEASE_CONFLICT',
+    });
+
+    now += 101;
+    const successor = await store.acquireExecutionLease(sessionId, {
+      ownerId: WorkerId('worker-after-expiry'),
+      leaseId: ExecutionLeaseId('lease-after-expiry'),
+      ttlMs: 100,
+    });
+    expect(successor.fencingToken).toBe(2);
+    await store.releaseExecutionLease(successor);
   });
 
   it('hands off a pending Request without terminalizing the durable Session', async () => {

--- a/src/session/events/DurableExecutionLease.ts
+++ b/src/session/events/DurableExecutionLease.ts
@@ -7,6 +7,7 @@ import {
   type DurableExecutionLease as DurableExecutionLeaseSnapshot,
   type DurableExecutionLeaseStore,
   executionFence,
+  isExecutionLeaseFailure,
   isDurableExecutionLeaseStore,
 } from './DurableExecutionLeaseStore.js';
 
@@ -160,7 +161,7 @@ export class DurableExecutionLease {
   }
 
   observeStoreFailure(error: unknown): void {
-    if (!this.isLeaseFailure(error)) {
+    if (!isExecutionLeaseFailure(error)) {
       return;
     }
     this.markLost(
@@ -198,7 +199,7 @@ export class DurableExecutionLease {
       this.released = true;
     } catch (cause) {
       if (
-        this.isLeaseFailure(cause) &&
+        isExecutionLeaseFailure(cause) &&
         typeof cause === 'object' &&
         cause !== null &&
         'code' in cause &&
@@ -294,14 +295,4 @@ export class DurableExecutionLease {
         );
   }
 
-  private isLeaseFailure(error: unknown): boolean {
-    return (
-      error instanceof DurableExecutionLeaseError ||
-      (typeof error === 'object' &&
-        error !== null &&
-        'code' in error &&
-        typeof error.code === 'string' &&
-        error.code.startsWith('DURABLE_EXECUTION_LEASE_'))
-    );
-  }
 }

--- a/src/session/events/DurableExecutionLease.ts
+++ b/src/session/events/DurableExecutionLease.ts
@@ -1,0 +1,276 @@
+import { nanoid } from 'nanoid';
+import { ExecutionLeaseId, type SessionId, type WorkerId } from '../../types/branded.js';
+import type { DurableEventStore } from './DurableEventStore.js';
+import {
+  type DurableExecutionFence,
+  DurableExecutionLeaseError,
+  type DurableExecutionLease as DurableExecutionLeaseSnapshot,
+  type DurableExecutionLeaseStore,
+  executionFence,
+  isDurableExecutionLeaseStore,
+} from './DurableExecutionLeaseStore.js';
+
+export const DEFAULT_EXECUTION_LEASE_TTL_MS = 30_000;
+export const DEFAULT_EXECUTION_LEASE_HEARTBEAT_INTERVAL_MS = 10_000;
+
+export interface DurableExecutionLeaseOptions {
+  readonly ownerId: WorkerId;
+  readonly leaseId?: ExecutionLeaseId;
+  readonly ttlMs?: number;
+  readonly heartbeatIntervalMs?: number;
+}
+
+type LeaseLostListener = (error: DurableExecutionLeaseError) => void;
+
+/**
+ * Process-local handle for a Store-backed execution lease.
+ *
+ * The Store remains authoritative for expiry and fencing. The heartbeat fails
+ * closed: any renewal or validation failure aborts the signal exactly once.
+ */
+export class DurableExecutionLease {
+  private current: DurableExecutionLeaseSnapshot;
+  private readonly controller = new AbortController();
+  private readonly listeners = new Set<LeaseLostListener>();
+  private heartbeatTimer: ReturnType<typeof setTimeout> | null = null;
+  private renewalPromise: Promise<void> | null = null;
+  private releasePromise: Promise<void> | null = null;
+  private released = false;
+  private loss: DurableExecutionLeaseError | null = null;
+
+  private constructor(
+    private readonly store: DurableExecutionLeaseStore,
+    lease: DurableExecutionLeaseSnapshot,
+    private readonly ttlMs: number,
+    private readonly heartbeatIntervalMs: number,
+  ) {
+    this.current = lease;
+    this.scheduleHeartbeat();
+  }
+
+  static async acquire(
+    store: DurableEventStore,
+    sessionId: SessionId,
+    options: DurableExecutionLeaseOptions,
+  ): Promise<DurableExecutionLease> {
+    if (!isDurableExecutionLeaseStore(store)) {
+      throw new DurableExecutionLeaseError(
+        'DURABLE_EXECUTION_LEASE_NOT_SUPPORTED',
+        'The configured DurableEventStore does not support execution leases',
+        { sessionId },
+      );
+    }
+    const ttlMs = options.ttlMs ?? DEFAULT_EXECUTION_LEASE_TTL_MS;
+    if (!Number.isSafeInteger(ttlMs) || ttlMs < 2) {
+      throw new DurableExecutionLeaseError(
+        'DURABLE_EXECUTION_LEASE_INVALID',
+        'Execution lease ttlMs must be a safe integer of at least 2',
+        { sessionId },
+      );
+    }
+    const heartbeatIntervalMs =
+      options.heartbeatIntervalMs ??
+      Math.max(1, Math.min(DEFAULT_EXECUTION_LEASE_HEARTBEAT_INTERVAL_MS, Math.floor(ttlMs / 3)));
+    if (
+      !Number.isSafeInteger(heartbeatIntervalMs) ||
+      heartbeatIntervalMs <= 0 ||
+      heartbeatIntervalMs > Math.floor(ttlMs / 2)
+    ) {
+      throw new DurableExecutionLeaseError(
+        'DURABLE_EXECUTION_LEASE_INVALID',
+        'Execution lease heartbeatIntervalMs must be positive and at most half of ttlMs',
+        { sessionId },
+      );
+    }
+    const lease = await store.acquireExecutionLease(sessionId, {
+      ownerId: options.ownerId,
+      leaseId: options.leaseId ?? ExecutionLeaseId(nanoid()),
+      ttlMs,
+    });
+    return new DurableExecutionLease(store, lease, ttlMs, heartbeatIntervalMs);
+  }
+
+  get snapshot(): DurableExecutionLeaseSnapshot {
+    return structuredClone(this.current);
+  }
+
+  get fence(): DurableExecutionFence {
+    return executionFence(this.current);
+  }
+
+  get signal(): AbortSignal {
+    return this.controller.signal;
+  }
+
+  belongsTo(store: DurableEventStore, sessionId: SessionId): boolean {
+    return this.store === store && this.current.sessionId === sessionId;
+  }
+
+  onLost(listener: LeaseLostListener): () => void {
+    this.listeners.add(listener);
+    if (this.loss) {
+      try {
+        listener(this.loss);
+      } catch {
+        // A listener cannot restore lease ownership or block registration.
+      }
+    }
+    return () => this.listeners.delete(listener);
+  }
+
+  async assertActive(): Promise<void> {
+    this.throwIfUnavailable();
+    try {
+      await this.store.assertExecutionLease(this.current);
+    } catch (cause) {
+      const error = this.toLeaseLostError(cause);
+      this.markLost(error);
+      throw error;
+    }
+  }
+
+  observeStoreFailure(error: unknown): void {
+    if (!this.isLeaseFailure(error)) {
+      return;
+    }
+    this.markLost(
+      error instanceof DurableExecutionLeaseError ? error : this.toLeaseLostError(error),
+    );
+  }
+
+  async release(): Promise<void> {
+    if (this.releasePromise) {
+      return this.releasePromise;
+    }
+    if (this.released) {
+      return;
+    }
+    const releasePromise = this.releaseInternal();
+    this.releasePromise = releasePromise;
+    try {
+      await releasePromise;
+    } catch (error) {
+      if (this.releasePromise === releasePromise) {
+        this.releasePromise = null;
+      }
+      throw error;
+    }
+  }
+
+  private async releaseInternal(): Promise<void> {
+    this.clearHeartbeat();
+    if (this.renewalPromise) {
+      await this.renewalPromise.catch(() => undefined);
+      this.clearHeartbeat();
+    }
+    try {
+      await this.store.releaseExecutionLease(this.current);
+      this.released = true;
+    } catch (cause) {
+      if (
+        this.isLeaseFailure(cause) &&
+        typeof cause === 'object' &&
+        cause !== null &&
+        'code' in cause &&
+        (cause.code === 'DURABLE_EXECUTION_LEASE_LOST' ||
+          cause.code === 'DURABLE_EXECUTION_LEASE_CONFLICT')
+      ) {
+        this.released = true;
+        return;
+      }
+      throw this.toLeaseLostError(cause);
+    }
+  }
+
+  private scheduleHeartbeat(): void {
+    if (this.released || this.loss || this.heartbeatTimer) {
+      return;
+    }
+    this.heartbeatTimer = setTimeout(() => {
+      this.heartbeatTimer = null;
+      if (this.released || this.loss) {
+        return;
+      }
+      this.renewalPromise = this.renew();
+      void this.renewalPromise.finally(() => {
+        this.renewalPromise = null;
+        this.scheduleHeartbeat();
+      });
+    }, this.heartbeatIntervalMs);
+    this.heartbeatTimer.unref?.();
+  }
+
+  private async renew(): Promise<void> {
+    try {
+      this.current = await this.store.renewExecutionLease(this.current, this.ttlMs);
+    } catch (cause) {
+      this.markLost(this.toLeaseLostError(cause));
+    }
+  }
+
+  private markLost(error: DurableExecutionLeaseError): void {
+    if (this.loss || this.released) {
+      return;
+    }
+    this.loss = error;
+    this.clearHeartbeat();
+    this.controller.abort(error);
+    for (const listener of this.listeners) {
+      try {
+        listener(error);
+      } catch {
+        // A listener cannot restore lease ownership or block the loss signal.
+      }
+    }
+  }
+
+  private clearHeartbeat(): void {
+    if (this.heartbeatTimer) {
+      clearTimeout(this.heartbeatTimer);
+      this.heartbeatTimer = null;
+    }
+  }
+
+  private throwIfUnavailable(): void {
+    if (this.loss) {
+      throw this.loss;
+    }
+    if (this.released) {
+      throw new DurableExecutionLeaseError(
+        'DURABLE_EXECUTION_LEASE_LOST',
+        `Execution lease ${this.current.leaseId} was already released`,
+        {
+          sessionId: this.current.sessionId,
+          leaseId: this.current.leaseId,
+          fencingToken: this.current.fencingToken,
+        },
+      );
+    }
+  }
+
+  private toLeaseLostError(cause: unknown): DurableExecutionLeaseError {
+    return cause instanceof DurableExecutionLeaseError
+      ? cause
+      : new DurableExecutionLeaseError(
+          'DURABLE_EXECUTION_LEASE_LOST',
+          `Execution lease ${this.current.leaseId} could not be verified`,
+          {
+            sessionId: this.current.sessionId,
+            leaseId: this.current.leaseId,
+            fencingToken: this.current.fencingToken,
+            cause,
+          },
+        );
+  }
+
+  private isLeaseFailure(error: unknown): boolean {
+    return (
+      error instanceof DurableExecutionLeaseError ||
+      (typeof error === 'object' &&
+        error !== null &&
+        'code' in error &&
+        typeof error.code === 'string' &&
+        error.code.startsWith('DURABLE_EXECUTION_LEASE_'))
+    );
+  }
+}

--- a/src/session/events/DurableExecutionLease.ts
+++ b/src/session/events/DurableExecutionLease.ts
@@ -129,6 +129,36 @@ export class DurableExecutionLease {
     }
   }
 
+  /** Serializes a short persistence operation against lease takeover. */
+  async runFenced<T>(operation: () => Promise<T>): Promise<T> {
+    this.throwIfUnavailable();
+    try {
+      return await this.store.withExecutionLease(this.current, operation);
+    } catch (error) {
+      this.observeStoreFailure(error);
+      throw error;
+    }
+  }
+
+  /** @internal Stops renewal without releasing Store ownership. */
+  abandon(cause?: unknown): void {
+    if (this.released || this.loss) {
+      return;
+    }
+    this.markLost(
+      new DurableExecutionLeaseError(
+        'DURABLE_EXECUTION_LEASE_LOST',
+        `Execution lease ${this.current.leaseId} was abandoned`,
+        {
+          sessionId: this.current.sessionId,
+          leaseId: this.current.leaseId,
+          fencingToken: this.current.fencingToken,
+          cause,
+        },
+      ),
+    );
+  }
+
   observeStoreFailure(error: unknown): void {
     if (!this.isLeaseFailure(error)) {
       return;
@@ -178,6 +208,7 @@ export class DurableExecutionLease {
         this.released = true;
         return;
       }
+      this.scheduleHeartbeat();
       throw this.toLeaseLostError(cause);
     }
   }

--- a/src/session/events/DurableExecutionLeaseStore.ts
+++ b/src/session/events/DurableExecutionLeaseStore.ts
@@ -1,0 +1,159 @@
+import { z } from 'zod';
+import { SdkError } from '../../errors/SdkError.js';
+import { ExecutionLeaseId, FencingToken, SessionId, WorkerId } from '../../types/branded.js';
+import type { DurableEventStore } from './DurableEventStore.js';
+
+export const DURABLE_EXECUTION_LEASE_FORMAT = 'blade.durable-execution-lease' as const;
+export const DURABLE_EXECUTION_LEASE_FORMAT_VERSION = 1 as const;
+
+export interface DurableExecutionFence {
+  readonly leaseId: ExecutionLeaseId;
+  readonly fencingToken: FencingToken;
+}
+
+export interface DurableExecutionLease extends DurableExecutionFence {
+  readonly sessionId: SessionId;
+  readonly ownerId: WorkerId;
+  readonly acquiredAt: string;
+  readonly renewedAt: string;
+  readonly expiresAt: string;
+}
+
+export interface DurableExecutionLeaseAcquireOptions {
+  readonly leaseId: ExecutionLeaseId;
+  readonly ownerId: WorkerId;
+  readonly ttlMs: number;
+}
+
+export interface PersistedDurableExecutionLeaseState {
+  readonly format: typeof DURABLE_EXECUTION_LEASE_FORMAT;
+  readonly version: typeof DURABLE_EXECUTION_LEASE_FORMAT_VERSION;
+  readonly sessionId: SessionId;
+  readonly fencingToken: FencingToken;
+  readonly leaseId: ExecutionLeaseId;
+  readonly ownerId: WorkerId;
+  readonly acquiredAt: string;
+  readonly renewedAt: string;
+  readonly expiresAt: string;
+  readonly releasedAt?: string;
+}
+
+export type DurableExecutionLeaseErrorCode =
+  | 'DURABLE_EXECUTION_LEASE_INVALID'
+  | 'DURABLE_EXECUTION_LEASE_NOT_SUPPORTED'
+  | 'DURABLE_EXECUTION_LEASE_CONFLICT'
+  | 'DURABLE_EXECUTION_LEASE_REQUIRED'
+  | 'DURABLE_EXECUTION_LEASE_LOST'
+  | 'DURABLE_EXECUTION_LEASE_CORRUPT'
+  | 'DURABLE_EXECUTION_LEASE_WRITE_FAILED';
+
+export class DurableExecutionLeaseError extends SdkError {
+  readonly sessionId?: SessionId;
+  readonly leaseId?: ExecutionLeaseId;
+  readonly fencingToken?: FencingToken;
+  readonly activeLease?: DurableExecutionLease;
+
+  constructor(
+    code: DurableExecutionLeaseErrorCode,
+    message: string,
+    options: {
+      sessionId?: SessionId;
+      leaseId?: ExecutionLeaseId;
+      fencingToken?: FencingToken;
+      activeLease?: DurableExecutionLease;
+      cause?: unknown;
+    } = {},
+  ) {
+    super(code, message, options.cause !== undefined ? { cause: options.cause } : undefined);
+    this.sessionId = options.sessionId;
+    this.leaseId = options.leaseId;
+    this.fencingToken = options.fencingToken;
+    this.activeLease = options.activeLease ? structuredClone(options.activeLease) : undefined;
+  }
+}
+
+export interface DurableExecutionLeaseStore extends DurableEventStore {
+  /**
+   * Returns true once the Session has entered fenced execution mode.
+   * This requirement remains sticky after expiry or release.
+   */
+  requiresExecutionLease(sessionId: SessionId): Promise<boolean>;
+
+  acquireExecutionLease(
+    sessionId: SessionId,
+    options: DurableExecutionLeaseAcquireOptions,
+  ): Promise<DurableExecutionLease>;
+
+  renewExecutionLease(lease: DurableExecutionLease, ttlMs: number): Promise<DurableExecutionLease>;
+
+  assertExecutionLease(lease: DurableExecutionLease): Promise<void>;
+
+  releaseExecutionLease(lease: DurableExecutionLease): Promise<void>;
+}
+
+export function isDurableExecutionLeaseStore(
+  store: DurableEventStore,
+): store is DurableExecutionLeaseStore {
+  const candidate = store as Partial<DurableExecutionLeaseStore>;
+  return (
+    typeof candidate.requiresExecutionLease === 'function' &&
+    typeof candidate.acquireExecutionLease === 'function' &&
+    typeof candidate.renewExecutionLease === 'function' &&
+    typeof candidate.assertExecutionLease === 'function' &&
+    typeof candidate.releaseExecutionLease === 'function'
+  );
+}
+
+export function executionFence(lease: DurableExecutionLease): DurableExecutionFence {
+  return {
+    leaseId: lease.leaseId,
+    fencingToken: lease.fencingToken,
+  };
+}
+
+const NonEmptyStringSchema = z.string().min(1);
+const PositiveIntegerSchema = z.number().int().positive().max(Number.MAX_SAFE_INTEGER);
+const TimestampSchema = z.string().datetime({ offset: true });
+const PersistedDurableExecutionLeaseStateSchema = z
+  .object({
+    format: z.literal(DURABLE_EXECUTION_LEASE_FORMAT),
+    version: z.literal(DURABLE_EXECUTION_LEASE_FORMAT_VERSION),
+    sessionId: NonEmptyStringSchema,
+    fencingToken: PositiveIntegerSchema,
+    leaseId: NonEmptyStringSchema,
+    ownerId: NonEmptyStringSchema,
+    acquiredAt: TimestampSchema,
+    renewedAt: TimestampSchema,
+    expiresAt: TimestampSchema,
+    releasedAt: TimestampSchema.optional(),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    const acquiredAt = Date.parse(value.acquiredAt);
+    const renewedAt = Date.parse(value.renewedAt);
+    const expiresAt = Date.parse(value.expiresAt);
+    const releasedAt = value.releasedAt ? Date.parse(value.releasedAt) : undefined;
+    if (
+      renewedAt < acquiredAt ||
+      expiresAt <= renewedAt ||
+      (releasedAt !== undefined && releasedAt < renewedAt)
+    ) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Durable execution lease timestamps are inconsistent',
+      });
+    }
+  });
+
+export function parsePersistedDurableExecutionLeaseState(
+  value: unknown,
+): PersistedDurableExecutionLeaseState {
+  const parsed = PersistedDurableExecutionLeaseStateSchema.parse(value);
+  return {
+    ...parsed,
+    sessionId: SessionId(parsed.sessionId),
+    fencingToken: FencingToken(parsed.fencingToken),
+    leaseId: ExecutionLeaseId(parsed.leaseId),
+    ownerId: WorkerId(parsed.ownerId),
+  };
+}

--- a/src/session/events/DurableExecutionLeaseStore.ts
+++ b/src/session/events/DurableExecutionLeaseStore.ts
@@ -88,6 +88,16 @@ export interface DurableExecutionLeaseStore extends DurableEventStore {
 
   assertExecutionLease(lease: DurableExecutionLease): Promise<void>;
 
+  /**
+   * Runs a short internal persistence operation while lease takeover is blocked.
+   * Implementations must validate the lease before invoking the callback.
+   * The callback must not re-enter this Store for the same Session.
+   */
+  withExecutionLease<T>(
+    lease: DurableExecutionLease,
+    operation: () => Promise<T>,
+  ): Promise<T>;
+
   releaseExecutionLease(lease: DurableExecutionLease): Promise<void>;
 }
 
@@ -100,6 +110,7 @@ export function isDurableExecutionLeaseStore(
     typeof candidate.acquireExecutionLease === 'function' &&
     typeof candidate.renewExecutionLease === 'function' &&
     typeof candidate.assertExecutionLease === 'function' &&
+    typeof candidate.withExecutionLease === 'function' &&
     typeof candidate.releaseExecutionLease === 'function'
   );
 }

--- a/src/session/events/DurableExecutionLeaseStore.ts
+++ b/src/session/events/DurableExecutionLeaseStore.ts
@@ -72,6 +72,58 @@ export class DurableExecutionLeaseError extends SdkError {
   }
 }
 
+const DURABLE_EXECUTION_LEASE_ERROR_CODES: ReadonlySet<string> = new Set([
+  'DURABLE_EXECUTION_LEASE_INVALID',
+  'DURABLE_EXECUTION_LEASE_NOT_SUPPORTED',
+  'DURABLE_EXECUTION_LEASE_CONFLICT',
+  'DURABLE_EXECUTION_LEASE_REQUIRED',
+  'DURABLE_EXECUTION_LEASE_LOST',
+  'DURABLE_EXECUTION_LEASE_CORRUPT',
+  'DURABLE_EXECUTION_LEASE_WRITE_FAILED',
+] satisfies readonly DurableExecutionLeaseErrorCode[]);
+
+export function isExecutionLeaseFailure(
+  error: unknown,
+): error is DurableExecutionLeaseError {
+  if (error instanceof DurableExecutionLeaseError) {
+    return true;
+  }
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    typeof error.code === 'string' &&
+    DURABLE_EXECUTION_LEASE_ERROR_CODES.has(error.code)
+  );
+}
+
+export interface ExecutionLeaseBoundary {
+  signal?: AbortSignal;
+  assertExecutionLease?: () => Promise<void>;
+  runWithExecutionLease?: <T>(operation: () => Promise<T>) => Promise<T>;
+}
+
+/** Runs short persistence work within the active execution-lease boundary. */
+export async function runWithExecutionLeaseBoundary<T>(
+  boundary: ExecutionLeaseBoundary,
+  operation: () => Promise<T>,
+): Promise<T> {
+  boundary.signal?.throwIfAborted();
+  if (boundary.runWithExecutionLease) {
+    const result = await boundary.runWithExecutionLease(async () => {
+      boundary.signal?.throwIfAborted();
+      return operation();
+    });
+    boundary.signal?.throwIfAborted();
+    return result;
+  }
+  await boundary.assertExecutionLease?.();
+  const result = await operation();
+  boundary.signal?.throwIfAborted();
+  await boundary.assertExecutionLease?.();
+  return result;
+}
+
 export interface DurableExecutionLeaseStore extends DurableEventStore {
   /**
    * Returns true once the Session has entered fenced execution mode.

--- a/src/session/events/DurableSessionJournal.ts
+++ b/src/session/events/DurableSessionJournal.ts
@@ -1,6 +1,12 @@
 import { SdkError } from '../../errors/SdkError.js';
 import { type CommandId, EventSequence, type SessionId } from '../../types/branded.js';
+import { canonicalJson } from './canonicalJson.js';
 import { DurableEventSequenceConflictError, type DurableEventStore } from './DurableEventStore.js';
+import type { DurableExecutionLease } from './DurableExecutionLease.js';
+import {
+  DurableExecutionLeaseError,
+  isDurableExecutionLeaseStore,
+} from './DurableExecutionLeaseStore.js';
 import {
   type DurableSessionProjection,
   DurableSessionProjector,
@@ -14,7 +20,6 @@ import type {
   DurableEventPage,
   DurableEventType,
 } from './types.js';
-import { canonicalJson } from './canonicalJson.js';
 
 const DEFAULT_PAGE_SIZE = 500;
 const DEFAULT_MAX_CONFLICT_RETRIES = 3;
@@ -47,6 +52,7 @@ export interface DurableCommandCommitResult extends DurableEventAppendResult {
 export interface DurableSessionJournalOptions {
   readonly pageSize?: number;
   readonly maxConflictRetries?: number;
+  readonly executionLease?: DurableExecutionLease;
 }
 
 export type DurableSessionJournalErrorCode =
@@ -173,6 +179,7 @@ export class DurableSessionJournal {
     readonly sessionId: SessionId,
     private readonly pageSize: number,
     private readonly maxConflictRetries: number,
+    private readonly executionLease?: DurableExecutionLease,
   ) {}
 
   static async open(
@@ -195,7 +202,31 @@ export class DurableSessionJournal {
       );
     }
 
-    const journal = new DurableSessionJournal(store, sessionId, pageSize, maxConflictRetries);
+    if (options.executionLease && !options.executionLease.belongsTo(store, sessionId)) {
+      throw new DurableSessionJournalError(
+        'DURABLE_COMMAND_INVALID',
+        `Execution lease does not belong to durable Session ${sessionId}`,
+      );
+    }
+    if (
+      !options.executionLease &&
+      isDurableExecutionLeaseStore(store) &&
+      (await store.requiresExecutionLease(sessionId))
+    ) {
+      throw new DurableExecutionLeaseError(
+        'DURABLE_EXECUTION_LEASE_REQUIRED',
+        `Durable Session ${sessionId} requires an execution lease`,
+        { sessionId },
+      );
+    }
+    await options.executionLease?.assertActive();
+    const journal = new DurableSessionJournal(
+      store,
+      sessionId,
+      pageSize,
+      maxConflictRetries,
+      options.executionLease,
+    );
     await journal.reload();
     return journal;
   }
@@ -236,6 +267,19 @@ export class DurableSessionJournal {
     command: DurableSessionCommand,
     options: DurableCommandCommitOptions,
   ): Promise<DurableCommandCommitResult> {
+    try {
+      await this.executionLease?.assertActive();
+      return await this.commitFenced(command, options);
+    } catch (error) {
+      this.executionLease?.observeStoreFailure(error);
+      throw error;
+    }
+  }
+
+  private async commitFenced(
+    command: DurableSessionCommand,
+    options: DurableCommandCommitOptions,
+  ): Promise<DurableCommandCommitResult> {
     const drafts = this.parseCommand(command);
     if (this.uncertainCommand) {
       if (this.uncertainCommand.commandId !== command.commandId) {
@@ -268,8 +312,8 @@ export class DurableSessionJournal {
     }
     const currentHeadSequence = this.projector.snapshot().headSequence;
     if (
-      options.expectedHeadSequence !== undefined
-      && currentHeadSequence !== options.expectedHeadSequence
+      options.expectedHeadSequence !== undefined &&
+      currentHeadSequence !== options.expectedHeadSequence
     ) {
       throw new DurableEventSequenceConflictError(
         options.expectedHeadSequence,
@@ -284,6 +328,7 @@ export class DurableSessionJournal {
         const expectedLastSequence = this.projector.snapshot().headSequence;
         const result = await this.store.append(this.sessionId, drafts, {
           expectedLastSequence,
+          ...(this.executionLease ? { executionFence: this.executionLease.fence } : {}),
         });
         try {
           this.validateCommitResult(result, drafts, expectedLastSequence);
@@ -309,10 +354,7 @@ export class DurableSessionJournal {
           if (committed) {
             return this.resolveExistingCommand('reconciled', command.commandId, committed, drafts);
           }
-          if (
-            options.expectedHeadSequence !== undefined
-            || conflicts >= this.maxConflictRetries
-          ) {
+          if (options.expectedHeadSequence !== undefined || conflicts >= this.maxConflictRetries) {
             throw error;
           }
           conflicts += 1;

--- a/src/session/events/JsonlDurableEventStore.ts
+++ b/src/session/events/JsonlDurableEventStore.ts
@@ -2,16 +2,21 @@ import { nanoid } from 'nanoid';
 import { Buffer } from 'node:buffer';
 import { mkdir, open, readFile, truncate } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
-import { EventId, EventSequence, type SessionId } from '../../types/branded.js';
+import writeFileAtomic from 'write-file-atomic';
+import { EventId, EventSequence, FencingToken, type SessionId } from '../../types/branded.js';
+import { syncParentDirectory, withAdvisoryFileLock } from '../../utils/advisoryFileLock.js';
+import { DurableEventSequenceConflictError, DurableEventStoreError } from './DurableEventStore.js';
 import {
-  syncParentDirectory,
-  withAdvisoryFileLock,
-} from '../../utils/advisoryFileLock.js';
-import {
-  DurableEventSequenceConflictError,
-  type DurableEventStore,
-  DurableEventStoreError,
-} from './DurableEventStore.js';
+  DURABLE_EXECUTION_LEASE_FORMAT,
+  DURABLE_EXECUTION_LEASE_FORMAT_VERSION,
+  type DurableExecutionFence,
+  type DurableExecutionLease,
+  type DurableExecutionLeaseAcquireOptions,
+  DurableExecutionLeaseError,
+  type DurableExecutionLeaseStore,
+  type PersistedDurableExecutionLeaseState,
+  parsePersistedDurableExecutionLeaseState,
+} from './DurableExecutionLeaseStore.js';
 import {
   DURABLE_EVENT_LOG_FORMAT,
   type PersistedDurableEventBatch,
@@ -33,6 +38,7 @@ const DEFAULT_PAGE_SIZE = 100;
 const MAX_PAGE_SIZE = 1000;
 const EVENT_DIRECTORY = 'durable-events';
 const DEFAULT_LOCK_TIMEOUT_MS = 10_000;
+const MAX_EXECUTION_LEASE_TTL_MS = 24 * 60 * 60 * 1000;
 
 export interface JsonlDurableEventStoreOptions {
   clock?: () => Date;
@@ -53,7 +59,7 @@ interface LoadedLog {
  * across Node.js processes sharing the same storage directory.
  * Distributed executors must still provide a Store with external CAS/fencing.
  */
-export class JsonlDurableEventStore implements DurableEventStore {
+export class JsonlDurableEventStore implements DurableExecutionLeaseStore {
   private readonly rootDirectory: string;
   private readonly clock: () => Date;
   private readonly eventIdFactory: () => EventId;
@@ -108,7 +114,9 @@ export class JsonlDurableEventStore implements DurableEventStore {
       this.assertExpectedSequence(options.expectedLastSequence, previousSequence);
 
       const eventIds = new Set<string>(loaded.events.map((event) => event.eventId));
-      const recordedAt = this.clock().toISOString();
+      const now = this.clock();
+      await this.assertExecutionFenceUnlocked(sessionId, options.executionFence, now);
+      const recordedAt = now.toISOString();
       const firstSequenceValue = Number(previousSequence ?? 0) + 1;
       const events = parsedDrafts.map((draft, index): DurableEventEnvelope => {
         const eventId = this.eventIdFactory();
@@ -221,6 +229,121 @@ export class JsonlDurableEventStore implements DurableEventStore {
     return join(this.rootDirectory, filename);
   }
 
+  getExecutionLeaseFilePath(sessionId: SessionId): string {
+    const filename = `${Buffer.from(sessionId).toString('base64url')}.lease.json`;
+    return join(this.rootDirectory, filename);
+  }
+
+  async requiresExecutionLease(sessionId: SessionId): Promise<boolean> {
+    return this.runWithExecutionLeaseLock(sessionId, 'read', async () => {
+      return (await this.loadExecutionLeaseState(sessionId)) !== null;
+    });
+  }
+
+  async acquireExecutionLease(
+    sessionId: SessionId,
+    options: DurableExecutionLeaseAcquireOptions,
+  ): Promise<DurableExecutionLease> {
+    this.assertLeaseIdentity(sessionId, options);
+    this.assertLeaseTtl(options.ttlMs);
+    return this.runWithExecutionLeaseLock(sessionId, 'write', async () => {
+      const current = await this.loadExecutionLeaseState(sessionId);
+      const now = this.clock();
+      if (current && this.isLeaseActive(current, now)) {
+        if (current.leaseId !== options.leaseId || current.ownerId !== options.ownerId) {
+          throw new DurableExecutionLeaseError(
+            'DURABLE_EXECUTION_LEASE_CONFLICT',
+            `Session ${sessionId} is leased by worker ${current.ownerId}`,
+            {
+              sessionId,
+              leaseId: options.leaseId,
+              fencingToken: current.fencingToken,
+              activeLease: this.toExecutionLease(current),
+            },
+          );
+        }
+      }
+
+      const reusesActiveLease =
+        current !== null &&
+        this.isLeaseActive(current, now) &&
+        current.leaseId === options.leaseId &&
+        current.ownerId === options.ownerId;
+      const fencingToken = reusesActiveLease
+        ? current.fencingToken
+        : this.nextFencingToken(sessionId, current?.fencingToken);
+      const timestamp = now.toISOString();
+      const state: PersistedDurableExecutionLeaseState = {
+        format: DURABLE_EXECUTION_LEASE_FORMAT,
+        version: DURABLE_EXECUTION_LEASE_FORMAT_VERSION,
+        sessionId,
+        fencingToken,
+        leaseId: options.leaseId,
+        ownerId: options.ownerId,
+        acquiredAt: reusesActiveLease ? current.acquiredAt : timestamp,
+        renewedAt: timestamp,
+        expiresAt: this.expiresAt(sessionId, now, options.ttlMs),
+      };
+      await this.writeExecutionLeaseState(state);
+      return this.toExecutionLease(state);
+    });
+  }
+
+  async renewExecutionLease(
+    lease: DurableExecutionLease,
+    ttlMs: number,
+  ): Promise<DurableExecutionLease> {
+    this.assertLeaseIdentity(lease.sessionId, lease);
+    this.assertLeaseTtl(ttlMs);
+    return this.runWithExecutionLeaseLock(lease.sessionId, 'write', async () => {
+      const current = await this.loadExecutionLeaseState(lease.sessionId);
+      const now = this.clock();
+      this.assertLeaseMatches(lease, current, now);
+      if (!current) {
+        throw this.createLeaseLostError(lease, 'no lease state exists');
+      }
+      const timestamp = now.toISOString();
+      const renewed: PersistedDurableExecutionLeaseState = {
+        ...current,
+        renewedAt: timestamp,
+        expiresAt: this.expiresAt(lease.sessionId, now, ttlMs),
+      };
+      await this.writeExecutionLeaseState(renewed);
+      return this.toExecutionLease(renewed);
+    });
+  }
+
+  async assertExecutionLease(lease: DurableExecutionLease): Promise<void> {
+    this.assertLeaseIdentity(lease.sessionId, lease);
+    await this.runWithExecutionLeaseLock(lease.sessionId, 'read', async () => {
+      const current = await this.loadExecutionLeaseState(lease.sessionId);
+      this.assertLeaseMatches(lease, current, this.clock());
+    });
+  }
+
+  async releaseExecutionLease(lease: DurableExecutionLease): Promise<void> {
+    this.assertLeaseIdentity(lease.sessionId, lease);
+    await this.runWithExecutionLeaseLock(lease.sessionId, 'write', async () => {
+      const current = await this.loadExecutionLeaseState(lease.sessionId);
+      const now = this.clock();
+      if (
+        current?.releasedAt &&
+        current.leaseId === lease.leaseId &&
+        current.fencingToken === lease.fencingToken
+      ) {
+        return;
+      }
+      this.assertLeaseMatches(lease, current, now, false);
+      if (!current) {
+        throw this.createLeaseLostError(lease, 'no lease state exists');
+      }
+      await this.writeExecutionLeaseState({
+        ...current,
+        releasedAt: now.toISOString(),
+      });
+    });
+  }
+
   private async runWithSessionLock<T>(
     sessionId: SessionId,
     operation: 'read' | 'write',
@@ -278,6 +401,273 @@ export class JsonlDurableEventStore implements DurableEventStore {
     if (expected !== undefined && expected !== actual) {
       throw new DurableEventSequenceConflictError(expected, actual);
     }
+  }
+
+  private async runWithExecutionLeaseLock<T>(
+    sessionId: SessionId,
+    operation: 'read' | 'write',
+    callback: () => Promise<T>,
+  ): Promise<T> {
+    return withAdvisoryFileLock(
+      this.getFilePath(sessionId),
+      {
+        timeoutMs: this.lockTimeoutMs,
+        errors: {
+          prepare: (cause) => this.createLeaseStorageError(sessionId, operation, cause),
+          initialize: (cause) => this.createLeaseStorageError(sessionId, operation, cause),
+          acquire: (cause) => this.createLeaseStorageError(sessionId, operation, cause),
+          timeout: () =>
+            new DurableExecutionLeaseError(
+              'DURABLE_EXECUTION_LEASE_WRITE_FAILED',
+              `Timed out acquiring the execution lease lock for Session ${sessionId}`,
+              { sessionId },
+            ),
+          release: (cause) => this.createLeaseStorageError(sessionId, operation, cause),
+        },
+      },
+      callback,
+    );
+  }
+
+  private createLeaseStorageError(
+    sessionId: SessionId,
+    operation: 'read' | 'write',
+    cause: unknown,
+  ): DurableExecutionLeaseError {
+    return new DurableExecutionLeaseError(
+      operation === 'write'
+        ? 'DURABLE_EXECUTION_LEASE_WRITE_FAILED'
+        : 'DURABLE_EXECUTION_LEASE_CORRUPT',
+      `Failed to ${operation} the execution lease for Session ${sessionId}`,
+      { sessionId, cause },
+    );
+  }
+
+  private async loadExecutionLeaseState(
+    sessionId: SessionId,
+  ): Promise<PersistedDurableExecutionLeaseState | null> {
+    const filePath = this.getExecutionLeaseFilePath(sessionId);
+    let content: string;
+    try {
+      content = await readFile(filePath, 'utf8');
+    } catch (error) {
+      if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
+        return null;
+      }
+      throw this.createLeaseStorageError(sessionId, 'read', error);
+    }
+    try {
+      const state = parsePersistedDurableExecutionLeaseState(JSON.parse(content));
+      if (state.sessionId !== sessionId) {
+        throw new Error(`Lease state belongs to Session ${state.sessionId}`);
+      }
+      return state;
+    } catch (error) {
+      if (error instanceof DurableExecutionLeaseError) {
+        throw error;
+      }
+      throw new DurableExecutionLeaseError(
+        'DURABLE_EXECUTION_LEASE_CORRUPT',
+        `Invalid execution lease state for Session ${sessionId}`,
+        { sessionId, cause: error },
+      );
+    }
+  }
+
+  private async writeExecutionLeaseState(
+    state: PersistedDurableExecutionLeaseState,
+  ): Promise<void> {
+    const filePath = this.getExecutionLeaseFilePath(state.sessionId);
+    try {
+      const validated = parsePersistedDurableExecutionLeaseState(state);
+      await mkdir(this.rootDirectory, { recursive: true, mode: 0o700 });
+      await writeFileAtomic(filePath, `${JSON.stringify(validated)}\n`, {
+        encoding: 'utf8',
+        fsync: true,
+        mode: 0o600,
+      });
+      await syncParentDirectory(filePath);
+    } catch (error) {
+      throw new DurableExecutionLeaseError(
+        'DURABLE_EXECUTION_LEASE_WRITE_FAILED',
+        `Failed to persist the execution lease for Session ${state.sessionId}`,
+        { sessionId: state.sessionId, cause: error },
+      );
+    }
+  }
+
+  private async assertExecutionFenceUnlocked(
+    sessionId: SessionId,
+    fence: DurableExecutionFence | undefined,
+    now: Date,
+  ): Promise<void> {
+    const current = await this.loadExecutionLeaseState(sessionId);
+    if (!current) {
+      if (fence) {
+        throw new DurableExecutionLeaseError(
+          'DURABLE_EXECUTION_LEASE_LOST',
+          `Execution lease ${fence.leaseId} does not exist for Session ${sessionId}`,
+          {
+            sessionId,
+            leaseId: fence.leaseId,
+            fencingToken: fence.fencingToken,
+          },
+        );
+      }
+      return;
+    }
+    if (!fence) {
+      throw new DurableExecutionLeaseError(
+        'DURABLE_EXECUTION_LEASE_REQUIRED',
+        `Session ${sessionId} requires an execution lease`,
+        {
+          sessionId,
+          ...(this.isLeaseActive(current, now)
+            ? { activeLease: this.toExecutionLease(current) }
+            : {}),
+        },
+      );
+    }
+    if (!this.isLeaseActive(current, now)) {
+      throw new DurableExecutionLeaseError(
+        'DURABLE_EXECUTION_LEASE_LOST',
+        `Execution lease ${fence.leaseId} is not active for Session ${sessionId}`,
+        {
+          sessionId,
+          leaseId: fence.leaseId,
+          fencingToken: fence.fencingToken,
+        },
+      );
+    }
+    if (current.leaseId !== fence.leaseId || current.fencingToken !== fence.fencingToken) {
+      throw new DurableExecutionLeaseError(
+        'DURABLE_EXECUTION_LEASE_LOST',
+        `Execution lease ${fence.leaseId} is stale for Session ${sessionId}`,
+        {
+          sessionId,
+          leaseId: fence.leaseId,
+          fencingToken: fence.fencingToken,
+          activeLease: this.toExecutionLease(current),
+        },
+      );
+    }
+  }
+
+  private assertLeaseMatches(
+    lease: DurableExecutionLease,
+    current: PersistedDurableExecutionLeaseState | null,
+    now: Date,
+    requireUnexpired = true,
+  ): void {
+    if (
+      !current ||
+      current.releasedAt ||
+      current.leaseId !== lease.leaseId ||
+      current.ownerId !== lease.ownerId ||
+      current.fencingToken !== lease.fencingToken ||
+      (requireUnexpired && !this.isLeaseActive(current, now))
+    ) {
+      throw this.createLeaseLostError(
+        lease,
+        current?.releasedAt
+          ? 'it was released'
+          : current && !this.isLeaseActive(current, now)
+            ? 'it expired'
+            : 'another owner holds the lease',
+        current && this.isLeaseActive(current, now) ? this.toExecutionLease(current) : undefined,
+      );
+    }
+  }
+
+  private createLeaseLostError(
+    lease: DurableExecutionLease,
+    detail: string,
+    activeLease?: DurableExecutionLease,
+  ): DurableExecutionLeaseError {
+    return new DurableExecutionLeaseError(
+      'DURABLE_EXECUTION_LEASE_LOST',
+      `Execution lease ${lease.leaseId} for Session ${lease.sessionId} is no longer valid: ${detail}`,
+      {
+        sessionId: lease.sessionId,
+        leaseId: lease.leaseId,
+        fencingToken: lease.fencingToken,
+        ...(activeLease ? { activeLease } : {}),
+      },
+    );
+  }
+
+  private assertLeaseIdentity(
+    sessionId: SessionId,
+    lease: {
+      readonly sessionId?: SessionId;
+      readonly leaseId: DurableExecutionLease['leaseId'];
+      readonly ownerId: DurableExecutionLease['ownerId'];
+    },
+  ): void {
+    if (
+      sessionId.trim() === '' ||
+      lease.leaseId.trim() === '' ||
+      lease.ownerId.trim() === '' ||
+      ('sessionId' in lease && lease.sessionId !== sessionId)
+    ) {
+      throw new DurableExecutionLeaseError(
+        'DURABLE_EXECUTION_LEASE_INVALID',
+        `Invalid execution lease identity for Session ${sessionId}`,
+        {
+          sessionId,
+          leaseId: lease.leaseId,
+        },
+      );
+    }
+  }
+
+  private assertLeaseTtl(ttlMs: number): void {
+    if (!Number.isSafeInteger(ttlMs) || ttlMs <= 0 || ttlMs > MAX_EXECUTION_LEASE_TTL_MS) {
+      throw new DurableExecutionLeaseError(
+        'DURABLE_EXECUTION_LEASE_INVALID',
+        `Execution lease ttlMs must be between 1 and ${MAX_EXECUTION_LEASE_TTL_MS}`,
+      );
+    }
+  }
+
+  private nextFencingToken(sessionId: SessionId, current: FencingToken | undefined): FencingToken {
+    const next = Number(current ?? 0) + 1;
+    if (!Number.isSafeInteger(next)) {
+      throw new DurableExecutionLeaseError(
+        'DURABLE_EXECUTION_LEASE_INVALID',
+        `Execution lease fencing token is exhausted for Session ${sessionId}`,
+        { sessionId },
+      );
+    }
+    return FencingToken(next);
+  }
+
+  private expiresAt(sessionId: SessionId, now: Date, ttlMs: number): string {
+    const expiresAt = new Date(now.getTime() + ttlMs);
+    if (!Number.isFinite(expiresAt.getTime())) {
+      throw new DurableExecutionLeaseError(
+        'DURABLE_EXECUTION_LEASE_INVALID',
+        `Execution lease expiry is outside the supported date range for Session ${sessionId}`,
+        { sessionId },
+      );
+    }
+    return expiresAt.toISOString();
+  }
+
+  private isLeaseActive(state: PersistedDurableExecutionLeaseState, now: Date): boolean {
+    return state.releasedAt === undefined && Date.parse(state.expiresAt) > now.getTime();
+  }
+
+  private toExecutionLease(state: PersistedDurableExecutionLeaseState): DurableExecutionLease {
+    return {
+      sessionId: state.sessionId,
+      leaseId: state.leaseId,
+      ownerId: state.ownerId,
+      fencingToken: state.fencingToken,
+      acquiredAt: state.acquiredAt,
+      renewedAt: state.renewedAt,
+      expiresAt: state.expiresAt,
+    };
   }
 
   private async writeBatch(

--- a/src/session/events/JsonlDurableEventStore.ts
+++ b/src/session/events/JsonlDurableEventStore.ts
@@ -321,6 +321,18 @@ export class JsonlDurableEventStore implements DurableExecutionLeaseStore {
     });
   }
 
+  async withExecutionLease<T>(
+    lease: DurableExecutionLease,
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    this.assertLeaseIdentity(lease.sessionId, lease);
+    return this.runWithExecutionLeaseLock(lease.sessionId, 'write', async () => {
+      const current = await this.loadExecutionLeaseState(lease.sessionId);
+      this.assertLeaseMatches(lease, current, this.clock());
+      return operation();
+    });
+  }
+
   async releaseExecutionLease(lease: DurableExecutionLease): Promise<void> {
     this.assertLeaseIdentity(lease.sessionId, lease);
     await this.runWithExecutionLeaseLock(lease.sessionId, 'write', async () => {

--- a/src/session/events/__tests__/DurableExecutionLease.test.ts
+++ b/src/session/events/__tests__/DurableExecutionLease.test.ts
@@ -8,6 +8,7 @@ import { DurableExecutionLease } from '../DurableExecutionLease.js';
 import {
   DurableExecutionLeaseError,
   type DurableExecutionLeaseStore,
+  isDurableExecutionLeaseStore,
 } from '../DurableExecutionLeaseStore.js';
 import { DurableSessionJournal } from '../DurableSessionJournal.js';
 import { DurableSessionRecoveryCoordinator } from '../DurableSessionRecoveryCoordinator.js';
@@ -279,8 +280,43 @@ describe('DurableExecutionLease', () => {
 
   it('accepts structural lease Stores without requiring the JSONL adapter', async () => {
     const store = await createStore();
-    const leaseStore: DurableExecutionLeaseStore = store;
+    const leaseStore = {
+      append: (...args: Parameters<DurableEventStore['append']>) =>
+        store.append(...args),
+      read: (...args: Parameters<DurableEventStore['read']>) =>
+        store.read(...args),
+      getHeadSequence: (
+        ...args: Parameters<DurableEventStore['getHeadSequence']>
+      ) => store.getHeadSequence(...args),
+      requiresExecutionLease: (
+        ...args: Parameters<DurableExecutionLeaseStore['requiresExecutionLease']>
+      ) => store.requiresExecutionLease(...args),
+      acquireExecutionLease: (
+        ...args: Parameters<DurableExecutionLeaseStore['acquireExecutionLease']>
+      ) => store.acquireExecutionLease(...args),
+      renewExecutionLease: (
+        ...args: Parameters<DurableExecutionLeaseStore['renewExecutionLease']>
+      ) => store.renewExecutionLease(...args),
+      assertExecutionLease: (
+        ...args: Parameters<DurableExecutionLeaseStore['assertExecutionLease']>
+      ) => store.assertExecutionLease(...args),
+      withExecutionLease: <T>(
+        lease: Parameters<DurableExecutionLeaseStore['withExecutionLease']>[0],
+        operation: () => Promise<T>,
+      ) => store.withExecutionLease(lease, operation),
+      releaseExecutionLease: (
+        ...args: Parameters<DurableExecutionLeaseStore['releaseExecutionLease']>
+      ) => store.releaseExecutionLease(...args),
+    } satisfies DurableExecutionLeaseStore;
 
-    expect(leaseStore).toBe(store);
+    expect(isDurableExecutionLeaseStore(leaseStore)).toBe(true);
+    const lease = await DurableExecutionLease.acquire(
+      leaseStore,
+      SessionId('structural-session'),
+      {
+        ownerId: WorkerId('worker-a'),
+      },
+    );
+    await lease.release();
   });
 });

--- a/src/session/events/__tests__/DurableExecutionLease.test.ts
+++ b/src/session/events/__tests__/DurableExecutionLease.test.ts
@@ -1,0 +1,218 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { CommandId, ExecutionLeaseId, SessionId, WorkerId } from '../../../types/branded.js';
+import type { DurableEventStore } from '../DurableEventStore.js';
+import { DurableExecutionLease } from '../DurableExecutionLease.js';
+import {
+  DurableExecutionLeaseError,
+  type DurableExecutionLeaseStore,
+} from '../DurableExecutionLeaseStore.js';
+import { DurableSessionJournal } from '../DurableSessionJournal.js';
+import { DurableSessionRecoveryCoordinator } from '../DurableSessionRecoveryCoordinator.js';
+import { JsonlDurableEventStore } from '../JsonlDurableEventStore.js';
+import { DurableEventType } from '../types.js';
+
+const roots: string[] = [];
+
+async function createStore(): Promise<JsonlDurableEventStore> {
+  const root = await mkdtemp(join(tmpdir(), 'durable-execution-lease-'));
+  roots.push(root);
+  return new JsonlDurableEventStore(root);
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe('DurableExecutionLease', () => {
+  it('heartbeats the lease and releases it idempotently', async () => {
+    const store = await createStore();
+    const renew = vi.spyOn(store, 'renewExecutionLease');
+    const release = vi.spyOn(store, 'releaseExecutionLease');
+    const lease = await DurableExecutionLease.acquire(store, SessionId('heartbeat-session'), {
+      ownerId: WorkerId('worker-a'),
+      leaseId: ExecutionLeaseId('lease-a'),
+      ttlMs: 100,
+      heartbeatIntervalMs: 20,
+    });
+
+    await vi.waitFor(() => expect(renew).toHaveBeenCalled(), { timeout: 1_000 });
+    await lease.release();
+    await lease.release();
+
+    expect(release).toHaveBeenCalledTimes(1);
+    expect(lease.signal.aborted).toBe(false);
+  });
+
+  it('does not reschedule heartbeat while release waits for an in-flight renewal', async () => {
+    const store = await createStore();
+    let resolveRenewal: (() => void) | undefined;
+    const renew = vi.spyOn(store, 'renewExecutionLease').mockImplementationOnce(async (current) => {
+      await new Promise<void>((resolve) => {
+        resolveRenewal = resolve;
+      });
+      return current;
+    });
+    const release = vi.spyOn(store, 'releaseExecutionLease');
+    const lease = await DurableExecutionLease.acquire(
+      store,
+      SessionId('release-during-heartbeat-session'),
+      {
+        ownerId: WorkerId('worker-a'),
+        ttlMs: 100,
+        heartbeatIntervalMs: 10,
+      },
+    );
+    await vi.waitFor(() => expect(renew).toHaveBeenCalledOnce(), { timeout: 1_000 });
+
+    const releasePromise = lease.release();
+    expect(release).not.toHaveBeenCalled();
+    resolveRenewal?.();
+    await releasePromise;
+    await new Promise<void>((resolve) => setTimeout(resolve, 30));
+
+    expect(renew).toHaveBeenCalledOnce();
+    expect(release).toHaveBeenCalledOnce();
+  });
+
+  it('aborts its signal when heartbeat ownership is lost', async () => {
+    const store = await createStore();
+    vi.spyOn(store, 'renewExecutionLease').mockRejectedValueOnce(
+      new DurableExecutionLeaseError('DURABLE_EXECUTION_LEASE_LOST', 'lease was replaced'),
+    );
+    const lease = await DurableExecutionLease.acquire(store, SessionId('lost-session'), {
+      ownerId: WorkerId('worker-a'),
+      ttlMs: 100,
+      heartbeatIntervalMs: 20,
+    });
+
+    await vi.waitFor(() => expect(lease.signal.aborted).toBe(true), {
+      timeout: 1_000,
+    });
+
+    expect(lease.signal.reason).toMatchObject({
+      code: 'DURABLE_EXECUTION_LEASE_LOST',
+    });
+    await expect(lease.assertActive()).rejects.toMatchObject({
+      code: 'DURABLE_EXECUTION_LEASE_LOST',
+    });
+    await expect(lease.release()).resolves.toBeUndefined();
+  });
+
+  it('requires a lease-capable Store and a safe heartbeat interval', async () => {
+    const store = await createStore();
+    const unsupported: DurableEventStore = {
+      append: (...args) => store.append(...args),
+      read: (...args) => store.read(...args),
+      getHeadSequence: (...args) => store.getHeadSequence(...args),
+    };
+
+    await expect(
+      DurableExecutionLease.acquire(unsupported, SessionId('unsupported-session'), {
+        ownerId: WorkerId('worker-a'),
+      }),
+    ).rejects.toMatchObject({
+      code: 'DURABLE_EXECUTION_LEASE_NOT_SUPPORTED',
+    });
+    await expect(
+      DurableExecutionLease.acquire(store, SessionId('invalid-heartbeat-session'), {
+        ownerId: WorkerId('worker-a'),
+        ttlMs: 100,
+        heartbeatIntervalMs: 51,
+      }),
+    ).rejects.toMatchObject({
+      code: 'DURABLE_EXECUTION_LEASE_INVALID',
+    });
+  });
+
+  it('fences Journal commits, including replayed command IDs', async () => {
+    const store = await createStore();
+    const sessionId = SessionId('journal-fence-session');
+    const lease = await DurableExecutionLease.acquire(store, sessionId, {
+      ownerId: WorkerId('worker-a'),
+      ttlMs: 10_000,
+      heartbeatIntervalMs: 5_000,
+    });
+    const journal = await DurableSessionJournal.open(store, sessionId, {
+      executionLease: lease,
+    });
+    const command = {
+      commandId: CommandId('create-session'),
+      events: [
+        {
+          type: DurableEventType.SESSION_CREATED,
+          data: { source: 'create' as const },
+        },
+      ],
+    };
+    await journal.commit(command);
+    await lease.release();
+
+    await expect(journal.commit(command)).rejects.toMatchObject({
+      code: 'DURABLE_EXECUTION_LEASE_LOST',
+    });
+  });
+
+  it('rejects a lease bound to a different Store or Session', async () => {
+    const firstStore = await createStore();
+    const secondStore = await createStore();
+    const lease = await DurableExecutionLease.acquire(firstStore, SessionId('lease-session'), {
+      ownerId: WorkerId('worker-a'),
+      ttlMs: 10_000,
+      heartbeatIntervalMs: 5_000,
+    });
+
+    await expect(
+      DurableSessionJournal.open(secondStore, SessionId('lease-session'), {
+        executionLease: lease,
+      }),
+    ).rejects.toThrow(/does not belong/);
+    await expect(
+      DurableSessionJournal.open(firstStore, SessionId('other-session'), { executionLease: lease }),
+    ).rejects.toThrow(/does not belong/);
+    await lease.release();
+  });
+
+  it('requires a lease when opening a previously fenced Journal or recovery coordinator', async () => {
+    const store = await createStore();
+    const sessionId = SessionId('sticky-journal-fence-session');
+    await expect(DurableSessionJournal.open(store, sessionId)).resolves.toBeDefined();
+    const firstLease = await DurableExecutionLease.acquire(store, sessionId, {
+      ownerId: WorkerId('worker-a'),
+      ttlMs: 10_000,
+      heartbeatIntervalMs: 5_000,
+    });
+    await firstLease.release();
+
+    await expect(DurableSessionJournal.open(store, sessionId)).rejects.toMatchObject({
+      code: 'DURABLE_EXECUTION_LEASE_REQUIRED',
+      sessionId,
+    });
+    await expect(DurableSessionRecoveryCoordinator.open(store, sessionId)).rejects.toMatchObject({
+      code: 'DURABLE_EXECUTION_LEASE_REQUIRED',
+      sessionId,
+    });
+
+    const successor = await DurableExecutionLease.acquire(store, sessionId, {
+      ownerId: WorkerId('worker-b'),
+      ttlMs: 10_000,
+      heartbeatIntervalMs: 5_000,
+    });
+    await expect(
+      DurableSessionRecoveryCoordinator.open(store, sessionId, {
+        executionLease: successor,
+      }),
+    ).resolves.toBeDefined();
+    await successor.release();
+  });
+
+  it('accepts structural lease Stores without requiring the JSONL adapter', async () => {
+    const store = await createStore();
+    const leaseStore: DurableExecutionLeaseStore = store;
+
+    expect(leaseStore).toBe(store);
+  });
+});

--- a/src/session/events/__tests__/DurableExecutionLease.test.ts
+++ b/src/session/events/__tests__/DurableExecutionLease.test.ts
@@ -35,7 +35,7 @@ describe('DurableExecutionLease', () => {
     const lease = await DurableExecutionLease.acquire(store, SessionId('heartbeat-session'), {
       ownerId: WorkerId('worker-a'),
       leaseId: ExecutionLeaseId('lease-a'),
-      ttlMs: 100,
+      ttlMs: 10_000,
       heartbeatIntervalMs: 20,
     });
 
@@ -62,7 +62,7 @@ describe('DurableExecutionLease', () => {
       SessionId('release-during-heartbeat-session'),
       {
         ownerId: WorkerId('worker-a'),
-        ttlMs: 100,
+        ttlMs: 10_000,
         heartbeatIntervalMs: 10,
       },
     );
@@ -78,6 +78,74 @@ describe('DurableExecutionLease', () => {
     expect(release).toHaveBeenCalledOnce();
   });
 
+  it('resumes heartbeats when lease release fails and remains retryable', async () => {
+    const store = await createStore();
+    const renew = vi.spyOn(store, 'renewExecutionLease');
+    const release = vi.spyOn(store, 'releaseExecutionLease');
+    release.mockRejectedValueOnce(new Error('temporary release failure'));
+    const lease = await DurableExecutionLease.acquire(
+      store,
+      SessionId('release-retry-heartbeat-session'),
+      {
+        ownerId: WorkerId('worker-a'),
+        ttlMs: 10_000,
+        heartbeatIntervalMs: 20,
+      },
+    );
+
+    await expect(lease.release()).rejects.toMatchObject({
+      code: 'DURABLE_EXECUTION_LEASE_LOST',
+    });
+    await vi.waitFor(() => expect(renew).toHaveBeenCalled(), { timeout: 1_000 });
+    await expect(lease.release()).resolves.toBeUndefined();
+    expect(release).toHaveBeenCalledTimes(2);
+  });
+
+  it('stops renewing an abandoned lease while preserving explicit release', async () => {
+    const store = await createStore();
+    const renew = vi.spyOn(store, 'renewExecutionLease');
+    const release = vi.spyOn(store, 'releaseExecutionLease');
+    const lease = await DurableExecutionLease.acquire(
+      store,
+      SessionId('abandoned-lease-session'),
+      {
+        ownerId: WorkerId('worker-a'),
+        ttlMs: 10_000,
+        heartbeatIntervalMs: 20,
+      },
+    );
+
+    lease.abandon(new Error('runtime cleanup failed'));
+    await new Promise<void>((resolve) => setTimeout(resolve, 40));
+
+    expect(renew).not.toHaveBeenCalled();
+    await expect(lease.assertActive()).rejects.toMatchObject({
+      code: 'DURABLE_EXECUTION_LEASE_LOST',
+    });
+    await expect(lease.release()).resolves.toBeUndefined();
+    expect(release).toHaveBeenCalledOnce();
+  });
+
+  it('runs short persistence work through the Store fencing boundary', async () => {
+    const store = await createStore();
+    const runFenced = vi.spyOn(store, 'withExecutionLease');
+    const lease = await DurableExecutionLease.acquire(
+      store,
+      SessionId('fenced-persistence-session'),
+      {
+        ownerId: WorkerId('worker-a'),
+        ttlMs: 10_000,
+        heartbeatIntervalMs: 5_000,
+      },
+    );
+
+    await expect(lease.runFenced(async () => 'persisted')).resolves.toBe(
+      'persisted',
+    );
+    expect(runFenced).toHaveBeenCalledOnce();
+    await lease.release();
+  });
+
   it('aborts its signal when heartbeat ownership is lost', async () => {
     const store = await createStore();
     vi.spyOn(store, 'renewExecutionLease').mockRejectedValueOnce(
@@ -85,7 +153,7 @@ describe('DurableExecutionLease', () => {
     );
     const lease = await DurableExecutionLease.acquire(store, SessionId('lost-session'), {
       ownerId: WorkerId('worker-a'),
-      ttlMs: 100,
+      ttlMs: 10_000,
       heartbeatIntervalMs: 20,
     });
 

--- a/src/session/events/__tests__/JsonlDurableEventStore.test.ts
+++ b/src/session/events/__tests__/JsonlDurableEventStore.test.ts
@@ -17,12 +17,16 @@ import {
   CommandId,
   EventId,
   EventSequence,
+  ExecutionLeaseId,
+  FencingToken,
   InputId,
   RequestId,
   SessionId,
   TurnId,
+  WorkerId,
 } from '../../../types/branded.js';
 import { DurableEventSequenceConflictError, DurableEventStoreError } from '../DurableEventStore.js';
+import { DurableExecutionLeaseError } from '../DurableExecutionLeaseStore.js';
 import { JsonlDurableEventStore } from '../JsonlDurableEventStore.js';
 import { DURABLE_EVENT_LOG_FORMAT } from '../schemas.js';
 import { DURABLE_EVENT_SCHEMA_VERSION, DurableEventType } from '../types.js';
@@ -34,6 +38,11 @@ const storeWriterPath = join(
   dirname(fileURLToPath(import.meta.url)),
   'fixtures',
   'jsonlStoreWriter.ts',
+);
+const leaseWorkerPath = join(
+  dirname(fileURLToPath(import.meta.url)),
+  'fixtures',
+  'jsonlLeaseWorker.ts',
 );
 
 interface ReadyChildProcess {
@@ -153,6 +162,14 @@ interface StoreWriterResult {
   actualSequence?: number | null;
 }
 
+interface LeaseWorkerResult {
+  status: 'fulfilled' | 'rejected';
+  workerId?: string;
+  leaseId?: string;
+  fencingToken?: number;
+  code?: string;
+}
+
 function parseStoreWriterResult(process: ReadyChildProcess): StoreWriterResult {
   const output = process.output();
   const resultLine = output.trim().split('\n').at(-1);
@@ -160,6 +177,15 @@ function parseStoreWriterResult(process: ReadyChildProcess): StoreWriterResult {
     throw new Error(`Store writer produced no result: ${output}`);
   }
   return JSON.parse(resultLine) as StoreWriterResult;
+}
+
+function parseLeaseWorkerResult(process: ReadyChildProcess): LeaseWorkerResult {
+  const output = process.output();
+  const resultLine = output.trim().split('\n').at(-1);
+  if (!resultLine) {
+    throw new Error(`Lease worker produced no result: ${output}`);
+  }
+  return JSON.parse(resultLine) as LeaseWorkerResult;
 }
 
 async function startStoreWriter(
@@ -183,6 +209,29 @@ async function startStoreWriter(
     ],
     'ready\n',
     'Store writer',
+  );
+}
+
+async function startLeaseWorker(
+  storageRoot: string,
+  sessionId: SessionId,
+  workerId: string,
+  leaseId: string,
+): Promise<ReadyChildProcess> {
+  return spawnReadyChild(
+    [
+      '--no-warnings',
+      '--experimental-transform-types',
+      '--loader',
+      sourceTypeScriptLoaderUrl,
+      leaseWorkerPath,
+      storageRoot,
+      sessionId,
+      workerId,
+      leaseId,
+    ],
+    'ready\n',
+    'Lease worker',
   );
 }
 
@@ -498,6 +547,197 @@ describe('JsonlDurableEventStore', () => {
     expect(await store.getHeadSequence(sessionId)).toBe(2);
   });
 
+  it('fences event appends with a monotonic execution lease', async () => {
+    const sessionId = SessionId('session-execution-lease');
+    const firstLeaseId = ExecutionLeaseId('lease-first');
+    const secondLeaseId = ExecutionLeaseId('lease-second');
+    let now = Date.parse('2026-08-22T12:00:00.000Z');
+    const leaseStore = new JsonlDurableEventStore(storageRoot, {
+      clock: () => new Date(now),
+      eventIdFactory: () => EventId(`lease-event-${++nextEventId}`),
+    });
+
+    await expect(leaseStore.requiresExecutionLease(sessionId)).resolves.toBe(false);
+    const firstLease = await leaseStore.acquireExecutionLease(sessionId, {
+      leaseId: firstLeaseId,
+      ownerId: WorkerId('worker-first'),
+      ttlMs: 1_000,
+    });
+    expect(firstLease).toMatchObject({
+      sessionId,
+      leaseId: firstLeaseId,
+      ownerId: 'worker-first',
+      fencingToken: 1,
+      acquiredAt: '2026-08-22T12:00:00.000Z',
+      renewedAt: '2026-08-22T12:00:00.000Z',
+      expiresAt: '2026-08-22T12:00:01.000Z',
+    });
+    await expect(leaseStore.requiresExecutionLease(sessionId)).resolves.toBe(true);
+    expect((await stat(leaseStore.getExecutionLeaseFilePath(sessionId))).mode & 0o777).toBe(0o600);
+    await expect(
+      leaseStore.acquireExecutionLease(sessionId, {
+        leaseId: secondLeaseId,
+        ownerId: WorkerId('worker-second'),
+        ttlMs: 1_000,
+      }),
+    ).rejects.toMatchObject({
+      code: 'DURABLE_EXECUTION_LEASE_CONFLICT',
+      activeLease: firstLease,
+    });
+    await expect(
+      leaseStore.append(sessionId, [{ type: DurableEventType.SESSION_CREATED, data: {} }], {
+        expectedLastSequence: null,
+      }),
+    ).rejects.toMatchObject({
+      code: 'DURABLE_EXECUTION_LEASE_REQUIRED',
+    });
+    await leaseStore.append(sessionId, [{ type: DurableEventType.SESSION_CREATED, data: {} }], {
+      expectedLastSequence: null,
+      executionFence: firstLease,
+    });
+
+    now += 1_001;
+    await expect(
+      leaseStore.append(
+        sessionId,
+        [
+          {
+            type: DurableEventType.REQUEST_ACCEPTED,
+            requestId: RequestId('unfenced-expired-request'),
+            commandId: CommandId('unfenced-expired-command'),
+            data: {
+              inputId: InputId('unfenced-expired-input'),
+              input: 'unfenced after expiry',
+              priority: 'next',
+            },
+          },
+        ],
+        { expectedLastSequence: EventSequence(1) },
+      ),
+    ).rejects.toMatchObject({
+      code: 'DURABLE_EXECUTION_LEASE_REQUIRED',
+    });
+    const secondLease = await leaseStore.acquireExecutionLease(sessionId, {
+      leaseId: secondLeaseId,
+      ownerId: WorkerId('worker-second'),
+      ttlMs: 1_000,
+    });
+    expect(secondLease.fencingToken).toBe(FencingToken(2));
+    await expect(
+      leaseStore.append(
+        sessionId,
+        [
+          {
+            type: DurableEventType.REQUEST_ACCEPTED,
+            requestId: RequestId('stale-request'),
+            commandId: CommandId('stale-command'),
+            data: {
+              inputId: InputId('stale-input'),
+              input: 'stale',
+              priority: 'next',
+            },
+          },
+        ],
+        {
+          expectedLastSequence: EventSequence(1),
+          executionFence: firstLease,
+        },
+      ),
+    ).rejects.toMatchObject({
+      code: 'DURABLE_EXECUTION_LEASE_LOST',
+      fencingToken: 1,
+      activeLease: secondLease,
+    });
+    await leaseStore.append(
+      sessionId,
+      [
+        {
+          type: DurableEventType.REQUEST_ACCEPTED,
+          requestId: RequestId('current-request'),
+          commandId: CommandId('current-command'),
+          data: {
+            inputId: InputId('current-input'),
+            input: 'current',
+            priority: 'next',
+          },
+        },
+      ],
+      {
+        expectedLastSequence: EventSequence(1),
+        executionFence: secondLease,
+      },
+    );
+
+    await leaseStore.releaseExecutionLease(secondLease);
+    await expect(leaseStore.releaseExecutionLease(secondLease)).resolves.toBeUndefined();
+    await expect(leaseStore.assertExecutionLease(secondLease)).rejects.toMatchObject({
+      code: 'DURABLE_EXECUTION_LEASE_LOST',
+    });
+    await expect(leaseStore.requiresExecutionLease(sessionId)).resolves.toBe(true);
+    await expect(
+      leaseStore.append(
+        sessionId,
+        [
+          {
+            type: DurableEventType.REQUEST_ACCEPTED,
+            requestId: RequestId('unfenced-released-request'),
+            commandId: CommandId('unfenced-released-command'),
+            data: {
+              inputId: InputId('unfenced-released-input'),
+              input: 'unfenced after release',
+              priority: 'next',
+            },
+          },
+        ],
+        { expectedLastSequence: EventSequence(2) },
+      ),
+    ).rejects.toMatchObject({
+      code: 'DURABLE_EXECUTION_LEASE_REQUIRED',
+    });
+  });
+
+  it('renews an execution lease without changing its fencing token', async () => {
+    const sessionId = SessionId('session-lease-renewal');
+    let now = Date.parse('2026-08-22T12:00:00.000Z');
+    const leaseStore = new JsonlDurableEventStore(storageRoot, {
+      clock: () => new Date(now),
+    });
+    const lease = await leaseStore.acquireExecutionLease(sessionId, {
+      leaseId: ExecutionLeaseId('lease-renewal'),
+      ownerId: WorkerId('worker-renewal'),
+      ttlMs: 1_000,
+    });
+
+    now += 400;
+    const renewed = await leaseStore.renewExecutionLease(lease, 1_000);
+
+    expect(renewed.fencingToken).toBe(lease.fencingToken);
+    expect(renewed.acquiredAt).toBe(lease.acquiredAt);
+    expect(renewed.renewedAt).toBe('2026-08-22T12:00:00.400Z');
+    expect(renewed.expiresAt).toBe('2026-08-22T12:00:01.400Z');
+    await expect(leaseStore.assertExecutionLease(renewed)).resolves.toBeUndefined();
+  });
+
+  it('fails closed on corrupt execution lease state', async () => {
+    const sessionId = SessionId('session-corrupt-lease');
+    const filePath = store.getExecutionLeaseFilePath(sessionId);
+    await mkdir(dirname(filePath), { recursive: true });
+    await writeFile(filePath, '{"format":"blade.durable-execution-lease"}\n');
+
+    await expect(
+      store.acquireExecutionLease(sessionId, {
+        leaseId: ExecutionLeaseId('lease-corrupt'),
+        ownerId: WorkerId('worker-corrupt'),
+        ttlMs: 1_000,
+      }),
+    ).rejects.toBeInstanceOf(DurableExecutionLeaseError);
+    await expect(
+      store.append(sessionId, [{ type: DurableEventType.SESSION_CREATED, data: {} }]),
+    ).rejects.toMatchObject({
+      code: 'DURABLE_EXECUTION_LEASE_CORRUPT',
+    });
+  });
+
   it('waits for a lock held by another process before appending', async () => {
     const sessionId = SessionId('session-cross-process-lock');
     const filePath = store.getFilePath(sessionId);
@@ -544,6 +784,33 @@ describe('JsonlDurableEventStore', () => {
     await expect(store.read(sessionId)).resolves.toMatchObject({
       events: [expect.objectContaining({ sequence: 1 })],
       headSequence: 1,
+    });
+  });
+
+  it('grants execution ownership to only one independent Store process', async () => {
+    const sessionId = SessionId('session-cross-process-lease');
+    const first = await startLeaseWorker(storageRoot, sessionId, 'worker-first', 'lease-first');
+    const second = await startLeaseWorker(storageRoot, sessionId, 'worker-second', 'lease-second');
+    first.child.stdin.end('go\n');
+    second.child.stdin.end('go\n');
+    await Promise.all([waitForChild(first), waitForChild(second)]);
+
+    const results = [first, second].map(parseLeaseWorkerResult);
+    expect(results.filter((result) => result.status === 'fulfilled')).toEqual([
+      expect.objectContaining({ fencingToken: 1 }),
+    ]);
+    expect(results.filter((result) => result.status === 'rejected')).toEqual([
+      expect.objectContaining({
+        code: 'DURABLE_EXECUTION_LEASE_CONFLICT',
+      }),
+    ]);
+
+    const unfencedWriter = await startStoreWriter(storageRoot, sessionId, 'unfenced-after-lease');
+    unfencedWriter.child.stdin.end('go\n');
+    await waitForChild(unfencedWriter);
+    expect(parseStoreWriterResult(unfencedWriter)).toMatchObject({
+      status: 'rejected',
+      code: 'DURABLE_EXECUTION_LEASE_REQUIRED',
     });
   });
 

--- a/src/session/events/__tests__/JsonlDurableEventStore.test.ts
+++ b/src/session/events/__tests__/JsonlDurableEventStore.test.ts
@@ -573,7 +573,9 @@ describe('JsonlDurableEventStore', () => {
       expiresAt: '2026-08-22T12:00:01.000Z',
     });
     await expect(leaseStore.requiresExecutionLease(sessionId)).resolves.toBe(true);
-    expect((await stat(leaseStore.getExecutionLeaseFilePath(sessionId))).mode & 0o777).toBe(0o600);
+    if (process.platform !== 'win32') {
+      expect((await stat(leaseStore.getExecutionLeaseFilePath(sessionId))).mode & 0o777).toBe(0o600);
+    }
     await expect(
       leaseStore.acquireExecutionLease(sessionId, {
         leaseId: secondLeaseId,

--- a/src/session/events/__tests__/JsonlDurableEventStore.test.ts
+++ b/src/session/events/__tests__/JsonlDurableEventStore.test.ts
@@ -720,6 +720,55 @@ describe('JsonlDurableEventStore', () => {
     await expect(leaseStore.assertExecutionLease(renewed)).resolves.toBeUndefined();
   });
 
+  it('blocks lease takeover while a fenced persistence operation is running', async () => {
+    const sessionId = SessionId('session-fenced-persistence');
+    let now = Date.parse('2026-08-22T12:00:00.000Z');
+    const firstStore = new JsonlDurableEventStore(storageRoot, {
+      clock: () => new Date(now),
+    });
+    const secondStore = new JsonlDurableEventStore(storageRoot, {
+      clock: () => new Date(now),
+    });
+    const firstLease = await firstStore.acquireExecutionLease(sessionId, {
+      leaseId: ExecutionLeaseId('lease-fenced-persistence-first'),
+      ownerId: WorkerId('worker-fenced-persistence-first'),
+      ttlMs: 1_000,
+    });
+    let enterOperation: (() => void) | undefined;
+    let finishOperation: (() => void) | undefined;
+    const operationEntered = new Promise<void>((resolve) => {
+      enterOperation = resolve;
+    });
+    const operationGate = new Promise<void>((resolve) => {
+      finishOperation = resolve;
+    });
+    const fencedOperation = firstStore.withExecutionLease(
+      firstLease,
+      async () => {
+        enterOperation?.();
+        await operationGate;
+      },
+    );
+    await operationEntered;
+    now += 1_001;
+    let takeoverSettled = false;
+    const takeover = secondStore.acquireExecutionLease(sessionId, {
+      leaseId: ExecutionLeaseId('lease-fenced-persistence-second'),
+      ownerId: WorkerId('worker-fenced-persistence-second'),
+      ttlMs: 1_000,
+    }).finally(() => {
+      takeoverSettled = true;
+    });
+
+    await new Promise<void>((resolveDelay) => setTimeout(resolveDelay, 25));
+    expect(takeoverSettled).toBe(false);
+    finishOperation?.();
+    await fencedOperation;
+    await expect(takeover).resolves.toMatchObject({
+      fencingToken: 2,
+    });
+  });
+
   it('fails closed on corrupt execution lease state', async () => {
     const sessionId = SessionId('session-corrupt-lease');
     const filePath = store.getExecutionLeaseFilePath(sessionId);

--- a/src/session/events/__tests__/fixtures/jsonlLeaseWorker.ts
+++ b/src/session/events/__tests__/fixtures/jsonlLeaseWorker.ts
@@ -1,0 +1,68 @@
+import { once } from 'node:events';
+import { writeSync } from 'node:fs';
+import { ExecutionLeaseId, SessionId, WorkerId } from '../../../../types/branded.js';
+import { JsonlDurableEventStore } from '../../JsonlDurableEventStore.js';
+
+const [storageRoot, rawSessionId, workerId, leaseId, rawTtlMs = '30000'] = process.argv.slice(2);
+const ttlMs = Number(rawTtlMs);
+
+if (
+  !storageRoot ||
+  !rawSessionId ||
+  !workerId ||
+  !leaseId ||
+  !Number.isSafeInteger(ttlMs) ||
+  ttlMs <= 0
+) {
+  process.stderr.write(
+    'Usage: jsonlLeaseWorker.ts <storage-root> <session-id> <worker-id> <lease-id> [ttl-ms]\n',
+  );
+  process.exit(2);
+}
+
+function errorField(error: unknown, field: string): unknown {
+  return typeof error === 'object' && error !== null && field in error
+    ? error[field as keyof typeof error]
+    : undefined;
+}
+
+async function main(): Promise<void> {
+  const store = new JsonlDurableEventStore(storageRoot);
+  const startSignal = once(process.stdin, 'data');
+  writeSync(process.stdout.fd, 'ready\n');
+  await startSignal;
+  process.stdin.destroy();
+
+  try {
+    const lease = await store.acquireExecutionLease(SessionId(rawSessionId), {
+      ownerId: WorkerId(workerId),
+      leaseId: ExecutionLeaseId(leaseId),
+      ttlMs,
+    });
+    writeSync(
+      process.stdout.fd,
+      `${JSON.stringify({
+        status: 'fulfilled',
+        workerId: lease.ownerId,
+        leaseId: lease.leaseId,
+        fencingToken: lease.fencingToken,
+      })}\n`,
+    );
+  } catch (error) {
+    writeSync(
+      process.stdout.fd,
+      `${JSON.stringify({
+        status: 'rejected',
+        code: errorField(error, 'code'),
+      })}\n`,
+    );
+  }
+}
+
+main().then(
+  () => process.exit(0),
+  (error) => {
+    writeSync(process.stderr.fd, `${error instanceof Error ? error.stack : String(error)}\n`);
+    process.exit(1);
+  },
+);

--- a/src/session/events/core.ts
+++ b/src/session/events/core.ts
@@ -1,4 +1,24 @@
 export {
+  DEFAULT_EXECUTION_LEASE_HEARTBEAT_INTERVAL_MS,
+  DEFAULT_EXECUTION_LEASE_TTL_MS,
+  DurableExecutionLease,
+  type DurableExecutionLeaseOptions,
+} from './DurableExecutionLease.js';
+export {
+  type DurableExecutionFence,
+  type DurableExecutionLease as DurableExecutionLeaseSnapshot,
+  type DurableExecutionLeaseAcquireOptions,
+  DurableExecutionLeaseError,
+  type DurableExecutionLeaseErrorCode,
+  type DurableExecutionLeaseStore,
+  DURABLE_EXECUTION_LEASE_FORMAT,
+  DURABLE_EXECUTION_LEASE_FORMAT_VERSION,
+  executionFence,
+  isDurableExecutionLeaseStore,
+  type PersistedDurableExecutionLeaseState,
+  parsePersistedDurableExecutionLeaseState,
+} from './DurableExecutionLeaseStore.js';
+export {
   DurableEventSequenceConflictError,
   type DurableEventStore,
   DurableEventStoreError,

--- a/src/session/events/types.ts
+++ b/src/session/events/types.ts
@@ -13,6 +13,7 @@ import type {
   TurnId,
 } from '../../types/branded.js';
 import type { JsonObject, JsonValue } from '../../types/common.js';
+import type { DurableExecutionFence } from './DurableExecutionLeaseStore.js';
 
 export const DURABLE_EVENT_SCHEMA_VERSION = 3 as const;
 export type DurableEventSchemaVersion = 2 | typeof DURABLE_EVENT_SCHEMA_VERSION;
@@ -66,10 +67,7 @@ export type DurableToolCancelReason =
   | 'cascade_abort'
   | 'process_restart';
 export type DurableToolOutcomeUnknownReason = 'process_restart' | 'commit_outcome_unknown';
-export type DurableModelRequestAbortReason =
-  | 'request_interrupted'
-  | 'steering'
-  | 'process_restart';
+export type DurableModelRequestAbortReason = 'request_interrupted' | 'steering' | 'process_restart';
 
 export interface DurableEventError {
   message: string;
@@ -355,6 +353,12 @@ export interface DurableEventAppendOptions {
    * - EventSequence: require an exact current head
    */
   expectedLastSequence?: EventSequence | null;
+  /**
+   * Fences the append to a currently active execution lease. Lease-capable
+   * stores must validate this in the same transaction as the append and reject
+   * an omitted fence once the Session has entered fenced execution mode.
+   */
+  executionFence?: DurableExecutionFence;
 }
 
 export interface DurableEventAppendResult {

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -42,6 +42,10 @@ import type { AgentLogger } from '../types/logging.js';
 import type { CanUseTool, PermissionHandler, PermissionUpdate } from '../types/permissions.js';
 import type { Assert, IsEqual } from '../types/typeAssertions.js';
 import type { DurableEventStore } from './events/DurableEventStore.js';
+import type { DurableExecutionLeaseOptions } from './events/DurableExecutionLease.js';
+import type {
+  DurableExecutionLease as DurableExecutionLeaseSnapshot,
+} from './events/DurableExecutionLeaseStore.js';
 import type {
   DurableEventSubscription,
   DurableEventSubscriptionOptions,
@@ -294,6 +298,7 @@ export interface SessionOptions {
   storagePath?: string;
   persistSession?: boolean;
   durableEventStore?: DurableEventStore;
+  executionLease?: DurableExecutionLeaseOptions;
 
   outputFormat?: OutputFormat;
 
@@ -392,6 +397,7 @@ export interface ISession extends AsyncDisposable {
   getTraces(): AgentTrace[];
   getDurableProjection(): DurableSessionProjection | null;
   getDurableRecoveryPlan(): DurableSessionRecoveryPlan | null;
+  getExecutionLease(): DurableExecutionLeaseSnapshot | null;
   /** Replays durable events from an optional cursor and then follows live commits. */
   subscribeDurableEvents(
     options?: DurableEventSubscriptionOptions,

--- a/src/tools/builtin/shell/BackgroundShellManager.ts
+++ b/src/tools/builtin/shell/BackgroundShellManager.ts
@@ -2,6 +2,12 @@ import { type ChildProcess, spawn } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import type { DurableExecutionFence } from '../../../session/events/DurableExecutionLeaseStore.js';
 import type { SessionId } from '../../../types/branded.js';
+import {
+  isProcessTreeAlive,
+  shellProcessSpawnOptions,
+  signalProcessTree,
+  waitForProcessTreeExit,
+} from './processTree.js';
 
 type BackgroundShellStatus = 'running' | 'exited' | 'killed' | 'error';
 const DEFAULT_TERMINATION_GRACE_MS = 2_000;
@@ -99,6 +105,7 @@ export class BackgroundShellManager {
       cwd: options.cwd,
       env: mergedEnv,
       stdio: ['ignore', 'pipe', 'pipe'],
+      ...shellProcessSpawnOptions(),
     });
 
     const processInfo: BackgroundShellProcess = {
@@ -128,11 +135,10 @@ export class BackgroundShellManager {
     });
 
     child.on('close', (code, signal) => {
-      processInfo.status = processInfo.status === 'killed' ? 'killed' : 'exited';
       processInfo.exitCode = code;
       processInfo.signal = signal;
-      processInfo.endTime = Date.now();
       processInfo.process = undefined;
+      this.refreshProcessStatus(processInfo);
     });
 
     child.on('error', (error) => {
@@ -152,6 +158,7 @@ export class BackgroundShellManager {
     if (!processInfo) {
       return undefined;
     }
+    this.refreshProcessStatus(processInfo);
 
     const snapshot: ShellOutputSnapshot = {
       id: processInfo.id,
@@ -174,7 +181,11 @@ export class BackgroundShellManager {
   }
 
   getProcess(shellId: string): BackgroundShellProcess | undefined {
-    return this.processes.get(shellId);
+    const processInfo = this.processes.get(shellId);
+    if (processInfo) {
+      this.refreshProcessStatus(processInfo);
+    }
+    return processInfo;
   }
 
   getActiveProcessIds(
@@ -185,9 +196,10 @@ export class BackgroundShellManager {
       .filter(
         (processInfo) =>
           processInfo.sessionId === sessionId &&
-          processInfo.process !== undefined &&
+          isProcessTreeAlive(processInfo.pid, processInfo.process) &&
           (
             executionFence === undefined ||
+            processInfo.executionFence === undefined ||
             this.sameExecutionFence(processInfo.executionFence, executionFence)
           ),
       )
@@ -258,7 +270,7 @@ export class BackgroundShellManager {
       return undefined;
     }
 
-    if (processInfo.status !== 'running' || !processInfo.process) {
+    if (!isProcessTreeAlive(processInfo.pid, processInfo.process)) {
       return {
         success: false,
         alreadyExited: true,
@@ -269,7 +281,11 @@ export class BackgroundShellManager {
       };
     }
 
-    const killed = processInfo.process.kill('SIGTERM');
+    const killed = signalProcessTree(
+      processInfo.pid,
+      'SIGTERM',
+      processInfo.process,
+    );
     if (!killed) {
       return {
         success: false,
@@ -296,39 +312,27 @@ export class BackgroundShellManager {
 
   private async waitForExit(shellId: string, gracePeriodMs: number): Promise<void> {
     const processInfo = this.processes.get(shellId);
-    const child = processInfo?.process;
-    if (!child || (await this.waitForChildClose(child, gracePeriodMs))) {
+    if (
+      !processInfo ||
+      await waitForProcessTreeExit(
+        processInfo.pid,
+        processInfo.process,
+        gracePeriodMs,
+      )
+    ) {
       return;
     }
 
-    child.kill('SIGKILL');
-    if (!(await this.waitForChildClose(child, gracePeriodMs))) {
+    signalProcessTree(processInfo.pid, 'SIGKILL', processInfo.process);
+    if (
+      !(await waitForProcessTreeExit(
+        processInfo.pid,
+        processInfo.process,
+        gracePeriodMs,
+      ))
+    ) {
       throw new Error(`Background shell ${shellId} did not terminate`);
     }
-  }
-
-  private waitForChildClose(child: ChildProcess, timeoutMs: number): Promise<boolean> {
-    if (child.exitCode !== null || child.signalCode !== null) {
-      return Promise.resolve(true);
-    }
-    return new Promise<boolean>((resolve) => {
-      let settled = false;
-      const finish = (closed: boolean): void => {
-        if (settled) {
-          return;
-        }
-        settled = true;
-        clearTimeout(timer);
-        child.off('close', onClose);
-        child.off('error', onError);
-        resolve(closed);
-      };
-      const onClose = (): void => finish(true);
-      const onError = (): void => finish(true);
-      const timer = setTimeout(() => finish(false), timeoutMs);
-      child.once('close', onClose);
-      child.once('error', onError);
-    });
   }
 
   private executionFenceKey(
@@ -348,15 +352,29 @@ export class BackgroundShellManager {
     );
   }
 
+  private refreshProcessStatus(processInfo: BackgroundShellProcess): void {
+    if (
+      processInfo.status === 'running' &&
+      !isProcessTreeAlive(processInfo.pid, processInfo.process)
+    ) {
+      processInfo.status = 'exited';
+      processInfo.endTime = Date.now();
+    }
+  }
+
   /**
    * 终止所有后台进程
    * 在应用退出时调用
    */
   killAll(): void {
     for (const [_shellId, processInfo] of this.processes) {
-      if (processInfo.status === 'running' && processInfo.process) {
+      if (isProcessTreeAlive(processInfo.pid, processInfo.process)) {
         try {
-          processInfo.process.kill('SIGTERM');
+          signalProcessTree(
+            processInfo.pid,
+            'SIGTERM',
+            processInfo.process,
+          );
           processInfo.status = 'killed';
           processInfo.endTime = Date.now();
           processInfo.process = undefined;

--- a/src/tools/builtin/shell/BackgroundShellManager.ts
+++ b/src/tools/builtin/shell/BackgroundShellManager.ts
@@ -1,20 +1,24 @@
 import { type ChildProcess, spawn } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
+import type { DurableExecutionFence } from '../../../session/events/DurableExecutionLeaseStore.js';
 import type { SessionId } from '../../../types/branded.js';
 
 type BackgroundShellStatus = 'running' | 'exited' | 'killed' | 'error';
+const DEFAULT_TERMINATION_GRACE_MS = 2_000;
 
 interface StartOptions {
   command: string;
   sessionId: SessionId;
   cwd: string;
   env?: Record<string, string | undefined>;
+  executionFence?: DurableExecutionFence;
 }
 
 interface BackgroundShellProcess {
   id: string;
   command: string;
   sessionId: SessionId;
+  executionFence?: DurableExecutionFence;
   cwd?: string;
   env?: Record<string, string | undefined>;
   process?: ChildProcess;
@@ -56,6 +60,7 @@ export class BackgroundShellManager {
   private static instance: BackgroundShellManager | null = null;
   private processes = new Map<string, BackgroundShellProcess>();
   private sealedSessionIds = new Set<SessionId>();
+  private revokedExecutionFences = new Set<string>();
 
   static getInstance(): BackgroundShellManager {
     if (!BackgroundShellManager.instance) {
@@ -65,7 +70,15 @@ export class BackgroundShellManager {
   }
 
   startBackgroundProcess(options: StartOptions): BackgroundShellProcess {
-    if (this.sealedSessionIds.has(options.sessionId)) {
+    if (
+      this.sealedSessionIds.has(options.sessionId) ||
+      (
+        options.executionFence &&
+        this.revokedExecutionFences.has(
+          this.executionFenceKey(options.sessionId, options.executionFence),
+        )
+      )
+    ) {
       throw new Error(`Background shell admission is closed for Session ${options.sessionId}`);
     }
 
@@ -92,6 +105,7 @@ export class BackgroundShellManager {
       id: shellId,
       command: options.command,
       sessionId: options.sessionId,
+      executionFence: options.executionFence,
       cwd: options.cwd,
       env: options.env,
       process: child,
@@ -163,11 +177,20 @@ export class BackgroundShellManager {
     return this.processes.get(shellId);
   }
 
-  getActiveProcessIds(sessionId: SessionId): readonly string[] {
+  getActiveProcessIds(
+    sessionId: SessionId,
+    executionFence?: DurableExecutionFence,
+  ): readonly string[] {
     return [...this.processes.values()]
-      .filter((processInfo) =>
-        processInfo.sessionId === sessionId
-        && processInfo.process !== undefined)
+      .filter(
+        (processInfo) =>
+          processInfo.sessionId === sessionId &&
+          processInfo.process !== undefined &&
+          (
+            executionFence === undefined ||
+            this.sameExecutionFence(processInfo.executionFence, executionFence)
+          ),
+      )
       .map((processInfo) => processInfo.id);
   }
 
@@ -177,6 +200,56 @@ export class BackgroundShellManager {
 
   openSession(sessionId: SessionId): void {
     this.sealedSessionIds.delete(sessionId);
+  }
+
+  sealExecutionFence(sessionId: SessionId, fence: DurableExecutionFence): void {
+    this.revokedExecutionFences.add(this.executionFenceKey(sessionId, fence));
+  }
+
+  killSession(sessionId: SessionId): readonly string[] {
+    this.sealSessionForHandoff(sessionId);
+    const shellIds = this.getActiveProcessIds(sessionId);
+    for (const shellId of shellIds) {
+      this.kill(shellId);
+    }
+    return shellIds;
+  }
+
+  async terminateSession(
+    sessionId: SessionId,
+    gracePeriodMs = DEFAULT_TERMINATION_GRACE_MS,
+  ): Promise<readonly string[]> {
+    if (!Number.isSafeInteger(gracePeriodMs) || gracePeriodMs < 0) {
+      throw new Error('Background shell termination grace period must be non-negative');
+    }
+    const shellIds = this.killSession(sessionId);
+    await Promise.all(shellIds.map((shellId) => this.waitForExit(shellId, gracePeriodMs)));
+    return shellIds;
+  }
+
+  killExecutionFence(
+    sessionId: SessionId,
+    fence: DurableExecutionFence,
+  ): readonly string[] {
+    this.sealExecutionFence(sessionId, fence);
+    const shellIds = this.getActiveProcessIds(sessionId, fence);
+    for (const shellId of shellIds) {
+      this.kill(shellId);
+    }
+    return shellIds;
+  }
+
+  async terminateExecutionFence(
+    sessionId: SessionId,
+    fence: DurableExecutionFence,
+    gracePeriodMs = DEFAULT_TERMINATION_GRACE_MS,
+  ): Promise<readonly string[]> {
+    if (!Number.isSafeInteger(gracePeriodMs) || gracePeriodMs < 0) {
+      throw new Error('Background shell termination grace period must be non-negative');
+    }
+    const shellIds = this.killExecutionFence(sessionId, fence);
+    await Promise.all(shellIds.map((shellId) => this.waitForExit(shellId, gracePeriodMs)));
+    return shellIds;
   }
 
   kill(shellId: string): KillResult | undefined {
@@ -221,6 +294,60 @@ export class BackgroundShellManager {
     };
   }
 
+  private async waitForExit(shellId: string, gracePeriodMs: number): Promise<void> {
+    const processInfo = this.processes.get(shellId);
+    const child = processInfo?.process;
+    if (!child || (await this.waitForChildClose(child, gracePeriodMs))) {
+      return;
+    }
+
+    child.kill('SIGKILL');
+    if (!(await this.waitForChildClose(child, gracePeriodMs))) {
+      throw new Error(`Background shell ${shellId} did not terminate`);
+    }
+  }
+
+  private waitForChildClose(child: ChildProcess, timeoutMs: number): Promise<boolean> {
+    if (child.exitCode !== null || child.signalCode !== null) {
+      return Promise.resolve(true);
+    }
+    return new Promise<boolean>((resolve) => {
+      let settled = false;
+      const finish = (closed: boolean): void => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimeout(timer);
+        child.off('close', onClose);
+        child.off('error', onError);
+        resolve(closed);
+      };
+      const onClose = (): void => finish(true);
+      const onError = (): void => finish(true);
+      const timer = setTimeout(() => finish(false), timeoutMs);
+      child.once('close', onClose);
+      child.once('error', onError);
+    });
+  }
+
+  private executionFenceKey(
+    sessionId: SessionId,
+    fence: DurableExecutionFence,
+  ): string {
+    return `${sessionId}\0${fence.leaseId}\0${fence.fencingToken}`;
+  }
+
+  private sameExecutionFence(
+    left: DurableExecutionFence | undefined,
+    right: DurableExecutionFence,
+  ): boolean {
+    return (
+      left?.leaseId === right.leaseId &&
+      left.fencingToken === right.fencingToken
+    );
+  }
+
   /**
    * 终止所有后台进程
    * 在应用退出时调用
@@ -240,5 +367,6 @@ export class BackgroundShellManager {
     }
     this.processes.clear();
     this.sealedSessionIds.clear();
+    this.revokedExecutionFences.clear();
   }
 }

--- a/src/tools/builtin/shell/BackgroundShellManager.ts
+++ b/src/tools/builtin/shell/BackgroundShellManager.ts
@@ -1,7 +1,7 @@
 import { type ChildProcess, spawn } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import type { DurableExecutionFence } from '../../../session/events/DurableExecutionLeaseStore.js';
-import type { SessionId } from '../../../types/branded.js';
+import type { FencingToken, SessionId } from '../../../types/branded.js';
 import {
   isProcessTreeAlive,
   shellProcessSpawnOptions,
@@ -66,7 +66,7 @@ export class BackgroundShellManager {
   private static instance: BackgroundShellManager | null = null;
   private processes = new Map<string, BackgroundShellProcess>();
   private sealedSessionIds = new Set<SessionId>();
-  private revokedExecutionFences = new Set<string>();
+  private revokedFencingTokens = new Map<SessionId, FencingToken>();
 
   static getInstance(): BackgroundShellManager {
     if (!BackgroundShellManager.instance) {
@@ -80,9 +80,7 @@ export class BackgroundShellManager {
       this.sealedSessionIds.has(options.sessionId) ||
       (
         options.executionFence &&
-        this.revokedExecutionFences.has(
-          this.executionFenceKey(options.sessionId, options.executionFence),
-        )
+        this.isExecutionFenceRevoked(options.sessionId, options.executionFence)
       )
     ) {
       throw new Error(`Background shell admission is closed for Session ${options.sessionId}`);
@@ -215,7 +213,10 @@ export class BackgroundShellManager {
   }
 
   sealExecutionFence(sessionId: SessionId, fence: DurableExecutionFence): void {
-    this.revokedExecutionFences.add(this.executionFenceKey(sessionId, fence));
+    const revokedThrough = this.revokedFencingTokens.get(sessionId);
+    if (revokedThrough === undefined || fence.fencingToken > revokedThrough) {
+      this.revokedFencingTokens.set(sessionId, fence.fencingToken);
+    }
   }
 
   killSession(sessionId: SessionId): readonly string[] {
@@ -281,11 +282,17 @@ export class BackgroundShellManager {
       };
     }
 
-    const killed = signalProcessTree(
-      processInfo.pid,
-      'SIGTERM',
-      processInfo.process,
-    );
+    let killed = false;
+    try {
+      killed = signalProcessTree(
+        processInfo.pid,
+        'SIGTERM',
+        processInfo.process,
+      );
+    } catch (error) {
+      processInfo.errorMessage =
+        error instanceof Error ? error.message : String(error);
+    }
     if (!killed) {
       return {
         success: false,
@@ -335,11 +342,12 @@ export class BackgroundShellManager {
     }
   }
 
-  private executionFenceKey(
+  private isExecutionFenceRevoked(
     sessionId: SessionId,
     fence: DurableExecutionFence,
-  ): string {
-    return `${sessionId}\0${fence.leaseId}\0${fence.fencingToken}`;
+  ): boolean {
+    const revokedThrough = this.revokedFencingTokens.get(sessionId);
+    return revokedThrough !== undefined && fence.fencingToken <= revokedThrough;
   }
 
   private sameExecutionFence(
@@ -385,6 +393,6 @@ export class BackgroundShellManager {
     }
     this.processes.clear();
     this.sealedSessionIds.clear();
-    this.revokedExecutionFences.clear();
+    this.revokedFencingTokens.clear();
   }
 }

--- a/src/tools/builtin/shell/__tests__/BackgroundShellManager.test.ts
+++ b/src/tools/builtin/shell/__tests__/BackgroundShellManager.test.ts
@@ -1,4 +1,6 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createContextSnapshot } from '../../../../runtime/index.js';
 import {
@@ -9,6 +11,20 @@ import {
 import { collectToolExecution } from '../../../types/index.js';
 import { BackgroundShellManager } from '../BackgroundShellManager.js';
 import { bashTool } from '../bash.js';
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return !(
+      typeof error === 'object' &&
+      error !== null &&
+      'code' in error &&
+      error.code === 'ESRCH'
+    );
+  }
+}
 
 describe('BackgroundShellManager handoff admission', () => {
   const manager = BackgroundShellManager.getInstance();
@@ -187,4 +203,43 @@ describe('BackgroundShellManager handoff admission', () => {
       }),
     ).not.toThrow();
   });
+
+  it.skipIf(process.platform === 'win32')(
+    'terminates the complete process group before releasing ownership',
+    async () => {
+      const sessionId = SessionId('process-tree-shell-session');
+      const executionFence = {
+        leaseId: ExecutionLeaseId('process-tree-shell-lease'),
+        fencingToken: FencingToken(1),
+      };
+      const root = await mkdtemp(join(tmpdir(), 'blade-shell-tree-'));
+      const childPidPath = join(root, 'child.pid');
+      manager.openSession(sessionId);
+      const shell = manager.startBackgroundProcess({
+        command: `sleep 30 >/dev/null 2>&1 & echo $! > ${JSON.stringify(childPidPath)}; wait`,
+        sessionId,
+        cwd: root,
+        executionFence,
+      });
+      let childPid = 0;
+      await vi.waitFor(async () => {
+        childPid = Number((await readFile(childPidPath, 'utf8')).trim());
+        expect(Number.isSafeInteger(childPid) && childPid > 0).toBe(true);
+      });
+
+      try {
+        await expect(
+          manager.terminateExecutionFence(sessionId, executionFence, 500),
+        ).resolves.toEqual([shell.id]);
+        await vi.waitFor(() => expect(isProcessAlive(childPid)).toBe(false), {
+          timeout: 2_000,
+        });
+      } finally {
+        if (isProcessAlive(childPid)) {
+          process.kill(childPid, 'SIGKILL');
+        }
+        await rm(root, { recursive: true, force: true });
+      }
+    },
+  );
 });

--- a/src/tools/builtin/shell/__tests__/BackgroundShellManager.test.ts
+++ b/src/tools/builtin/shell/__tests__/BackgroundShellManager.test.ts
@@ -64,7 +64,9 @@ describe('BackgroundShellManager handoff admission', () => {
       success: true,
       status: 'killed',
     });
-    expect(manager.getActiveProcessIds(firstSession)).toEqual([processInfo.id]);
+    if (process.platform !== 'win32') {
+      expect(manager.getActiveProcessIds(firstSession)).toEqual([processInfo.id]);
+    }
     await vi.waitFor(() => expect(manager.getActiveProcessIds(firstSession)).toEqual([]), {
       timeout: 2_000,
     });

--- a/src/tools/builtin/shell/__tests__/BackgroundShellManager.test.ts
+++ b/src/tools/builtin/shell/__tests__/BackgroundShellManager.test.ts
@@ -1,7 +1,11 @@
 import { tmpdir } from 'node:os';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createContextSnapshot } from '../../../../runtime/index.js';
-import { SessionId } from '../../../../types/branded.js';
+import {
+  ExecutionLeaseId,
+  FencingToken,
+  SessionId,
+} from '../../../../types/branded.js';
 import { collectToolExecution } from '../../../types/index.js';
 import { BackgroundShellManager } from '../BackgroundShellManager.js';
 import { bashTool } from '../bash.js';
@@ -45,10 +49,9 @@ describe('BackgroundShellManager handoff admission', () => {
       status: 'killed',
     });
     expect(manager.getActiveProcessIds(firstSession)).toEqual([processInfo.id]);
-    await vi.waitFor(
-      () => expect(manager.getActiveProcessIds(firstSession)).toEqual([]),
-      { timeout: 2_000 },
-    );
+    await vi.waitFor(() => expect(manager.getActiveProcessIds(firstSession)).toEqual([]), {
+      timeout: 2_000,
+    });
 
     expect(() =>
       manager.startBackgroundProcess({
@@ -62,6 +65,10 @@ describe('BackgroundShellManager handoff admission', () => {
   it('attributes Bash background processes to the calling Session', async () => {
     const rootSessionId = SessionId('bash-tool-root-session');
     const childSessionId = SessionId('bash-tool-child-session');
+    const executionFence = {
+      leaseId: ExecutionLeaseId('bash-tool-lease'),
+      fencingToken: FencingToken(3),
+    };
     manager.openSession(rootSessionId);
     const invocation = bashTool.build({
       command: 'sleep 30',
@@ -75,6 +82,7 @@ describe('BackgroundShellManager handoff admission', () => {
         backgroundAgentManager: {
           getOwnerSessionId: () => rootSessionId,
         } as never,
+        executionFence,
         contextSnapshot: createContextSnapshot(childSessionId, 'shell-turn', {
           capabilities: {
             filesystem: {
@@ -89,13 +97,94 @@ describe('BackgroundShellManager handoff admission', () => {
     expect(result.status).toBe('success');
     const [shellId] = manager.getActiveProcessIds(rootSessionId);
     expect(shellId).toMatch(/^bash_/);
+    expect(shellId ? manager.getProcess(shellId)?.executionFence : undefined).toEqual(
+      executionFence,
+    );
     expect(manager.getActiveProcessIds(childSessionId)).toEqual([]);
     if (shellId) {
       manager.kill(shellId);
     }
-    await vi.waitFor(
-      () => expect(manager.getActiveProcessIds(rootSessionId)).toEqual([]),
-      { timeout: 2_000 },
-    );
+    await vi.waitFor(() => expect(manager.getActiveProcessIds(rootSessionId)).toEqual([]), {
+      timeout: 2_000,
+    });
+  });
+
+  it('seals a Session and terminates all of its shells after ownership loss', async () => {
+    const lostSessionId = SessionId('lost-shell-session');
+    const otherSessionId = SessionId('unrelated-shell-session');
+    manager.openSession(lostSessionId);
+    manager.openSession(otherSessionId);
+    const first = manager.startBackgroundProcess({
+      command: 'sleep 30',
+      sessionId: lostSessionId,
+      cwd: tmpdir(),
+    });
+    const second = manager.startBackgroundProcess({
+      command: 'sleep 30',
+      sessionId: lostSessionId,
+      cwd: tmpdir(),
+    });
+    const unrelated = manager.startBackgroundProcess({
+      command: 'sleep 30',
+      sessionId: otherSessionId,
+      cwd: tmpdir(),
+    });
+
+    await expect(manager.terminateSession(lostSessionId)).resolves.toEqual([first.id, second.id]);
+    expect(() =>
+      manager.startBackgroundProcess({
+        command: 'true',
+        sessionId: lostSessionId,
+        cwd: tmpdir(),
+      }),
+    ).toThrow(/admission is closed/);
+    expect(manager.getActiveProcessIds(lostSessionId)).toEqual([]);
+    expect(manager.getActiveProcessIds(otherSessionId)).toEqual([unrelated.id]);
+  });
+
+  it('revokes only shells owned by the stale execution fence', async () => {
+    const sessionId = SessionId('fenced-shell-session');
+    const staleFence = {
+      leaseId: ExecutionLeaseId('stale-shell-lease'),
+      fencingToken: FencingToken(1),
+    };
+    const currentFence = {
+      leaseId: ExecutionLeaseId('current-shell-lease'),
+      fencingToken: FencingToken(2),
+    };
+    manager.openSession(sessionId);
+    const stale = manager.startBackgroundProcess({
+      command: 'sleep 30',
+      sessionId,
+      cwd: tmpdir(),
+      executionFence: staleFence,
+    });
+    const current = manager.startBackgroundProcess({
+      command: 'sleep 30',
+      sessionId,
+      cwd: tmpdir(),
+      executionFence: currentFence,
+    });
+
+    await expect(
+      manager.terminateExecutionFence(sessionId, staleFence),
+    ).resolves.toEqual([stale.id]);
+    expect(manager.getActiveProcessIds(sessionId)).toEqual([current.id]);
+    expect(() =>
+      manager.startBackgroundProcess({
+        command: 'true',
+        sessionId,
+        cwd: tmpdir(),
+        executionFence: staleFence,
+      }),
+    ).toThrow(/admission is closed/);
+    expect(() =>
+      manager.startBackgroundProcess({
+        command: 'true',
+        sessionId,
+        cwd: tmpdir(),
+        executionFence: currentFence,
+      }),
+    ).not.toThrow();
   });
 });

--- a/src/tools/builtin/shell/bash.ts
+++ b/src/tools/builtin/shell/bash.ts
@@ -18,6 +18,11 @@ import { lazySchema } from '../../validation/lazySchema.js';
 import { ToolSchemas } from '../../validation/zodSchemas.js';
 import { BackgroundShellManager } from './BackgroundShellManager.js';
 import { OutputTruncator } from './OutputTruncator.js';
+import {
+  isProcessTreeAlive,
+  shellProcessSpawnOptions,
+  signalProcessTree,
+} from './processTree.js';
 
 /**
  * Bash Tool - Shell command executor
@@ -421,6 +426,7 @@ async function executeWithTimeout(
       cwd,
       env: { ...process.env, ...env, BLADE_CLI: '1' },
       stdio: ['pipe', 'pipe', 'pipe'],
+      ...shellProcessSpawnOptions(),
     });
 
     // 收集 stdout
@@ -436,19 +442,19 @@ async function executeWithTimeout(
     // 设置超时
     const timeoutHandle = setTimeout(() => {
       timedOut = true;
-      bashProcess.kill('SIGTERM');
+      signalProcessTree(bashProcess.pid, 'SIGTERM', bashProcess);
 
       // 如果 SIGTERM 无效,强制 SIGKILL
       setTimeout(() => {
-        if (!bashProcess.killed) {
-          bashProcess.kill('SIGKILL');
+        if (isProcessTreeAlive(bashProcess.pid, bashProcess)) {
+          signalProcessTree(bashProcess.pid, 'SIGKILL', bashProcess);
         }
       }, 1000);
     }, timeout);
 
     // 处理中止信号
     const abortHandler = () => {
-      bashProcess.kill('SIGTERM');
+      signalProcessTree(bashProcess.pid, 'SIGTERM', bashProcess);
       clearTimeout(timeoutHandle);
     };
 

--- a/src/tools/builtin/shell/bash.ts
+++ b/src/tools/builtin/shell/bash.ts
@@ -281,6 +281,7 @@ Before executing commands:
             ?? context.sessionId
             ?? SessionId(randomUUID()),
           env,
+          context.executionFence,
         );
       }
 
@@ -361,7 +362,8 @@ function executeInBackground(
   command: string,
   cwd: string,
   sessionId: SessionId,
-  env?: Record<string, string>
+  env?: Record<string, string>,
+  executionFence?: ExecutionContext['executionFence'],
 ): ToolResult {
   const manager = BackgroundShellManager.getInstance();
   const backgroundProcess = manager.startBackgroundProcess({
@@ -369,6 +371,7 @@ function executeInBackground(
     sessionId,
     cwd,
     env,
+    executionFence,
   });
 
   const cmdPreview = command.length > 30 ? `${command.substring(0, 30)}...` : command;

--- a/src/tools/builtin/shell/bash.ts
+++ b/src/tools/builtin/shell/bash.ts
@@ -439,22 +439,30 @@ async function executeWithTimeout(
       stderr += data.toString();
     });
 
+    const safeSignalTree = (signalName: NodeJS.Signals): void => {
+      try {
+        signalProcessTree(bashProcess.pid, signalName, bashProcess);
+      } catch (error) {
+        stderr += `\nFailed to signal command process tree: ${getErrorMessage(error)}`;
+      }
+    };
+
     // 设置超时
     const timeoutHandle = setTimeout(() => {
       timedOut = true;
-      signalProcessTree(bashProcess.pid, 'SIGTERM', bashProcess);
+      safeSignalTree('SIGTERM');
 
       // 如果 SIGTERM 无效,强制 SIGKILL
       setTimeout(() => {
         if (isProcessTreeAlive(bashProcess.pid, bashProcess)) {
-          signalProcessTree(bashProcess.pid, 'SIGKILL', bashProcess);
+          safeSignalTree('SIGKILL');
         }
       }, 1000);
     }, timeout);
 
     // 处理中止信号
     const abortHandler = () => {
-      signalProcessTree(bashProcess.pid, 'SIGTERM', bashProcess);
+      safeSignalTree('SIGTERM');
       clearTimeout(timeoutHandle);
     };
 

--- a/src/tools/builtin/shell/processTree.ts
+++ b/src/tools/builtin/shell/processTree.ts
@@ -1,0 +1,99 @@
+import { type ChildProcess, spawnSync } from 'node:child_process';
+
+const PROCESS_TREE_POLL_INTERVAL_MS = 20;
+
+function isMissingProcess(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    error.code === 'ESRCH'
+  );
+}
+
+export function shellProcessSpawnOptions(): {
+  detached: boolean;
+  windowsHide: boolean;
+} {
+  return {
+    detached: process.platform !== 'win32',
+    windowsHide: true,
+  };
+}
+
+export function signalProcessTree(
+  pid: number | undefined,
+  signal: NodeJS.Signals,
+  child?: ChildProcess,
+): boolean {
+  if (!pid) {
+    return child?.kill(signal) ?? false;
+  }
+
+  if (process.platform === 'win32') {
+    const result = spawnSync(
+      'taskkill',
+      [
+        '/pid',
+        String(pid),
+        '/t',
+        '/f',
+      ],
+      {
+        stdio: 'ignore',
+        windowsHide: true,
+      },
+    );
+    if (result.status === 0) {
+      return true;
+    }
+    return child?.kill(signal) ?? false;
+  }
+
+  try {
+    process.kill(-pid, signal);
+    return true;
+  } catch (error) {
+    if (!isMissingProcess(error)) {
+      throw error;
+    }
+    return child?.kill(signal) ?? false;
+  }
+}
+
+export function isProcessTreeAlive(
+  pid: number | undefined,
+  child?: ChildProcess,
+): boolean {
+  if (!pid) {
+    return child?.exitCode === null && child.signalCode === null;
+  }
+
+  try {
+    process.kill(process.platform === 'win32' ? pid : -pid, 0);
+    return true;
+  } catch (error) {
+    return !isMissingProcess(error);
+  }
+}
+
+export async function waitForProcessTreeExit(
+  pid: number | undefined,
+  child: ChildProcess | undefined,
+  timeoutMs: number,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (isProcessTreeAlive(pid, child)) {
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) {
+      return false;
+    }
+    await new Promise<void>((resolve) => {
+      setTimeout(
+        resolve,
+        Math.min(PROCESS_TREE_POLL_INTERVAL_MS, remainingMs),
+      );
+    });
+  }
+  return true;
+}

--- a/src/tools/builtin/shell/processTree.ts
+++ b/src/tools/builtin/shell/processTree.ts
@@ -31,6 +31,8 @@ export function signalProcessTree(
   }
 
   if (process.platform === 'win32') {
+    // Windows has no POSIX signal semantics for console process trees.
+    // taskkill /T /F therefore force-terminates the complete tree.
     const result = spawnSync(
       'taskkill',
       [
@@ -54,10 +56,14 @@ export function signalProcessTree(
     process.kill(-pid, signal);
     return true;
   } catch (error) {
-    if (!isMissingProcess(error)) {
-      throw error;
+    try {
+      return child?.kill(signal) ?? false;
+    } catch {
+      if (!isMissingProcess(error)) {
+        throw error;
+      }
+      return false;
     }
-    return child?.kill(signal) ?? false;
   }
 }
 

--- a/src/tools/builtin/task/__tests__/taskTools.test.ts
+++ b/src/tools/builtin/task/__tests__/taskTools.test.ts
@@ -4,7 +4,9 @@ import { getBuiltinTools } from '../../index.js';
 import type { ChatContext, LoopOptions } from '../../../../agent/types.js';
 import { AgentSessionStore } from '../../../../agent/subagents/AgentSessionStore.js';
 import { BackgroundAgentManager } from '../../../../agent/subagents/BackgroundAgentManager.js';
+import { SubagentRegistry } from '../../../../agent/subagents/SubagentRegistry.js';
 import { AgentId, SessionId } from '../../../../types/branded.js';
+import { DurableExecutionLeaseError } from '../../../../session/events/DurableExecutionLeaseStore.js';
 import {
   collectToolExecution,
   type ExecutionContext,
@@ -14,6 +16,7 @@ import { createTaskCreateTool } from '../taskCreate.js';
 import { createTaskGetTool } from '../taskGet.js';
 import { createTaskListTool } from '../taskList.js';
 import { createTaskStopTool } from '../taskStop.js';
+import { createTaskTool } from '../task.js';
 import { createTaskUpdateTool } from '../taskUpdate.js';
 
 const { runAgenticLoop, createAgent } = vi.hoisted(() => ({
@@ -282,5 +285,65 @@ describe('task tools', () => {
     expect(stopped.status).toBe('success');
     expect(fakeManager.getAgent).toHaveBeenCalledWith('agent-1');
     expect(fakeManager.killAgent).toHaveBeenCalledWith('agent-1');
+  });
+
+  it('reports an error when a running agent belongs to another execution', async () => {
+    const stopTool = createTaskStopTool({ sessionId: SessionId(`factory-${Date.now()}`) });
+    const session = {
+      id: AgentId('agent-owned-elsewhere'),
+      status: 'running',
+    };
+    const fakeManager = {
+      getAgent: vi.fn(() => session),
+      killAgent: vi.fn(async () => false),
+    };
+
+    const stopped = await executeWithContext(
+      stopTool,
+      { taskId: session.id },
+      {
+        sessionId: SessionId(`runtime-${Date.now()}`),
+        backgroundAgentManager: fakeManager,
+      } as never,
+    );
+
+    expect(stopped).toMatchObject({
+      status: 'error',
+      metadata: {
+        stoppedBackgroundAgent: false,
+      },
+    });
+  });
+
+  it('propagates lease loss while starting a background agent', async () => {
+    const registry = new SubagentRegistry();
+    registry.register(subagentConfig);
+    const taskTool = createTaskTool({ registry });
+    const leaseError = new DurableExecutionLeaseError(
+      'DURABLE_EXECUTION_LEASE_LOST',
+      'worker is stale',
+    );
+    const fakeManager = {
+      startBackgroundAgent: vi.fn(async () => {
+        throw leaseError;
+      }),
+    };
+
+    await expect(
+      executeWithContext(
+        taskTool,
+        {
+          subagent_type: subagentConfig.name,
+          description: 'Inspect repository',
+          prompt: 'inspect code',
+          run_in_background: true,
+        },
+        {
+          sessionId: SessionId('stale-task-session'),
+          bladeConfig,
+          backgroundAgentManager: fakeManager,
+        } as never,
+      ),
+    ).rejects.toBe(leaseError);
   });
 });

--- a/src/tools/builtin/task/__tests__/taskTools.test.ts
+++ b/src/tools/builtin/task/__tests__/taskTools.test.ts
@@ -229,7 +229,7 @@ describe('task tools', () => {
         }),
     );
 
-    const agentId = AgentId(manager.startBackgroundAgent({
+    const agentId = AgentId(await manager.startBackgroundAgent({
       config: subagentConfig,
       bladeConfig,
       description: 'Inspect repository',
@@ -267,7 +267,7 @@ describe('task tools', () => {
     const stopTool = createTaskStopTool({ sessionId: SessionId(`factory-${Date.now()}`) });
     const fakeManager = {
       getAgent: vi.fn(() => ({ id: AgentId('agent-1'), status: 'running' })),
-      killAgent: vi.fn(() => true),
+      killAgent: vi.fn(async () => true),
     };
 
     const stopped = await executeWithContext(

--- a/src/tools/builtin/task/task.ts
+++ b/src/tools/builtin/task/task.ts
@@ -268,6 +268,9 @@ export function createTaskTool({ registry }: { registry: SubagentRegistry }) {
           permissionMode: context.permissionMode,
           subagentSessionId,
           snapshot: context.contextSnapshot,
+          signal: context.signal,
+          executionFence: context.executionFence,
+          assertExecutionLease: context.assertExecutionLease,
         };
 
         yield {
@@ -308,6 +311,9 @@ export function createTaskTool({ registry }: { registry: SubagentRegistry }) {
               permissionMode: context.permissionMode,
               subagentSessionId,
               snapshot: context.contextSnapshot,
+              signal: context.signal,
+              executionFence: context.executionFence,
+              assertExecutionLease: context.assertExecutionLease,
             };
 
             const continueStartTime = Date.now();
@@ -450,6 +456,8 @@ function handleBackgroundExecution(
     permissionMode: context.permissionMode,
     agentId: subagentSessionId,
     snapshot: context.contextSnapshot,
+    executionFence: context.executionFence,
+    assertExecutionLease: context.assertExecutionLease,
   });
 
   return {
@@ -552,6 +560,8 @@ function handleResume(
     context.permissionMode,
     registry,
     description,
+    context.executionFence,
+    context.assertExecutionLease,
   );
 
   if (!newAgentId) {

--- a/src/tools/builtin/task/task.ts
+++ b/src/tools/builtin/task/task.ts
@@ -19,6 +19,7 @@ import type {
   SubagentResult,
 } from '../../../agent/subagents/types.js';
 import { HookManager } from '../../../hooks/HookManager.js';
+import { isExecutionLeaseFailure } from '../../../session/events/DurableExecutionLeaseStore.js';
 import { AgentId, SessionId } from '../../../types/branded.js';
 import { PermissionMode } from '../../../types/common.js';
 import { getErrorMessage } from '../../../utils/errorUtils.js';
@@ -332,6 +333,9 @@ export function createTaskTool({ registry }: { registry: SubagentRegistry }) {
 
         return buildTaskResult(result, subagent_type, description, duration, subagentSessionId);
       } catch (error) {
+        if (isExecutionLeaseFailure(error)) {
+          throw error;
+        }
         const _errorMessage = extractUserFriendlyError(
           error instanceof Error ? error : new Error(getErrorMessage(error))
         );

--- a/src/tools/builtin/task/task.ts
+++ b/src/tools/builtin/task/task.ts
@@ -216,7 +216,7 @@ export function createTaskTool({ registry }: { registry: SubagentRegistry }) {
         }
 
         if (resume) {
-          return handleResume(
+          return await handleResume(
             AgentId(resume),
             prompt,
             subagentConfig,
@@ -227,7 +227,7 @@ export function createTaskTool({ registry }: { registry: SubagentRegistry }) {
         }
 
         if (run_in_background) {
-          return handleBackgroundExecution(
+          return await handleBackgroundExecution(
             subagentConfig,
             description,
             prompt,
@@ -271,6 +271,7 @@ export function createTaskTool({ registry }: { registry: SubagentRegistry }) {
           signal: context.signal,
           executionFence: context.executionFence,
           assertExecutionLease: context.assertExecutionLease,
+          runWithExecutionLease: context.runWithExecutionLease,
         };
 
         yield {
@@ -314,6 +315,7 @@ export function createTaskTool({ registry }: { registry: SubagentRegistry }) {
               signal: context.signal,
               executionFence: context.executionFence,
               assertExecutionLease: context.assertExecutionLease,
+              runWithExecutionLease: context.runWithExecutionLease,
             };
 
             const continueStartTime = Date.now();
@@ -404,7 +406,7 @@ function buildTaskResult(
   };
 }
 
-function handleBackgroundExecution(
+async function handleBackgroundExecution(
   subagentConfig: {
     name: string;
     description: string;
@@ -416,7 +418,7 @@ function handleBackgroundExecution(
   context: ExecutionContext,
   subagentSessionId: AgentId,
   registry: SubagentRegistry,
-): ToolResult {
+): Promise<ToolResult> {
   if (!context.bladeConfig) {
     return {
       status: 'error',
@@ -446,7 +448,7 @@ function handleBackgroundExecution(
     };
   }
 
-  const agentId = manager.startBackgroundAgent({
+  const agentId = await manager.startBackgroundAgent({
     config: subagentConfig,
     bladeConfig: context.bladeConfig,
     subagentRegistry: registry,
@@ -458,6 +460,7 @@ function handleBackgroundExecution(
     snapshot: context.contextSnapshot,
     executionFence: context.executionFence,
     assertExecutionLease: context.assertExecutionLease,
+    runWithExecutionLease: context.runWithExecutionLease,
   });
 
   return {
@@ -480,7 +483,7 @@ function handleBackgroundExecution(
   };
 }
 
-function handleResume(
+async function handleResume(
   agentId: AgentId,
   prompt: string,
   subagentConfig: {
@@ -492,7 +495,7 @@ function handleResume(
   description: string,
   context: ExecutionContext,
   registry: SubagentRegistry,
-): ToolResult {
+): Promise<ToolResult> {
   if (!context.bladeConfig) {
     return {
       status: 'error',
@@ -551,7 +554,7 @@ function handleResume(
     };
   }
 
-  const newAgentId = manager.resumeAgent(
+  const newAgentId = await manager.resumeAgent(
     agentId,
     prompt,
     subagentConfig,
@@ -562,6 +565,7 @@ function handleResume(
     description,
     context.executionFence,
     context.assertExecutionLease,
+    context.runWithExecutionLease,
   );
 
   if (!newAgentId) {

--- a/src/tools/builtin/task/taskStop.ts
+++ b/src/tools/builtin/task/taskStop.ts
@@ -25,7 +25,7 @@ export function createTaskStopTool({ sessionId }: { sessionId: SessionId }) {
       const agentManager = context.backgroundAgentManager;
       const aid = AgentId(taskId);
       if (agentManager?.getAgent(aid)) {
-        const stopped = agentManager.killAgent(aid);
+        const stopped = await agentManager.killAgent(aid);
         const latestSession = agentManager.getAgent(aid);
         return {
           status: 'success',

--- a/src/tools/builtin/task/taskStop.ts
+++ b/src/tools/builtin/task/taskStop.ts
@@ -27,6 +27,21 @@ export function createTaskStopTool({ sessionId }: { sessionId: SessionId }) {
       if (agentManager?.getAgent(aid)) {
         const stopped = await agentManager.killAgent(aid);
         const latestSession = agentManager.getAgent(aid);
+        if (!stopped && latestSession?.status === 'running') {
+          return {
+            status: 'error',
+            model: `Background agent ${taskId} could not be stopped`,
+            error: {
+              type: ToolErrorType.EXECUTION_ERROR,
+              message: `Background agent ${taskId} is owned by another execution`,
+            },
+            metadata: {
+              summary: '无法停止后台 Agent',
+              task: latestSession,
+              stoppedBackgroundAgent: false,
+            },
+          };
+        }
         return {
           status: 'success',
           model: toJsonValue(

--- a/src/tools/execution/ExecutionPipeline.ts
+++ b/src/tools/execution/ExecutionPipeline.ts
@@ -83,6 +83,16 @@ interface PipelineExecutionState {
  */
 export type ConfirmationReasonSource = 'tool' | 'rule' | 'path' | 'handler' | 'hook';
 
+function isExecutionLeaseFailure(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    typeof error.code === 'string' &&
+    error.code.startsWith('DURABLE_EXECUTION_LEASE_')
+  );
+}
+
 export interface ConfirmationReasonEntry {
   source: ConfirmationReasonSource;
   message: string;
@@ -214,6 +224,7 @@ export class ExecutionPipeline {
       fileLease = filePath
         ? await FileLockManager.getInstance(this.logger).acquire(filePath, lockMode)
         : undefined;
+      await state.context.assertExecutionLease?.();
       return yield* this.executeWithPipeline(state, executionId, startTime);
     } finally {
       fileLease?.release();
@@ -251,6 +262,7 @@ export class ExecutionPipeline {
       if (!state.result) {
         yield* this.executeInvocation(state);
       }
+      await state.context.assertExecutionLease?.();
 
       let result = await this.normalizeExecutionResult(state);
       result = await this.applyPostExecutionHooks(
@@ -276,6 +288,9 @@ export class ExecutionPipeline {
 
       return result;
     } catch (error) {
+      if (isExecutionLeaseFailure(error)) {
+        throw error;
+      }
       const endTime = Date.now();
       const errorMsg = getErrorMessage(error);
       const isTimeout =

--- a/src/tools/execution/ExecutionPipeline.ts
+++ b/src/tools/execution/ExecutionPipeline.ts
@@ -2,44 +2,44 @@ import type { HookRuntime } from '../../hooks/HookRuntime.js';
 import { type InternalLogger, LogCategory, NOOP_LOGGER } from '../../logging/Logger.js';
 import { isSteeringInterruptSignal } from '../../types/abort.js';
 import {
-    type PermissionRequestId,
-    SessionId,
-    ToolUseId,
+  type PermissionRequestId,
+  SessionId,
+  ToolUseId,
 } from '../../types/branded.js';
 import { type JsonObject, PermissionMode, type PermissionsConfig } from '../../types/common.js';
 import {
-    type CanUseTool,
-    type PermissionResult as CanUseToolResult,
-    createModePermissionHandler,
-    createPathSafetyPermissionHandler,
-    createPermissionHandlerFromCanUseTool,
-    createRuleBasedPermissionHandler,
-    type PermissionHandler,
-    type PermissionHandlerRequest,
-    type PermissionUpdate,
+  type CanUseTool,
+  type PermissionResult as CanUseToolResult,
+  createModePermissionHandler,
+  createPathSafetyPermissionHandler,
+  createPermissionHandlerFromCanUseTool,
+  createRuleBasedPermissionHandler,
+  type PermissionHandler,
+  type PermissionHandlerRequest,
+  type PermissionUpdate,
 } from '../../types/permissions.js';
 import { getErrorMessage, getErrorName } from '../../utils/errorUtils.js';
 import type { ToolCatalog } from '../catalog/ToolCatalog.js';
 import type { ToolRegistry } from '../registry/ToolRegistry.js';
 import type {
-    ConfirmationDetails,
-    ExecutionContext,
-    ExecutionHistoryEntry,
-    ToolExecution,
-    ToolResult,
-    ToolYield,
+  ConfirmationDetails,
+  ExecutionContext,
+  ExecutionHistoryEntry,
+  ToolExecution,
+  ToolResult,
+  ToolYield,
 } from '../types/index.js';
 import { normalizePermissionEffects } from '../types/index.js';
 import type { Tool, ToolInvocation } from '../types/ToolDefinition.js';
 import {
-    isReadOnlyKind,
-    resolveToolBehaviorSafely,
-    type ToolBehavior,
-    ToolKind,
+  isReadOnlyKind,
+  resolveToolBehaviorSafely,
+  type ToolBehavior,
+  ToolKind,
 } from '../types/ToolKind.js';
 import {
-    ToolErrorType,
-    validationErrorToToolResult,
+  ToolErrorType,
+  validationErrorToToolResult,
 } from '../types/ToolResult.js';
 import { type ConcurrencyLimits, ConcurrencyScheduler } from './ConcurrencyScheduler.js';
 import { DenialTracker } from './DenialTracker.js';
@@ -192,6 +192,8 @@ export class ExecutionPipeline {
       confirmationReasons: [],
       interrupted: false,
     };
+
+    await state.context.assertExecutionLease?.();
 
     // 检查工具是否需要文件锁
     const resolvedBehavior = resolveToolBehaviorSafely(tool, nextParams);
@@ -554,6 +556,7 @@ export class ExecutionPipeline {
       input: structuredClone(state.params),
       sideEffect: state.resolvedBehavior?.sideEffect ?? state.tool.sideEffect,
     });
+    await state.context.assertExecutionLease?.();
     if (state.context.signal?.aborted) {
       state.result = this.createAbortedResult('Task was aborted before tool execution');
       return;

--- a/src/tools/execution/ExecutionPipeline.ts
+++ b/src/tools/execution/ExecutionPipeline.ts
@@ -1,5 +1,6 @@
 import type { HookRuntime } from '../../hooks/HookRuntime.js';
 import { type InternalLogger, LogCategory, NOOP_LOGGER } from '../../logging/Logger.js';
+import { isExecutionLeaseFailure } from '../../session/events/DurableExecutionLeaseStore.js';
 import { isSteeringInterruptSignal } from '../../types/abort.js';
 import {
   type PermissionRequestId,
@@ -82,16 +83,6 @@ interface PipelineExecutionState {
  * Ranked for display: deny > tool > rule > path > handler.
  */
 export type ConfirmationReasonSource = 'tool' | 'rule' | 'path' | 'handler' | 'hook';
-
-function isExecutionLeaseFailure(error: unknown): boolean {
-  return (
-    typeof error === 'object' &&
-    error !== null &&
-    'code' in error &&
-    typeof error.code === 'string' &&
-    error.code.startsWith('DURABLE_EXECUTION_LEASE_')
-  );
-}
 
 export interface ConfirmationReasonEntry {
   source: ConfirmationReasonSource;

--- a/src/tools/execution/__tests__/ExecutionPipeline.test.ts
+++ b/src/tools/execution/__tests__/ExecutionPipeline.test.ts
@@ -3,6 +3,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
+import { DurableExecutionLeaseError } from '../../../session/events/DurableExecutionLeaseStore.js';
 import { createTool } from '../../core/createTool.js';
 import { ToolRegistry } from '../../registry/ToolRegistry.js';
 import { PermissionRequestId, SessionId } from '../../../types/branded.js';
@@ -1223,30 +1224,74 @@ describe('ExecutionPipeline', () => {
     const pipeline = new ExecutionPipeline(registry, {
       permissionMode: PermissionMode.YOLO,
     });
+    const leaseError = new DurableExecutionLeaseError(
+      'DURABLE_EXECUTION_LEASE_LOST',
+      'execution lease lost',
+    );
     const assertExecutionLease = vi.fn()
       .mockResolvedValueOnce(undefined)
-      .mockRejectedValueOnce(new Error('execution lease lost'));
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(leaseError);
 
-    const result = await executePipeline(
-      pipeline,
-      'FencedTool',
-      {},
-      {
-        permissionMode: PermissionMode.YOLO,
-        assertExecutionLease,
-        toolInvocationLifecycle: {
-          onExecutionStarted: async () => {},
+    await expect(
+      executePipeline(
+        pipeline,
+        'FencedTool',
+        {},
+        {
+          permissionMode: PermissionMode.YOLO,
+          assertExecutionLease,
+          toolInvocationLifecycle: {
+            onExecutionStarted: async () => {},
+          },
         },
-      },
-    );
+      ),
+    ).rejects.toBe(leaseError);
+    expect(assertExecutionLease).toHaveBeenCalledTimes(3);
+    expect(executeSpy).not.toHaveBeenCalled();
+  });
 
-    expect(result).toMatchObject({
-      status: 'error',
-      error: {
-        message: 'execution lease lost',
-      },
+  it('rechecks the execution fence after lock acquisition and before hooks', async () => {
+    const registry = new ToolRegistry();
+    const executeSpy = vi.fn(() => completeToolExecution({
+      status: 'success',
+      model: 'unexpected',
+    }));
+    registerTool(
+      registry,
+      createTool({
+        name: 'QueuedFencedTool',
+        displayName: 'Queued Fenced Tool',
+        kind: ToolKind.Execute,
+        sideEffect: 'non_idempotent',
+        description: { short: 'Queued fenced tool' },
+        schema: z.object({}),
+        execute: executeSpy,
+      }),
+    );
+    const pipeline = new ExecutionPipeline(registry, {
+      permissionMode: PermissionMode.YOLO,
     });
+    const assertExecutionLease = vi.fn()
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('execution lease lost while queued'));
+    const onExecutionStarted = vi.fn(async () => {});
+
+    await expect(
+      executePipeline(
+        pipeline,
+        'QueuedFencedTool',
+        {},
+        {
+          permissionMode: PermissionMode.YOLO,
+          assertExecutionLease,
+          toolInvocationLifecycle: { onExecutionStarted },
+        },
+      ),
+    ).rejects.toThrow('execution lease lost while queued');
+
     expect(assertExecutionLease).toHaveBeenCalledTimes(2);
+    expect(onExecutionStarted).not.toHaveBeenCalled();
     expect(executeSpy).not.toHaveBeenCalled();
   });
 

--- a/src/tools/execution/__tests__/ExecutionPipeline.test.ts
+++ b/src/tools/execution/__tests__/ExecutionPipeline.test.ts
@@ -1202,6 +1202,54 @@ describe('ExecutionPipeline', () => {
     expect(executeSpy).not.toHaveBeenCalled();
   });
 
+  it('checks the execution fence immediately before the tool side effect', async () => {
+    const registry = new ToolRegistry();
+    const executeSpy = vi.fn(() => completeToolExecution({
+      status: 'success',
+      model: 'unexpected',
+    }));
+    registerTool(
+      registry,
+      createTool({
+        name: 'FencedTool',
+        displayName: 'Fenced Tool',
+        kind: ToolKind.Execute,
+        sideEffect: 'non_idempotent',
+        description: { short: 'Fenced tool' },
+        schema: z.object({}),
+        execute: executeSpy,
+      }),
+    );
+    const pipeline = new ExecutionPipeline(registry, {
+      permissionMode: PermissionMode.YOLO,
+    });
+    const assertExecutionLease = vi.fn()
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('execution lease lost'));
+
+    const result = await executePipeline(
+      pipeline,
+      'FencedTool',
+      {},
+      {
+        permissionMode: PermissionMode.YOLO,
+        assertExecutionLease,
+        toolInvocationLifecycle: {
+          onExecutionStarted: async () => {},
+        },
+      },
+    );
+
+    expect(result).toMatchObject({
+      status: 'error',
+      error: {
+        message: 'execution lease lost',
+      },
+    });
+    expect(assertExecutionLease).toHaveBeenCalledTimes(2);
+    expect(executeSpy).not.toHaveBeenCalled();
+  });
+
   it('blocks the side effect when cancellation wins during the execution-start boundary', async () => {
     const registry = new ToolRegistry();
     const boundary = deferred();

--- a/src/tools/types/ExecutionTypes.ts
+++ b/src/tools/types/ExecutionTypes.ts
@@ -7,6 +7,7 @@ import type {
 } from '@/types/branded.js';
 import type { IBackgroundAgentManager } from '../../agent/types.js';
 import type { ContextSnapshot } from '../../runtime/index.js';
+import type { DurableExecutionFence } from '../../session/events/DurableExecutionLeaseStore.js';
 import type { BladeConfig, JsonObject, PermissionMode } from '../../types/common.js';
 import type { ToolCatalog } from '../catalog/index.js';
 import type { ToolRegistry } from '../registry/ToolRegistry.js';
@@ -118,6 +119,9 @@ export interface ExecutionContext {
   permissionMode?: PermissionMode;
   bladeConfig?: BladeConfig;
   backgroundAgentManager?: IBackgroundAgentManager;
+  executionFence?: DurableExecutionFence;
+  /** @internal Validates execution ownership immediately before a side effect. */
+  assertExecutionLease?: () => Promise<void>;
   toolRegistry?: ToolRegistry;
   toolCatalog?: ToolCatalog;
   discoveredTools?: string[];

--- a/src/tools/types/ExecutionTypes.ts
+++ b/src/tools/types/ExecutionTypes.ts
@@ -122,6 +122,8 @@ export interface ExecutionContext {
   executionFence?: DurableExecutionFence;
   /** @internal Validates execution ownership immediately before a side effect. */
   assertExecutionLease?: () => Promise<void>;
+  /** @internal Serializes a short persistence operation against lease takeover. */
+  runWithExecutionLease?: <T>(operation: () => Promise<T>) => Promise<T>;
   toolRegistry?: ToolRegistry;
   toolCatalog?: ToolCatalog;
   discoveredTools?: string[];

--- a/src/types/branded.ts
+++ b/src/types/branded.ts
@@ -15,6 +15,9 @@ export type ModelAttemptId = Brand<string, 'ModelAttemptId'>;
 export type ToolAttemptId = Brand<string, 'ToolAttemptId'>;
 export type CommandId = Brand<string, 'CommandId'>;
 export type PermissionRequestId = Brand<string, 'PermissionRequestId'>;
+export type WorkerId = Brand<string, 'WorkerId'>;
+export type ExecutionLeaseId = Brand<string, 'ExecutionLeaseId'>;
+export type FencingToken = Brand<number, 'FencingToken'>;
 
 export const SessionId = (value: string): SessionId => value as SessionId;
 export const AgentId = (value: string): AgentId => value as AgentId;
@@ -30,3 +33,6 @@ export const ToolAttemptId = (value: string): ToolAttemptId => value as ToolAtte
 export const CommandId = (value: string): CommandId => value as CommandId;
 export const PermissionRequestId = (value: string): PermissionRequestId =>
   value as PermissionRequestId;
+export const WorkerId = (value: string): WorkerId => value as WorkerId;
+export const ExecutionLeaseId = (value: string): ExecutionLeaseId => value as ExecutionLeaseId;
+export const FencingToken = (value: number): FencingToken => value as FencingToken;


### PR DESCRIPTION
## Summary

- add Store-backed Session execution leases with automatic heartbeat and monotonic fencing tokens
- validate every Journal append under the same Store transaction/lock as the lease, with sticky fencing after first enablement
- fail closed on lease loss, stop the local execution tree, and fence model, compaction, tool, subagent, and background-shell work
- release ownership only after controlled close or handoff cleanup, with fence-scoped shell cleanup for overlapping workers
- document the public API, JSONL guarantees, recovery workflow, and downstream hard-fencing requirement in English and Chinese

## Compatibility and deployment boundary

- this is opt-in for Sessions that have never enabled execution leases
- once enabled for a Session, subsequent Journal writers must acquire a lease
- `JsonlDurableEventStore` supports processes sharing one supported local filesystem; cross-host Stores must implement transactional lease mutation and fenced append themselves
- tools that mutate external shared resources must forward `ExecutionContext.executionFence` and have the downstream system reject stale tokens

## Verification

- `pnpm test` (1514 passed, 62 credential-gated tests skipped)
- `pnpm run type-check`
- `pnpm run lint`
- `pnpm run verify:entrypoints`
- `pnpm run docs:build`
- `pnpm run changelog:check -- --base origin/main`
- `pnpm run audit:prod`
- `git diff --check origin/main...HEAD`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional durable execution leases with automatic heartbeats, ownership validation, fencing tokens, and controlled handoff.
  * Sessions now expose lease status and stop active work when ownership is lost.
  * Protected journal, transcript, model, tool, subagent, and background shell operations against stale execution owners.
  * Added process-tree cancellation and safer background task cleanup.

* **Documentation**
  * Added English and Simplified Chinese documentation covering lease configuration, recovery, fencing, errors, and API usage.
  * Updated capability descriptions to highlight lease-fenced execution ownership.

* **Tests**
  * Expanded coverage for lease acquisition, renewal, takeover, fencing, cancellation, recovery, and process cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->