### PR TITLE
fix: bound inline hook callbacks

### DIFF
--- a/.changes/bounded-inline-hooks.json
+++ b/.changes/bounded-inline-hooks.json
@@ -1,0 +1,5 @@
+{
+  "type": "fix",
+  "en": "Bound Session inline hook events with configurable deadlines, propagate cancellation signals into callbacks, and fail closed while timed-out callbacks remain pending.",
+  "zh-CN": "为 Session inline hook 事件增加可配置时限，将取消信号传入 callback，并在超时 callback 尚未结束时保持 fail-closed。"
+}

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ console.log(result.usage);
 - Tools: generator-only custom tools, capability-grouped built-ins, MCP tools, and typed progress/effects
 - Extensibility: onion-style model/tool middleware and declarative plugins that bundle middleware, hooks, and tools
 - Collaboration: foreground and background subagents, task tools, and project Skills
-- Safety: bounded model and tool execution, permission modes, policy callbacks, hooks, path checks, and optional OS sandbox integration
+- Safety: bounded model, tool, and inline-hook execution, permission modes, policy callbacks, path checks, and optional OS sandbox integration
 - Runtime: optional workspace context, structured output, crash-safe local transcripts, context compaction, token budgets, and traces
 
 ## Steer an Active Request

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -67,7 +67,7 @@ console.log(result.usage);
 - 工具：仅 generator 的自定义工具、按能力分组的内置工具、MCP 工具和类型化进度/副作用
 - 扩展：洋葱式模型/工具 middleware，以及可打包 middleware、hooks 与工具的声明式插件
 - 协作：前台/后台子 Agent、任务工具，以及项目级 Skills
-- 安全：有界模型与工具执行、权限模式、策略回调、Hooks、路径检查和可选 OS 沙箱集成
+- 安全：有界模型、工具与 inline hook 执行、权限模式、策略回调、路径检查和可选 OS 沙箱集成
 - 运行时：可选 workspace、结构化输出、崩溃安全的本地会话记录、上下文压缩、token 预算和 trace
 
 ## 转向活动请求

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -338,7 +338,7 @@ Node-local 能力外，这些函数都从根入口导出；实际 subpath 以“
 | `AgentTrace` / `TraceEvent` / `TraceSpan` | 一次 Agent 请求的结构化执行轨迹 |
 | `TracePayloadSummary` / `TraceSink` | Trace 摘要与输出接口 |
 | `TraceSpanKind` / `TraceStatus` | Span 类型与状态 |
-| `SdkErrorOptions` / `SessionInputErrorCode` / `ModelTimeoutErrorCode` | SDK 错误元数据 |
+| `SdkErrorOptions` / `SessionInputErrorCode` / `HookTimeoutErrorCode` / `ModelTimeoutErrorCode` | SDK 错误元数据 |
 | `TokenBudgetConfig` / `TokenBudgetSnapshot` | 跨轮次 token 预算配置与快照 |
 
 ### 错误、生命周期与标识符
@@ -346,6 +346,7 @@ Node-local 能力外，这些函数都从根入口导出；实际 subpath 以“
 | 导出 | 说明 |
 |------|------|
 | `SdkError` / `AbortError` / `ConfigError` | SDK 基础错误、中止错误与配置错误 |
+| `HookTimeoutError` | inline hook 事件总时限错误 |
 | `ModelTimeoutError` | 非流式模型请求或流式空闲超时错误 |
 | `PermissionDeniedError` / `ToolExecutionError` | 权限与工具执行错误 |
 | `getErrorCode` / `getErrorMessage` / `getErrorName` / `toError` | 未知错误规范化辅助函数 |

--- a/docs/en/api-reference.md
+++ b/docs/en/api-reference.md
@@ -436,6 +436,7 @@ Classes:
 - `SdkError`
 - `AbortError`
 - `ConfigError`
+- `HookTimeoutError`
 - `ModelTimeoutError`
 - `PermissionDeniedError`
 - `SessionInputError`
@@ -444,6 +445,7 @@ Classes:
 Types and helpers:
 
 - `SdkErrorOptions`
+- `HookTimeoutErrorCode`
 - `ModelTimeoutErrorCode`
 - `SessionInputErrorCode`
 - `getErrorCode`

--- a/docs/en/hooks.md
+++ b/docs/en/hooks.md
@@ -88,6 +88,9 @@ inline hook dispatches and Session close or handoff fail closed until it
 settles. These options do not replace the independent timeout configuration
 used by file hooks.
 
+`SessionEnd` callbacks are one-shot for a runtime shutdown attempt. A failed or
+timed-out callback is not invoked again when `close()` is retried.
+
 ## Modify a prompt
 
 `UserPromptSubmit` uses the `userPrompt` field:

--- a/docs/en/hooks.md
+++ b/docs/en/hooks.md
@@ -50,6 +50,7 @@ entry point does not currently re-export it.
 ```ts
 interface HookInput {
   event: HookEvent;
+  abortSignal?: AbortSignal;
   toolName?: string;
   toolInput?: JsonObject;
   toolOutput?: ToolModelContent;
@@ -71,6 +72,21 @@ type HookCallback = (input: HookInput) => Promise<HookOutput>;
 `skip` avoids execution and produces a successful result containing the
 reason. `abort` produces an error result. Neither action permanently closes
 the Session.
+
+## Deadlines and cancellation
+
+Each inline hook event has one wall-clock budget shared by its callbacks in
+registration order. `SessionOptions.hookTimeoutMs` defaults to `600000` (10
+minutes). `SessionEnd` uses the shorter
+`SessionOptions.sessionEndHookTimeoutMs`, which defaults to `3000`.
+
+The SDK combines the caller signal with the deadline and exposes it as
+`HookInput.abortSignal`. A deadline rejects the event with `HookTimeoutError`
+and code `HOOK_TIMEOUT`. Callback implementations must observe the signal and
+release resources. If a callback remains pending after cancellation, later
+inline hook dispatches and Session close or handoff fail closed until it
+settles. These options do not replace the independent timeout configuration
+used by file hooks.
 
 ## Modify a prompt
 

--- a/docs/en/hooks.md
+++ b/docs/en/hooks.md
@@ -89,7 +89,8 @@ settles. These options do not replace the independent timeout configuration
 used by file hooks.
 
 `SessionEnd` callbacks are one-shot for a runtime shutdown attempt. A failed or
-timed-out callback is not invoked again when `close()` is retried.
+timed-out callback is not invoked again when `close()` is retried; file hooks
+retain their existing retry behavior.
 
 ## Modify a prompt
 

--- a/docs/en/session.md
+++ b/docs/en/session.md
@@ -699,6 +699,8 @@ Payload capture is opt-in because prompts and tool data may be sensitive.
 | `maxTurns` | `number` | Agent turn limit |
 | `agents` | `Record<string, AgentDefinition>` | Session-local subagents |
 | `hooks` | `Partial<Record<SessionHookEvent, HookCallback[]>>` | Eight inline hook events |
+| `hookTimeoutMs` | `number` | Total inline hook event deadline; defaults to `600000` |
+| `sessionEndHookTimeoutMs` | `number` | Inline `SessionEnd` deadline; defaults to `3000` |
 | `middleware` | `AgentMiddlewareConfig` | Direct model and tool onion middleware |
 | `plugins` | `readonly AgentPlugin[]` | Declarative bundles of middleware, hooks, and tools |
 | `defaultContext` | `RuntimeContext` | Optional runtime capabilities |

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -50,6 +50,7 @@ const session = await createSession({
 ```ts
 interface HookInput {
   event: HookEvent;
+  abortSignal?: AbortSignal;
   toolName?: string;
   toolInput?: JsonObject;
   toolOutput?: ToolModelContent;
@@ -73,6 +74,18 @@ type HookCallback = (input: HookInput) => Promise<HookOutput>;
 | `continue` | 继续处理，可同时返回修改后的输入或输出 |
 | `skip` | 跳过当前工具调用 |
 | `abort` | 中止当前 prompt 或工具调用；不会永久关闭 Session |
+
+## 时限与取消
+
+每次 inline hook 事件共享一份总 wall-clock 预算，callback 按注册顺序执行。
+`SessionOptions.hookTimeoutMs` 默认是 `600000`（10 分钟）。`SessionEnd`
+使用更短的 `SessionOptions.sessionEndHookTimeoutMs`，默认是 `3000`。
+
+SDK 会组合调用方 signal 与 deadline，并通过 `HookInput.abortSignal` 传给
+callback。到期后事件以 `HookTimeoutError`（code 为 `HOOK_TIMEOUT`）失败。
+callback 必须监听 signal 并释放资源；如果取消后仍未结束，后续 inline hook
+dispatch 以及 Session close/handoff 都会 fail-closed，直至该 callback
+settle。上述选项不替代文件 Hook 自己的独立超时配置。
 
 ## 修改用户输入
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -88,7 +88,7 @@ dispatch 以及 Session close/handoff 都会 fail-closed，直至该 callback
 settle。上述选项不替代文件 Hook 自己的独立超时配置。
 
 `SessionEnd` callback 在一次 runtime 关闭流程中只执行一次；callback 失败或
-超时后，重试 `close()` 不会再次调用它。
+超时后，重试 `close()` 不会再次调用它；文件 Hook 保持原有重试行为。
 
 ## 修改用户输入
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -87,6 +87,9 @@ callback 必须监听 signal 并释放资源；如果取消后仍未结束，后
 dispatch 以及 Session close/handoff 都会 fail-closed，直至该 callback
 settle。上述选项不替代文件 Hook 自己的独立超时配置。
 
+`SessionEnd` callback 在一次 runtime 关闭流程中只执行一次；callback 失败或
+超时后，重试 `close()` 不会再次调用它。
+
 ## 修改用户输入
 
 `UserPromptSubmit` 的文本字段名是 `userPrompt`。返回 `modifiedInput.userPrompt` 可替换文本，同时保留原消息中的图片：

--- a/docs/session.md
+++ b/docs/session.md
@@ -1785,6 +1785,7 @@ type HookCallback = (input: HookInput) => Promise<HookOutput>;
 
 interface HookInput {
   event: HookEvent;
+  abortSignal?: AbortSignal;
   toolName?: string;
   toolInput?: JsonObject;
   toolOutput?: ToolModelContent;

--- a/docs/session.md
+++ b/docs/session.md
@@ -1744,6 +1744,8 @@ async function analyzeCodeManual() {
 | `agents`          | `Record<string, AgentDefinition>`                       | —  | —           | 命名子代理定义                                           |
 | `subagent`        | `SubagentInfo`                                          | —  | —           | 子代理上下文信息（内部使用）                                    |
 | `hooks`           | `Partial<Record<SessionHookEvent, HookCallback[]>>`     | —  | —           | 生命周期 Hook 回调                                      |
+| `hookTimeoutMs`   | `number`                                                 | —  | `600000`    | 单次 inline hook 事件的总时限（毫秒）                         |
+| `sessionEndHookTimeoutMs` | `number`                                      | —  | `3000`      | inline `SessionEnd` 的时限（毫秒）                           |
 | `middleware`      | `AgentMiddlewareConfig`                                 | —  | —           | 直接注册模型与工具洋葱 middleware                            |
 | `plugins`         | `readonly AgentPlugin[]`                                | —  | —           | 声明式打包 middleware、hooks 与工具                         |
 | `defaultContext`  | `RuntimeContext`                                        | —  | `{}`        | 会话级默认运行时上下文                                       |

--- a/src/__tests__/rootExports.test.ts
+++ b/src/__tests__/rootExports.test.ts
@@ -85,6 +85,8 @@ import {
   ExecutionLeaseId,
   FencingToken,
   FileSystemMemoryStore,
+  HookEvent,
+  HookTimeoutError,
   InputId,
   InputPriority,
   JsonlDurableEventStore,
@@ -122,6 +124,11 @@ describe('root exports', () => {
     expect(definePlugin({ name: 'test' })).toEqual({ name: 'test' });
     expect(new ModelTimeoutError('MODEL_REQUEST_TIMEOUT', 1000)).toMatchObject({
       code: 'MODEL_REQUEST_TIMEOUT',
+      timeoutMs: 1000,
+    });
+    expect(new HookTimeoutError(HookEvent.PreToolUse, 1000)).toMatchObject({
+      code: 'HOOK_TIMEOUT',
+      event: HookEvent.PreToolUse,
       timeoutMs: 1000,
     });
     expect(InputPriority.NEXT).toBe('next');

--- a/src/agent/LoopHookBuilder.ts
+++ b/src/agent/LoopHookBuilder.ts
@@ -114,7 +114,9 @@ export function buildLoopConfig(deps: LoopHookBuilderDeps): AgentLoopConfig {
           );
         }
         const hookContent = hookRuntime
-          ? await hookRuntime.applyUserPromptSubmit(input.content)
+          ? await hookRuntime.applyUserPromptSubmit(input.content, {
+              abortSignal: context.signal,
+            })
           : input.content;
         const content = options?.prepareInput
           ? await options.prepareInput(hookContent)

--- a/src/errors/HookTimeoutError.ts
+++ b/src/errors/HookTimeoutError.ts
@@ -1,0 +1,21 @@
+import type { HookEvent } from '../types/constants.js';
+import { SdkError } from './SdkError.js';
+
+export type HookTimeoutErrorCode = 'HOOK_TIMEOUT';
+
+export class HookTimeoutError extends SdkError {
+  constructor(
+    public readonly event: HookEvent,
+    public readonly timeoutMs: number,
+  ) {
+    super('HOOK_TIMEOUT', `Hook ${event} exceeded ${timeoutMs}ms`);
+  }
+
+  override toJSON(): Record<string, unknown> {
+    return {
+      ...super.toJSON(),
+      event: this.event,
+      timeoutMs: this.timeoutMs,
+    };
+  }
+}

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,5 +1,7 @@
 export { AbortError } from './AbortError.js';
 export { ConfigError } from './ConfigError.js';
+export { HookTimeoutError } from './HookTimeoutError.js';
+export type { HookTimeoutErrorCode } from './HookTimeoutError.js';
 export { ModelTimeoutError } from './ModelTimeoutError.js';
 export type { ModelTimeoutErrorCode } from './ModelTimeoutError.js';
 export { PermissionDeniedError } from './PermissionDeniedError.js';

--- a/src/hooks/HookBus.ts
+++ b/src/hooks/HookBus.ts
@@ -1,50 +1,11 @@
 import { HookTimeoutError } from '../errors/HookTimeoutError.js';
 import type { HookCallback, HookInput, HookOutput } from '../session/types.js';
 import type { HookEvent } from '../types/constants.js';
+import { awaitWithAbortSignal } from '../utils/abortPromise.js';
 
 interface HookDispatchOptions {
   signal?: AbortSignal;
   timeoutMs: number;
-}
-
-function abortReason(signal: AbortSignal): unknown {
-  if (signal.reason !== undefined) {
-    return signal.reason;
-  }
-  const error = new Error('Hook execution was aborted');
-  error.name = 'AbortError';
-  return error;
-}
-
-function awaitWithSignal<T>(operation: PromiseLike<T>, signal: AbortSignal): Promise<T> {
-  if (signal.aborted) {
-    return Promise.reject(abortReason(signal));
-  }
-
-  return new Promise<T>((resolve, reject) => {
-    let settled = false;
-    const cleanup = (): void => {
-      signal.removeEventListener('abort', onAbort);
-    };
-    const resolveOnce = (value: T): void => {
-      if (settled) return;
-      settled = true;
-      cleanup();
-      resolve(value);
-    };
-    const rejectOnce = (error: unknown): void => {
-      if (settled) return;
-      settled = true;
-      cleanup();
-      reject(error);
-    };
-    const onAbort = (): void => {
-      rejectOnce(abortReason(signal));
-    };
-
-    signal.addEventListener('abort', onAbort, { once: true });
-    operation.then(resolveOnce, rejectOnce);
-  });
 }
 
 export class HookBus {
@@ -102,7 +63,7 @@ export class HookBus {
           () => undefined,
           () => undefined,
         );
-        results.push(await awaitWithSignal(callback, signal));
+        results.push(await awaitWithAbortSignal(() => callback, signal));
         activeCallbackCleanup = undefined;
       }
       signal.throwIfAborted();

--- a/src/hooks/HookBus.ts
+++ b/src/hooks/HookBus.ts
@@ -21,6 +21,12 @@ export class HookBus {
     return this.pendingCallbackCleanups.size > 0;
   }
 
+  assertNoPendingCallbackCleanup(): void {
+    if (this.hasPendingCallbackCleanup()) {
+      throw new Error('An inline hook callback is still cleaning up');
+    }
+  }
+
   async dispatch(
     event: HookEvent,
     input: HookInput,
@@ -30,9 +36,7 @@ export class HookBus {
     if (!hooks || hooks.length === 0) {
       return [];
     }
-    if (this.hasPendingCallbackCleanup()) {
-      throw new Error('An inline hook callback is still cleaning up');
-    }
+    this.assertNoPendingCallbackCleanup();
 
     options.signal?.throwIfAborted();
     const timeoutController = new AbortController();

--- a/src/hooks/HookBus.ts
+++ b/src/hooks/HookBus.ts
@@ -1,25 +1,122 @@
-import type { HookEvent } from '../types/constants.js';
+import { HookTimeoutError } from '../errors/HookTimeoutError.js';
 import type { HookCallback, HookInput, HookOutput } from '../session/types.js';
+import type { HookEvent } from '../types/constants.js';
+
+interface HookDispatchOptions {
+  signal?: AbortSignal;
+  timeoutMs: number;
+}
+
+function abortReason(signal: AbortSignal): unknown {
+  if (signal.reason !== undefined) {
+    return signal.reason;
+  }
+  const error = new Error('Hook execution was aborted');
+  error.name = 'AbortError';
+  return error;
+}
+
+function awaitWithSignal<T>(operation: PromiseLike<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) {
+    return Promise.reject(abortReason(signal));
+  }
+
+  return new Promise<T>((resolve, reject) => {
+    let settled = false;
+    const cleanup = (): void => {
+      signal.removeEventListener('abort', onAbort);
+    };
+    const resolveOnce = (value: T): void => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve(value);
+    };
+    const rejectOnce = (error: unknown): void => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(error);
+    };
+    const onAbort = (): void => {
+      rejectOnce(abortReason(signal));
+    };
+
+    signal.addEventListener('abort', onAbort, { once: true });
+    operation.then(resolveOnce, rejectOnce);
+  });
+}
 
 export class HookBus {
-  constructor(
-    private readonly callbacks: Partial<Record<HookEvent, HookCallback[]>> = {},
-  ) {}
+  private readonly pendingCallbackCleanups = new Set<Promise<void>>();
+
+  constructor(private readonly callbacks: Partial<Record<HookEvent, HookCallback[]>> = {}) {}
 
   has(event: HookEvent): boolean {
     return (this.callbacks[event]?.length ?? 0) > 0;
   }
 
-  async dispatch(event: HookEvent, input: HookInput): Promise<HookOutput[]> {
+  hasPendingCallbackCleanup(): boolean {
+    return this.pendingCallbackCleanups.size > 0;
+  }
+
+  async dispatch(
+    event: HookEvent,
+    input: HookInput,
+    options: HookDispatchOptions,
+  ): Promise<HookOutput[]> {
     const hooks = this.callbacks[event];
     if (!hooks || hooks.length === 0) {
       return [];
     }
+    if (this.hasPendingCallbackCleanup()) {
+      throw new Error('An inline hook callback is still cleaning up');
+    }
+
+    options.signal?.throwIfAborted();
+    const timeoutController = new AbortController();
+    const timeoutError = new HookTimeoutError(event, options.timeoutMs);
+    const signal = options.signal
+      ? AbortSignal.any([options.signal, timeoutController.signal])
+      : timeoutController.signal;
+    let activeCallbackCleanup: Promise<void> | undefined;
+    const trackActiveCallback = (): void => {
+      if (activeCallbackCleanup) {
+        this.trackPendingCallbackCleanup(activeCallbackCleanup);
+      }
+    };
+    signal.addEventListener('abort', trackActiveCallback, { once: true });
+    const timeout = setTimeout(() => timeoutController.abort(timeoutError), options.timeoutMs);
 
     const results: HookOutput[] = [];
-    for (const hook of hooks) {
-      results.push(await hook(input));
+    try {
+      for (const hook of hooks) {
+        signal.throwIfAborted();
+        const callback = Promise.resolve().then(() =>
+          hook({
+            ...input,
+            abortSignal: signal,
+          }),
+        );
+        activeCallbackCleanup = callback.then(
+          () => undefined,
+          () => undefined,
+        );
+        results.push(await awaitWithSignal(callback, signal));
+        activeCallbackCleanup = undefined;
+      }
+      signal.throwIfAborted();
+      return results;
+    } finally {
+      clearTimeout(timeout);
+      signal.removeEventListener('abort', trackActiveCallback);
     }
-    return results;
+  }
+
+  private trackPendingCallbackCleanup(cleanup: Promise<void>): void {
+    this.pendingCallbackCleanups.add(cleanup);
+    void cleanup.finally(() => {
+      this.pendingCallbackCleanups.delete(cleanup);
+    });
   }
 }

--- a/src/hooks/HookRuntime.ts
+++ b/src/hooks/HookRuntime.ts
@@ -79,6 +79,7 @@ export class HookRuntime {
   private readonly hookManager: HookManager;
   private readonly hookTimeoutMs: number;
   private readonly sessionEndHookTimeoutMs: number;
+  private sessionEndCallbacksAttempted = false;
   private traceCollector?: HookTraceCollector;
   private readonly runtimeHookRegistrations = new Map<string, {
     event: HookEvent;
@@ -549,12 +550,16 @@ export class HookRuntime {
       abortSignal?: AbortSignal;
     },
   ): Promise<void> {
-    await this.runCallbackGroup(
-      HookEvent.SessionEnd,
-      payload,
-      payload.abortSignal,
-      this.sessionEndHookTimeoutMs,
-    );
+    if (!this.sessionEndCallbacksAttempted) {
+      this.bus.assertNoPendingCallbackCleanup();
+      this.sessionEndCallbacksAttempted = true;
+      await this.runCallbackGroup(
+        HookEvent.SessionEnd,
+        payload,
+        payload.abortSignal,
+        this.sessionEndHookTimeoutMs,
+      );
+    }
 
     const projectDir = this.options.resolveProjectDir();
     if (!projectDir) {

--- a/src/hooks/HookRuntime.ts
+++ b/src/hooks/HookRuntime.ts
@@ -1,5 +1,6 @@
 import { nanoid } from 'nanoid';
 import type { UserMessageContent } from '../agent/types.js';
+import { ConfigError } from '../errors/ConfigError.js';
 import type { RuntimeHookRegistration } from '../runtime/index.js';
 import type { ContentPart } from '../services/ChatServiceInterface.js';
 import { cloneContentPart } from '../services/messageUtils.js';
@@ -17,8 +18,28 @@ interface HookRuntimeOptions {
   sessionId: SessionId;
   permissionMode: PermissionMode;
   callbacks?: Partial<Record<HookEvent, HookCallback[]>>;
+  hookTimeoutMs?: number;
+  sessionEndHookTimeoutMs?: number;
   resolveProjectDir: () => string | undefined;
   hookManager?: HookManager;
+}
+
+export const DEFAULT_INLINE_HOOK_TIMEOUT_MS = 600_000;
+export const DEFAULT_SESSION_END_HOOK_TIMEOUT_MS = 3_000;
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
+function resolveHookTimeoutMs(
+  value: number | undefined,
+  fallback: number,
+  name: string,
+): number {
+  const resolved = value ?? fallback;
+  if (!Number.isSafeInteger(resolved) || resolved <= 0 || resolved > MAX_TIMER_DELAY_MS) {
+    throw new ConfigError(
+      `${name} must be a positive integer no greater than ${MAX_TIMER_DELAY_MS}`,
+    );
+  }
+  return resolved;
 }
 
 export interface PreToolUseRuntimeResult {
@@ -56,6 +77,8 @@ export class HookRuntime {
   private readonly bus: HookBus;
   private readonly callbacks: Partial<Record<HookEvent, HookCallback[]>>;
   private readonly hookManager: HookManager;
+  private readonly hookTimeoutMs: number;
+  private readonly sessionEndHookTimeoutMs: number;
   private traceCollector?: HookTraceCollector;
   private readonly runtimeHookRegistrations = new Map<string, {
     event: HookEvent;
@@ -71,10 +94,24 @@ export class HookRuntime {
     ) as Partial<Record<HookEvent, HookCallback[]>>;
     this.bus = new HookBus(this.callbacks);
     this.hookManager = options.hookManager ?? HookManager.getInstance();
+    this.hookTimeoutMs = resolveHookTimeoutMs(
+      options.hookTimeoutMs,
+      DEFAULT_INLINE_HOOK_TIMEOUT_MS,
+      'hookTimeoutMs',
+    );
+    this.sessionEndHookTimeoutMs = resolveHookTimeoutMs(
+      options.sessionEndHookTimeoutMs,
+      DEFAULT_SESSION_END_HOOK_TIMEOUT_MS,
+      'sessionEndHookTimeoutMs',
+    );
   }
 
   getCallbacks(): Partial<Record<HookEvent, HookCallback[]>> {
     return this.callbacks;
+  }
+
+  hasPendingCallbackCleanup(): boolean {
+    return this.bus.hasPendingCallbackCleanup();
   }
 
   setTraceCollector(traceCollector: HookTraceCollector | undefined): void {
@@ -138,6 +175,7 @@ export class HookRuntime {
           toolName,
           toolInput: nextInput,
         }),
+        options.abortSignal,
       );
 
       for (const output of outputs) {
@@ -236,6 +274,7 @@ export class HookRuntime {
       input,
       nextResult,
       toolUseId,
+      options.abortSignal,
     );
   }
 
@@ -290,6 +329,7 @@ export class HookRuntime {
       input,
       nextResult,
       toolUseId,
+      options.abortSignal,
     );
   }
 
@@ -316,6 +356,7 @@ export class HookRuntime {
           affectedPaths: options.affectedPaths,
           toolKind: options.toolKind,
         }),
+        options.abortSignal,
       );
 
       for (const output of outputs) {
@@ -387,6 +428,7 @@ export class HookRuntime {
           hasImages: imageMeta.hasImages,
           imageCount: imageMeta.imageCount,
         }),
+        options.abortSignal,
       );
 
       for (const output of outputs) {
@@ -441,7 +483,7 @@ export class HookRuntime {
   async runSessionStart(
     payload: { isResume: boolean; resumeSessionId?: string; abortSignal?: AbortSignal },
   ): Promise<void> {
-    await this.runCallbackGroup(HookEvent.SessionStart, payload);
+    await this.runCallbackGroup(HookEvent.SessionStart, payload, payload.abortSignal);
 
     const projectDir = this.options.resolveProjectDir();
     if (!projectDir) {
@@ -471,7 +513,7 @@ export class HookRuntime {
       [key: string]: unknown;
     },
   ): Promise<void> {
-    await this.runCallbackGroup(HookEvent.TaskCompleted, payload);
+    await this.runCallbackGroup(HookEvent.TaskCompleted, payload, payload.abortSignal);
 
     const projectDir = this.options.resolveProjectDir();
     if (!projectDir) {
@@ -507,7 +549,12 @@ export class HookRuntime {
       abortSignal?: AbortSignal;
     },
   ): Promise<void> {
-    await this.runCallbackGroup(HookEvent.SessionEnd, payload);
+    await this.runCallbackGroup(
+      HookEvent.SessionEnd,
+      payload,
+      payload.abortSignal,
+      this.sessionEndHookTimeoutMs,
+    );
 
     const projectDir = this.options.resolveProjectDir();
     if (!projectDir) {
@@ -545,6 +592,8 @@ export class HookRuntime {
   private async runCallbackGroup(
     event: HookEvent,
     payload: Record<string, unknown>,
+    abortSignal?: AbortSignal,
+    timeoutMs = this.hookTimeoutMs,
   ): Promise<void> {
     if (!this.bus.has(event)) {
       return;
@@ -553,6 +602,8 @@ export class HookRuntime {
     const outputs = await this.dispatchObserved(
       event,
       buildHookInput(this.options.sessionId, event, payload),
+      abortSignal,
+      timeoutMs,
     );
     for (const output of outputs) {
       if (output.action === 'abort') {
@@ -597,6 +648,7 @@ export class HookRuntime {
     input: JsonObject,
     result: ToolResult,
     toolUseId: ToolUseId,
+    abortSignal?: AbortSignal,
   ): Promise<PostToolUseRuntimeResult> {
     if (!this.bus.has(event)) {
       return { toolUseId, result };
@@ -614,6 +666,7 @@ export class HookRuntime {
           ? undefined
           : new Error(result.error.message),
       }),
+      abortSignal,
     );
 
     for (const output of outputs) {
@@ -642,10 +695,18 @@ export class HookRuntime {
     return { toolUseId, result: nextResult };
   }
 
-  private async dispatchObserved(event: HookEvent, input: HookInput) {
+  private async dispatchObserved(
+    event: HookEvent,
+    input: HookInput,
+    abortSignal?: AbortSignal,
+    timeoutMs = this.hookTimeoutMs,
+  ) {
     const spanId = this.traceCollector?.recordHookStart(event, input);
     try {
-      const outputs = await this.bus.dispatch(event, input);
+      const outputs = await this.bus.dispatch(event, input, {
+        signal: abortSignal,
+        timeoutMs,
+      });
       if (spanId) {
         this.traceCollector?.recordHookEnd(spanId, {
           outputCount: outputs.length,

--- a/src/hooks/__tests__/HookRuntime.test.ts
+++ b/src/hooks/__tests__/HookRuntime.test.ts
@@ -98,6 +98,33 @@ describe('HookRuntime', () => {
     expect(runtime.hasPendingCallbackCleanup()).toBe(false);
   });
 
+  it('does not rerun inline SessionEnd callbacks while preserving file-hook retries', async () => {
+    const inlineCallback = vi.fn(async () => {
+      throw new Error('inline SessionEnd failed');
+    });
+    const executeSessionEndHooks = vi.fn(async () => ({}));
+    const runtime = new HookRuntime({
+      sessionId: SessionId('session-end-once'),
+      permissionMode: PermissionMode.DEFAULT,
+      callbacks: {
+        [HookEvent.SessionEnd]: [inlineCallback],
+      },
+      resolveProjectDir: () => '/tmp/project',
+      hookManager: {
+        executeSessionEndHooks,
+      } as never,
+    });
+
+    await expect(runtime.runSessionEnd({ reason: 'other' })).rejects.toThrow(
+      'inline SessionEnd failed',
+    );
+    expect(executeSessionEndHooks).not.toHaveBeenCalled();
+
+    await expect(runtime.runSessionEnd({ reason: 'other' })).resolves.toBeUndefined();
+    expect(inlineCallback).toHaveBeenCalledOnce();
+    expect(executeSessionEndHooks).toHaveBeenCalledOnce();
+  });
+
   it('shares one timeout budget across callbacks in an event', async () => {
     vi.useFakeTimers();
     const secondStarted = deferred();

--- a/src/hooks/__tests__/HookRuntime.test.ts
+++ b/src/hooks/__tests__/HookRuntime.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ConfigError } from '../../errors/ConfigError.js';
+import { HookTimeoutError } from '../../errors/HookTimeoutError.js';
 import type { ContentPart } from '../../services/ChatServiceInterface.js';
 import type { ToolResult } from '../../tools/types/index.js';
 import { SessionId, ToolUseId } from '../../types/branded.js';
@@ -6,7 +8,197 @@ import { PermissionMode } from '../../types/common.js';
 import { HookEvent } from '../../types/constants.js';
 import { HookRuntime } from '../HookRuntime.js';
 
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
 describe('HookRuntime', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('bounds inline hooks, propagates abort, and blocks while cleanup is pending', async () => {
+    vi.useFakeTimers();
+    const started = deferred();
+    const release = deferred();
+    let callbackSignal: AbortSignal | undefined;
+    const runtime = new HookRuntime({
+      sessionId: SessionId('session-timeout'),
+      permissionMode: PermissionMode.DEFAULT,
+      hookTimeoutMs: 50,
+      callbacks: {
+        [HookEvent.UserPromptSubmit]: [
+          async (input) => {
+            callbackSignal = input.abortSignal;
+            started.resolve();
+            await release.promise;
+            return { action: 'continue' };
+          },
+        ],
+      },
+      resolveProjectDir: () => undefined,
+    });
+
+    const dispatch = runtime.applyUserPromptSubmit('prompt');
+    const timeoutResult = expect(dispatch).rejects.toMatchObject({
+      code: 'HOOK_TIMEOUT',
+      event: HookEvent.UserPromptSubmit,
+      timeoutMs: 50,
+    });
+    await started.promise;
+    await vi.advanceTimersByTimeAsync(50);
+
+    await timeoutResult;
+    expect(callbackSignal?.aborted).toBe(true);
+    expect(runtime.hasPendingCallbackCleanup()).toBe(true);
+    await expect(runtime.applyUserPromptSubmit('blocked')).rejects.toThrow('still cleaning up');
+
+    release.resolve();
+    await vi.waitFor(() => {
+      expect(runtime.hasPendingCallbackCleanup()).toBe(false);
+    });
+  });
+
+  it('uses the dedicated SessionEnd hook timeout', async () => {
+    vi.useFakeTimers();
+    const started = deferred();
+    const runtime = new HookRuntime({
+      sessionId: SessionId('session-end-timeout'),
+      permissionMode: PermissionMode.DEFAULT,
+      hookTimeoutMs: 10_000,
+      sessionEndHookTimeoutMs: 50,
+      callbacks: {
+        [HookEvent.SessionEnd]: [
+          async (input) => {
+            started.resolve();
+            await new Promise<void>((_resolve, reject) => {
+              input.abortSignal?.addEventListener(
+                'abort',
+                () => reject(input.abortSignal?.reason),
+                { once: true },
+              );
+            });
+            return { action: 'continue' };
+          },
+        ],
+      },
+      resolveProjectDir: () => undefined,
+    });
+
+    const dispatch = runtime.runSessionEnd({ reason: 'other' });
+    const timeoutResult = expect(dispatch).rejects.toBeInstanceOf(HookTimeoutError);
+    await started.promise;
+    await vi.advanceTimersByTimeAsync(50);
+
+    await timeoutResult;
+    expect(runtime.hasPendingCallbackCleanup()).toBe(false);
+  });
+
+  it('shares one timeout budget across callbacks in an event', async () => {
+    vi.useFakeTimers();
+    const secondStarted = deferred();
+    const runtime = new HookRuntime({
+      sessionId: SessionId('session-shared-hook-budget'),
+      permissionMode: PermissionMode.DEFAULT,
+      hookTimeoutMs: 50,
+      callbacks: {
+        [HookEvent.UserPromptSubmit]: [
+          async () => {
+            await new Promise((resolve) => setTimeout(resolve, 30));
+            return { action: 'continue' };
+          },
+          async (input) => {
+            secondStarted.resolve();
+            await new Promise<void>((_resolve, reject) => {
+              input.abortSignal?.addEventListener(
+                'abort',
+                () => reject(input.abortSignal?.reason),
+                { once: true },
+              );
+            });
+            return { action: 'continue' };
+          },
+        ],
+      },
+      resolveProjectDir: () => undefined,
+    });
+
+    const dispatch = runtime.applyUserPromptSubmit('prompt');
+    const timeoutResult = expect(dispatch).rejects.toMatchObject({
+      code: 'HOOK_TIMEOUT',
+      timeoutMs: 50,
+    });
+    await vi.advanceTimersByTimeAsync(30);
+    await secondStarted.promise;
+    await vi.advanceTimersByTimeAsync(19);
+    expect(runtime.hasPendingCallbackCleanup()).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+
+    await timeoutResult;
+  });
+
+  it('propagates caller cancellation into an inline callback', async () => {
+    const controller = new AbortController();
+    const started = deferred();
+    const cancellation = new Error('request cancelled');
+    let callbackSignal: AbortSignal | undefined;
+    const runtime = new HookRuntime({
+      sessionId: SessionId('session-hook-cancel'),
+      permissionMode: PermissionMode.DEFAULT,
+      callbacks: {
+        [HookEvent.UserPromptSubmit]: [
+          async (input) => {
+            callbackSignal = input.abortSignal;
+            started.resolve();
+            await new Promise<void>((_resolve, reject) => {
+              input.abortSignal?.addEventListener(
+                'abort',
+                () => reject(input.abortSignal?.reason),
+                { once: true },
+              );
+            });
+            return { action: 'continue' };
+          },
+        ],
+      },
+      resolveProjectDir: () => undefined,
+    });
+
+    const dispatch = runtime.applyUserPromptSubmit('prompt', {
+      abortSignal: controller.signal,
+    });
+    const cancellationResult = expect(dispatch).rejects.toBe(cancellation);
+    await started.promise;
+    controller.abort(cancellation);
+
+    await cancellationResult;
+    expect(callbackSignal?.aborted).toBe(true);
+    expect(runtime.hasPendingCallbackCleanup()).toBe(false);
+  });
+
+  it('rejects invalid inline hook timeout configuration', () => {
+    for (const [name, value] of [
+      ['hookTimeoutMs', 0],
+      ['hookTimeoutMs', Number.NaN],
+      ['sessionEndHookTimeoutMs', -1],
+      ['sessionEndHookTimeoutMs', 2_147_483_648],
+    ] as const) {
+      expect(
+        () =>
+          new HookRuntime({
+            sessionId: SessionId('session-invalid-timeout'),
+            permissionMode: PermissionMode.DEFAULT,
+            [name]: value,
+            resolveProjectDir: () => undefined,
+          }),
+      ).toThrow(ConfigError);
+    }
+  });
+
   it('computes image metadata once per applyUserPromptSubmit stage', async () => {
     const hookManager = {
       executeUserPromptSubmitHooks: vi.fn(async () => ({ proceed: true })),

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ export type {
 } from './agent/subagents/types.js';
 export type { TokenBudgetConfig, TokenBudgetSnapshot } from './agent/TokenBudget.js';
 export type {
+  HookTimeoutErrorCode,
   ModelTimeoutErrorCode,
   SdkErrorOptions,
   SessionHandoffErrorCode,
@@ -20,6 +21,7 @@ export type {
 export {
   AbortError,
   ConfigError,
+  HookTimeoutError,
   ModelTimeoutError,
   PermissionDeniedError,
   SdkError,

--- a/src/services/ChatServiceTimeout.ts
+++ b/src/services/ChatServiceTimeout.ts
@@ -1,6 +1,10 @@
 import type { JSONSchema7 } from 'json-schema';
 import { ConfigError } from '../errors/ConfigError.js';
 import { ModelTimeoutError, type ModelTimeoutErrorCode } from '../errors/ModelTimeoutError.js';
+import {
+  awaitWithAbortSignal,
+  getAbortSignalReason,
+} from '../utils/abortPromise.js';
 import type {
   ChatConfig,
   ChatResponse,
@@ -45,15 +49,6 @@ function resolveModelTimeouts(config: ChatConfig): ResolvedModelTimeouts {
   };
 }
 
-function abortReason(signal: AbortSignal): unknown {
-  if (signal.reason !== undefined) {
-    return signal.reason;
-  }
-  const error = new Error('The operation was aborted');
-  error.name = 'AbortError';
-  return error;
-}
-
 function awaitWithTimeout<T>(
   operation: () => PromiseLike<T>,
   timeoutMs: number,
@@ -62,7 +57,7 @@ function awaitWithTimeout<T>(
   signal: AbortSignal,
 ): Promise<T> {
   if (signal.aborted) {
-    return Promise.reject(abortReason(signal));
+    return Promise.reject(getAbortSignalReason(signal));
   }
 
   return new Promise<T>((resolve, reject) => {
@@ -84,44 +79,13 @@ function awaitWithTimeout<T>(
       reject(error);
     };
     const onAbort = (): void => {
-      rejectOnce(abortReason(signal));
+      rejectOnce(getAbortSignalReason(signal));
     };
     const timer = setTimeout(() => {
       const error = new ModelTimeoutError(code, timeoutMs);
       timeoutController.abort(error);
       rejectOnce(error);
     }, timeoutMs);
-
-    signal.addEventListener('abort', onAbort, { once: true });
-    Promise.resolve().then(operation).then(resolveOnce, rejectOnce);
-  });
-}
-
-function awaitWithSignal<T>(operation: () => PromiseLike<T>, signal: AbortSignal): Promise<T> {
-  if (signal.aborted) {
-    return Promise.reject(abortReason(signal));
-  }
-
-  return new Promise<T>((resolve, reject) => {
-    let settled = false;
-    const cleanup = (): void => {
-      signal.removeEventListener('abort', onAbort);
-    };
-    const resolveOnce = (value: T): void => {
-      if (settled) return;
-      settled = true;
-      cleanup();
-      resolve(value);
-    };
-    const rejectOnce = (error: unknown): void => {
-      if (settled) return;
-      settled = true;
-      cleanup();
-      reject(error);
-    };
-    const onAbort = (): void => {
-      rejectOnce(abortReason(signal));
-    };
 
     signal.addEventListener('abort', onAbort, { once: true });
     Promise.resolve().then(operation).then(resolveOnce, rejectOnce);
@@ -215,7 +179,7 @@ async function* runGeneratorWithTimeout<TYield, TReturn>(
       try {
         step =
           mode === 'request'
-            ? await awaitWithSignal(() => source.next(), signal)
+            ? await awaitWithAbortSignal(() => source.next(), signal)
             : await awaitWithTimeout(
                 () => source.next(),
                 timeoutMs,

--- a/src/session/Session.ts
+++ b/src/session/Session.ts
@@ -894,10 +894,18 @@ class Session implements ISession {
     } catch (error) {
       const handingOff = isHandoffRequested();
       const leaseFailure = this.executionLeaseFailure;
+      const requestAborted = signal.aborted;
       let terminalError = error;
       if (!handingOff && !leaseFailure) {
         try {
-          await finishDurableRequest({ status: 'failed', error });
+          await finishDurableRequest(
+            requestAborted
+              ? {
+                  status: 'interrupted',
+                  reason: this.getDurableInterruptReason(requestController),
+                }
+              : { status: 'failed', error },
+          );
         } catch (durableError) {
           terminalError = new AggregateError(
             [error, durableError],
@@ -907,12 +915,14 @@ class Session implements ISession {
       }
       const errorMessage =
         terminalError instanceof Error ? terminalError.message : String(terminalError);
-      await finishTrace(handingOff || leaseFailure ? 'aborted' : 'error', {
+      await finishTrace(handingOff || leaseFailure || requestAborted ? 'aborted' : 'error', {
         ...(handingOff
           ? { reason: 'session_handoff' }
           : leaseFailure
             ? { reason: 'process_restart' }
-            : { error: errorMessage }),
+            : requestAborted
+              ? { reason: this.getDurableInterruptReason(requestController) }
+              : { error: errorMessage }),
       });
       try {
         if (handingOff) {
@@ -923,6 +933,9 @@ class Session implements ISession {
         }
         if (durableRecorder && !durableFinishCommitted) {
           throw terminalError;
+        }
+        if (requestAborted) {
+          return;
         }
         yield { type: 'error', message: errorMessage, sessionId: this.sessionId };
       } finally {
@@ -1275,15 +1288,17 @@ class Session implements ISession {
 
       this._messages = context.messages;
       const imageCount = this.getImageCount(message);
-      await runtime.getHookRuntime().runTaskCompleted({
-        taskId: this.sessionId,
-        taskDescription: this.getTextContent(message),
-        hasImages: imageCount > 0,
-        imageCount,
-        resultSummary: loopResult.finalMessage || '',
-        success: loopResult.success,
-        abortSignal: signal,
-      });
+      if (!signal.aborted) {
+        await runtime.getHookRuntime().runTaskCompleted({
+          taskId: this.sessionId,
+          taskDescription: this.getTextContent(message),
+          hasImages: imageCount > 0,
+          imageCount,
+          resultSummary: loopResult.finalMessage || '',
+          success: loopResult.success,
+          abortSignal: signal,
+        });
+      }
       await finishTrace(isAborted ? 'aborted' : 'success', {
         content: loopResult.finalMessage || '',
         usage: totalUsage,
@@ -1308,10 +1323,18 @@ class Session implements ISession {
     } catch (error) {
       const handingOff = isHandoffRequested();
       const leaseFailure = this.executionLeaseFailure;
+      const requestAborted = signal.aborted;
       let terminalError = error;
       if (!handingOff && !leaseFailure && !durableFinishAttempted) {
         try {
-          await finishDurableRequest({ status: 'failed', error });
+          await finishDurableRequest(
+            requestAborted
+              ? {
+                  status: 'interrupted',
+                  reason: this.getDurableInterruptReason(requestController),
+                }
+              : { status: 'failed', error },
+          );
         } catch (durableError) {
           terminalError = new AggregateError(
             [error, durableError],
@@ -1321,12 +1344,14 @@ class Session implements ISession {
       }
       const errorMessage =
         terminalError instanceof Error ? terminalError.message : String(terminalError);
-      await finishTrace(handingOff || leaseFailure ? 'aborted' : 'error', {
+      await finishTrace(handingOff || leaseFailure || requestAborted ? 'aborted' : 'error', {
         ...(handingOff
           ? { reason: 'session_handoff' }
           : leaseFailure
             ? { reason: 'process_restart' }
-            : { error: errorMessage }),
+            : requestAborted
+              ? { reason: this.getDurableInterruptReason(requestController) }
+              : { error: errorMessage }),
       });
       if (handingOff) {
         return;
@@ -1336,6 +1361,9 @@ class Session implements ISession {
       }
       if (durableRecorder && !durableFinishCommitted) {
         throw terminalError;
+      }
+      if (requestAborted) {
+        return;
       }
       yield { type: 'error', message: errorMessage, sessionId: this.sessionId };
     } finally {
@@ -1460,6 +1488,7 @@ class Session implements ISession {
     disposition: 'terminal' | 'detached',
     abortReason: RequestAbortReason = { kind: 'session_close' },
   ): Promise<void> {
+    this.runtime?.assertNoPendingCleanup();
     const recordDurableClose = disposition === 'terminal';
     // 关闭时对 executionState 的读写走 inputMutex，避免与并发 send()/stream()
     // 交错（例如 send() 在 await 处让出后用 pending 覆盖 closed）。
@@ -1529,6 +1558,7 @@ class Session implements ISession {
       });
     }
 
+    this.runtime?.assertNoPendingCleanup();
     if (this.runtime) {
       closeErrors.push(...(await this.releaseLocalRuntime()));
     }
@@ -1562,6 +1592,7 @@ class Session implements ISession {
       throw new SessionHandoffError('SESSION_HANDOFF_UNAVAILABLE', 'Session is not initialized');
     }
     const runtime = this.getRuntime();
+    runtime.assertNoPendingCleanup();
     const journal = this.durableJournal;
     if (!journal) {
       throw new SessionHandoffError(
@@ -1582,11 +1613,17 @@ class Session implements ISession {
       }
 
       const durableRecorder =
-        this.executionState.phase === 'pending' || this.executionState.phase === 'running'
+        this.executionState.phase === 'pending'
+        || this.executionState.phase === 'running'
+        || this.executionState.phase === 'suspending'
           ? this.executionState.durableRecorder
           : null;
       if (
-        (this.executionState.phase === 'pending' || this.executionState.phase === 'running') &&
+        (
+          this.executionState.phase === 'pending'
+          || this.executionState.phase === 'running'
+          || this.executionState.phase === 'suspending'
+        ) &&
         !durableRecorder
       ) {
         throw new SessionHandoffError(
@@ -1605,6 +1642,12 @@ class Session implements ISession {
         );
       }
 
+      if (this.executionState.phase === 'suspending') {
+        return {
+          durableRecorder,
+          executions: [...this.streamExecutions],
+        };
+      }
       if (this.executionState.phase === 'running') {
         const { requestId, controller, execution } = this.executionState;
         if (!durableRecorder) {
@@ -1658,6 +1701,7 @@ class Session implements ISession {
         handoffErrors.push(result.reason);
       }
     }
+    runtime.assertNoPendingCleanup();
     if (handoffState.durableRecorder) {
       try {
         await handoffState.durableRecorder.finalizeHandoff();
@@ -1731,9 +1775,9 @@ class Session implements ISession {
     if (runtime) {
       let runtimeClosed = false;
       if (!this.runtimeEndAttempted) {
+        this.runtimeEndAttempted = true;
         try {
           await runtime.getHookRuntime().runSessionEnd({ reason: 'other' });
-          this.runtimeEndAttempted = true;
         } catch (error) {
           errors.push(error);
         }

--- a/src/session/Session.ts
+++ b/src/session/Session.ts
@@ -319,6 +319,7 @@ class Session implements ISession {
       await this.runtime.getHookRuntime().runSessionStart({
         isResume: this.isResumeSession,
         resumeSessionId: this.isResumeSession ? this.sessionId : undefined,
+        abortSignal: this.executionLease?.signal,
       });
       await this.executionLease?.assertActive();
       if (this.executionLeaseFailure) {
@@ -886,7 +887,9 @@ class Session implements ISession {
     runtime.getHookRuntime().setTraceCollector(traceRecorder);
     try {
       if (initialInputPreparation !== RECONCILED_INITIAL_INPUT) {
-        message = await runtime.getHookRuntime().applyUserPromptSubmit(message);
+        message = await runtime.getHookRuntime().applyUserPromptSubmit(message, {
+          abortSignal: signal,
+        });
       }
     } catch (error) {
       const handingOff = isHandoffRequested();
@@ -1279,6 +1282,7 @@ class Session implements ISession {
         imageCount,
         resultSummary: loopResult.finalMessage || '',
         success: loopResult.success,
+        abortSignal: signal,
       });
       await finishTrace(isAborted ? 'aborted' : 'success', {
         content: loopResult.finalMessage || '',

--- a/src/session/Session.ts
+++ b/src/session/Session.ts
@@ -1775,9 +1775,9 @@ class Session implements ISession {
     if (runtime) {
       let runtimeClosed = false;
       if (!this.runtimeEndAttempted) {
-        this.runtimeEndAttempted = true;
         try {
           await runtime.getHookRuntime().runSessionEnd({ reason: 'other' });
+          this.runtimeEndAttempted = true;
         } catch (error) {
           errors.push(error);
         }

--- a/src/session/SessionRuntime.ts
+++ b/src/session/SessionRuntime.ts
@@ -275,7 +275,32 @@ export class SessionRuntime {
     });
   }
 
+  assertNoPendingCleanup(): void {
+    const errors: Error[] = [];
+    if (this.executionPipeline.hasPendingExecutionCleanup()) {
+      errors.push(
+        new Error(
+          `Session runtime ${this.sessionId} still has a tool execution cleaning up`,
+        ),
+      );
+    }
+    if (this.hookRuntime.hasPendingCallbackCleanup()) {
+      errors.push(
+        new Error(
+          `Session runtime ${this.sessionId} still has an inline hook callback cleaning up`,
+        ),
+      );
+    }
+    if (errors.length === 1) {
+      throw errors[0];
+    }
+    if (errors.length > 1) {
+      throw new AggregateError(errors, `Session runtime ${this.sessionId} cleanup is pending`);
+    }
+  }
+
   async close(executionFence?: DurableExecutionFence): Promise<void> {
+    this.assertNoPendingCleanup();
     const shellManager = BackgroundShellManager.getInstance();
     const shutdownResults = await Promise.allSettled([
       this.backgroundAgentManager.sealCancelAndWait(),
@@ -291,19 +316,10 @@ export class SessionRuntime {
     } catch (error) {
       errors.push(error);
     }
-    if (this.executionPipeline.hasPendingExecutionCleanup()) {
-      errors.push(
-        new Error(
-          `Session runtime ${this.sessionId} still has a tool execution cleaning up`,
-        ),
-      );
-    }
-    if (this.hookRuntime.hasPendingCallbackCleanup()) {
-      errors.push(
-        new Error(
-          `Session runtime ${this.sessionId} still has an inline hook callback cleaning up`,
-        ),
-      );
+    try {
+      this.assertNoPendingCleanup();
+    } catch (error) {
+      errors.push(error);
     }
     if (errors.length === 1) {
       throw errors[0];

--- a/src/session/SessionRuntime.ts
+++ b/src/session/SessionRuntime.ts
@@ -154,6 +154,8 @@ export class SessionRuntime {
       sessionId,
       permissionMode,
       callbacks: this.hookCallbacks,
+      hookTimeoutMs: options.hookTimeoutMs,
+      sessionEndHookTimeoutMs: options.sessionEndHookTimeoutMs,
       resolveProjectDir: () => getContextCwd(this.defaultContext),
     });
     this.executionPipeline = this.createExecutionPipeline();
@@ -293,6 +295,13 @@ export class SessionRuntime {
       errors.push(
         new Error(
           `Session runtime ${this.sessionId} still has a tool execution cleaning up`,
+        ),
+      );
+    }
+    if (this.hookRuntime.hasPendingCallbackCleanup()) {
+      errors.push(
+        new Error(
+          `Session runtime ${this.sessionId} still has an inline hook callback cleaning up`,
         ),
       );
     }

--- a/src/session/__tests__/SessionDurableEvents.test.ts
+++ b/src/session/__tests__/SessionDurableEvents.test.ts
@@ -1809,7 +1809,7 @@ describe('Session durable events', () => {
     expect(session.getExecutionLease()).toBeNull();
   });
 
-  it('does not rerun a failed one-shot SessionEnd hook before releasing ownership', async () => {
+  it('retries a failed SessionEnd hook before releasing ownership', async () => {
     const { root, store } = createStore();
     const session = await createSession({
       ...options(store),
@@ -1845,7 +1845,7 @@ describe('Session durable events', () => {
     expect(session.getExecutionLease()).not.toBeNull();
 
     await expect(session.close()).resolves.toBeUndefined();
-    expect(sessionEnd).toHaveBeenCalledOnce();
+    expect(sessionEnd).toHaveBeenCalledTimes(2);
     expect(release).toHaveBeenCalledOnce();
     expect(session.getExecutionLease()).toBeNull();
   });

--- a/src/session/__tests__/SessionDurableEvents.test.ts
+++ b/src/session/__tests__/SessionDurableEvents.test.ts
@@ -27,6 +27,7 @@ import {
   WorkerId,
 } from '../../types/branded.js';
 import type { JsonValue } from '../../types/common.js';
+import { HookEvent } from '../../types/constants.js';
 import { type DurableEventStore, DurableEventStoreError } from '../events/DurableEventStore.js';
 import {
   DurableEventSubscriptionError,
@@ -1808,7 +1809,7 @@ describe('Session durable events', () => {
     expect(session.getExecutionLease()).toBeNull();
   });
 
-  it('retries a failed SessionEnd hook before releasing ownership', async () => {
+  it('does not rerun a failed one-shot SessionEnd hook before releasing ownership', async () => {
     const { root, store } = createStore();
     const session = await createSession({
       ...options(store),
@@ -1844,7 +1845,7 @@ describe('Session durable events', () => {
     expect(session.getExecutionLease()).not.toBeNull();
 
     await expect(session.close()).resolves.toBeUndefined();
-    expect(sessionEnd).toHaveBeenCalledTimes(2);
+    expect(sessionEnd).toHaveBeenCalledOnce();
     expect(release).toHaveBeenCalledOnce();
     expect(session.getExecutionLease()).toBeNull();
   });
@@ -1883,6 +1884,65 @@ describe('Session durable events', () => {
 
     await expect(session.close()).resolves.toBeUndefined();
     expect(release).toHaveBeenCalledOnce();
+    expect(session.getExecutionLease()).toBeNull();
+  });
+
+  it('keeps handoff retryable while an aborted inline hook is still cleaning up', async () => {
+    const { root, store } = createStore();
+    const started = Promise.withResolvers<void>();
+    const releaseHook = Promise.withResolvers<void>();
+    const session = await createSession({
+      ...options(store),
+      persistSession: true,
+      storagePath: root,
+      executionLease: {
+        ownerId: WorkerId('worker-handoff-hook-cleanup'),
+        ttlMs: 10_000,
+        heartbeatIntervalMs: 5_000,
+      },
+      hooks: {
+        [HookEvent.UserPromptSubmit]: [
+          async () => {
+            started.resolve();
+            await releaseHook.promise;
+            return { action: 'continue' };
+          },
+        ],
+      },
+    });
+    const runtime = (
+      session as unknown as {
+        runtime: {
+          getHookRuntime(): { hasPendingCallbackCleanup(): boolean };
+        } | null;
+      }
+    ).runtime;
+    if (!runtime) {
+      throw new Error('Expected an initialized Session runtime');
+    }
+    const releaseLease = vi.spyOn(store, 'releaseExecutionLease');
+
+    await session.send('handoff during hook');
+    const output = session.stream();
+    const firstEvent = output.next();
+    await started.promise;
+
+    await expect(session.suspendForHandoff()).rejects.toThrow(
+      'inline hook callback cleaning up',
+    );
+    await expect(firstEvent).resolves.toEqual({ value: undefined, done: true });
+    expect(releaseLease).not.toHaveBeenCalled();
+    expect(session.getExecutionLease()).not.toBeNull();
+
+    releaseHook.resolve();
+    await vi.waitFor(() => {
+      expect(runtime.getHookRuntime().hasPendingCallbackCleanup()).toBe(false);
+    });
+
+    await expect(session.suspendForHandoff()).resolves.toMatchObject({
+      recoveryPlan: { action: 'rollover_request' },
+    });
+    expect(releaseLease).toHaveBeenCalledOnce();
     expect(session.getExecutionLease()).toBeNull();
   });
 

--- a/src/session/__tests__/SessionRuntime.test.ts
+++ b/src/session/__tests__/SessionRuntime.test.ts
@@ -330,6 +330,51 @@ describe('SessionRuntime', () => {
     await runtime.close();
   });
 
+  it('fails closed while a timed-out inline hook is still cleaning up', async () => {
+    vi.useFakeTimers();
+    const started = deferred();
+    const release = deferred();
+    const runtime = new SessionRuntime(
+      SessionId('session-hook-cleanup'),
+      createOptions({
+        hookTimeoutMs: 50,
+        hooks: {
+          [HookEvent.UserPromptSubmit]: [
+            async () => {
+              started.resolve();
+              await release.promise;
+              return { action: 'continue' };
+            },
+          ],
+        },
+      }),
+      {
+        models: [],
+      },
+      PermissionMode.DEFAULT,
+      createFilesystemContext(workspaceRoot),
+      NOOP_LOGGER,
+    );
+
+    await runtime.initialize();
+    const dispatch = runtime.getHookRuntime().applyUserPromptSubmit('prompt');
+    const timeoutResult = expect(dispatch).rejects.toMatchObject({ code: 'HOOK_TIMEOUT' });
+    await started.promise;
+    await vi.advanceTimersByTimeAsync(50);
+    await timeoutResult;
+    await expect(runtime.close()).rejects.toThrow(
+      'still has an inline hook callback cleaning up',
+    );
+
+    release.resolve();
+    await vi.waitFor(() => {
+      expect(runtime.getHookRuntime().hasPendingCallbackCleanup()).toBe(false);
+    });
+
+    vi.useRealTimers();
+    await runtime.close();
+  });
+
   it('should install plugin tools and tool middleware through one declarative entry', async () => {
     const calls: string[] = [];
     const pluginTool = createTool({

--- a/src/session/__tests__/SessionSteeringResilience.test.ts
+++ b/src/session/__tests__/SessionSteeringResilience.test.ts
@@ -140,9 +140,9 @@ describe('Session steering resilience', () => {
     await started.promise;
     controller.abort(cancellation);
 
-    await expect(firstEvent).resolves.toMatchObject({
-      value: { type: 'error' },
-      done: false,
+    await expect(firstEvent).resolves.toEqual({
+      value: undefined,
+      done: true,
     });
     expect(hookSignal?.aborted).toBe(true);
     expect(hookSignal?.reason).toEqual({

--- a/src/session/__tests__/SessionSteeringResilience.test.ts
+++ b/src/session/__tests__/SessionSteeringResilience.test.ts
@@ -108,6 +108,54 @@ describe('Session steering resilience', () => {
     await session.close();
   });
 
+  it('propagates request cancellation into the initial UserPromptSubmit hook', async () => {
+    const storagePath = createWorkspaceRoot();
+    const started = Promise.withResolvers<void>();
+    const cancellation = new Error('cancel hook wait');
+    let hookSignal: AbortSignal | undefined;
+    const session = await createSession({
+      ...baseOptions(storagePath),
+      hooks: {
+        [HookEvent.UserPromptSubmit]: [
+          async (input) => {
+            hookSignal = input.abortSignal;
+            started.resolve();
+            await new Promise<void>((_resolve, reject) => {
+              input.abortSignal?.addEventListener(
+                'abort',
+                () => reject(input.abortSignal?.reason),
+                { once: true },
+              );
+            });
+            return { action: 'continue' };
+          },
+        ],
+      },
+    });
+    const controller = new AbortController();
+    await session.send('cancel during hook', { signal: controller.signal });
+    const stream = session.stream();
+    const firstEvent = stream.next();
+
+    await started.promise;
+    controller.abort(cancellation);
+
+    await expect(firstEvent).resolves.toMatchObject({
+      value: { type: 'error' },
+      done: false,
+    });
+    expect(hookSignal?.aborted).toBe(true);
+    expect(hookSignal?.reason).toEqual({
+      kind: 'external_abort',
+      cause: cancellation,
+    });
+
+    for await (const _event of stream) {
+      // drain
+    }
+    await session.close();
+  });
+
   it('closes cleanly when the consumer pauses on a setup-hook error', async () => {
     const session = await createSession({
       ...baseOptions(createWorkspaceRoot()),

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -210,6 +210,7 @@ type _AssertStreamMessageComplete = Assert<IsEqual<StreamMessage['type'], Stream
 
 export interface HookInput {
   event: HookEvent;
+  abortSignal?: AbortSignal;
   toolName?: string;
   toolInput?: JsonObject;
   toolOutput?: ToolModelContent;
@@ -294,6 +295,10 @@ export interface SessionOptions {
   subagent?: SubagentInfo;
 
   hooks?: Partial<Record<SessionHookEvent, HookCallback[]>>;
+  /** Total deadline for one inline hook event. Defaults to 600000ms. */
+  hookTimeoutMs?: number;
+  /** Deadline for inline SessionEnd hooks. Defaults to 3000ms. */
+  sessionEndHookTimeoutMs?: number;
   middleware?: AgentMiddlewareConfig;
   plugins?: readonly AgentPlugin[];
 

--- a/src/utils/abortPromise.ts
+++ b/src/utils/abortPromise.ts
@@ -1,0 +1,42 @@
+export function getAbortSignalReason(signal: AbortSignal): unknown {
+  if (signal.reason !== undefined) {
+    return signal.reason;
+  }
+  const error = new Error('The operation was aborted');
+  error.name = 'AbortError';
+  return error;
+}
+
+export function awaitWithAbortSignal<T>(
+  operation: () => PromiseLike<T>,
+  signal: AbortSignal,
+): Promise<T> {
+  if (signal.aborted) {
+    return Promise.reject(getAbortSignalReason(signal));
+  }
+
+  return new Promise<T>((resolve, reject) => {
+    let settled = false;
+    const cleanup = (): void => {
+      signal.removeEventListener('abort', onAbort);
+    };
+    const resolveOnce = (value: T): void => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve(value);
+    };
+    const rejectOnce = (error: unknown): void => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(error);
+    };
+    const onAbort = (): void => {
+      rejectOnce(getAbortSignalReason(signal));
+    };
+
+    signal.addEventListener('abort', onAbort, { once: true });
+    Promise.resolve().then(operation).then(resolveOnce, rejectOnce);
+  });
+}


### PR DESCRIPTION
## Summary

- add configurable 10-minute inline hook event deadlines and a 3-second `SessionEnd` deadline
- propagate combined request/deadline signals through initial, steering, task-completion, and session-start callbacks
- export typed `HookTimeoutError` and share abort-aware promise handling with model streams
- fail closed while cancelled callbacks remain pending without making close or durable handoff unretryable
- keep inline `SessionEnd` callbacks one-shot while preserving file-hook retry behavior
- document the contract in English and Chinese with a patch changelog fragment

## Verification

- `pnpm test` (1597 passed, 62 skipped)
- `pnpm run type-check`
- `pnpm run lint`
- `pnpm run verify:entrypoints`
- `pnpm run docs:build`
- `pnpm run changelog:check -- --base origin/main`
- `pnpm run audit:prod`
- `git diff origin/main...HEAD --check`

Expected release: `5.3.3`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Inline hooks now support configurable time limits: 10 minutes by default, or 3 seconds for session-end hooks.
  - Hook callbacks receive cancellation signals, allowing interrupted requests to stop cleanly.
  - Added `HookTimeoutError` with the `HOOK_TIMEOUT` error code and timeout details.

- **Bug Fixes**
  - Prevented shutdown and handoff while timed-out hook callbacks are still cleaning up.
  - Session-end callbacks run only once per runtime close attempt sequence.

- **Documentation**
  - Updated English and Chinese guides with timeout, cancellation, and error-handling details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->