### PR TITLE
fix: bound session tool execution

### DIFF
--- a/.changes/bounded-tool-execution.json
+++ b/.changes/bounded-tool-execution.json
@@ -1,5 +1,5 @@
 {
   "type": "fix",
-  "en": "Bound tool invocations to 10 minutes by default, expose SessionOptions.toolTimeoutMs, keep the deadline active across progress yields, and cap cancellation cleanup.",
-  "zh-CN": "工具调用默认限制为 10 分钟，新增 SessionOptions.toolTimeoutMs，并确保 progress yield 期间持续计时且取消清理有界。"
+  "en": "Bound tool invocations to 10 minutes by default, expose SessionOptions.toolTimeoutMs, keep the deadline active across progress yields, and fail closed while timed-out cleanup remains pending.",
+  "zh-CN": "工具调用默认限制为 10 分钟，新增 SessionOptions.toolTimeoutMs，确保 progress yield 期间持续计时，并在超时清理未完成时保持 fail-closed。"
 }

--- a/.changes/bounded-tool-execution.json
+++ b/.changes/bounded-tool-execution.json
@@ -1,0 +1,5 @@
+{
+  "type": "fix",
+  "en": "Bound tool invocations to 10 minutes by default, expose SessionOptions.toolTimeoutMs, keep the deadline active across progress yields, and cap cancellation cleanup.",
+  "zh-CN": "工具调用默认限制为 10 分钟，新增 SessionOptions.toolTimeoutMs，并确保 progress yield 期间持续计时且取消清理有界。"
+}

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ console.log(result.usage);
 - Tools: generator-only custom tools, capability-grouped built-ins, MCP tools, and typed progress/effects
 - Extensibility: onion-style model/tool middleware and declarative plugins that bundle middleware, hooks, and tools
 - Collaboration: foreground and background subagents, task tools, and project Skills
-- Safety: bounded model requests, permission modes, policy callbacks, hooks, path checks, and optional OS sandbox integration
+- Safety: bounded model and tool execution, permission modes, policy callbacks, hooks, path checks, and optional OS sandbox integration
 - Runtime: optional workspace context, structured output, crash-safe local transcripts, context compaction, token budgets, and traces
 
 ## Steer an Active Request

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -67,7 +67,7 @@ console.log(result.usage);
 - 工具：仅 generator 的自定义工具、按能力分组的内置工具、MCP 工具和类型化进度/副作用
 - 扩展：洋葱式模型/工具 middleware，以及可打包 middleware、hooks 与工具的声明式插件
 - 协作：前台/后台子 Agent、任务工具，以及项目级 Skills
-- 安全：有界模型请求、权限模式、策略回调、Hooks、路径检查和可选 OS 沙箱集成
+- 安全：有界模型与工具执行、权限模式、策略回调、Hooks、路径检查和可选 OS 沙箱集成
 - 运行时：可选 workspace、结构化输出、崩溃安全的本地会话记录、上下文压缩、token 预算和 trace
 
 ## 转向活动请求

--- a/docs/en/session.md
+++ b/docs/en/session.md
@@ -689,6 +689,7 @@ Payload capture is opt-in because prompts and tool data may be sensitive.
 | `thinkingEnabled` / `thinkingBudget` | `boolean` / `number` | Reasoning controls |
 | `tokenBudget` | `TokenBudgetConfig` | Request and cost limits |
 | `tools` | `SessionTool[]` | Custom `ToolDefinition` or complete `Tool` instances |
+| `toolTimeoutMs` | `number` | Per-invocation wall-clock timeout; defaults to `600000` |
 | `allowedTools` / `disallowedTools` | `string[]` | Tool filters |
 | `toolSourcePolicy` | `ToolCatalogSourcePolicy` | Source and trust filtering |
 | `mcpServers` | `Record<string, McpServerConfig \| SdkMcpServerHandle>` | MCP configuration |

--- a/docs/en/tools.md
+++ b/docs/en/tools.md
@@ -207,9 +207,10 @@ request `AbortSignal` even when they block `now`-priority steering.
 `600000` (10 minutes). The deadline starts after permission checks and the
 durable `tool_started` boundary, remains active across progress yields, and
 aborts the tool's signal on expiry. The terminal result has
-`ToolErrorType.TIMEOUT_ERROR`. Cleanup is awaited for at most 5 seconds so a
-tool that ignores cancellation cannot indefinitely block Session shutdown or
-handoff.
+`ToolErrorType.TIMEOUT_ERROR`. Cleanup is awaited for at most 5 seconds. If it
+is still pending, the pipeline refuses new tool work and Session shutdown or
+handoff fails closed until the generator exits; JavaScript cannot preempt
+custom tool code that ignores cancellation.
 
 `interruptBehavior` belongs to the `ToolConfig` accepted by `createTool()`;
 `defineTool()` / `ToolDefinition` does not expose it. Use `createTool()` with

--- a/docs/en/tools.md
+++ b/docs/en/tools.md
@@ -203,6 +203,14 @@ Explicit `session.abort()` and `session.close()` are request-level cancellation 
 Both methods wait for active tool cleanup, so custom tools must honor the
 request `AbortSignal` even when they block `now`-priority steering.
 
+`SessionOptions.toolTimeoutMs` bounds each tool invocation and defaults to
+`600000` (10 minutes). The deadline starts after permission checks and the
+durable `tool_started` boundary, remains active across progress yields, and
+aborts the tool's signal on expiry. The terminal result has
+`ToolErrorType.TIMEOUT_ERROR`. Cleanup is awaited for at most 5 seconds so a
+tool that ignores cancellation cannot indefinitely block Session shutdown or
+handoff.
+
 `interruptBehavior` belongs to the `ToolConfig` accepted by `createTool()`;
 `defineTool()` / `ToolDefinition` does not expose it. Use `createTool()` with
 `cancel` when a custom Session tool can safely stop for a `now` input.

--- a/docs/session.md
+++ b/docs/session.md
@@ -1736,6 +1736,7 @@ async function analyzeCodeManual() {
 | `disallowedTools` | `string[]`                                              | —  | —           | 工具黑名单                                             |
 | `toolSourcePolicy` | `ToolCatalogSourcePolicy`                              | —  | —           | 工具来源策略，按来源类型和信任级别过滤工具                            |
 | `tools`           | `SessionTool[]`                                          | —  | —           | 追加的 `ToolDefinition` 或完整 `Tool`                        |
+| `toolTimeoutMs`   | `number`                                                 | —  | `600000`    | 单次工具调用的总时限（毫秒）                                   |
 | `mcpServers`      | `Record<string, McpServerConfig \| SdkMcpServerHandle>` | —  | —           | MCP 服务器配置映射                                       |
 | `permissionMode`  | `PermissionMode`                                        | —  | `'default'` | 权限审批模式                                            |
 | `permissionHandler` | `PermissionHandler`                                   | —  | —           | 底层权限处理器（比 `canUseTool` 更低级）                       |

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -426,8 +426,9 @@ const tool = createTool({
 `SessionOptions.toolTimeoutMs` 限制每次工具调用的总时长，默认值为 `600000`
 （10 分钟）。时限从权限检查及 durable `tool_started` 边界完成后开始，在
 progress yield 之间持续计时，并在到期时中止工具的 signal。终态结果的错误类型为
-`ToolErrorType.TIMEOUT_ERROR`。SDK 最多等待工具清理 5 秒，避免忽略取消信号的
-工具无限阻塞 Session 关闭或 handoff。
+`ToolErrorType.TIMEOUT_ERROR`。SDK 最多等待工具清理 5 秒；若清理仍未结束，
+pipeline 会拒绝新的工具执行，Session 关闭或 handoff 也会 fail-closed，直至
+generator 退出。JavaScript 无法强制抢占忽略取消信号的自定义工具代码。
 
 `interruptBehavior` 属于 `createTool()` 的 `ToolConfig`，轻量
 `defineTool()` / `ToolDefinition` 不暴露该字段。需要让 Session 中的自定义

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -423,6 +423,12 @@ const tool = createTool({
   两者都会等待活动工具完成清理，因此自定义工具即使阻止 `now` 转向，也必须监听
   request `AbortSignal`。
 
+`SessionOptions.toolTimeoutMs` 限制每次工具调用的总时长，默认值为 `600000`
+（10 分钟）。时限从权限检查及 durable `tool_started` 边界完成后开始，在
+progress yield 之间持续计时，并在到期时中止工具的 signal。终态结果的错误类型为
+`ToolErrorType.TIMEOUT_ERROR`。SDK 最多等待工具清理 5 秒，避免忽略取消信号的
+工具无限阻塞 Session 关闭或 handoff。
+
 `interruptBehavior` 属于 `createTool()` 的 `ToolConfig`，轻量
 `defineTool()` / `ToolDefinition` 不暴露该字段。需要让 Session 中的自定义
 工具响应 `now` 转向时，应使用 `createTool()` 并声明 `cancel`。

--- a/src/agent/Agent.ts
+++ b/src/agent/Agent.ts
@@ -400,6 +400,7 @@ export class Agent {
       permissionMode,
       maxHistorySize: 1000,
       permissionHandler,
+      toolTimeoutMs: this.config.toolTimeoutMs,
       middleware,
       toolCatalog: new ToolCatalog(registry),
     });

--- a/src/middleware/__tests__/ToolMiddleware.test.ts
+++ b/src/middleware/__tests__/ToolMiddleware.test.ts
@@ -549,55 +549,60 @@ describe('ToolMiddleware', () => {
     ).resolves.toEqual(coreFailure);
   });
 
-  it('does not let middleware replace a timeout after the tool handles abort', async () => {
-    const registry = new ToolRegistry();
-    registry.register(
-      createTool({
-        name: 'TimeoutRecovery',
-        displayName: 'Timeout Recovery',
-        kind: ToolKind.Execute,
-        sideEffect: 'non_idempotent',
-        description: { short: 'Return an error after timeout abort' },
-        schema: z.object({}),
-        async *execute(_params, context) {
-          await new Promise<void>((resolve) => {
-            context.signal?.addEventListener('abort', () => resolve(), { once: true });
-          });
-          return {
-            status: 'error',
-            model: 'tool handled abort',
-            error: {
-              type: ToolErrorType.INTERRUPTED,
-              message: 'tool handled abort',
-            },
-          };
-        },
-      }) as unknown as Tool,
-    );
-    const pipeline = new ExecutionPipeline(registry, {
-      permissionMode: PermissionMode.YOLO,
-      toolTimeoutMs: 10,
-      middleware: [
-        async function* (_request, next) {
-          yield* next();
-          return {
-            status: 'error',
-            model: 'middleware replacement',
-            error: {
-              type: ToolErrorType.EXECUTION_ERROR,
-              message: 'middleware replacement',
-            },
-          };
-        },
-      ],
-    });
+  it('preserves a timeout when middleware returns or throws during unwind', async () => {
+    for (const behavior of ['return', 'throw'] as const) {
+      const registry = new ToolRegistry();
+      registry.register(
+        createTool({
+          name: 'TimeoutRecovery',
+          displayName: 'Timeout Recovery',
+          kind: ToolKind.Execute,
+          sideEffect: 'non_idempotent',
+          description: { short: 'Return an error after timeout abort' },
+          schema: z.object({}),
+          async *execute(_params, context) {
+            await new Promise<void>((resolve) => {
+              context.signal?.addEventListener('abort', () => resolve(), { once: true });
+            });
+            return {
+              status: 'error',
+              model: 'tool handled abort',
+              error: {
+                type: ToolErrorType.INTERRUPTED,
+                message: 'tool handled abort',
+              },
+            };
+          },
+        }) as unknown as Tool,
+      );
+      const pipeline = new ExecutionPipeline(registry, {
+        permissionMode: PermissionMode.YOLO,
+        toolTimeoutMs: 10,
+        middleware: [
+          async function* (_request, next) {
+            yield* next();
+            if (behavior === 'throw') {
+              throw new Error('middleware failure');
+            }
+            return {
+              status: 'error',
+              model: 'middleware replacement',
+              error: {
+                type: ToolErrorType.EXECUTION_ERROR,
+                message: 'middleware replacement',
+              },
+            };
+          },
+        ],
+      });
 
-    await expect(
-      collectToolExecution(pipeline.execute('TimeoutRecovery', {}, {})),
-    ).resolves.toMatchObject({
-      status: 'error',
-      error: { type: ToolErrorType.TIMEOUT_ERROR },
-    });
+      await expect(
+        collectToolExecution(pipeline.execute('TimeoutRecovery', {}, {})),
+      ).resolves.toMatchObject({
+        status: 'error',
+        error: { type: ToolErrorType.TIMEOUT_ERROR },
+      });
+    }
   });
 
   it('preserves the core cancellation result after middleware unwinds', async () => {

--- a/src/middleware/__tests__/ToolMiddleware.test.ts
+++ b/src/middleware/__tests__/ToolMiddleware.test.ts
@@ -549,6 +549,57 @@ describe('ToolMiddleware', () => {
     ).resolves.toEqual(coreFailure);
   });
 
+  it('does not let middleware replace a timeout after the tool handles abort', async () => {
+    const registry = new ToolRegistry();
+    registry.register(
+      createTool({
+        name: 'TimeoutRecovery',
+        displayName: 'Timeout Recovery',
+        kind: ToolKind.Execute,
+        sideEffect: 'non_idempotent',
+        description: { short: 'Return an error after timeout abort' },
+        schema: z.object({}),
+        async *execute(_params, context) {
+          await new Promise<void>((resolve) => {
+            context.signal?.addEventListener('abort', () => resolve(), { once: true });
+          });
+          return {
+            status: 'error',
+            model: 'tool handled abort',
+            error: {
+              type: ToolErrorType.INTERRUPTED,
+              message: 'tool handled abort',
+            },
+          };
+        },
+      }) as unknown as Tool,
+    );
+    const pipeline = new ExecutionPipeline(registry, {
+      permissionMode: PermissionMode.YOLO,
+      toolTimeoutMs: 10,
+      middleware: [
+        async function* (_request, next) {
+          yield* next();
+          return {
+            status: 'error',
+            model: 'middleware replacement',
+            error: {
+              type: ToolErrorType.EXECUTION_ERROR,
+              message: 'middleware replacement',
+            },
+          };
+        },
+      ],
+    });
+
+    await expect(
+      collectToolExecution(pipeline.execute('TimeoutRecovery', {}, {})),
+    ).resolves.toMatchObject({
+      status: 'error',
+      error: { type: ToolErrorType.TIMEOUT_ERROR },
+    });
+  });
+
   it('preserves the core cancellation result after middleware unwinds', async () => {
     const controller = new AbortController();
     const coreCancellation: ToolResult = {

--- a/src/session/Session.ts
+++ b/src/session/Session.ts
@@ -420,6 +420,7 @@ class Session implements ISession {
       models: [modelConfig],
       currentModelId: modelConfig.id,
       temperature: this.options.temperature ?? 0.7,
+      toolTimeoutMs: this.options.toolTimeoutMs,
       permissions: {
         allow: [],
         deny: [],

--- a/src/session/SessionRuntime.ts
+++ b/src/session/SessionRuntime.ts
@@ -353,6 +353,7 @@ export class SessionRuntime {
       maxHistorySize: 1000,
       permissionHandler: this.createPermissionHandler(),
       hookRuntime: this.hookRuntime,
+      toolTimeoutMs: this.bladeConfig.toolTimeoutMs,
       middleware: this.pluginHost.getToolMiddleware(),
       logger: this.rootLogger,
       toolCatalog: this.toolCatalog,

--- a/src/session/SessionRuntime.ts
+++ b/src/session/SessionRuntime.ts
@@ -289,6 +289,13 @@ export class SessionRuntime {
     } catch (error) {
       errors.push(error);
     }
+    if (this.executionPipeline.hasPendingExecutionCleanup()) {
+      errors.push(
+        new Error(
+          `Session runtime ${this.sessionId} still has a tool execution cleaning up`,
+        ),
+      );
+    }
     if (errors.length === 1) {
       throw errors[0];
     }

--- a/src/session/__tests__/SessionModelConfig.test.ts
+++ b/src/session/__tests__/SessionModelConfig.test.ts
@@ -30,6 +30,7 @@ describe('Session model config', () => {
       temperature: 0.2,
       maxOutputTokens: 4096,
       maxContextTokens: 32000,
+      toolTimeoutMs: 45_000,
       providerOptions,
       thinkingEnabled: true,
       thinkingBudget: 1024,
@@ -38,6 +39,7 @@ describe('Session model config', () => {
     const [config] = createAgent.mock.calls.at(-1) ?? [];
     expect(config).toMatchObject({
       temperature: 0.2,
+      toolTimeoutMs: 45_000,
       models: [
         expect.objectContaining({
           temperature: 0.2,

--- a/src/session/__tests__/SessionRuntime.test.ts
+++ b/src/session/__tests__/SessionRuntime.test.ts
@@ -193,71 +193,79 @@ describe('SessionRuntime', () => {
     await runtime.close();
   });
 
-  it('applies the Session tool timeout to runtime tool execution', async () => {
-    let observedAbort = false;
-    const slowTool = createTool({
-      name: 'SlowTool',
-      displayName: 'Slow Tool',
-      kind: ToolKind.Execute,
-      sideEffect: 'non_idempotent',
-      description: { short: 'Wait until cancelled' },
-      schema: z.object({}),
-      async *execute(_params, context) {
-        await new Promise<void>((_resolve, reject) => {
-          context.signal?.addEventListener(
-            'abort',
-            () => {
-              observedAbort = true;
-              reject(context.signal?.reason);
-            },
-            { once: true },
-          );
-        });
-        return {
-          status: 'success',
-          model: 'unexpected',
-        };
-      },
-    });
-    const runtime = new SessionRuntime(
-      SessionId('session-tool-timeout'),
-      createOptions({
-        allowedTools: ['SlowTool'],
-        tools: [slowTool],
-        toolTimeoutMs: 10,
-        hooks: {
-          [HookEvent.PostToolUseFailure]: [
-            async () => ({
-              action: 'abort',
-              reason: 'hook attempted to replace timeout',
-            }),
-          ],
+  it.each(['abort', 'throw'] as const)(
+    'preserves the Session tool timeout when a failure hook returns %s',
+    async (hookBehavior) => {
+      let observedAbort = false;
+      const slowTool = createTool({
+        name: 'SlowTool',
+        displayName: 'Slow Tool',
+        kind: ToolKind.Execute,
+        sideEffect: 'non_idempotent',
+        description: { short: 'Wait until cancelled' },
+        schema: z.object({}),
+        async *execute(_params, context) {
+          await new Promise<void>((_resolve, reject) => {
+            context.signal?.addEventListener(
+              'abort',
+              () => {
+                observedAbort = true;
+                reject(context.signal?.reason);
+              },
+              { once: true },
+            );
+          });
+          return {
+            status: 'success',
+            model: 'unexpected',
+          };
         },
-      }),
-      {
-        models: [],
-        toolTimeoutMs: 10,
-      },
-      PermissionMode.YOLO,
-      createFilesystemContext(workspaceRoot),
-      NOOP_LOGGER,
-    );
+      });
+      const runtime = new SessionRuntime(
+        SessionId('session-tool-timeout'),
+        createOptions({
+          allowedTools: ['SlowTool'],
+          tools: [slowTool],
+          toolTimeoutMs: 10,
+          hooks: {
+            [HookEvent.PostToolUseFailure]: [
+              async () => {
+                if (hookBehavior === 'throw') {
+                  throw new Error('hook failed after timeout');
+                }
+                return {
+                  action: 'abort',
+                  reason: 'hook attempted to replace timeout',
+                };
+              },
+            ],
+          },
+        }),
+        {
+          models: [],
+          toolTimeoutMs: 10,
+        },
+        PermissionMode.YOLO,
+        createFilesystemContext(workspaceRoot),
+        NOOP_LOGGER,
+      );
 
-    await runtime.initialize();
-    const executionPipeline = runtime.getAgentRuntimeDeps().executionPipeline;
-    assertDefined(executionPipeline);
-    const result = await collectToolExecution(
-      executionPipeline.execute('SlowTool', {}, {}),
-    );
+      await runtime.initialize();
+      const executionPipeline = runtime.getAgentRuntimeDeps().executionPipeline;
+      assertDefined(executionPipeline);
+      const result = await collectToolExecution(
+        executionPipeline.execute('SlowTool', {}, {}),
+      );
 
-    expect(result).toMatchObject({
-      status: 'error',
-      error: { type: 'timeout_error' },
-    });
-    expect(observedAbort).toBe(true);
+      expect(result).toMatchObject({
+        status: 'error',
+        error: { type: 'timeout_error' },
+      });
+      expect(observedAbort).toBe(true);
 
-    await runtime.close();
-  });
+      await runtime.close();
+    },
+  );
 
   it('fails closed while a timed-out tool is still cleaning up', async () => {
     vi.useFakeTimers();

--- a/src/session/__tests__/SessionRuntime.test.ts
+++ b/src/session/__tests__/SessionRuntime.test.ts
@@ -90,6 +90,14 @@ function createFilesystemContext(workspaceRoot: string): RuntimeContext {
   };
 }
 
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
 describe('SessionRuntime', () => {
   let workspaceRoot: string;
 
@@ -106,6 +114,7 @@ describe('SessionRuntime', () => {
 
   afterEach(async () => {
     vi.restoreAllMocks();
+    vi.useRealTimers();
     const runtime = new SessionRuntime(
       SessionId('cleanup'),
       createOptions(),
@@ -216,6 +225,14 @@ describe('SessionRuntime', () => {
         allowedTools: ['SlowTool'],
         tools: [slowTool],
         toolTimeoutMs: 10,
+        hooks: {
+          [HookEvent.PostToolUseFailure]: [
+            async () => ({
+              action: 'abort',
+              reason: 'hook attempted to replace timeout',
+            }),
+          ],
+        },
       }),
       {
         models: [],
@@ -239,6 +256,70 @@ describe('SessionRuntime', () => {
     });
     expect(observedAbort).toBe(true);
 
+    await runtime.close();
+  });
+
+  it('fails closed while a timed-out tool is still cleaning up', async () => {
+    vi.useFakeTimers();
+    const started = deferred();
+    const release = deferred();
+    const slowTool = createTool({
+      name: 'UncooperativeTool',
+      displayName: 'Uncooperative Tool',
+      kind: ToolKind.Execute,
+      sideEffect: 'non_idempotent',
+      description: { short: 'Ignore cancellation until released' },
+      schema: z.object({}),
+      // biome-ignore lint/correctness/useYield: exercises an uncooperative terminal execution
+      async *execute() {
+        started.resolve();
+        await release.promise;
+        return {
+          status: 'success',
+          model: 'late success',
+        };
+      },
+    });
+    const runtime = new SessionRuntime(
+      SessionId('session-tool-cleanup'),
+      createOptions({
+        allowedTools: ['UncooperativeTool'],
+        tools: [slowTool],
+        toolTimeoutMs: 50,
+      }),
+      {
+        models: [],
+        toolTimeoutMs: 50,
+      },
+      PermissionMode.YOLO,
+      createFilesystemContext(workspaceRoot),
+      NOOP_LOGGER,
+    );
+
+    await runtime.initialize();
+    const executionPipeline = runtime.getAgentRuntimeDeps().executionPipeline;
+    assertDefined(executionPipeline);
+    const resultPromise = collectToolExecution(
+      executionPipeline.execute('UncooperativeTool', {}, {}),
+    );
+
+    await started.promise;
+    await vi.advanceTimersToNextTimerAsync();
+    await vi.advanceTimersToNextTimerAsync();
+    await vi.advanceTimersByTimeAsync(5_000);
+    await expect(resultPromise).resolves.toMatchObject({
+      status: 'error',
+      error: { type: 'timeout_error' },
+    });
+    await expect(runtime.close()).rejects.toThrow('still has a tool execution cleaning up');
+
+    release.resolve();
+    for (let index = 0; index < 10; index += 1) {
+      await Promise.resolve();
+    }
+    expect(executionPipeline.hasPendingExecutionCleanup()).toBe(false);
+
+    vi.useRealTimers();
     await runtime.close();
   });
 

--- a/src/session/__tests__/SessionRuntime.test.ts
+++ b/src/session/__tests__/SessionRuntime.test.ts
@@ -184,6 +184,64 @@ describe('SessionRuntime', () => {
     await runtime.close();
   });
 
+  it('applies the Session tool timeout to runtime tool execution', async () => {
+    let observedAbort = false;
+    const slowTool = createTool({
+      name: 'SlowTool',
+      displayName: 'Slow Tool',
+      kind: ToolKind.Execute,
+      sideEffect: 'non_idempotent',
+      description: { short: 'Wait until cancelled' },
+      schema: z.object({}),
+      async *execute(_params, context) {
+        await new Promise<void>((_resolve, reject) => {
+          context.signal?.addEventListener(
+            'abort',
+            () => {
+              observedAbort = true;
+              reject(context.signal?.reason);
+            },
+            { once: true },
+          );
+        });
+        return {
+          status: 'success',
+          model: 'unexpected',
+        };
+      },
+    });
+    const runtime = new SessionRuntime(
+      SessionId('session-tool-timeout'),
+      createOptions({
+        allowedTools: ['SlowTool'],
+        tools: [slowTool],
+        toolTimeoutMs: 10,
+      }),
+      {
+        models: [],
+        toolTimeoutMs: 10,
+      },
+      PermissionMode.YOLO,
+      createFilesystemContext(workspaceRoot),
+      NOOP_LOGGER,
+    );
+
+    await runtime.initialize();
+    const executionPipeline = runtime.getAgentRuntimeDeps().executionPipeline;
+    assertDefined(executionPipeline);
+    const result = await collectToolExecution(
+      executionPipeline.execute('SlowTool', {}, {}),
+    );
+
+    expect(result).toMatchObject({
+      status: 'error',
+      error: { type: 'timeout_error' },
+    });
+    expect(observedAbort).toBe(true);
+
+    await runtime.close();
+  });
+
   it('should install plugin tools and tool middleware through one declarative entry', async () => {
     const calls: string[] = [];
     const pluginTool = createTool({

--- a/src/session/__tests__/SessionRuntime.test.ts
+++ b/src/session/__tests__/SessionRuntime.test.ts
@@ -314,10 +314,9 @@ describe('SessionRuntime', () => {
     await expect(runtime.close()).rejects.toThrow('still has a tool execution cleaning up');
 
     release.resolve();
-    for (let index = 0; index < 10; index += 1) {
-      await Promise.resolve();
-    }
-    expect(executionPipeline.hasPendingExecutionCleanup()).toBe(false);
+    await vi.waitFor(() => {
+      expect(executionPipeline.hasPendingExecutionCleanup()).toBe(false);
+    });
 
     vi.useRealTimers();
     await runtime.close();

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -288,6 +288,8 @@ export interface SessionOptions {
 
   systemPrompt?: string;
   maxTurns?: number;
+  /** Maximum wall-clock duration of one tool invocation. */
+  toolTimeoutMs?: number;
   agents?: Record<string, AgentDefinition>;
   subagent?: SubagentInfo;
 

--- a/src/tools/execution/ExecutionPipeline.ts
+++ b/src/tools/execution/ExecutionPipeline.ts
@@ -1,3 +1,4 @@
+import { ConfigError } from '../../errors/ConfigError.js';
 import type { HookRuntime } from '../../hooks/HookRuntime.js';
 import { type InternalLogger, LogCategory, NOOP_LOGGER } from '../../logging/Logger.js';
 import { composeMiddleware } from '../../middleware/composeMiddleware.js';
@@ -52,6 +53,20 @@ import { type ConcurrencyLimits, ConcurrencyScheduler } from './ConcurrencySched
 import { DenialTracker } from './DenialTracker.js';
 import { type FileLockLease, FileLockManager } from './FileLockManager.js';
 import { ResultArtifactStore } from './ResultArtifactStore.js';
+
+const DEFAULT_TOOL_TIMEOUT_MS = 600_000;
+const MAX_TOOL_CLEANUP_WAIT_MS = 5_000;
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
+function resolveToolTimeoutMs(value: number | undefined): number {
+  const resolved = value ?? DEFAULT_TOOL_TIMEOUT_MS;
+  if (!Number.isSafeInteger(resolved) || resolved <= 0 || resolved > MAX_TIMER_DELAY_MS) {
+    throw new ConfigError(
+      `toolTimeoutMs must be a positive integer no greater than ${MAX_TIMER_DELAY_MS}`,
+    );
+  }
+  return resolved;
+}
 
 function getString(params: JsonObject, key: string, defaultValue = ''): string {
   const value = params[key];
@@ -108,7 +123,7 @@ export interface ConfirmationReasonEntry {
 export class ExecutionPipeline {
   private executionHistory: ExecutionHistoryEntry[] = [];
   private readonly maxHistorySize: number;
-  private readonly toolTimeoutMs: number | undefined;
+  private readonly toolTimeoutMs: number;
   private readonly sessionApprovals = new Set<string>();
   private readonly denialTracker = new DenialTracker();
   private readonly hookRuntime?: HookRuntime;
@@ -127,7 +142,7 @@ export class ExecutionPipeline {
     config: ExecutionPipelineConfig = {}
   ) {
     this.maxHistorySize = config.maxHistorySize || 1000;
-    this.toolTimeoutMs = config.toolTimeoutMs;
+    this.toolTimeoutMs = resolveToolTimeoutMs(config.toolTimeoutMs);
     this.hookRuntime = config.hookRuntime;
     this.logger = (config.logger ?? NOOP_LOGGER).child(LogCategory.EXECUTION);
     this.toolCatalog = config.toolCatalog;
@@ -766,25 +781,28 @@ export class ExecutionPipeline {
       state.result = this.createAbortedResult('Task was aborted before tool execution');
       return;
     }
-    const timeoutController = this.toolTimeoutMs ? new AbortController() : undefined;
-    const executionSignal = timeoutController
-      ? state.context.signal
-        ? AbortSignal.any([state.context.signal, timeoutController.signal])
-        : timeoutController.signal
-      : state.context.signal ?? new AbortController().signal;
+    let completed = false;
+    let timedOut = false;
+    const timeoutController = new AbortController();
+    const timeoutError = this.createTimeoutError(state.toolName);
+    const timeout = setTimeout(
+      () => {
+        timedOut = true;
+        timeoutController.abort(timeoutError);
+      },
+      this.toolTimeoutMs,
+    );
+    const executionSignal = state.context.signal
+      ? AbortSignal.any([state.context.signal, timeoutController.signal])
+      : timeoutController.signal;
     const execution = state.invocation.execute(executionSignal, {
       ...state.context,
       signal: executionSignal,
     });
-    const deadline = this.toolTimeoutMs
-      ? Date.now() + this.toolTimeoutMs
-      : undefined;
-    let completed = false;
-    let timedOut = false;
 
     try {
       while (true) {
-        const step = await this.nextExecutionStep(execution, state.toolName, deadline);
+        const step = await this.nextExecutionStep(execution, executionSignal);
         if (step.done) {
           state.result = step.value;
           if (
@@ -806,13 +824,10 @@ export class ExecutionPipeline {
         yield step.value;
       }
     } catch (error) {
-      timedOut = getErrorName(error) === 'TimeoutError';
-      state.interrupted =
-        !timedOut
-        && isSteeringInterruptSignal(executionSignal);
-      if (timedOut) {
-        timeoutController?.abort(error);
-      }
+      timedOut =
+        timeoutController.signal.aborted
+        || getErrorName(error) === 'TimeoutError';
+      state.interrupted = !timedOut && isSteeringInterruptSignal(executionSignal);
       state.result = this.createExecutionFailureResult(
         timedOut
           ? `Tool execution timeout after ${this.toolTimeoutMs}ms`
@@ -824,16 +839,16 @@ export class ExecutionPipeline {
             : ToolErrorType.EXECUTION_ERROR,
       );
     } finally {
+      clearTimeout(timeout);
       if (!completed) {
+        if (!executionSignal.aborted) {
+          timeoutController.abort(new Error('Tool execution closed before completion'));
+        }
         const closing = execution.return(undefined as never);
-        if (timedOut) {
-          void closing.catch(() => {});
-        } else {
-          try {
-            await closing;
-          } catch {
-            // Preserve the original execution or consumer failure.
-          }
+        try {
+          await this.waitForExecutionClose(closing);
+        } catch {
+          // Preserve the original execution or consumer failure.
         }
       }
     }
@@ -841,30 +856,54 @@ export class ExecutionPipeline {
 
   private async nextExecutionStep(
     execution: ToolExecution,
-    toolName: string,
-    deadline?: number,
+    signal: AbortSignal,
   ): Promise<IteratorResult<ToolYield, ToolResult>> {
-    if (deadline === undefined) {
-      return execution.next();
-    }
-
-    const remaining = deadline - Date.now();
-    if (remaining <= 0) {
-      throw this.createTimeoutError(toolName);
+    if (signal.aborted) {
+      throw signal.reason;
     }
 
     return new Promise<IteratorResult<ToolYield, ToolResult>>((resolve, reject) => {
-      const timer = setTimeout(() => reject(this.createTimeoutError(toolName)), remaining);
+      let settled = false;
+      const cleanup = (): void => {
+        signal.removeEventListener('abort', onAbort);
+      };
+      const resolveOnce = (step: IteratorResult<ToolYield, ToolResult>): void => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        resolve(step);
+      };
+      const rejectOnce = (error: unknown): void => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        reject(error);
+      };
+      const onAbort = (): void => {
+        rejectOnce(signal.reason);
+      };
+
+      signal.addEventListener('abort', onAbort, { once: true });
       execution.next().then(
-        (step) => {
-          clearTimeout(timer);
-          resolve(step);
-        },
-        (error) => {
-          clearTimeout(timer);
-          reject(error);
-        },
+        resolveOnce,
+        rejectOnce,
       );
+    });
+  }
+
+  private async waitForExecutionClose(
+    closing: PromiseLike<unknown>,
+  ): Promise<void> {
+    await new Promise<void>((resolve) => {
+      let settled = false;
+      const finish = (): void => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeout);
+        resolve();
+      };
+      const timeout = setTimeout(finish, MAX_TOOL_CLEANUP_WAIT_MS);
+      closing.then(finish, finish);
     });
   }
 
@@ -1411,7 +1450,7 @@ export interface ExecutionPipelineConfig {
   /**
    * Per-tool execution timeout in milliseconds.
    * When a tool exceeds this limit it is aborted and returns a TIMEOUT error.
-   * Defaults to no timeout (undefined).
+   * Defaults to 600000 (10 minutes).
    */
   toolTimeoutMs?: number;
   scheduler?: ConcurrencyScheduler;

--- a/src/tools/execution/ExecutionPipeline.ts
+++ b/src/tools/execution/ExecutionPipeline.ts
@@ -330,7 +330,16 @@ export class ExecutionPipeline {
           if (isExecutionLeaseFailure(protectedContext.signal?.reason)) {
             throw protectedContext.signal.reason;
           }
-          if (protectedContext.signal?.aborted) {
+          if (
+            coreCompleted
+            && coreResult?.status === 'error'
+            && coreResult.error.type === ToolErrorType.TIMEOUT_ERROR
+          ) {
+            this.logger.warn(
+              `Tool middleware failed after ${toolName} timed out; preserving the core timeout`,
+            );
+            result = coreResult;
+          } else if (protectedContext.signal?.aborted) {
             const isInterrupt = isSteeringInterruptSignal(protectedContext.signal);
             result = this.createAbortedResult(
               isInterrupt ? '工具执行被新的用户输入中断' : '任务已被用户中止',
@@ -510,19 +519,31 @@ export class ExecutionPipeline {
       await state.context.assertExecutionLease?.();
 
       const normalizedResult = await this.normalizeExecutionResult(state);
-      const result = await this.applyPostExecutionHooks(
-        state.toolName,
-        state.params,
-        state.context,
-        normalizedResult,
-        executionId,
-        {
-          isTimeout:
-            normalizedResult.status === 'error'
-            && normalizedResult.error.type === ToolErrorType.TIMEOUT_ERROR,
-          isInterrupt: state.interrupted,
-        },
-      );
+      const isTimeout =
+        normalizedResult.status === 'error'
+        && normalizedResult.error.type === ToolErrorType.TIMEOUT_ERROR;
+      let result: ToolResult;
+      try {
+        result = await this.applyPostExecutionHooks(
+          state.toolName,
+          state.params,
+          state.context,
+          normalizedResult,
+          executionId,
+          { isTimeout, isInterrupt: state.interrupted },
+        );
+      } catch (error) {
+        if (isExecutionLeaseFailure(error)) {
+          throw error;
+        }
+        if (isTimeout) {
+          this.logger.warn(
+            `Post-execution hooks failed after ${state.toolName} timed out; preserving the timeout`,
+          );
+          return normalizedResult;
+        }
+        throw error;
+      }
 
       return this.preserveTimeoutFailure(
         normalizedResult,

--- a/src/tools/execution/ExecutionPipeline.ts
+++ b/src/tools/execution/ExecutionPipeline.ts
@@ -191,9 +191,7 @@ export class ExecutionPipeline {
     context: ExecutionContext
   ): ToolExecution {
     if (this.hasPendingExecutionCleanup()) {
-      return this.createExecutionFailureResult(
-        'A tool execution is still cleaning up; refusing to start another tool',
-      );
+      return this.createPendingCleanupResult();
     }
     const startTime = Date.now();
     const executionId = this.generateExecutionId();
@@ -466,6 +464,9 @@ export class ExecutionPipeline {
     let fileLease: FileLockLease | undefined;
 
     try {
+      if (this.hasPendingExecutionCleanup()) {
+        return this.createPendingCleanupResult();
+      }
       fileLease = filePath
         ? await FileLockManager.getInstance(this.logger).acquire(filePath, lockMode)
         : undefined;
@@ -805,12 +806,20 @@ export class ExecutionPipeline {
       );
       return;
     }
+    if (this.hasPendingExecutionCleanup()) {
+      state.result = this.createPendingCleanupResult();
+      return;
+    }
 
     await state.context.toolInvocationLifecycle?.onExecutionStarted?.({
       input: structuredClone(state.params),
       sideEffect: state.resolvedBehavior?.sideEffect ?? state.tool.sideEffect,
     });
     await state.context.assertExecutionLease?.();
+    if (this.hasPendingExecutionCleanup()) {
+      state.result = this.createPendingCleanupResult();
+      return;
+    }
     if (state.context.signal?.aborted) {
       state.result = this.createAbortedResult('Task was aborted before tool execution');
       return;
@@ -1298,6 +1307,12 @@ export class ExecutionPipeline {
         message,
       },
     };
+  }
+
+  private createPendingCleanupResult(): ToolResult {
+    return this.createExecutionFailureResult(
+      'A tool execution is still cleaning up; refusing to start another tool',
+    );
   }
 
   private preserveTimeoutFailure(

--- a/src/tools/execution/ExecutionPipeline.ts
+++ b/src/tools/execution/ExecutionPipeline.ts
@@ -803,6 +803,7 @@ export class ExecutionPipeline {
     try {
       while (true) {
         const step = await this.nextExecutionStep(execution, executionSignal);
+        timeoutController.signal.throwIfAborted();
         if (step.done) {
           state.result = step.value;
           if (

--- a/src/tools/execution/ExecutionPipeline.ts
+++ b/src/tools/execution/ExecutionPipeline.ts
@@ -913,9 +913,8 @@ export class ExecutionPipeline {
           () => undefined,
           () => undefined,
         );
-        if (!await this.waitForExecutionClose(closing)) {
-          this.trackPendingExecutionCleanup(closing);
-        }
+        this.trackPendingExecutionCleanup(closing);
+        await this.waitForExecutionClose(closing);
       }
     }
   }
@@ -964,20 +963,17 @@ export class ExecutionPipeline {
 
   private async waitForExecutionClose(
     closing: PromiseLike<unknown>,
-  ): Promise<boolean> {
-    return await new Promise<boolean>((resolve) => {
+  ): Promise<void> {
+    await new Promise<void>((resolve) => {
       let settled = false;
-      const finish = (closed: boolean): void => {
+      const finish = (): void => {
         if (settled) return;
         settled = true;
         clearTimeout(timeout);
-        resolve(closed);
+        resolve();
       };
-      const timeout = setTimeout(() => finish(false), MAX_TOOL_CLEANUP_WAIT_MS);
-      closing.then(
-        () => finish(true),
-        () => finish(true),
-      );
+      const timeout = setTimeout(finish, MAX_TOOL_CLEANUP_WAIT_MS);
+      closing.then(finish, finish);
     });
   }
 

--- a/src/tools/execution/ExecutionPipeline.ts
+++ b/src/tools/execution/ExecutionPipeline.ts
@@ -136,6 +136,7 @@ export class ExecutionPipeline {
   private readonly middleware: readonly ToolMiddleware[];
   private readonly scheduler: ConcurrencyScheduler;
   private readonly resultArtifactStore = new ResultArtifactStore();
+  private readonly pendingExecutionCleanups = new Set<Promise<void>>();
 
   constructor(
     private registry: ToolRegistry,
@@ -177,6 +178,10 @@ export class ExecutionPipeline {
     return this.toolCatalog;
   }
 
+  hasPendingExecutionCleanup(): boolean {
+    return this.pendingExecutionCleanups.size > 0;
+  }
+
   /**
    * 执行工具
    */
@@ -185,6 +190,11 @@ export class ExecutionPipeline {
     params: JsonObject,
     context: ExecutionContext
   ): ToolExecution {
+    if (this.hasPendingExecutionCleanup()) {
+      return this.createExecutionFailureResult(
+        'A tool execution is still cleaning up; refusing to start another tool',
+      );
+    }
     const startTime = Date.now();
     const executionId = this.generateExecutionId();
     const protectedContext = Object.freeze({
@@ -294,7 +304,16 @@ export class ExecutionPipeline {
             );
             result = yield* delegatedExecution;
           }
-          if (coreResult?.status === 'error' && result.status === 'success') {
+          if (
+            coreResult?.status === 'error'
+            && coreResult.error.type === ToolErrorType.TIMEOUT_ERROR
+          ) {
+            result = this.preserveTimeoutFailure(
+              coreResult,
+              result,
+              `Tool middleware for ${toolName}`,
+            );
+          } else if (coreResult?.status === 'error' && result.status === 'success') {
             this.logger.warn(
               `Tool middleware attempted to replace failed ${toolName} core execution with success; preserving the core failure`,
             );
@@ -489,17 +508,26 @@ export class ExecutionPipeline {
       }
       await state.context.assertExecutionLease?.();
 
-      let result = await this.normalizeExecutionResult(state);
-      result = await this.applyPostExecutionHooks(
+      const normalizedResult = await this.normalizeExecutionResult(state);
+      const result = await this.applyPostExecutionHooks(
         state.toolName,
         state.params,
         state.context,
-        result,
+        normalizedResult,
         executionId,
-        { isInterrupt: state.interrupted },
+        {
+          isTimeout:
+            normalizedResult.status === 'error'
+            && normalizedResult.error.type === ToolErrorType.TIMEOUT_ERROR,
+          isInterrupt: state.interrupted,
+        },
       );
 
-      return result;
+      return this.preserveTimeoutFailure(
+        normalizedResult,
+        result,
+        `Post-execution hooks for ${state.toolName}`,
+      );
     } catch (error) {
       if (isExecutionLeaseFailure(error)) {
         throw error;
@@ -512,7 +540,7 @@ export class ExecutionPipeline {
         state.interrupted
         || isSteeringInterruptSignal(state.context.signal);
 
-      let errorResult: ToolResult = {
+      const originalErrorResult: ToolResult = {
         status: 'error',
         model: `Tool execution failed: ${errorMsg}`,
         error: {
@@ -524,15 +552,21 @@ export class ExecutionPipeline {
           message: errorMsg,
         },
       };
+      let errorResult: ToolResult = originalErrorResult;
 
       try {
-        errorResult = await this.applyPostExecutionHooks(
+        const hookResult = await this.applyPostExecutionHooks(
           state.toolName,
           state.params,
           state.context,
           errorResult,
           executionId,
           { isTimeout, isInterrupt },
+        );
+        errorResult = this.preserveTimeoutFailure(
+          originalErrorResult,
+          hookResult,
+          `Post-execution hooks for ${state.toolName}`,
         );
       } catch (hookError) {
         if (isExecutionLeaseFailure(hookError)) {
@@ -845,11 +879,12 @@ export class ExecutionPipeline {
         if (!executionSignal.aborted) {
           timeoutController.abort(new Error('Tool execution closed before completion'));
         }
-        const closing = execution.return(undefined as never);
-        try {
-          await this.waitForExecutionClose(closing);
-        } catch {
-          // Preserve the original execution or consumer failure.
+        const closing = Promise.resolve(execution.return(undefined as never)).then(
+          () => undefined,
+          () => undefined,
+        );
+        if (!await this.waitForExecutionClose(closing)) {
+          this.trackPendingExecutionCleanup(closing);
         }
       }
     }
@@ -899,17 +934,27 @@ export class ExecutionPipeline {
 
   private async waitForExecutionClose(
     closing: PromiseLike<unknown>,
-  ): Promise<void> {
-    await new Promise<void>((resolve) => {
+  ): Promise<boolean> {
+    return await new Promise<boolean>((resolve) => {
       let settled = false;
-      const finish = (): void => {
+      const finish = (closed: boolean): void => {
         if (settled) return;
         settled = true;
         clearTimeout(timeout);
-        resolve();
+        resolve(closed);
       };
-      const timeout = setTimeout(finish, MAX_TOOL_CLEANUP_WAIT_MS);
-      closing.then(finish, finish);
+      const timeout = setTimeout(() => finish(false), MAX_TOOL_CLEANUP_WAIT_MS);
+      closing.then(
+        () => finish(true),
+        () => finish(true),
+      );
+    });
+  }
+
+  private trackPendingExecutionCleanup(closing: Promise<void>): void {
+    this.pendingExecutionCleanups.add(closing);
+    void closing.finally(() => {
+      this.pendingExecutionCleanups.delete(closing);
     });
   }
 
@@ -1251,6 +1296,35 @@ export class ExecutionPipeline {
       error: {
         type,
         message,
+      },
+    };
+  }
+
+  private preserveTimeoutFailure(
+    original: ToolResult,
+    transformed: ToolResult,
+    source: string,
+  ): ToolResult {
+    if (
+      original.status !== 'error'
+      || original.error.type !== ToolErrorType.TIMEOUT_ERROR
+      || (
+        transformed.status === 'error'
+        && transformed.error.type === ToolErrorType.TIMEOUT_ERROR
+      )
+    ) {
+      return transformed;
+    }
+
+    this.logger.warn(`${source} attempted to replace a tool timeout; preserving timeout semantics`);
+    if (transformed.status === 'success') {
+      return original;
+    }
+    return {
+      ...transformed,
+      error: {
+        ...transformed.error,
+        type: ToolErrorType.TIMEOUT_ERROR,
       },
     };
   }

--- a/src/tools/execution/ExecutionPipeline.ts
+++ b/src/tools/execution/ExecutionPipeline.ts
@@ -864,7 +864,11 @@ export class ExecutionPipeline {
 
     return new Promise<IteratorResult<ToolYield, ToolResult>>((resolve, reject) => {
       let settled = false;
+      let abortTimer: ReturnType<typeof setTimeout> | undefined;
       const cleanup = (): void => {
+        if (abortTimer !== undefined) {
+          clearTimeout(abortTimer);
+        }
         signal.removeEventListener('abort', onAbort);
       };
       const resolveOnce = (step: IteratorResult<ToolYield, ToolResult>): void => {
@@ -880,7 +884,8 @@ export class ExecutionPipeline {
         reject(error);
       };
       const onAbort = (): void => {
-        rejectOnce(signal.reason);
+        // Preserve a terminal result produced in the same turn as cancellation.
+        abortTimer = setTimeout(() => rejectOnce(signal.reason), 0);
       };
 
       signal.addEventListener('abort', onAbort, { once: true });

--- a/src/tools/execution/__tests__/ExecutionPipeline.test.ts
+++ b/src/tools/execution/__tests__/ExecutionPipeline.test.ts
@@ -218,6 +218,50 @@ describe('ExecutionPipeline', () => {
     expect(finalized).toBe(true);
   });
 
+  it('preserves timeout precedence when a tool returns success after abort', async () => {
+    vi.useFakeTimers();
+    const registry = new ToolRegistry();
+    const started = deferred();
+
+    registerTool(
+      registry,
+      createTool({
+        name: 'AbortRecovery',
+        displayName: 'Abort Recovery',
+        kind: ToolKind.Execute,
+        sideEffect: 'non_idempotent',
+        description: { short: 'Return success after abort' },
+        schema: z.object({}),
+        async *execute(_params, context) {
+          started.resolve();
+          await new Promise<void>((resolve) => {
+            context.signal?.addEventListener('abort', () => resolve(), { once: true });
+          });
+          return { status: 'success', model: 'recovered' };
+        },
+      }),
+    );
+
+    const pipeline = new ExecutionPipeline(registry, {
+      permissionMode: PermissionMode.YOLO,
+      toolTimeoutMs: 50,
+    });
+    const resultPromise = executePipeline(
+      pipeline,
+      'AbortRecovery',
+      {},
+      { permissionMode: PermissionMode.YOLO },
+    );
+
+    await started.promise;
+    await vi.advanceTimersToNextTimerAsync();
+
+    await expect(resultPromise).resolves.toMatchObject({
+      status: 'error',
+      error: { type: ToolErrorType.TIMEOUT_ERROR },
+    });
+  });
+
   it('keeps the tool deadline active while the consumer pauses after progress', async () => {
     vi.useFakeTimers();
     const registry = new ToolRegistry();

--- a/src/tools/execution/__tests__/ExecutionPipeline.test.ts
+++ b/src/tools/execution/__tests__/ExecutionPipeline.test.ts
@@ -312,7 +312,8 @@ describe('ExecutionPipeline', () => {
     });
 
     await started.promise;
-    await vi.advanceTimersByTimeAsync(50);
+    await vi.advanceTimersToNextTimerAsync();
+    await vi.advanceTimersToNextTimerAsync();
     expect(settled).toBe(false);
 
     await vi.advanceTimersByTimeAsync(4_999);

--- a/src/tools/execution/__tests__/ExecutionPipeline.test.ts
+++ b/src/tools/execution/__tests__/ExecutionPipeline.test.ts
@@ -321,7 +321,12 @@ describe('ExecutionPipeline', () => {
   it('waits for bounded cleanup when a timed-out tool ignores cancellation', async () => {
     vi.useFakeTimers();
     const registry = new ToolRegistry();
+    const scheduler = new ConcurrencyScheduler({ execute: 1 });
     const started = deferred();
+    const queuedExecute = vi.fn(() => ({
+      status: 'success',
+      model: 'unexpected queued execution',
+    }) as ToolResult);
 
     registerTool(
       registry,
@@ -339,10 +344,23 @@ describe('ExecutionPipeline', () => {
         },
       }),
     );
+    registerTool(
+      registry,
+      createTool({
+        name: 'QueuedTool',
+        displayName: 'Queued Tool',
+        kind: ToolKind.Execute,
+        sideEffect: 'non_idempotent',
+        description: { short: 'Wait behind the timed-out tool' },
+        schema: z.object({}),
+        execute: () => completeToolExecution(queuedExecute()),
+      }),
+    );
 
     const pipeline = new ExecutionPipeline(registry, {
       permissionMode: PermissionMode.YOLO,
       toolTimeoutMs: 50,
+      scheduler,
     });
     const resultPromise = executePipeline(
       pipeline,
@@ -356,6 +374,17 @@ describe('ExecutionPipeline', () => {
     });
 
     await started.promise;
+    const queuedResultPromise = executePipeline(
+      pipeline,
+      'QueuedTool',
+      {},
+      { permissionMode: PermissionMode.YOLO },
+    );
+    for (let index = 0; index < 10; index += 1) {
+      await Promise.resolve();
+    }
+    expect(scheduler.getStats()[ToolKind.Execute].queued).toBe(1);
+
     await vi.advanceTimersToNextTimerAsync();
     await vi.advanceTimersToNextTimerAsync();
     expect(settled).toBe(false);
@@ -369,6 +398,14 @@ describe('ExecutionPipeline', () => {
       error: { type: ToolErrorType.TIMEOUT_ERROR },
     });
     expect(pipeline.hasPendingExecutionCleanup()).toBe(true);
+    await expect(queuedResultPromise).resolves.toMatchObject({
+      status: 'error',
+      error: {
+        type: ToolErrorType.EXECUTION_ERROR,
+        message: expect.stringContaining('still cleaning up'),
+      },
+    });
+    expect(queuedExecute).not.toHaveBeenCalled();
 
     await expect(
       executePipeline(

--- a/src/tools/execution/__tests__/ExecutionPipeline.test.ts
+++ b/src/tools/execution/__tests__/ExecutionPipeline.test.ts
@@ -388,6 +388,7 @@ describe('ExecutionPipeline', () => {
     await vi.advanceTimersToNextTimerAsync();
     await vi.advanceTimersToNextTimerAsync();
     expect(settled).toBe(false);
+    expect(pipeline.hasPendingExecutionCleanup()).toBe(true);
 
     await vi.advanceTimersByTimeAsync(4_999);
     expect(settled).toBe(false);

--- a/src/tools/execution/__tests__/ExecutionPipeline.test.ts
+++ b/src/tools/execution/__tests__/ExecutionPipeline.test.ts
@@ -368,6 +368,22 @@ describe('ExecutionPipeline', () => {
       status: 'error',
       error: { type: ToolErrorType.TIMEOUT_ERROR },
     });
+    expect(pipeline.hasPendingExecutionCleanup()).toBe(true);
+
+    await expect(
+      executePipeline(
+        pipeline,
+        'UncooperativeTool',
+        {},
+        { permissionMode: PermissionMode.YOLO },
+      ),
+    ).resolves.toMatchObject({
+      status: 'error',
+      error: {
+        type: ToolErrorType.EXECUTION_ERROR,
+        message: expect.stringContaining('still cleaning up'),
+      },
+    });
   });
 
   it('uses a bounded default and rejects invalid tool timeout values', () => {

--- a/src/tools/execution/__tests__/ExecutionPipeline.test.ts
+++ b/src/tools/execution/__tests__/ExecutionPipeline.test.ts
@@ -1,8 +1,9 @@
 import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
+import { ConfigError } from '../../../errors/ConfigError.js';
 import { DurableExecutionLeaseError } from '../../../session/events/DurableExecutionLeaseStore.js';
 import { createTool } from '../../core/createTool.js';
 import { ToolRegistry } from '../../registry/ToolRegistry.js';
@@ -13,6 +14,7 @@ import {
   completeToolExecution,
   type ExecutionContext,
   type Tool,
+  ToolErrorType,
   type ToolResult,
   type ToolYield,
 } from '../../types/index.js';
@@ -44,6 +46,10 @@ function executePipeline(
 }
 
 describe('ExecutionPipeline', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('does not expose stage-pipeline management on the default execution path', () => {
     const registry = new ToolRegistry();
     const pipeline = new ExecutionPipeline(registry, {
@@ -210,6 +216,134 @@ describe('ExecutionPipeline', () => {
     expect(result.status === 'error' ? result.error.type : undefined).toBe('timeout_error');
     expect(observedAbort).toBe(true);
     expect(finalized).toBe(true);
+  });
+
+  it('keeps the tool deadline active while the consumer pauses after progress', async () => {
+    vi.useFakeTimers();
+    const registry = new ToolRegistry();
+    let observedSignal: AbortSignal | undefined;
+    let finalized = false;
+
+    registerTool(
+      registry,
+      createTool({
+        name: 'PausedStream',
+        displayName: 'Paused Stream',
+        kind: ToolKind.Execute,
+        sideEffect: 'non_idempotent',
+        description: { short: 'Paused streaming tool' },
+        schema: z.object({}),
+        async *execute(_params, context) {
+          observedSignal = context.signal;
+          try {
+            yield { kind: 'progress', message: 'started' };
+            await new Promise(() => {});
+            return { status: 'success', model: 'unexpected' };
+          } finally {
+            finalized = true;
+          }
+        },
+      }),
+    );
+
+    const pipeline = new ExecutionPipeline(registry, {
+      permissionMode: PermissionMode.YOLO,
+      toolTimeoutMs: 50,
+    });
+    const execution = pipeline.execute(
+      'PausedStream',
+      {},
+      { permissionMode: PermissionMode.YOLO },
+    );
+
+    await expect(execution.next()).resolves.toEqual({
+      done: false,
+      value: { kind: 'progress', message: 'started' },
+    });
+    await vi.advanceTimersByTimeAsync(50);
+    expect(observedSignal?.aborted).toBe(true);
+
+    await expect(execution.next()).resolves.toMatchObject({
+      done: true,
+      value: {
+        status: 'error',
+        error: { type: ToolErrorType.TIMEOUT_ERROR },
+      },
+    });
+    await Promise.resolve();
+    expect(finalized).toBe(true);
+  });
+
+  it('waits for bounded cleanup when a timed-out tool ignores cancellation', async () => {
+    vi.useFakeTimers();
+    const registry = new ToolRegistry();
+    const started = deferred();
+
+    registerTool(
+      registry,
+      createTool({
+        name: 'UncooperativeTool',
+        displayName: 'Uncooperative Tool',
+        kind: ToolKind.Execute,
+        sideEffect: 'non_idempotent',
+        description: { short: 'Ignore cancellation' },
+        schema: z.object({}),
+        async *execute() {
+          started.resolve();
+          await new Promise(() => {});
+          return { status: 'success', model: 'unexpected' };
+        },
+      }),
+    );
+
+    const pipeline = new ExecutionPipeline(registry, {
+      permissionMode: PermissionMode.YOLO,
+      toolTimeoutMs: 50,
+    });
+    const resultPromise = executePipeline(
+      pipeline,
+      'UncooperativeTool',
+      {},
+      { permissionMode: PermissionMode.YOLO },
+    );
+    let settled = false;
+    void resultPromise.finally(() => {
+      settled = true;
+    });
+
+    await started.promise;
+    await vi.advanceTimersByTimeAsync(50);
+    expect(settled).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(4_999);
+    expect(settled).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(resultPromise).resolves.toMatchObject({
+      status: 'error',
+      error: { type: ToolErrorType.TIMEOUT_ERROR },
+    });
+  });
+
+  it('uses a bounded default and rejects invalid tool timeout values', () => {
+    const registry = new ToolRegistry();
+    const defaultPipeline = new ExecutionPipeline(registry);
+    expect(
+      (defaultPipeline as unknown as { toolTimeoutMs: number }).toolTimeoutMs,
+    ).toBe(600_000);
+
+    for (const toolTimeoutMs of [
+      0,
+      -1,
+      1.5,
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      2_147_483_648,
+    ]) {
+      expect(
+        () => new ExecutionPipeline(registry, { toolTimeoutMs }),
+      ).toThrow(ConfigError);
+    }
   });
 
   it('returns a single-prefixed model message for thrown tool errors', async () => {

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -87,6 +87,8 @@ export interface BladeConfig {
   debug?: boolean | string;
   temperature?: number;
   maxTurns?: number;
+  /** Maximum wall-clock duration of one tool invocation. */
+  toolTimeoutMs?: number;
   /**
    * Plan 文件的保存目录。
    * 不配置时 ExitPlanMode 工具不会将计划写入磁盘。


### PR DESCRIPTION
## Summary

- expose `SessionOptions.toolTimeoutMs` and default tool invocations to a 10-minute wall-clock limit
- keep one watchdog active across progress yields, abort the tool signal on expiry, and cap generator cleanup at 5 seconds
- preserve `TIMEOUT_ERROR` through terminal-result races, failure hooks, and middleware unwinding
- fail closed for new, queued, shutdown, and handoff work while an uncooperative tool is still cleaning up
- document the contract in English and Chinese and add a patch changelog fragment

## Verification

- `pnpm test` (1588 passed, 62 skipped)
- `pnpm run type-check`
- `pnpm run lint`
- `pnpm run verify:entrypoints`
- `pnpm run docs:build`
- `pnpm run changelog:check -- --base origin/main`
- `pnpm run audit:prod`
- `git diff origin/main...HEAD --check`

Expected release: `5.3.2`.