### PR TITLE
fix(model): bound stalled provider requests

### DIFF
--- a/.changes/model-timeout-boundaries.json
+++ b/.changes/model-timeout-boundaries.json
@@ -1,0 +1,5 @@
+{
+  "type": "fix",
+  "en": "Bound stalled model calls with configurable request and stream-idle timeouts that abort the provider and preserve typed failure semantics.",
+  "zh-CN": "为停滞的模型调用增加可配置的请求与流空闲超时，主动中止 provider 并保留类型化失败语义。"
+}

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ console.log(result.usage);
 - Tools: generator-only custom tools, capability-grouped built-ins, MCP tools, and typed progress/effects
 - Extensibility: onion-style model/tool middleware and declarative plugins that bundle middleware, hooks, and tools
 - Collaboration: foreground and background subagents, task tools, and project Skills
-- Safety: permission modes, policy callbacks, hooks, path checks, and optional OS sandbox integration
+- Safety: bounded model requests, permission modes, policy callbacks, hooks, path checks, and optional OS sandbox integration
 - Runtime: optional workspace context, structured output, crash-safe local transcripts, context compaction, token budgets, and traces
 
 ## Steer an Active Request

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -67,7 +67,7 @@ console.log(result.usage);
 - 工具：仅 generator 的自定义工具、按能力分组的内置工具、MCP 工具和类型化进度/副作用
 - 扩展：洋葱式模型/工具 middleware，以及可打包 middleware、hooks 与工具的声明式插件
 - 协作：前台/后台子 Agent、任务工具，以及项目级 Skills
-- 安全：权限模式、策略回调、Hooks、路径检查和可选 OS 沙箱集成
+- 安全：有界模型请求、权限模式、策略回调、Hooks、路径检查和可选 OS 沙箱集成
 - 运行时：可选 workspace、结构化输出、崩溃安全的本地会话记录、上下文压缩、token 预算和 trace
 
 ## 转向活动请求

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -338,7 +338,7 @@ Node-local 能力外，这些函数都从根入口导出；实际 subpath 以“
 | `AgentTrace` / `TraceEvent` / `TraceSpan` | 一次 Agent 请求的结构化执行轨迹 |
 | `TracePayloadSummary` / `TraceSink` | Trace 摘要与输出接口 |
 | `TraceSpanKind` / `TraceStatus` | Span 类型与状态 |
-| `SdkErrorOptions` / `SessionInputErrorCode` | SDK 错误元数据 |
+| `SdkErrorOptions` / `SessionInputErrorCode` / `ModelTimeoutErrorCode` | SDK 错误元数据 |
 | `TokenBudgetConfig` / `TokenBudgetSnapshot` | 跨轮次 token 预算配置与快照 |
 
 ### 错误、生命周期与标识符
@@ -346,6 +346,7 @@ Node-local 能力外，这些函数都从根入口导出；实际 subpath 以“
 | 导出 | 说明 |
 |------|------|
 | `SdkError` / `AbortError` / `ConfigError` | SDK 基础错误、中止错误与配置错误 |
+| `ModelTimeoutError` | 非流式模型请求或流式空闲超时错误 |
 | `PermissionDeniedError` / `ToolExecutionError` | 权限与工具执行错误 |
 | `getErrorCode` / `getErrorMessage` / `getErrorName` / `toError` | 未知错误规范化辅助函数 |
 | `registerCleanup` / `gracefulShutdown` / `resetCleanupRegistry` | 进程级清理生命周期 |

--- a/docs/en/api-reference.md
+++ b/docs/en/api-reference.md
@@ -436,6 +436,7 @@ Classes:
 - `SdkError`
 - `AbortError`
 - `ConfigError`
+- `ModelTimeoutError`
 - `PermissionDeniedError`
 - `SessionInputError`
 - `ToolExecutionError`
@@ -443,6 +444,7 @@ Classes:
 Types and helpers:
 
 - `SdkErrorOptions`
+- `ModelTimeoutErrorCode`
 - `SessionInputErrorCode`
 - `getErrorCode`
 - `getErrorMessage`

--- a/docs/en/providers.md
+++ b/docs/en/providers.md
@@ -30,8 +30,18 @@ interface ProviderConfig {
   organization?: string;
   apiVersion?: string;
   projectId?: string;
+  requestTimeoutMs?: number;
+  streamIdleTimeoutMs?: number;
 }
 ```
+
+`requestTimeoutMs` bounds one non-streaming model operation, including retry
+delays, and defaults to 10 minutes. `streamIdleTimeoutMs` bounds the wait for
+each next streaming chunk and defaults to 5 minutes. Both values
+must be positive integers in milliseconds. A timeout aborts the underlying
+provider request and throws `ModelTimeoutError` with code
+`MODEL_REQUEST_TIMEOUT` or `MODEL_STREAM_IDLE_TIMEOUT`; it is not reported as a
+user cancellation.
 
 ## OpenAI
 

--- a/docs/en/session.md
+++ b/docs/en/session.md
@@ -710,6 +710,10 @@ Payload capture is opt-in because prompts and tool data may be sensitive.
 | `sandbox` | `SandboxSettings` | Bash sandbox settings |
 | `observability` | `ObservabilityOptions` | Trace collection |
 
+`ProviderConfig.requestTimeoutMs` defaults to `600000`, and
+`ProviderConfig.streamIdleTimeoutMs` defaults to `300000`. See
+[Providers and Logging](./providers) for timeout semantics.
+
 ## ISession
 
 ```ts

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -22,8 +22,16 @@ interface ProviderConfig {
   organization?: string;
   apiVersion?: string;
   projectId?: string;
+  requestTimeoutMs?: number;
+  streamIdleTimeoutMs?: number;
 }
 ```
+
+`requestTimeoutMs` 限制一次非流式模型操作的总时长（包括重试等待），默认
+10 分钟。`streamIdleTimeoutMs` 限制等待下一个流式 chunk 的时长，默认
+5 分钟。两者都必须是以毫秒为单位的正整数。超时会主动中止底层 provider
+请求，并抛出 `ModelTimeoutError`；错误码分别为
+`MODEL_REQUEST_TIMEOUT` 和 `MODEL_STREAM_IDLE_TIMEOUT`，不会伪装成用户取消。
 
 ## 配置示例
 

--- a/docs/session.md
+++ b/docs/session.md
@@ -126,6 +126,8 @@ interface ProviderConfig {
   organization?: string;   // OpenAI 专用
   apiVersion?: string;      // Azure OpenAI 专用
   projectId?: string;       // OpenAI 专用
+  requestTimeoutMs?: number; // 非流式模型操作总时限，默认 600000
+  streamIdleTimeoutMs?: number; // 等待下一个流式 chunk 的时限，默认 300000
 }
 ```
 
@@ -1752,6 +1754,10 @@ async function analyzeCodeManual() {
 | `outputFormat`    | `OutputFormat`                                          | —  | —           | 结构化 JSON Schema 输出格式                              |
 | `sandbox`         | `SandboxSettings`                                       | —  | —           | 命令执行沙箱设置                                          |
 | `observability`   | `ObservabilityOptions`                                  | —  | —           | Trace 收集、payload 捕获与 sink 配置                         |
+
+`ProviderConfig.requestTimeoutMs` 默认 `600000`，
+`ProviderConfig.streamIdleTimeoutMs` 默认 `300000`。具体超时语义见
+[Provider 配置](./providers)。
 
 ### SessionHookEvent
 

--- a/src/__tests__/rootExports.test.ts
+++ b/src/__tests__/rootExports.test.ts
@@ -164,11 +164,10 @@ describe('root exports', () => {
   });
 
   it('exports runtime tool contracts at the root entrypoint', () => {
-    expectTypeOf<AgentPlugin['middleware']>().toEqualTypeOf<
-      AgentMiddlewareConfig | undefined
-    >();
-    expectTypeOf<NonNullable<AgentMiddlewareConfig['tool']>[number]>()
-      .toEqualTypeOf<ToolMiddleware>();
+    expectTypeOf<AgentPlugin['middleware']>().toEqualTypeOf<AgentMiddlewareConfig | undefined>();
+    expectTypeOf<
+      NonNullable<AgentMiddlewareConfig['tool']>[number]
+    >().toEqualTypeOf<ToolMiddleware>();
     expectTypeOf<RuntimePatch['scope']>().toEqualTypeOf<'turn' | 'session'>();
     expectTypeOf<ToolEffect['type']>().toEqualTypeOf<
       'runtimePatch' | 'contextPatch' | 'newMessages' | 'permissionUpdates'

--- a/src/__tests__/rootExports.test.ts
+++ b/src/__tests__/rootExports.test.ts
@@ -90,6 +90,7 @@ import {
   JsonlDurableEventStore,
   MemoryManager,
   ModelAttemptId,
+  ModelTimeoutError,
   PermissionRequestId,
   projectDurableSession,
   RequestId,
@@ -119,6 +120,10 @@ describe('root exports', () => {
     expect(completeToolExecution).toBeTypeOf('function');
     expect(composeMiddleware).toBeTypeOf('function');
     expect(definePlugin({ name: 'test' })).toEqual({ name: 'test' });
+    expect(new ModelTimeoutError('MODEL_REQUEST_TIMEOUT', 1000)).toMatchObject({
+      code: 'MODEL_REQUEST_TIMEOUT',
+      timeoutMs: 1000,
+    });
     expect(InputPriority.NEXT).toBe('next');
     expect(InputId('input-1')).toBe('input-1');
     expect(RequestId('request-1')).toBe('request-1');

--- a/src/agent/ModelManager.ts
+++ b/src/agent/ModelManager.ts
@@ -6,10 +6,7 @@
 
 import { ContextManager } from '../context/ContextManager.js';
 import { type InternalLogger, LogCategory, NOOP_LOGGER } from '../logging/Logger.js';
-import {
-  type ModelMiddleware,
-  wrapChatService,
-} from '../middleware/ModelMiddleware.js';
+import { type ModelMiddleware, wrapChatService } from '../middleware/ModelMiddleware.js';
 import { createChatServiceAsync, type IChatService } from '../services/ChatServiceInterface.js';
 import { wrapChatServiceWithTimeouts } from '../services/ChatServiceTimeout.js';
 import { withDeepSeekDefaults } from '../services/deepseek.js';

--- a/src/agent/ModelManager.ts
+++ b/src/agent/ModelManager.ts
@@ -11,6 +11,7 @@ import {
   wrapChatService,
 } from '../middleware/ModelMiddleware.js';
 import { createChatServiceAsync, type IChatService } from '../services/ChatServiceInterface.js';
+import { wrapChatServiceWithTimeouts } from '../services/ChatServiceTimeout.js';
 import { withDeepSeekDefaults } from '../services/deepseek.js';
 import type { BladeConfig, ModelConfig, OutputFormat } from '../types/common.js';
 import { isThinkingModel } from '../utils/modelDetection.js';
@@ -95,11 +96,15 @@ export class ModelManager {
       temperature: modelConfig.temperature ?? this.config.temperature,
       maxContextTokens: this.currentModelMaxContextTokens,
       maxOutputTokens: modelConfig.maxOutputTokens,
+      requestTimeoutMs: modelConfig.requestTimeoutMs,
+      streamIdleTimeoutMs: modelConfig.streamIdleTimeoutMs,
       supportsThinking,
       providerOptions: modelConfig.providerOptions as never,
       outputFormat: this.outputFormat,
     });
-    this.chatService = wrapChatService(chatService, this.modelMiddleware);
+    this.chatService = wrapChatServiceWithTimeouts(
+      wrapChatService(chatService, this.modelMiddleware),
+    );
 
     this.currentModelId = modelConfig.id;
     this.config.currentModelId = modelConfig.id;

--- a/src/agent/__tests__/ModelManager.setModel.test.ts
+++ b/src/agent/__tests__/ModelManager.setModel.test.ts
@@ -29,11 +29,13 @@ function createModelConfig(overrides: Partial<ModelConfig> = {}): ModelConfig {
 }
 
 describe('ModelManager.setModel', () => {
-  it('passes model output token limits into chat service config', async () => {
+  it('passes model output and timeout limits into chat service config', async () => {
     const config: BladeConfig = {
       models: [
         createModelConfig({
           maxOutputTokens: 4096,
+          requestTimeoutMs: 120_000,
+          streamIdleTimeoutMs: 30_000,
         }),
       ],
       currentModelId: 'default',
@@ -50,6 +52,8 @@ describe('ModelManager.setModel', () => {
     expect(mockCreateChatServiceAsync).toHaveBeenLastCalledWith(
       expect.objectContaining({
         maxOutputTokens: 4096,
+        requestTimeoutMs: 120_000,
+        streamIdleTimeoutMs: 30_000,
       }),
     );
   });

--- a/src/context/CompactionService.ts
+++ b/src/context/CompactionService.ts
@@ -7,17 +7,18 @@ import { nanoid } from 'nanoid';
 import { HookManager } from '../hooks/HookManager.js';
 import { NOOP_LOGGER } from '../logging/Logger.js';
 import {
-    createChatServiceAsync,
-    type Message,
+  createChatServiceAsync,
+  type Message,
 } from '../services/ChatServiceInterface.js';
+import { wrapChatServiceWithTimeouts } from '../services/ChatServiceTimeout.js';
 import { isExecutionLeaseFailure } from '../session/events/DurableExecutionLeaseStore.js';
 import { SessionId } from '../types/branded.js';
 import { PermissionMode, type ProviderType } from '../types/common.js';
 import { FileAnalyzer, type FileContent } from './FileAnalyzer.js';
 import {
-    microcompact,
-    type MicrocompactOptions,
-    type MicrocompactResult,
+  microcompact,
+  type MicrocompactOptions,
+  type MicrocompactResult,
 } from './strategies/MicrocompactStrategy.js';
 import { TokenCounter } from './TokenCounter.js';
 
@@ -338,16 +339,18 @@ async function generateSummary(
 
   console.log('[CompactionService] 使用压缩模型:', options.modelName);
 
-  const chatService = await createChatServiceAsync({
-    apiKey: options.apiKey || process.env.BLADE_API_KEY || '',
-    baseUrl: baseURL,
-    model: options.modelName,
-    temperature: 0.3,
-    maxOutputTokens: 8000,
-    timeout: 60000,
-    provider: options.provider || inferProvider(baseURL),
-    customHeaders: options.customHeaders,
-  }, NOOP_LOGGER);
+  const chatService = wrapChatServiceWithTimeouts(
+    await createChatServiceAsync({
+      apiKey: options.apiKey || process.env.BLADE_API_KEY || '',
+      baseUrl: baseURL,
+      model: options.modelName,
+      temperature: 0.3,
+      maxOutputTokens: 8000,
+      timeout: 60000,
+      provider: options.provider || inferProvider(baseURL),
+      customHeaders: options.customHeaders,
+    }, NOOP_LOGGER),
+  );
 
   const response = await chatService.sideQuery(
     [{ role: 'user', content: prompt }],

--- a/src/context/CompactionService.ts
+++ b/src/context/CompactionService.ts
@@ -6,10 +6,7 @@
 import { nanoid } from 'nanoid';
 import { HookManager } from '../hooks/HookManager.js';
 import { NOOP_LOGGER } from '../logging/Logger.js';
-import {
-  createChatServiceAsync,
-  type Message,
-} from '../services/ChatServiceInterface.js';
+import { createChatServiceAsync, type Message } from '../services/ChatServiceInterface.js';
 import { wrapChatServiceWithTimeouts } from '../services/ChatServiceTimeout.js';
 import { isExecutionLeaseFailure } from '../session/events/DurableExecutionLeaseStore.js';
 import { SessionId } from '../types/branded.js';
@@ -124,88 +121,84 @@ export function retainRecentMessages(messages: Message[], retainPercent: number)
  */
 export async function compact(
   messages: Message[],
-  options: CompactionOptions
+  options: CompactionOptions,
 ): Promise<CompactionResult> {
   options.signal?.throwIfAborted();
   await options.assertExecutionLease?.();
   const preTokens =
     options.actualPreTokens ?? TokenCounter.countTokens(messages, options.modelName);
-  const tokenSource = options.actualPreTokens
-    ? 'actual (from LLM usage)'
-    : 'estimated';
+  const tokenSource = options.actualPreTokens ? 'actual (from LLM usage)' : 'estimated';
   console.log(`[CompactionService] preTokens source: ${tokenSource}`);
 
   if (options.projectDir) {
     try {
-    const hookManager = HookManager.getInstance();
+      const hookManager = HookManager.getInstance();
 
-    const preCompactResult = await hookManager.executePreCompactHooks(
-      {
-        trigger: options.trigger,
-        messages_before: messages.length,
-        tokens_before: preTokens,
-      },
-      options.projectDir,
-      options.sessionId || SessionId('unknown'),
-      options.permissionMode || PermissionMode.DEFAULT,
-      options.signal,
-    );
-    options.signal?.throwIfAborted();
-    await options.assertExecutionLease?.();
-
-    if (preCompactResult.blockCompaction) {
-      console.log(
-        `[CompactionService] PreCompact hook 阻止压缩: ${preCompactResult.blockReason || '(无原因)'}`
+      const preCompactResult = await hookManager.executePreCompactHooks(
+        {
+          trigger: options.trigger,
+          messages_before: messages.length,
+          tokens_before: preTokens,
+        },
+        options.projectDir,
+        options.sessionId || SessionId('unknown'),
+        options.permissionMode || PermissionMode.DEFAULT,
+        options.signal,
       );
-      return {
-        success: false,
-        summary: '',
-        preTokens,
-        postTokens: preTokens,
-        filesIncluded: [],
-        compactedMessages: messages,
-        boundaryMessage: { role: 'system', content: '' },
-        summaryMessage: { role: 'user', content: '' },
-        error: preCompactResult.blockReason || 'Compaction blocked by PreCompact hook',
-      };
-    }
-    if (preCompactResult.warning) {
-      console.warn(`[CompactionService] PreCompact hook warning: ${preCompactResult.warning}`);
-    }
+      options.signal?.throwIfAborted();
+      await options.assertExecutionLease?.();
 
-    const hookResult = await hookManager.executeCompactionHooks(options.trigger, {
-      projectDir: options.projectDir,
-      sessionId: options.sessionId || SessionId('unknown'),
-      permissionMode: options.permissionMode || PermissionMode.DEFAULT,
-      messagesBefore: messages.length,
-      tokensBefore: preTokens,
-      abortSignal: options.signal,
-    });
-    options.signal?.throwIfAborted();
-    await options.assertExecutionLease?.();
+      if (preCompactResult.blockCompaction) {
+        console.log(
+          `[CompactionService] PreCompact hook 阻止压缩: ${preCompactResult.blockReason || '(无原因)'}`,
+        );
+        return {
+          success: false,
+          summary: '',
+          preTokens,
+          postTokens: preTokens,
+          filesIncluded: [],
+          compactedMessages: messages,
+          boundaryMessage: { role: 'system', content: '' },
+          summaryMessage: { role: 'user', content: '' },
+          error: preCompactResult.blockReason || 'Compaction blocked by PreCompact hook',
+        };
+      }
+      if (preCompactResult.warning) {
+        console.warn(`[CompactionService] PreCompact hook warning: ${preCompactResult.warning}`);
+      }
 
-    if (hookResult.blockCompaction) {
-      console.log(
-        `[CompactionService] Compaction hook 阻止压缩: ${hookResult.blockReason || '(无原因)'}`
-      );
-      return {
-        success: false,
-        summary: '',
-        preTokens,
-        postTokens: preTokens,
-        filesIncluded: [],
-        compactedMessages: messages,
-        boundaryMessage: { role: 'system', content: '' },
-        summaryMessage: { role: 'user', content: '' },
-        error: hookResult.blockReason || 'Compaction blocked by hook',
-      };
-    }
+      const hookResult = await hookManager.executeCompactionHooks(options.trigger, {
+        projectDir: options.projectDir,
+        sessionId: options.sessionId || SessionId('unknown'),
+        permissionMode: options.permissionMode || PermissionMode.DEFAULT,
+        messagesBefore: messages.length,
+        tokensBefore: preTokens,
+        abortSignal: options.signal,
+      });
+      options.signal?.throwIfAborted();
+      await options.assertExecutionLease?.();
 
-    if (hookResult.warning) {
-      console.warn(
-        `[CompactionService] Compaction hook warning: ${hookResult.warning}`
-      );
-    }
+      if (hookResult.blockCompaction) {
+        console.log(
+          `[CompactionService] Compaction hook 阻止压缩: ${hookResult.blockReason || '(无原因)'}`,
+        );
+        return {
+          success: false,
+          summary: '',
+          preTokens,
+          postTokens: preTokens,
+          filesIncluded: [],
+          compactedMessages: messages,
+          boundaryMessage: { role: 'system', content: '' },
+          summaryMessage: { role: 'user', content: '' },
+          error: hookResult.blockReason || 'Compaction blocked by hook',
+        };
+      }
+
+      if (hookResult.warning) {
+        console.warn(`[CompactionService] Compaction hook warning: ${hookResult.warning}`);
+      }
     } catch (hookError) {
       if (options.signal?.aborted || isExecutionLeaseFailure(hookError)) {
         throw hookError;
@@ -239,11 +232,7 @@ export async function compact(
     console.log('[CompactionService] 过滤后保留消息数:', retainedMessages.length);
 
     const boundaryMessageId = nanoid();
-    const boundaryMessage = createBoundaryMessage(
-      boundaryMessageId,
-      options.trigger,
-      preTokens
-    );
+    const boundaryMessage = createBoundaryMessage(boundaryMessageId, options.trigger, preTokens);
 
     const summaryMessageId = nanoid();
     const summaryMessage = createSummaryMessage(summaryMessageId, summary);
@@ -257,7 +246,7 @@ export async function compact(
       preTokens,
       '→',
       postTokens,
-      `(-${((1 - postTokens / preTokens) * 100).toFixed(1)}%)`
+      `(-${((1 - postTokens / preTokens) * 100).toFixed(1)}%)`,
     );
 
     if (options.projectDir) {
@@ -331,31 +320,30 @@ export function microcompactMessages(
 async function generateSummary(
   messages: Message[],
   fileContents: FileContent[],
-  options: CompactionOptions
+  options: CompactionOptions,
 ): Promise<string> {
   const prompt = buildCompactionPrompt(messages, fileContents);
-  const baseURL =
-    options.baseURL || process.env.BLADE_BASE_URL || 'https://api.openai.com/v1';
+  const baseURL = options.baseURL || process.env.BLADE_BASE_URL || 'https://api.openai.com/v1';
 
   console.log('[CompactionService] 使用压缩模型:', options.modelName);
 
   const chatService = wrapChatServiceWithTimeouts(
-    await createChatServiceAsync({
-      apiKey: options.apiKey || process.env.BLADE_API_KEY || '',
-      baseUrl: baseURL,
-      model: options.modelName,
-      temperature: 0.3,
-      maxOutputTokens: 8000,
-      timeout: 60000,
-      provider: options.provider || inferProvider(baseURL),
-      customHeaders: options.customHeaders,
-    }, NOOP_LOGGER),
+    await createChatServiceAsync(
+      {
+        apiKey: options.apiKey || process.env.BLADE_API_KEY || '',
+        baseUrl: baseURL,
+        model: options.modelName,
+        temperature: 0.3,
+        maxOutputTokens: 8000,
+        timeout: 60000,
+        provider: options.provider || inferProvider(baseURL),
+        customHeaders: options.customHeaders,
+      },
+      NOOP_LOGGER,
+    ),
   );
 
-  const response = await chatService.sideQuery(
-    [{ role: 'user', content: prompt }],
-    options.signal,
-  );
+  const response = await chatService.sideQuery([{ role: 'user', content: prompt }], options.signal);
 
   const content = response.content || '';
   const summaryMatch = content.match(/<summary>([\s\S]*?)<\/summary>/);
@@ -384,8 +372,8 @@ function inferProvider(baseURL?: string): ProviderType {
     return 'anthropic';
   }
   if (
-    normalized.includes('generativelanguage.googleapis.com')
-    || normalized.includes('aiplatform.googleapis.com')
+    normalized.includes('generativelanguage.googleapis.com') ||
+    normalized.includes('aiplatform.googleapis.com')
   ) {
     return 'gemini';
   }
@@ -399,21 +387,15 @@ function inferProvider(baseURL?: string): ProviderType {
  * @param fileContents - 文件内容列表
  * @returns 压缩 prompt
  */
-function buildCompactionPrompt(
-  messages: Message[],
-  fileContents: FileContent[]
-): string {
+function buildCompactionPrompt(messages: Message[], fileContents: FileContent[]): string {
   const messagesText = messages
     .map((msg, i) => {
       const role = msg.role || 'unknown';
-      const content =
-        typeof msg.content === 'string' ? msg.content : JSON.stringify(msg.content);
+      const content = typeof msg.content === 'string' ? msg.content : JSON.stringify(msg.content);
 
       const maxLength = 5000;
       const truncatedContent =
-        content.length > maxLength
-          ? `${content.substring(0, maxLength)}...`
-          : content;
+        content.length > maxLength ? `${content.substring(0, maxLength)}...` : content;
 
       return `[${i + 1}] ${role}: ${truncatedContent}`;
     })
@@ -477,7 +459,7 @@ Please provide your summary following the structure specified above, with both <
 function createBoundaryMessage(
   parentId: string,
   trigger: 'auto' | 'manual',
-  preTokens: number
+  preTokens: number,
 ): Message {
   return {
     id: nanoid(),
@@ -527,23 +509,19 @@ function fallbackCompact(
   messages: Message[],
   options: CompactionOptions,
   preTokens: number,
-  error: unknown
+  error: unknown,
 ): CompactionResult {
   const retainCount = Math.ceil(messages.length * FALLBACK_RETAIN_PERCENT);
   const retainedMessages = retainRecentMessages(messages, FALLBACK_RETAIN_PERCENT);
 
   const boundaryMessageId = nanoid();
-  const boundaryMessage = createBoundaryMessage(
-    boundaryMessageId,
-    options.trigger,
-    preTokens
-  );
+  const boundaryMessage = createBoundaryMessage(boundaryMessageId, options.trigger, preTokens);
 
   const errorMsg = error instanceof Error ? error.message : String(error);
   const summaryMessageId = nanoid();
   const summaryMessage = createSummaryMessage(
     summaryMessageId,
-    `[Automatic compaction failed; using fallback]\n\nAn error occurred during compaction. Retained the latest ${retainCount} messages (~30%).\n\nError: ${errorMsg}\n\nThe conversation can continue, but consider retrying compaction later with /compact.`
+    `[Automatic compaction failed; using fallback]\n\nAn error occurred during compaction. Retained the latest ${retainCount} messages (~30%).\n\nError: ${errorMsg}\n\nThe conversation can continue, but consider retrying compaction later with /compact.`,
   );
 
   const compactedMessages = [summaryMessage, ...retainedMessages];

--- a/src/context/__tests__/CompactionService.test.ts
+++ b/src/context/__tests__/CompactionService.test.ts
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { Message } from '../../services/ChatServiceInterface.js';
+import type {
+    ChatConfig,
+    Message,
+} from '../../services/ChatServiceInterface.js';
 
 const mockChat = vi.fn(async () => ({
   content: '<summary>ok</summary>',
@@ -7,10 +10,22 @@ const mockChat = vi.fn(async () => ({
 const mockSideQuery = vi.fn(async () => ({
   content: '<summary>ok</summary>',
 }));
-const mockCreateChatServiceAsync = vi.fn(async (_config: Record<string, unknown>) => ({
-  chat: mockChat,
-  sideQuery: mockSideQuery,
-}));
+const mockCreateChatServiceAsync = vi.fn(async (config: ChatConfig) => {
+  let currentConfig = config;
+  return {
+    chat: mockChat,
+    sideQuery: mockSideQuery,
+    async *streamChat() {
+      yield { content: 'unused' };
+    },
+    getConfig() {
+      return currentConfig;
+    },
+    updateConfig(next: Partial<ChatConfig>) {
+      currentConfig = { ...currentConfig, ...next };
+    },
+  };
+});
 
 vi.mock('../../services/ChatServiceInterface.js', () => ({
   createChatServiceAsync: mockCreateChatServiceAsync,
@@ -50,12 +65,14 @@ describe('CompactionService', () => {
         provider: 'openai',
         baseUrl: 'https://api.openai.com/v1',
         model: 'gpt-5',
+        timeout: 60_000,
       }),
       expect.anything(),
     );
     expect(mockSideQuery).toHaveBeenCalledWith(
       expect.anything(),
-      controller.signal,
+      expect.any(AbortSignal),
+      undefined,
     );
     expect(mockChat).not.toHaveBeenCalled();
   });

--- a/src/context/__tests__/CompactionService.test.ts
+++ b/src/context/__tests__/CompactionService.test.ts
@@ -1,8 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type {
-    ChatConfig,
-    Message,
-} from '../../services/ChatServiceInterface.js';
+import type { ChatConfig, Message } from '../../services/ChatServiceInterface.js';
 
 const mockChat = vi.fn(async () => ({
   content: '<summary>ok</summary>',
@@ -99,12 +96,22 @@ describe('CompactionService', () => {
 
   it('retainRecentMessages drops orphan tool results outside the retained window', () => {
     const messages: Message[] = [
-      { role: 'assistant', content: 'a', tool_calls: [{ id: 'tc-keep', type: 'function', function: { name: 'x', arguments: '{}' } }] },
+      {
+        role: 'assistant',
+        content: 'a',
+        tool_calls: [{ id: 'tc-keep', type: 'function', function: { name: 'x', arguments: '{}' } }],
+      },
       { role: 'user', content: 'b' },
       { role: 'assistant', content: 'c' },
       { role: 'tool', tool_call_id: 'tc-keep', content: 'kept' },
       { role: 'tool', tool_call_id: 'tc-orphan', content: 'dropped' },
-      { role: 'assistant', content: 'd', tool_calls: [{ id: 'tc-orphan', type: 'function', function: { name: 'y', arguments: '{}' } }] },
+      {
+        role: 'assistant',
+        content: 'd',
+        tool_calls: [
+          { id: 'tc-orphan', type: 'function', function: { name: 'y', arguments: '{}' } },
+        ],
+      },
     ];
 
     // retain 50%: last 3 messages = tool(tc-keep) + tool(tc-orphan) + assistant(tc-orphan).
@@ -116,7 +123,11 @@ describe('CompactionService', () => {
 
   it('retainRecentMessages keeps tool results whose tool_calls are in the window', () => {
     const messages: Message[] = [
-      { role: 'assistant', content: 'a', tool_calls: [{ id: 'tc-1', type: 'function', function: { name: 'x', arguments: '{}' } }] },
+      {
+        role: 'assistant',
+        content: 'a',
+        tool_calls: [{ id: 'tc-1', type: 'function', function: { name: 'x', arguments: '{}' } }],
+      },
       { role: 'tool', tool_call_id: 'tc-1', content: 'result-1' },
     ];
 

--- a/src/errors/ModelTimeoutError.ts
+++ b/src/errors/ModelTimeoutError.ts
@@ -1,0 +1,26 @@
+import { SdkError } from './SdkError.js';
+
+export type ModelTimeoutErrorCode =
+  | 'MODEL_REQUEST_TIMEOUT'
+  | 'MODEL_STREAM_IDLE_TIMEOUT';
+
+export class ModelTimeoutError extends SdkError {
+  constructor(
+    code: ModelTimeoutErrorCode,
+    public readonly timeoutMs: number,
+  ) {
+    super(
+      code,
+      code === 'MODEL_STREAM_IDLE_TIMEOUT'
+        ? `Model stream produced no chunk for ${timeoutMs}ms`
+        : `Model request exceeded ${timeoutMs}ms`,
+    );
+  }
+
+  override toJSON(): Record<string, unknown> {
+    return {
+      ...super.toJSON(),
+      timeoutMs: this.timeoutMs,
+    };
+  }
+}

--- a/src/errors/ModelTimeoutError.ts
+++ b/src/errors/ModelTimeoutError.ts
@@ -1,8 +1,6 @@
 import { SdkError } from './SdkError.js';
 
-export type ModelTimeoutErrorCode =
-  | 'MODEL_REQUEST_TIMEOUT'
-  | 'MODEL_STREAM_IDLE_TIMEOUT';
+export type ModelTimeoutErrorCode = 'MODEL_REQUEST_TIMEOUT' | 'MODEL_STREAM_IDLE_TIMEOUT';
 
 export class ModelTimeoutError extends SdkError {
   constructor(

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,10 +1,12 @@
 export { AbortError } from './AbortError.js';
 export { ConfigError } from './ConfigError.js';
+export { ModelTimeoutError } from './ModelTimeoutError.js';
+export type { ModelTimeoutErrorCode } from './ModelTimeoutError.js';
 export { PermissionDeniedError } from './PermissionDeniedError.js';
-export type { SessionHandoffErrorCode } from './SessionHandoffError.js';
-export { SessionHandoffError } from './SessionHandoffError.js';
-export type { SessionInputErrorCode } from './SessionInputError.js';
-export { SessionInputError } from './SessionInputError.js';
-export type { SdkErrorOptions } from './SdkError.js';
 export { SdkError } from './SdkError.js';
+export type { SdkErrorOptions } from './SdkError.js';
+export { SessionHandoffError } from './SessionHandoffError.js';
+export type { SessionHandoffErrorCode } from './SessionHandoffError.js';
+export { SessionInputError } from './SessionInputError.js';
+export type { SessionInputErrorCode } from './SessionInputError.js';
 export { ToolExecutionError } from './ToolExecutionError.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ export type {
 } from './agent/subagents/types.js';
 export type { TokenBudgetConfig, TokenBudgetSnapshot } from './agent/TokenBudget.js';
 export type {
+  ModelTimeoutErrorCode,
   SdkErrorOptions,
   SessionHandoffErrorCode,
   SessionInputErrorCode,
@@ -19,6 +20,7 @@ export type {
 export {
   AbortError,
   ConfigError,
+  ModelTimeoutError,
   PermissionDeniedError,
   SdkError,
   SessionHandoffError,

--- a/src/middleware/__tests__/ModelManagerMiddleware.test.ts
+++ b/src/middleware/__tests__/ModelManagerMiddleware.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import type {
   ChatConfig,
   IChatService,
@@ -38,6 +38,10 @@ function createService(config: ChatConfig): IChatService {
 }
 
 describe('ModelManager middleware integration', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('reapplies model middleware when switching provider services', async () => {
     createChatServiceAsync.mockImplementation(async (config: ChatConfig) =>
       createService(config),
@@ -90,5 +94,50 @@ describe('ModelManager middleware integration', () => {
       content: 'model-b:wrapped',
     });
     expect(observedModels).toEqual(['model-a', 'model-b']);
+  });
+
+  it('applies request timeouts outside model middleware', async () => {
+    vi.useFakeTimers();
+    createChatServiceAsync.mockImplementation(async (config: ChatConfig) =>
+      createService(config),
+    );
+    const config: BladeConfig = {
+      currentModelId: 'default',
+      models: [
+        {
+          id: 'default',
+          name: 'Default',
+          provider: 'openai-compatible',
+          model: 'model-a',
+          apiKey: 'test',
+          baseUrl: 'https://example.test',
+          requestTimeoutMs: 25,
+        },
+      ],
+    };
+    const manager = new ModelManager(
+      config,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      [
+        {
+          async wrapChat() {
+            return await new Promise<never>(() => {});
+          },
+        },
+      ],
+    );
+    await manager.applyModelConfig(manager.resolveModelConfig(), 'initial');
+    const result = manager.getChatService().chat([]);
+    const rejection = expect(result).rejects.toMatchObject({
+      code: 'MODEL_REQUEST_TIMEOUT',
+      timeoutMs: 25,
+    });
+
+    await vi.advanceTimersByTimeAsync(25);
+
+    await rejection;
   });
 });

--- a/src/middleware/__tests__/ModelManagerMiddleware.test.ts
+++ b/src/middleware/__tests__/ModelManagerMiddleware.test.ts
@@ -1,8 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import type {
-  ChatConfig,
-  IChatService,
-} from '../../services/ChatServiceInterface.js';
+import type { ChatConfig, IChatService } from '../../services/ChatServiceInterface.js';
 import type { BladeConfig } from '../../types/common.js';
 import type { ModelMiddleware } from '../ModelMiddleware.js';
 
@@ -43,9 +40,7 @@ describe('ModelManager middleware integration', () => {
   });
 
   it('reapplies model middleware when switching provider services', async () => {
-    createChatServiceAsync.mockImplementation(async (config: ChatConfig) =>
-      createService(config),
-    );
+    createChatServiceAsync.mockImplementation(async (config: ChatConfig) => createService(config));
     const observedModels: string[] = [];
     const middleware: ModelMiddleware = {
       async wrapChat(request, next) {
@@ -75,14 +70,9 @@ describe('ModelManager middleware integration', () => {
         },
       ],
     };
-    const manager = new ModelManager(
-      config,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      [middleware],
-    );
+    const manager = new ModelManager(config, undefined, undefined, undefined, undefined, [
+      middleware,
+    ]);
 
     await manager.applyModelConfig(manager.resolveModelConfig(), 'initial');
     await expect(manager.getChatService().chat([])).resolves.toEqual({
@@ -98,9 +88,7 @@ describe('ModelManager middleware integration', () => {
 
   it('applies request timeouts outside model middleware', async () => {
     vi.useFakeTimers();
-    createChatServiceAsync.mockImplementation(async (config: ChatConfig) =>
-      createService(config),
-    );
+    createChatServiceAsync.mockImplementation(async (config: ChatConfig) => createService(config));
     const config: BladeConfig = {
       currentModelId: 'default',
       models: [
@@ -115,20 +103,13 @@ describe('ModelManager middleware integration', () => {
         },
       ],
     };
-    const manager = new ModelManager(
-      config,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      [
-        {
-          async wrapChat() {
-            return await new Promise<never>(() => {});
-          },
+    const manager = new ModelManager(config, undefined, undefined, undefined, undefined, [
+      {
+        async wrapChat() {
+          return await new Promise<never>(() => {});
         },
-      ],
-    );
+      },
+    ]);
     await manager.applyModelConfig(manager.resolveModelConfig(), 'initial');
     const result = manager.getChatService().chat([]);
     const rejection = expect(result).rejects.toMatchObject({

--- a/src/services/ChatServiceInterface.ts
+++ b/src/services/ChatServiceInterface.ts
@@ -119,7 +119,12 @@ export interface ChatConfig {
   temperature?: number;
   maxContextTokens?: number; // 上下文窗口大小（用于压缩判断）
   maxOutputTokens?: number; // 输出 token 限制（传给 API 的 max_tokens）
+  /** @deprecated Use requestTimeoutMs. */
   timeout?: number;
+  /** Maximum wall-clock wait for a non-streaming model operation. */
+  requestTimeoutMs?: number;
+  /** Maximum wait between model stream chunks. */
+  streamIdleTimeoutMs?: number;
   apiVersion?: string; // GPT OpenAI Platform 专用：API 版本（如 '2024-03-01-preview'）
   supportsThinking?: boolean; // 是否支持 thinking 模式（DeepSeek Reasoner 等）
   providerOptions?: ProviderOptions;

--- a/src/services/ChatServiceInterface.ts
+++ b/src/services/ChatServiceInterface.ts
@@ -194,7 +194,7 @@ export interface IChatService {
       description: string;
       parameters: JSONSchema7;
     }>,
-    signal?: AbortSignal
+    signal?: AbortSignal,
   ): Promise<ChatResponse>;
 
   /**
@@ -204,7 +204,7 @@ export interface IChatService {
   sideQuery(
     messages: readonly Message[],
     signal?: AbortSignal,
-    options?: SideQueryOptions
+    options?: SideQueryOptions,
   ): Promise<ChatResponse>;
 
   /**
@@ -217,7 +217,7 @@ export interface IChatService {
       description: string;
       parameters: JSONSchema7;
     }>,
-    signal?: AbortSignal
+    signal?: AbortSignal,
   ): AsyncGenerator<StreamChunk, void, unknown>;
 
   /**
@@ -232,7 +232,7 @@ export interface IChatService {
       description: string;
       parameters: JSONSchema7;
     }>,
-    signal?: AbortSignal
+    signal?: AbortSignal,
   ): AsyncGenerator<RetryEvent, ChatResponse>;
 
   /**
@@ -269,14 +269,19 @@ export async function createChatServiceAsync(
           ...resolvedConfig.customHeaders, // 用户配置优先
         },
       };
-      logger.child(LogCategory.SERVICE).debug(`🔧 注入 ${resolvedConfig.providerId} 特定 headers:`, Object.keys(providerHeaders));
+      logger
+        .child(LogCategory.SERVICE)
+        .debug(`🔧 注入 ${resolvedConfig.providerId} 特定 headers:`, Object.keys(providerHeaders));
     }
   }
 
   return await createChatServiceInternal(resolvedConfig, logger);
 }
 
-async function createChatServiceInternal(config: ChatConfig, logger: InternalLogger): Promise<IChatService> {
+async function createChatServiceInternal(
+  config: ChatConfig,
+  logger: InternalLogger,
+): Promise<IChatService> {
   const service = new VercelAIChatService(config, logger);
   await service.ready();
   return service;

--- a/src/services/ChatServiceTimeout.ts
+++ b/src/services/ChatServiceTimeout.ts
@@ -1,0 +1,293 @@
+import type { JSONSchema7 } from 'json-schema';
+import { ConfigError } from '../errors/ConfigError.js';
+import {
+  ModelTimeoutError,
+  type ModelTimeoutErrorCode,
+} from '../errors/ModelTimeoutError.js';
+import type {
+  ChatConfig,
+  ChatResponse,
+  IChatService,
+  Message,
+  StreamChunk,
+} from './ChatServiceInterface.js';
+import type { RetryEvent } from './RetryPolicy.js';
+
+export const DEFAULT_MODEL_REQUEST_TIMEOUT_MS = 600_000;
+export const DEFAULT_MODEL_STREAM_IDLE_TIMEOUT_MS = 300_000;
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
+interface ResolvedModelTimeouts {
+  requestTimeoutMs: number;
+  streamIdleTimeoutMs: number;
+}
+
+function resolveTimeout(
+  value: number | undefined,
+  fallback: number,
+  name: string,
+): number {
+  const resolved = value ?? fallback;
+  if (
+    !Number.isSafeInteger(resolved)
+    || resolved <= 0
+    || resolved > MAX_TIMER_DELAY_MS
+  ) {
+    throw new ConfigError(
+      `${name} must be a positive integer no greater than ${MAX_TIMER_DELAY_MS}`,
+    );
+  }
+  return resolved;
+}
+
+function resolveModelTimeouts(config: ChatConfig): ResolvedModelTimeouts {
+  return {
+    requestTimeoutMs: resolveTimeout(
+      config.requestTimeoutMs ?? config.timeout,
+      DEFAULT_MODEL_REQUEST_TIMEOUT_MS,
+      'requestTimeoutMs',
+    ),
+    streamIdleTimeoutMs: resolveTimeout(
+      config.streamIdleTimeoutMs,
+      DEFAULT_MODEL_STREAM_IDLE_TIMEOUT_MS,
+      'streamIdleTimeoutMs',
+    ),
+  };
+}
+
+function abortReason(signal: AbortSignal): unknown {
+  if (signal.reason !== undefined) {
+    return signal.reason;
+  }
+  const error = new Error('The operation was aborted');
+  error.name = 'AbortError';
+  return error;
+}
+
+function awaitWithTimeout<T>(
+  operation: () => PromiseLike<T>,
+  timeoutMs: number,
+  code: ModelTimeoutErrorCode,
+  timeoutController: AbortController,
+  externalSignal?: AbortSignal,
+): Promise<T> {
+  if (externalSignal?.aborted) {
+    return Promise.reject(abortReason(externalSignal));
+  }
+
+  return new Promise<T>((resolve, reject) => {
+    let settled = false;
+    const cleanup = (): void => {
+      clearTimeout(timer);
+      externalSignal?.removeEventListener('abort', onAbort);
+    };
+    const resolveOnce = (value: T): void => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve(value);
+    };
+    const rejectOnce = (error: unknown): void => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(error);
+    };
+    const onAbort = (): void => {
+      rejectOnce(externalSignal ? abortReason(externalSignal) : undefined);
+    };
+    const timer = setTimeout(() => {
+      const error = new ModelTimeoutError(code, timeoutMs);
+      timeoutController.abort(error);
+      rejectOnce(error);
+    }, timeoutMs);
+
+    externalSignal?.addEventListener('abort', onAbort, { once: true });
+    Promise.resolve()
+      .then(operation)
+      .then(resolveOnce, rejectOnce);
+  });
+}
+
+function executionSignal(
+  timeoutController: AbortController,
+  externalSignal?: AbortSignal,
+): AbortSignal {
+  return externalSignal
+    ? AbortSignal.any([externalSignal, timeoutController.signal])
+    : timeoutController.signal;
+}
+
+async function runWithRequestTimeout<T>(
+  operation: (signal: AbortSignal) => PromiseLike<T>,
+  timeoutMs: number,
+  externalSignal?: AbortSignal,
+): Promise<T> {
+  const timeoutController = new AbortController();
+  return await awaitWithTimeout(
+    () => operation(executionSignal(timeoutController, externalSignal)),
+    timeoutMs,
+    'MODEL_REQUEST_TIMEOUT',
+    timeoutController,
+    externalSignal,
+  );
+}
+
+async function* runGeneratorWithTimeout<TYield, TReturn>(
+  createSource: (signal: AbortSignal) => AsyncGenerator<TYield, TReturn, unknown>,
+  timeoutMs: number,
+  mode: 'request' | 'idle',
+  externalSignal?: AbortSignal,
+): AsyncGenerator<TYield, TReturn, unknown> {
+  externalSignal?.throwIfAborted();
+  const timeoutController = new AbortController();
+  const signal = executionSignal(timeoutController, externalSignal);
+  const source = createSource(signal);
+  const startedAt = performance.now();
+  let completed = false;
+  let timedOut = false;
+
+  try {
+    while (true) {
+      const remainingMs =
+        mode === 'request'
+          ? timeoutMs - (performance.now() - startedAt)
+          : timeoutMs;
+      if (remainingMs <= 0) {
+        const code =
+          mode === 'request'
+            ? 'MODEL_REQUEST_TIMEOUT'
+            : 'MODEL_STREAM_IDLE_TIMEOUT';
+        const error = new ModelTimeoutError(code, timeoutMs);
+        timedOut = true;
+        timeoutController.abort(error);
+        throw error;
+      }
+
+      let step: IteratorResult<TYield, TReturn>;
+      try {
+        step = await awaitWithTimeout(
+          () => source.next(),
+          Math.max(1, Math.ceil(remainingMs)),
+          mode === 'request'
+            ? 'MODEL_REQUEST_TIMEOUT'
+            : 'MODEL_STREAM_IDLE_TIMEOUT',
+          timeoutController,
+          externalSignal,
+        );
+      } catch (error) {
+        timedOut = error instanceof ModelTimeoutError;
+        throw error;
+      }
+
+      if (step.done) {
+        completed = true;
+        return step.value;
+      }
+      yield step.value;
+    }
+  } finally {
+    if (!completed) {
+      if (!timeoutController.signal.aborted) {
+        timeoutController.abort(new Error('Model stream closed before completion'));
+      }
+      const closing = source.return(undefined as never);
+      if (timedOut || externalSignal?.aborted) {
+        void closing.catch(() => {});
+      } else {
+        await closing;
+      }
+    }
+  }
+}
+
+/**
+ * Adds bounded request and stream-idle waits around any chat service.
+ *
+ * This wrapper remains outside model middleware so a middleware that stalls
+ * before or after delegating is subject to the same timeout as the provider.
+ */
+export function wrapChatServiceWithTimeouts(service: IChatService): IChatService {
+  resolveModelTimeouts(service.getConfig());
+
+  const wrapped: IChatService = {
+    async chat(messages, tools, signal) {
+      const { requestTimeoutMs } = resolveModelTimeouts(service.getConfig());
+      return await runWithRequestTimeout(
+        (operationSignal) => service.chat(
+          messages,
+          tools,
+          operationSignal,
+        ),
+        requestTimeoutMs,
+        signal,
+      );
+    },
+    async sideQuery(messages, signal, options) {
+      const { requestTimeoutMs } = resolveModelTimeouts(service.getConfig());
+      return await runWithRequestTimeout(
+        (operationSignal) => service.sideQuery(
+          messages,
+          operationSignal,
+          options,
+        ),
+        requestTimeoutMs,
+        signal,
+      );
+    },
+    async *streamChat(
+      messages: readonly Message[],
+      tools?: Array<{
+        name: string;
+        description: string;
+        parameters: JSONSchema7;
+      }>,
+      signal?: AbortSignal,
+    ): AsyncGenerator<StreamChunk, void, unknown> {
+      const { streamIdleTimeoutMs } = resolveModelTimeouts(service.getConfig());
+      yield* runGeneratorWithTimeout(
+        (operationSignal) => service.streamChat(
+          messages,
+          tools,
+          operationSignal,
+        ),
+        streamIdleTimeoutMs,
+        'idle',
+        signal,
+      );
+    },
+    getConfig() {
+      return service.getConfig();
+    },
+    updateConfig(newConfig) {
+      resolveModelTimeouts({
+        ...service.getConfig(),
+        ...newConfig,
+      });
+      service.updateConfig(newConfig);
+    },
+  };
+
+  if (service.chatWithRetryEvents) {
+    const chatWithRetryEvents = service.chatWithRetryEvents.bind(service);
+    wrapped.chatWithRetryEvents = async function* (
+      messages,
+      tools,
+      signal,
+    ): AsyncGenerator<RetryEvent, ChatResponse> {
+      const { requestTimeoutMs } = resolveModelTimeouts(service.getConfig());
+      return yield* runGeneratorWithTimeout(
+        (operationSignal) => chatWithRetryEvents(
+          messages,
+          tools,
+          operationSignal,
+        ),
+        requestTimeoutMs,
+        'request',
+        signal,
+      );
+    };
+  }
+
+  return wrapped;
+}

--- a/src/services/ChatServiceTimeout.ts
+++ b/src/services/ChatServiceTimeout.ts
@@ -1,9 +1,6 @@
 import type { JSONSchema7 } from 'json-schema';
 import { ConfigError } from '../errors/ConfigError.js';
-import {
-  ModelTimeoutError,
-  type ModelTimeoutErrorCode,
-} from '../errors/ModelTimeoutError.js';
+import { ModelTimeoutError, type ModelTimeoutErrorCode } from '../errors/ModelTimeoutError.js';
 import type {
   ChatConfig,
   ChatResponse,
@@ -15,6 +12,7 @@ import type { RetryEvent } from './RetryPolicy.js';
 
 export const DEFAULT_MODEL_REQUEST_TIMEOUT_MS = 600_000;
 export const DEFAULT_MODEL_STREAM_IDLE_TIMEOUT_MS = 300_000;
+const MAX_MODEL_STREAM_CLEANUP_WAIT_MS = 5_000;
 const MAX_TIMER_DELAY_MS = 2_147_483_647;
 
 interface ResolvedModelTimeouts {
@@ -22,17 +20,9 @@ interface ResolvedModelTimeouts {
   streamIdleTimeoutMs: number;
 }
 
-function resolveTimeout(
-  value: number | undefined,
-  fallback: number,
-  name: string,
-): number {
+function resolveTimeout(value: number | undefined, fallback: number, name: string): number {
   const resolved = value ?? fallback;
-  if (
-    !Number.isSafeInteger(resolved)
-    || resolved <= 0
-    || resolved > MAX_TIMER_DELAY_MS
-  ) {
+  if (!Number.isSafeInteger(resolved) || resolved <= 0 || resolved > MAX_TIMER_DELAY_MS) {
     throw new ConfigError(
       `${name} must be a positive integer no greater than ${MAX_TIMER_DELAY_MS}`,
     );
@@ -69,17 +59,17 @@ function awaitWithTimeout<T>(
   timeoutMs: number,
   code: ModelTimeoutErrorCode,
   timeoutController: AbortController,
-  externalSignal?: AbortSignal,
+  signal: AbortSignal,
 ): Promise<T> {
-  if (externalSignal?.aborted) {
-    return Promise.reject(abortReason(externalSignal));
+  if (signal.aborted) {
+    return Promise.reject(abortReason(signal));
   }
 
   return new Promise<T>((resolve, reject) => {
     let settled = false;
     const cleanup = (): void => {
       clearTimeout(timer);
-      externalSignal?.removeEventListener('abort', onAbort);
+      signal.removeEventListener('abort', onAbort);
     };
     const resolveOnce = (value: T): void => {
       if (settled) return;
@@ -94,7 +84,7 @@ function awaitWithTimeout<T>(
       reject(error);
     };
     const onAbort = (): void => {
-      rejectOnce(externalSignal ? abortReason(externalSignal) : undefined);
+      rejectOnce(abortReason(signal));
     };
     const timer = setTimeout(() => {
       const error = new ModelTimeoutError(code, timeoutMs);
@@ -102,10 +92,66 @@ function awaitWithTimeout<T>(
       rejectOnce(error);
     }, timeoutMs);
 
-    externalSignal?.addEventListener('abort', onAbort, { once: true });
-    Promise.resolve()
-      .then(operation)
-      .then(resolveOnce, rejectOnce);
+    signal.addEventListener('abort', onAbort, { once: true });
+    Promise.resolve().then(operation).then(resolveOnce, rejectOnce);
+  });
+}
+
+function awaitWithSignal<T>(operation: () => PromiseLike<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) {
+    return Promise.reject(abortReason(signal));
+  }
+
+  return new Promise<T>((resolve, reject) => {
+    let settled = false;
+    const cleanup = (): void => {
+      signal.removeEventListener('abort', onAbort);
+    };
+    const resolveOnce = (value: T): void => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve(value);
+    };
+    const rejectOnce = (error: unknown): void => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(error);
+    };
+    const onAbort = (): void => {
+      rejectOnce(abortReason(signal));
+    };
+
+    signal.addEventListener('abort', onAbort, { once: true });
+    Promise.resolve().then(operation).then(resolveOnce, rejectOnce);
+  });
+}
+
+async function waitForGeneratorClose(
+  closing: PromiseLike<unknown>,
+  timeoutMs: number,
+): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    let settled = false;
+    const cleanup = (): void => {
+      clearTimeout(timer);
+    };
+    const resolveOnce = (): void => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve();
+    };
+    const rejectOnce = (error: unknown): void => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(error);
+    };
+    const timer = setTimeout(resolveOnce, Math.min(timeoutMs, MAX_MODEL_STREAM_CLEANUP_WAIT_MS));
+
+    closing.then(resolveOnce, rejectOnce);
   });
 }
 
@@ -124,12 +170,13 @@ async function runWithRequestTimeout<T>(
   externalSignal?: AbortSignal,
 ): Promise<T> {
   const timeoutController = new AbortController();
+  const signal = executionSignal(timeoutController, externalSignal);
   return await awaitWithTimeout(
-    () => operation(executionSignal(timeoutController, externalSignal)),
+    () => operation(signal),
     timeoutMs,
     'MODEL_REQUEST_TIMEOUT',
     timeoutController,
-    externalSignal,
+    signal,
   );
 }
 
@@ -143,38 +190,39 @@ async function* runGeneratorWithTimeout<TYield, TReturn>(
   const timeoutController = new AbortController();
   const signal = executionSignal(timeoutController, externalSignal);
   const source = createSource(signal);
-  const startedAt = performance.now();
   let completed = false;
   let timedOut = false;
+  const timeoutCode: ModelTimeoutErrorCode =
+    mode === 'request' ? 'MODEL_REQUEST_TIMEOUT' : 'MODEL_STREAM_IDLE_TIMEOUT';
+  const requestTimeoutError =
+    mode === 'request' ? new ModelTimeoutError(timeoutCode, timeoutMs) : undefined;
+  const requestTimer = requestTimeoutError
+    ? setTimeout(() => {
+        timedOut = true;
+        timeoutController.abort(requestTimeoutError);
+      }, timeoutMs)
+    : undefined;
+  const clearRequestTimer = (): void => {
+    if (requestTimer !== undefined) {
+      clearTimeout(requestTimer);
+    }
+  };
+  signal.addEventListener('abort', clearRequestTimer, { once: true });
 
   try {
     while (true) {
-      const remainingMs =
-        mode === 'request'
-          ? timeoutMs - (performance.now() - startedAt)
-          : timeoutMs;
-      if (remainingMs <= 0) {
-        const code =
-          mode === 'request'
-            ? 'MODEL_REQUEST_TIMEOUT'
-            : 'MODEL_STREAM_IDLE_TIMEOUT';
-        const error = new ModelTimeoutError(code, timeoutMs);
-        timedOut = true;
-        timeoutController.abort(error);
-        throw error;
-      }
-
       let step: IteratorResult<TYield, TReturn>;
       try {
-        step = await awaitWithTimeout(
-          () => source.next(),
-          Math.max(1, Math.ceil(remainingMs)),
+        step =
           mode === 'request'
-            ? 'MODEL_REQUEST_TIMEOUT'
-            : 'MODEL_STREAM_IDLE_TIMEOUT',
-          timeoutController,
-          externalSignal,
-        );
+            ? await awaitWithSignal(() => source.next(), signal)
+            : await awaitWithTimeout(
+                () => source.next(),
+                timeoutMs,
+                timeoutCode,
+                timeoutController,
+                signal,
+              );
       } catch (error) {
         timedOut = error instanceof ModelTimeoutError;
         throw error;
@@ -187,6 +235,8 @@ async function* runGeneratorWithTimeout<TYield, TReturn>(
       yield step.value;
     }
   } finally {
+    clearRequestTimer();
+    signal.removeEventListener('abort', clearRequestTimer);
     if (!completed) {
       if (!timeoutController.signal.aborted) {
         timeoutController.abort(new Error('Model stream closed before completion'));
@@ -195,7 +245,7 @@ async function* runGeneratorWithTimeout<TYield, TReturn>(
       if (timedOut || externalSignal?.aborted) {
         void closing.catch(() => {});
       } else {
-        await closing;
+        await waitForGeneratorClose(closing, timeoutMs);
       }
     }
   }
@@ -214,11 +264,7 @@ export function wrapChatServiceWithTimeouts(service: IChatService): IChatService
     async chat(messages, tools, signal) {
       const { requestTimeoutMs } = resolveModelTimeouts(service.getConfig());
       return await runWithRequestTimeout(
-        (operationSignal) => service.chat(
-          messages,
-          tools,
-          operationSignal,
-        ),
+        (operationSignal) => service.chat(messages, tools, operationSignal),
         requestTimeoutMs,
         signal,
       );
@@ -226,11 +272,7 @@ export function wrapChatServiceWithTimeouts(service: IChatService): IChatService
     async sideQuery(messages, signal, options) {
       const { requestTimeoutMs } = resolveModelTimeouts(service.getConfig());
       return await runWithRequestTimeout(
-        (operationSignal) => service.sideQuery(
-          messages,
-          operationSignal,
-          options,
-        ),
+        (operationSignal) => service.sideQuery(messages, operationSignal, options),
         requestTimeoutMs,
         signal,
       );
@@ -246,11 +288,7 @@ export function wrapChatServiceWithTimeouts(service: IChatService): IChatService
     ): AsyncGenerator<StreamChunk, void, unknown> {
       const { streamIdleTimeoutMs } = resolveModelTimeouts(service.getConfig());
       yield* runGeneratorWithTimeout(
-        (operationSignal) => service.streamChat(
-          messages,
-          tools,
-          operationSignal,
-        ),
+        (operationSignal) => service.streamChat(messages, tools, operationSignal),
         streamIdleTimeoutMs,
         'idle',
         signal,
@@ -277,11 +315,7 @@ export function wrapChatServiceWithTimeouts(service: IChatService): IChatService
     ): AsyncGenerator<RetryEvent, ChatResponse> {
       const { requestTimeoutMs } = resolveModelTimeouts(service.getConfig());
       return yield* runGeneratorWithTimeout(
-        (operationSignal) => chatWithRetryEvents(
-          messages,
-          tools,
-          operationSignal,
-        ),
+        (operationSignal) => chatWithRetryEvents(messages, tools, operationSignal),
         requestTimeoutMs,
         'request',
         signal,

--- a/src/services/ChatServiceTimeout.ts
+++ b/src/services/ChatServiceTimeout.ts
@@ -224,7 +224,7 @@ async function* runGeneratorWithTimeout<TYield, TReturn>(
                 signal,
               );
       } catch (error) {
-        timedOut = error instanceof ModelTimeoutError;
+        timedOut = timedOut || error instanceof ModelTimeoutError;
         throw error;
       }
 

--- a/src/services/__tests__/ChatServiceTimeout.test.ts
+++ b/src/services/__tests__/ChatServiceTimeout.test.ts
@@ -1,10 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ConfigError } from '../../errors/ConfigError.js';
 import { ModelTimeoutError } from '../../errors/ModelTimeoutError.js';
-import type {
-  ChatConfig,
-  IChatService,
-} from '../ChatServiceInterface.js';
+import type { ChatConfig, IChatService } from '../ChatServiceInterface.js';
 import { wrapChatServiceWithTimeouts } from '../ChatServiceTimeout.js';
 
 function createService(
@@ -175,6 +172,38 @@ describe('wrapChatServiceWithTimeouts', () => {
     expect(providerSignal?.aborted).toBe(true);
   });
 
+  it('bounds provider cleanup when a closed generator does not settle', async () => {
+    vi.useFakeTimers();
+    let providerSignal: AbortSignal | undefined;
+    const service = createService(
+      {
+        async *streamChat(_messages, _tools, signal) {
+          providerSignal = signal;
+          try {
+            yield { content: 'first' };
+          } finally {
+            await new Promise(() => {});
+          }
+        },
+      },
+      { streamIdleTimeoutMs: 50 },
+    );
+    const stream = wrapChatServiceWithTimeouts(service).streamChat([]);
+    await stream.next();
+    const closing = stream.return(undefined);
+    let closed = false;
+    void closing.then(() => {
+      closed = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(49);
+    expect(closed).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+
+    await expect(closing).resolves.toMatchObject({ done: true });
+    expect(providerSignal?.aborted).toBe(true);
+  });
+
   it('applies one request deadline across retry-event yields', async () => {
     vi.useFakeTimers();
     let providerSignal: AbortSignal | undefined;
@@ -195,8 +224,7 @@ describe('wrapChatServiceWithTimeouts', () => {
       },
       { requestTimeoutMs: 50 },
     );
-    const stream = wrapChatServiceWithTimeouts(service)
-      .chatWithRetryEvents?.([]);
+    const stream = wrapChatServiceWithTimeouts(service).chatWithRetryEvents?.([]);
     expect(stream).toBeDefined();
     if (!stream) {
       throw new Error('Expected retry-event support');
@@ -206,36 +234,32 @@ describe('wrapChatServiceWithTimeouts', () => {
       done: false,
       value: { type: 'retry_attempt' },
     });
-    await vi.advanceTimersByTimeAsync(100);
+    await vi.advanceTimersByTimeAsync(50);
+    expect(providerSignal?.aborted).toBe(true);
     await expect(stream.next()).rejects.toMatchObject({
       code: 'MODEL_REQUEST_TIMEOUT',
       timeoutMs: 50,
     });
-    expect(providerSignal?.aborted).toBe(true);
   });
 
   it('does not invent retry-event support', () => {
-    expect(
-      wrapChatServiceWithTimeouts(createService()).chatWithRetryEvents,
-    ).toBeUndefined();
+    expect(wrapChatServiceWithTimeouts(createService()).chatWithRetryEvents).toBeUndefined();
   });
 
   it('rejects every invalid timeout configuration before use or update', () => {
     const invalidValues = [0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY, 2_147_483_648];
     for (const field of ['requestTimeoutMs', 'streamIdleTimeoutMs'] as const) {
       for (const value of invalidValues) {
-        expect(() =>
-          wrapChatServiceWithTimeouts(
-            createService({}, { [field]: value }),
-          )
-        ).toThrow(ConfigError);
+        expect(() => wrapChatServiceWithTimeouts(createService({}, { [field]: value }))).toThrow(
+          ConfigError,
+        );
       }
     }
 
     const wrapped = wrapChatServiceWithTimeouts(createService());
-    expect(() =>
-      wrapped.updateConfig({ requestTimeoutMs: Number.POSITIVE_INFINITY })
-    ).toThrow(ConfigError);
+    expect(() => wrapped.updateConfig({ requestTimeoutMs: Number.POSITIVE_INFINITY })).toThrow(
+      ConfigError,
+    );
     expect(wrapped.getConfig().requestTimeoutMs).toBeUndefined();
   });
 

--- a/src/services/__tests__/ChatServiceTimeout.test.ts
+++ b/src/services/__tests__/ChatServiceTimeout.test.ts
@@ -1,0 +1,262 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ConfigError } from '../../errors/ConfigError.js';
+import { ModelTimeoutError } from '../../errors/ModelTimeoutError.js';
+import type {
+  ChatConfig,
+  IChatService,
+} from '../ChatServiceInterface.js';
+import { wrapChatServiceWithTimeouts } from '../ChatServiceTimeout.js';
+
+function createService(
+  overrides: Partial<IChatService> = {},
+  configOverrides: Partial<ChatConfig> = {},
+): IChatService {
+  let config: ChatConfig = {
+    provider: 'openai-compatible',
+    apiKey: 'test',
+    baseUrl: 'https://example.test',
+    model: 'test-model',
+    ...configOverrides,
+  };
+
+  return {
+    async chat() {
+      return { content: 'chat' };
+    },
+    async sideQuery() {
+      return { content: 'side' };
+    },
+    async *streamChat() {
+      yield { content: 'stream' };
+    },
+    getConfig() {
+      return config;
+    },
+    updateConfig(next) {
+      config = { ...config, ...next };
+    },
+    ...overrides,
+  };
+}
+
+describe('wrapChatServiceWithTimeouts', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('aborts a stalled non-streaming request with a typed timeout', async () => {
+    vi.useFakeTimers();
+    let providerSignal: AbortSignal | undefined;
+    const callerController = new AbortController();
+    const service = createService(
+      {
+        chat: vi.fn(async (_messages, _tools, signal) => {
+          providerSignal = signal;
+          return await new Promise<never>(() => {});
+        }),
+      },
+      { requestTimeoutMs: 50 },
+    );
+    const wrapped = wrapChatServiceWithTimeouts(service);
+    const result = wrapped.chat([], undefined, callerController.signal);
+    const rejection = expect(result).rejects.toMatchObject({
+      name: 'ModelTimeoutError',
+      code: 'MODEL_REQUEST_TIMEOUT',
+      timeoutMs: 50,
+    });
+
+    await vi.advanceTimersByTimeAsync(50);
+
+    await rejection;
+    expect(providerSignal?.aborted).toBe(true);
+    expect(providerSignal?.reason).toBeInstanceOf(ModelTimeoutError);
+    expect(callerController.signal.aborted).toBe(false);
+  });
+
+  it('aborts a stream that produces no next chunk before the idle deadline', async () => {
+    vi.useFakeTimers();
+    let providerSignal: AbortSignal | undefined;
+    const service = createService(
+      {
+        async *streamChat(_messages, _tools, signal) {
+          providerSignal = signal;
+          await new Promise(() => {});
+        },
+      },
+      { streamIdleTimeoutMs: 75 },
+    );
+    const stream = wrapChatServiceWithTimeouts(service).streamChat([]);
+    const next = stream.next();
+    const rejection = expect(next).rejects.toMatchObject({
+      name: 'ModelTimeoutError',
+      code: 'MODEL_STREAM_IDLE_TIMEOUT',
+      timeoutMs: 75,
+    });
+
+    await vi.advanceTimersByTimeAsync(75);
+
+    await rejection;
+    expect(providerSignal?.aborted).toBe(true);
+    expect(providerSignal?.reason).toBeInstanceOf(ModelTimeoutError);
+  });
+
+  it('does not count consumer backpressure as stream idle time', async () => {
+    vi.useFakeTimers();
+    const service = createService(
+      {
+        async *streamChat() {
+          yield { content: 'first' };
+          await new Promise(() => {});
+        },
+      },
+      { streamIdleTimeoutMs: 50 },
+    );
+    const stream = wrapChatServiceWithTimeouts(service).streamChat([]);
+
+    await expect(stream.next()).resolves.toEqual({
+      done: false,
+      value: { content: 'first' },
+    });
+    await vi.advanceTimersByTimeAsync(500);
+
+    const next = stream.next();
+    const rejection = expect(next).rejects.toMatchObject({
+      code: 'MODEL_STREAM_IDLE_TIMEOUT',
+    });
+    await vi.advanceTimersByTimeAsync(50);
+    await rejection;
+  });
+
+  it('preserves caller abort reasons instead of reporting a timeout', async () => {
+    vi.useFakeTimers();
+    const abortController = new AbortController();
+    let providerSignal: AbortSignal | undefined;
+    const service = createService({
+      chat: vi.fn(async (_messages, _tools, signal) => {
+        providerSignal = signal;
+        return await new Promise<never>(() => {});
+      }),
+    });
+    const wrapped = wrapChatServiceWithTimeouts(service);
+    const reason = new Error('caller cancelled');
+    const result = wrapped.chat([], undefined, abortController.signal);
+    const rejection = expect(result).rejects.toBe(reason);
+
+    abortController.abort(reason);
+
+    await rejection;
+    expect(providerSignal?.aborted).toBe(true);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('closes the provider generator when the consumer stops early', async () => {
+    let providerClosed = false;
+    let providerSignal: AbortSignal | undefined;
+    const service = createService({
+      async *streamChat(_messages, _tools, signal) {
+        providerSignal = signal;
+        try {
+          yield { content: 'first' };
+          yield { content: 'second' };
+        } finally {
+          providerClosed = true;
+        }
+      },
+    });
+    const stream = wrapChatServiceWithTimeouts(service).streamChat([]);
+
+    await expect(stream.next()).resolves.toEqual({
+      done: false,
+      value: { content: 'first' },
+    });
+    await stream.return(undefined);
+
+    expect(providerClosed).toBe(true);
+    expect(providerSignal?.aborted).toBe(true);
+  });
+
+  it('applies one request deadline across retry-event yields', async () => {
+    vi.useFakeTimers();
+    let providerSignal: AbortSignal | undefined;
+    const service = createService(
+      {
+        async *chatWithRetryEvents(_messages, _tools, signal) {
+          providerSignal = signal;
+          yield {
+            type: 'retry_attempt',
+            attempt: 1,
+            maxRetries: 3,
+            delayMs: 10,
+            error: { message: 'retry' },
+          };
+          await new Promise(() => {});
+          return { content: 'unreachable' };
+        },
+      },
+      { requestTimeoutMs: 50 },
+    );
+    const stream = wrapChatServiceWithTimeouts(service)
+      .chatWithRetryEvents?.([]);
+    expect(stream).toBeDefined();
+    if (!stream) {
+      throw new Error('Expected retry-event support');
+    }
+
+    await expect(stream.next()).resolves.toMatchObject({
+      done: false,
+      value: { type: 'retry_attempt' },
+    });
+    await vi.advanceTimersByTimeAsync(100);
+    await expect(stream.next()).rejects.toMatchObject({
+      code: 'MODEL_REQUEST_TIMEOUT',
+      timeoutMs: 50,
+    });
+    expect(providerSignal?.aborted).toBe(true);
+  });
+
+  it('does not invent retry-event support', () => {
+    expect(
+      wrapChatServiceWithTimeouts(createService()).chatWithRetryEvents,
+    ).toBeUndefined();
+  });
+
+  it('rejects every invalid timeout configuration before use or update', () => {
+    const invalidValues = [0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY, 2_147_483_648];
+    for (const field of ['requestTimeoutMs', 'streamIdleTimeoutMs'] as const) {
+      for (const value of invalidValues) {
+        expect(() =>
+          wrapChatServiceWithTimeouts(
+            createService({}, { [field]: value }),
+          )
+        ).toThrow(ConfigError);
+      }
+    }
+
+    const wrapped = wrapChatServiceWithTimeouts(createService());
+    expect(() =>
+      wrapped.updateConfig({ requestTimeoutMs: Number.POSITIVE_INFINITY })
+    ).toThrow(ConfigError);
+    expect(wrapped.getConfig().requestTimeoutMs).toBeUndefined();
+  });
+
+  it('honors the legacy ChatConfig timeout as the request deadline', async () => {
+    vi.useFakeTimers();
+    const service = createService(
+      {
+        async sideQuery() {
+          return await new Promise<never>(() => {});
+        },
+      },
+      { timeout: 25 },
+    );
+    const result = wrapChatServiceWithTimeouts(service).sideQuery([]);
+    const rejection = expect(result).rejects.toMatchObject({
+      code: 'MODEL_REQUEST_TIMEOUT',
+      timeoutMs: 25,
+    });
+
+    await vi.advanceTimersByTimeAsync(25);
+
+    await rejection;
+  });
+});

--- a/src/session/Session.ts
+++ b/src/session/Session.ts
@@ -449,6 +449,8 @@ class Session implements ISession {
       apiKey: provider.apiKey || '',
       baseUrl: provider.baseUrl || this.getDefaultBaseUrl(provider.type),
       headers: Object.keys(headers).length > 0 ? headers : undefined,
+      requestTimeoutMs: provider.requestTimeoutMs,
+      streamIdleTimeoutMs: provider.streamIdleTimeoutMs,
       maxContextTokens: this.options.maxContextTokens ?? 128000,
       maxOutputTokens: this.options.maxOutputTokens,
       temperature: this.options.temperature,

--- a/src/session/Session.ts
+++ b/src/session/Session.ts
@@ -1534,10 +1534,7 @@ class Session implements ISession {
         closeErrors.push(error);
       }
     }
-    if (
-      !this.runtime &&
-      (closeErrors.length === 0 || this.executionLeaseFailure)
-    ) {
+    if (!this.runtime && (closeErrors.length === 0 || this.executionLeaseFailure)) {
       try {
         await this.releaseExecutionLease();
       } catch (error) {
@@ -1594,9 +1591,7 @@ class Session implements ISession {
       }
       durableRecorder?.assertHandoffReady();
 
-      const blockers = runtime.sealBackgroundWorkForHandoff(
-        this.executionLease?.fence,
-      );
+      const blockers = runtime.sealBackgroundWorkForHandoff(this.executionLease?.fence);
       if (blockers.activeSubagentIds.length > 0 || blockers.activeShellIds.length > 0) {
         throw new SessionHandoffError(
           'SESSION_HANDOFF_ACTIVE_WORK',
@@ -1691,10 +1686,7 @@ class Session implements ISession {
     } catch (error) {
       handoffErrors.push(error);
     }
-    if (
-      !this.runtime &&
-      (handoffErrors.length === 0 || this.executionLeaseFailure)
-    ) {
+    if (!this.runtime && (handoffErrors.length === 0 || this.executionLeaseFailure)) {
       try {
         await this.releaseExecutionLease();
       } catch (error) {
@@ -1747,11 +1739,7 @@ class Session implements ISession {
       } catch (error) {
         errors.push(error);
       }
-      if (
-        this.runtimeEndAttempted &&
-        runtimeClosed &&
-        this.runtime === runtime
-      ) {
+      if (this.runtimeEndAttempted && runtimeClosed && this.runtime === runtime) {
         this.runtime = null;
       }
     }
@@ -1782,9 +1770,7 @@ class Session implements ISession {
   }
 
   private runWithExecutionLease<T>(operation: () => Promise<T>): Promise<T> {
-    return this.executionLease
-      ? this.executionLease.runFenced(operation)
-      : operation();
+    return this.executionLease ? this.executionLease.runFenced(operation) : operation();
   }
 
   private async releaseExecutionLease(): Promise<void> {

--- a/src/session/__tests__/SessionModelConfig.test.ts
+++ b/src/session/__tests__/SessionModelConfig.test.ts
@@ -20,7 +20,12 @@ describe('Session model config', () => {
       },
     };
     const session = await createSession({
-      provider: { type: 'openai', apiKey: 'test-key' },
+      provider: {
+        type: 'openai',
+        apiKey: 'test-key',
+        requestTimeoutMs: 120_000,
+        streamIdleTimeoutMs: 30_000,
+      },
       model: 'gpt-5',
       temperature: 0.2,
       maxOutputTokens: 4096,
@@ -38,6 +43,8 @@ describe('Session model config', () => {
           temperature: 0.2,
           maxOutputTokens: 4096,
           maxContextTokens: 32000,
+          requestTimeoutMs: 120_000,
+          streamIdleTimeoutMs: 30_000,
           providerOptions,
           thinkingEnabled: true,
           thinkingBudget: 1024,

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -1,10 +1,7 @@
 import type { TokenBudgetConfig } from '../agent/TokenBudget.js';
 import type { UserMessageContent } from '../agent/types.js';
 import type { SdkMcpServerHandle } from '../mcp/SdkMcpServer.js';
-import type {
-  AgentMiddlewareConfig,
-  AgentPlugin,
-} from '../middleware/AgentPlugin.js';
+import type { AgentMiddlewareConfig, AgentPlugin } from '../middleware/AgentPlugin.js';
 import type { AgentTrace, ObservabilityOptions } from '../observability/index.js';
 import type {
   ContextSnapshot,
@@ -25,12 +22,7 @@ import type {
   ToolProgress,
   ToolResult,
 } from '../tools/types/index.js';
-import type {
-  EventSequence,
-  InputId,
-  RequestId,
-  SessionId,
-} from '../types/branded.js';
+import type { EventSequence, InputId, RequestId, SessionId } from '../types/branded.js';
 import type {
   JsonObject,
   JsonValue,
@@ -47,9 +39,7 @@ import type { CanUseTool, PermissionHandler, PermissionUpdate } from '../types/p
 import type { Assert, IsEqual } from '../types/typeAssertions.js';
 import type { DurableEventStore } from './events/DurableEventStore.js';
 import type { DurableExecutionLeaseOptions } from './events/DurableExecutionLease.js';
-import type {
-  DurableExecutionLease as DurableExecutionLeaseSnapshot,
-} from './events/DurableExecutionLeaseStore.js';
+import type { DurableExecutionLease as DurableExecutionLeaseSnapshot } from './events/DurableExecutionLeaseStore.js';
 import type {
   DurableEventSubscription,
   DurableEventSubscriptionOptions,

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -111,6 +111,10 @@ export interface ProviderConfig {
   organization?: string;
   apiVersion?: string;
   projectId?: string;
+  /** Maximum wall-clock wait for a non-streaming model operation. */
+  requestTimeoutMs?: number;
+  /** Maximum wait between model stream chunks. */
+  streamIdleTimeoutMs?: number;
 }
 
 export interface ToolCallRecord {

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -33,6 +33,10 @@ export interface ModelConfig {
   maxContextTokens?: number;
   maxOutputTokens?: number;
   temperature?: number;
+  /** Maximum wall-clock wait for a non-streaming model operation. */
+  requestTimeoutMs?: number;
+  /** Maximum wait between model stream chunks. */
+  streamIdleTimeoutMs?: number;
   headers?: Record<string, string>;
   providerOptions?: JsonObject;
   thinkingEnabled?: boolean;


### PR DESCRIPTION
## Summary

- enforce a 10-minute default deadline for non-streaming model operations and a 5-minute idle deadline between stream chunks
- abort the underlying provider through a composed signal while preserving caller abort reasons
- keep retry-generator deadlines active across yielded retry events and bound provider-generator cleanup
- apply the boundary outside model middleware and to compaction, including the existing legacy `ChatConfig.timeout` value
- expose typed `ModelTimeoutError` codes and provider-level timeout overrides

## Reference behavior

- Claude Code uses a request timeout plus a streaming idle watchdog
- Codex applies an idle timeout while reading SSE frames
- Grok applies configurable per-chunk inference idle timeouts

## Verification

- `pnpm test` (`1580 passed`, `62 skipped`)
- `pnpm run type-check`
- `pnpm run lint`
- `pnpm exec biome format <changed TypeScript files>`
- `pnpm run verify:entrypoints`
- `pnpm run docs:build`
- `pnpm run changelog:check -- --base origin/main`
- `pnpm run audit:prod`
- `git diff --check origin/main...HEAD`

## Release

Expected semantic release: `5.3.1`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable timeouts for model requests and streaming inactivity.
  - Timed-out operations are automatically stopped and report typed timeout errors.
  - Timeout settings are supported across sessions, providers, retries, and compaction workflows.
  - Added separate controls for total request duration and stream idle duration, with defaults.

- **Documentation**
  - Documented timeout configuration, defaults, validation, behavior, and error types.
  - Added API documentation for timeout-related errors and token budget types.

- **Tests**
  - Added coverage for timeout handling, cancellation, cleanup, signal propagation, and configuration validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->