### PR TITLE
fix(tools): cancel permission waits with requests

### DIFF
--- a/.changes/abort-aware-permission-callbacks.json
+++ b/.changes/abort-aware-permission-callbacks.json
@@ -1,0 +1,5 @@
+{
+  "type": "fix",
+  "en": "Cancel permission and confirmation waits with the active Request signal, and retain Session ownership until uncooperative callbacks finish cleaning up.",
+  "zh-CN": "权限与确认等待现在响应当前 Request 的取消信号；若回调忽略取消，Session 会保留执行所有权直至清理完成。"
+}

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -191,6 +191,9 @@ Node-local 能力外，这些函数都从根入口导出；实际 subpath 以“
 | `ToolInvocationLifecycle` | 单次工具权限与副作用开始边界 |
 | `ToolScheduledLifecycle` / `ToolSettledLifecycle` | 工具调度与终态 payload |
 | `ToolPermissionResolution` | 权限请求的 durable 决策 payload |
+| `ConfirmationDetails` | 确认请求详情；`abortSignal` 为当前 Request 的取消信号 |
+| `ConfirmationHandler` | 交互式确认处理器 |
+| `ConfirmationResponse` | 交互式确认结果 |
 | `ToolYield` | 工具产生的结构化进度、展示消息或 effect |
 | `ToolProgress` | 可选包含计数、结构化数据和恢复令牌的进度事件 |
 | `ToolMessage` | 面向用户界面的执行消息 |

--- a/docs/en/api-reference.md
+++ b/docs/en/api-reference.md
@@ -200,6 +200,7 @@ Authoring and execution:
 
 Types:
 
+`ConfirmationDetails`, `ConfirmationHandler`, `ConfirmationResponse`,
 `FunctionDeclaration`, `Tool`, `ToolBehavior`, `ToolConfig`, `ToolDescription`,
 `ToolDescriptionResolver`, `ToolDisplayContent`, `ToolEffect`,
 `ToolEffectYield`, `ToolError`, `ToolExecution`, `ToolExecutionLifecycle`,
@@ -287,6 +288,9 @@ Types:
 
 - `CanUseTool`
 - `CanUseToolOptions`
+- `ConfirmationDetails` (`abortSignal` is the active Request signal)
+- `ConfirmationHandler`
+- `ConfirmationResponse`
 - `PermissionHandler`
 - `PermissionHandlerRequest`
 - `PermissionResult`

--- a/docs/en/permissions.md
+++ b/docs/en/permissions.md
@@ -97,6 +97,13 @@ interface CanUseToolOptions {
 }
 ```
 
+The signal belongs to the active Request. The SDK races `canUseTool`,
+`permissionHandler`, tool validation, tool-level permission checks, and
+interactive confirmation against it. Interactive handlers receive the same
+signal as `ConfirmationDetails.abortSignal`. These waits have no wall-clock
+timeout. A callback that ignores cancellation remains tracked, blocks new tool
+work, and prevents Session close or handoff until its Promise settles.
+
 ## Low-level handlers
 
 The root package exports composable permission helpers:

--- a/docs/en/session.md
+++ b/docs/en/session.md
@@ -609,6 +609,15 @@ const session = await createSession({
 });
 ```
 
+Permission and confirmation callbacks are not covered by `toolTimeoutMs`;
+interactive approval may wait indefinitely. They are instead raced against the
+active Request signal. Observe `CanUseToolOptions.signal`,
+`PermissionHandlerRequest.signal`, or `ConfirmationDetails.abortSignal` and
+stop promptly when aborted. If a callback ignores cancellation, the Session
+retains its runtime and durable execution lease, rejects new tool work, and
+makes `close()` or `suspendForHandoff()` retryable only after that callback
+settles.
+
 See [Tools](./tools), [Permissions](./permissions), and [Hooks](./hooks).
 
 ## MCP

--- a/docs/en/tools.md
+++ b/docs/en/tools.md
@@ -212,6 +212,17 @@ is still pending, the pipeline refuses new tool work and Session shutdown or
 handoff fails closed until the generator exits; JavaScript cannot preempt
 custom tool code that ignores cancellation.
 
+Permission waits are cancellation-bounded instead of time-bounded because a
+human approval may legitimately remain open. Input validation and tool-level
+permission checks receive `ExecutionContext.signal`; `permissionHandler` and
+`canUseTool` receive `request.signal`; interactive handlers receive
+`ConfirmationDetails.abortSignal`. The pipeline races every callback against
+that request signal. A callback should stop work when it aborts. If it ignores
+the signal, the request still cancels, but new tool calls and Session
+close/handoff fail closed until the callback Promise settles. A durable
+permission request is resolved with `decision: 'cancel'` before cancellation
+completes.
+
 `interruptBehavior` belongs to the `ToolConfig` accepted by `createTool()`;
 `defineTool()` / `ToolDefinition` does not expose it. Use `createTool()` with
 `cancel` when a custom Session tool can safely stop for a `now` input.
@@ -276,6 +287,19 @@ interface ExecutionContext {
   toolCatalog?: ToolCatalog;
   discoveredTools?: string[];
   toolInvocationLifecycle?: ToolInvocationLifecycle; // injected by the runtime
+}
+```
+
+```ts
+interface ConfirmationDetails {
+  // ...
+  abortSignal?: AbortSignal;
+}
+
+interface ConfirmationHandler {
+  requestConfirmation(
+    details: ConfirmationDetails,
+  ): Promise<ConfirmationResponse>;
 }
 ```
 

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -91,6 +91,12 @@ interface CanUseToolOptions {
 }
 ```
 
+该信号归属于当前 Request。SDK 会将 `canUseTool`、`permissionHandler`、工具输入
+校验、工具级权限检查和交互式确认与此信号竞速；交互式处理器通过
+`ConfirmationDetails.abortSignal` 收到同一信号。这些等待没有固定墙钟超时。
+忽略取消的回调会被持续跟踪，并阻止新的工具执行以及 Session close/handoff，
+直至其 Promise 结束。
+
 ## 权限与沙箱的关系
 
 权限控制「是否询问」，沙箱控制「能做什么」。两者独立工作，可以组合使用：

--- a/docs/session.md
+++ b/docs/session.md
@@ -1237,6 +1237,13 @@ type PermissionResult =
 `canUseTool` 的优先级低于 Hook 系统中的 `PermissionRequest` 事件。如果 Hook 已做出决策（`abort` 或 `skip`），`canUseTool` 不会被调用。
 :::
 
+权限和确认回调不受 `toolTimeoutMs` 限制，因为交互式人工审批可以合理地无限期
+等待。SDK 会改为将它们与当前 Request 的取消信号竞速。回调必须监听
+`CanUseToolOptions.signal`、`PermissionHandlerRequest.signal` 或
+`ConfirmationDetails.abortSignal` 并在中止后尽快退出。若回调忽略取消，Session
+会保留 Runtime 和 durable execution lease、拒绝新的工具执行，并让 `close()`
+或 `suspendForHandoff()` 保持可重试失败，直至该回调结束。
+
 ## 子 Agent
 
 通过 `agents` 字段定义命名子代理，供内置任务工具（如 Task）在运行时调度：

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -334,6 +334,19 @@ interface ExecutionContext {
 }
 ```
 
+```ts
+interface ConfirmationDetails {
+  // ...
+  abortSignal?: AbortSignal;
+}
+
+interface ConfirmationHandler {
+  requestConfirmation(
+    details: ConfirmationDetails,
+  ): Promise<ConfirmationResponse>;
+}
+```
+
 ### Durable lifecycle 边界
 
 Runtime 可以通过 `ToolExecutionLifecycle` 观察并阻塞工具的关键持久化边界：
@@ -429,6 +442,14 @@ progress yield 之间持续计时，并在到期时中止工具的 signal。终�
 `ToolErrorType.TIMEOUT_ERROR`。SDK 最多等待工具清理 5 秒；若清理仍未结束，
 pipeline 会拒绝新的工具执行，Session 关闭或 handoff 也会 fail-closed，直至
 generator 退出。JavaScript 无法强制抢占忽略取消信号的自定义工具代码。
+
+权限等待采用取消边界而不是固定超时，因为人工审批可以合理地长时间保持打开。
+输入校验和工具级权限检查通过 `ExecutionContext.signal` 接收信号，
+`permissionHandler` 与 `canUseTool` 通过 `request.signal` 接收信号，交互式
+处理器通过 `ConfirmationDetails.abortSignal` 接收信号。Pipeline 会将每个回调
+与该 Request 信号竞速；回调应在信号中止时停止工作。若回调忽略信号，Request
+仍会完成取消，但新的工具调用以及 Session close/handoff 会 fail-closed，直至
+该回调 Promise 结束。已持久化的权限请求会先以 `decision: 'cancel'` 完成解析。
 
 `interruptBehavior` 属于 `createTool()` 的 `ToolConfig`，轻量
 `defineTool()` / `ToolDefinition` 不暴露该字段。需要让 Session 中的自定义

--- a/src/__tests__/rootExports.test.ts
+++ b/src/__tests__/rootExports.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, expectTypeOf, it } from 'vitest';
 import type {
   AgentMiddlewareConfig,
   AgentPlugin,
+  ConfirmationDetails,
+  ConfirmationHandler,
   DurableAcceptedRequestRecovery,
   DurableCommandCommitOptions,
   DurableCommandEventDraft,
@@ -192,6 +194,10 @@ describe('root exports', () => {
     expectTypeOf<ToolPermissionResolution['decision']>().toEqualTypeOf<
       'allow' | 'deny' | 'cancel'
     >();
+    expectTypeOf<ConfirmationDetails['abortSignal']>().toEqualTypeOf<
+      AbortSignal | undefined
+    >();
+    expectTypeOf<ConfirmationHandler['requestConfirmation']>().toBeFunction();
     expectTypeOf<ToolScheduledLifecycle['interruptBehavior']>().toEqualTypeOf<'block' | 'cancel'>();
     expectTypeOf<ToolScheduledLifecycle['sideEffect']>().toEqualTypeOf<
       'pure' | 'idempotent' | 'non_idempotent'

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -1,5 +1,8 @@
 export type {
   AgentTrace,
+  ConfirmationDetails,
+  ConfirmationHandler,
+  ConfirmationResponse,
   ContextSnapshot,
   ExecutionContext,
   InputSubmission,

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -35,6 +35,9 @@ export type {
 } from '../session/types.js';
 export { InputPriority } from '../session/types.js';
 export type {
+  ConfirmationDetails,
+  ConfirmationHandler,
+  ConfirmationResponse,
   ExecutionContext,
   FunctionDeclaration,
   ToolBehavior,

--- a/src/index.ts
+++ b/src/index.ts
@@ -187,6 +187,9 @@ export type {
 export { ToolCatalog } from './tools/catalog/index.js';
 export { createTool, defineTool, toolFromDefinition } from './tools/core/createTool.js';
 export type {
+  ConfirmationDetails,
+  ConfirmationHandler,
+  ConfirmationResponse,
   FunctionDeclaration,
   Tool,
   ToolBehavior,

--- a/src/session/SessionRuntime.ts
+++ b/src/session/SessionRuntime.ts
@@ -284,6 +284,13 @@ export class SessionRuntime {
         ),
       );
     }
+    if (this.executionPipeline.hasPendingPermissionCleanup()) {
+      errors.push(
+        new Error(
+          `Session runtime ${this.sessionId} still has a permission callback cleaning up`,
+        ),
+      );
+    }
     if (this.hookRuntime.hasPendingCallbackCleanup()) {
       errors.push(
         new Error(

--- a/src/session/__tests__/SessionDurableEvents.test.ts
+++ b/src/session/__tests__/SessionDurableEvents.test.ts
@@ -2015,14 +2015,15 @@ describe('Session durable events', () => {
 
     await started.promise;
     controller.abort(new Error('handoff permission cancelled'));
+    const blockedHandoff = expect(session.suspendForHandoff()).rejects.toThrow(
+      'permission callback cleaning up',
+    );
     await expect(execution).resolves.toMatchObject({
       status: 'error',
       error: { message: 'handoff permission cancelled' },
     });
 
-    await expect(session.suspendForHandoff()).rejects.toThrow(
-      'permission callback cleaning up',
-    );
+    await blockedHandoff;
     expect(releaseLease).not.toHaveBeenCalled();
     expect(session.getExecutionLease()).not.toBeNull();
 

--- a/src/session/__tests__/SessionDurableEvents.test.ts
+++ b/src/session/__tests__/SessionDurableEvents.test.ts
@@ -12,6 +12,11 @@ import { SessionHandoffError } from '../../errors/SessionHandoffError.js';
 import { HookRuntime } from '../../hooks/HookRuntime.js';
 import type { Message } from '../../services/ChatServiceInterface.js';
 import { BackgroundShellManager } from '../../tools/builtin/shell/BackgroundShellManager.js';
+import type { ExecutionPipeline } from '../../tools/execution/ExecutionPipeline.js';
+import {
+  collectToolExecution,
+  completeToolExecution,
+} from '../../tools/types/index.js';
 import {
   AgentId,
   CommandId,
@@ -26,7 +31,7 @@ import {
   TurnId,
   WorkerId,
 } from '../../types/branded.js';
-import type { JsonValue } from '../../types/common.js';
+import { type JsonValue, PermissionMode } from '../../types/common.js';
 import { HookEvent } from '../../types/constants.js';
 import { type DurableEventStore, DurableEventStoreError } from '../events/DurableEventStore.js';
 import {
@@ -1942,6 +1947,91 @@ describe('Session durable events', () => {
     await expect(session.suspendForHandoff()).resolves.toMatchObject({
       recoveryPlan: { action: 'rollover_request' },
     });
+    expect(releaseLease).toHaveBeenCalledOnce();
+    expect(session.getExecutionLease()).toBeNull();
+  });
+
+  it('keeps handoff retryable while an aborted permission callback is still cleaning up', async () => {
+    const { root, store } = createStore();
+    const started = Promise.withResolvers<void>();
+    const releasePermission = Promise.withResolvers<void>();
+    const controller = new AbortController();
+    const session = await createSession({
+      ...options(store),
+      persistSession: true,
+      storagePath: root,
+      executionLease: {
+        ownerId: WorkerId('worker-handoff-permission-cleanup'),
+        ttlMs: 10_000,
+        heartbeatIntervalMs: 5_000,
+      },
+      tools: [
+        {
+          name: 'PermissionCleanupTool',
+          description: 'Permission cleanup test tool',
+          sideEffect: 'non_idempotent',
+          parameters: {
+            type: 'object',
+            properties: {},
+          },
+          execute: () => completeToolExecution({
+            status: 'success',
+            model: 'unexpected',
+          }),
+        },
+      ],
+      allowedTools: ['PermissionCleanupTool'],
+      permissionHandler: async ({ signal }) => {
+        expect(signal).toBe(controller.signal);
+        started.resolve();
+        await releasePermission.promise;
+        return { behavior: 'allow' };
+      },
+    });
+    const runtime = (
+      session as unknown as {
+        runtime: {
+          getAgentRuntimeDeps(): {
+            executionPipeline: ExecutionPipeline;
+          };
+        } | null;
+      }
+    ).runtime;
+    if (!runtime) {
+      throw new Error('Expected an initialized Session runtime');
+    }
+    const executionPipeline = runtime.getAgentRuntimeDeps().executionPipeline;
+    const execution = collectToolExecution(
+      executionPipeline.execute(
+        'PermissionCleanupTool',
+        {},
+        {
+          permissionMode: PermissionMode.DEFAULT,
+          signal: controller.signal,
+        },
+      ),
+    );
+    const releaseLease = vi.spyOn(store, 'releaseExecutionLease');
+
+    await started.promise;
+    controller.abort(new Error('handoff permission cancelled'));
+    await expect(execution).resolves.toMatchObject({
+      status: 'error',
+      error: { message: 'handoff permission cancelled' },
+    });
+
+    await expect(session.suspendForHandoff()).rejects.toThrow(
+      'permission callback cleaning up',
+    );
+    expect(releaseLease).not.toHaveBeenCalled();
+    expect(session.getExecutionLease()).not.toBeNull();
+
+    releasePermission.resolve();
+    await vi.waitFor(() => {
+      expect(executionPipeline.hasPendingPermissionCleanup()).toBe(false);
+    });
+
+    await expect(session.suspendForHandoff()).resolves.toBeDefined();
     expect(releaseLease).toHaveBeenCalledOnce();
     expect(session.getExecutionLease()).toBeNull();
   });

--- a/src/session/__tests__/SessionRuntime.test.ts
+++ b/src/session/__tests__/SessionRuntime.test.ts
@@ -375,6 +375,58 @@ describe('SessionRuntime', () => {
     await runtime.close();
   });
 
+  it('fails closed while an aborted permission callback is still cleaning up', async () => {
+    const started = deferred();
+    const release = deferred();
+    const controller = new AbortController();
+    const runtime = new SessionRuntime(
+      SessionId('session-permission-cleanup'),
+      createOptions({
+        tools: [customTool],
+        allowedTools: ['CustomTool'],
+        permissionHandler: async ({ signal }) => {
+          expect(signal).toBe(controller.signal);
+          started.resolve();
+          await release.promise;
+          return { behavior: 'allow' };
+        },
+      }),
+      {
+        models: [],
+      },
+      PermissionMode.YOLO,
+      createFilesystemContext(workspaceRoot),
+      NOOP_LOGGER,
+    );
+
+    await runtime.initialize();
+    const executionPipeline = runtime.getAgentRuntimeDeps().executionPipeline;
+    assertDefined(executionPipeline);
+    const resultPromise = collectToolExecution(
+      executionPipeline.execute('CustomTool', {}, {
+        permissionMode: PermissionMode.YOLO,
+        signal: controller.signal,
+      }),
+    );
+
+    await started.promise;
+    controller.abort(new Error('request cancelled'));
+    await expect(resultPromise).resolves.toMatchObject({
+      status: 'error',
+      error: { message: 'request cancelled' },
+    });
+    await expect(runtime.close()).rejects.toThrow(
+      'still has a permission callback cleaning up',
+    );
+
+    release.resolve();
+    await vi.waitFor(() => {
+      expect(executionPipeline.hasPendingPermissionCleanup()).toBe(false);
+    });
+
+    await runtime.close();
+  });
+
   it('should install plugin tools and tool middleware through one declarative entry', async () => {
     const calls: string[] = [];
     const pluginTool = createTool({

--- a/src/session/__tests__/SessionRuntime.test.ts
+++ b/src/session/__tests__/SessionRuntime.test.ts
@@ -411,13 +411,14 @@ describe('SessionRuntime', () => {
 
     await started.promise;
     controller.abort(new Error('request cancelled'));
+    const closeResult = expect(runtime.close()).rejects.toThrow(
+      'still has a permission callback cleaning up',
+    );
     await expect(resultPromise).resolves.toMatchObject({
       status: 'error',
       error: { message: 'request cancelled' },
     });
-    await expect(runtime.close()).rejects.toThrow(
-      'still has a permission callback cleaning up',
-    );
+    await closeResult;
 
     release.resolve();
     await vi.waitFor(() => {

--- a/src/tools/builtin/plan/EnterPlanModeTool.ts
+++ b/src/tools/builtin/plan/EnterPlanModeTool.ts
@@ -103,6 +103,7 @@ User: "What files handle routing?"
       try {
         const response = await context.confirmationHandler.requestConfirmation({
           type: 'enterPlanMode',
+          abortSignal: context.signal,
           message:
             'The assistant requests to enter Plan mode for this complex task. In Plan mode, the assistant will:\n\n' +
             '1. Research the codebase thoroughly (read-only)\n' +

--- a/src/tools/builtin/plan/ExitPlanModeTool.ts
+++ b/src/tools/builtin/plan/ExitPlanModeTool.ts
@@ -85,6 +85,7 @@ Before using this tool, ensure your plan is clear and unambiguous. If there are 
       try {
         const response = await context.confirmationHandler.requestConfirmation({
           type: 'exitPlanMode',
+          abortSignal: context.signal,
           message:
             'The assistant has finished planning and is ready for your review.\n\n' +
             '⚠️ Before approving, please verify:\n' +

--- a/src/tools/builtin/plan/__tests__/EnterPlanModeTool.test.ts
+++ b/src/tools/builtin/plan/__tests__/EnterPlanModeTool.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ExecutionContext } from '../../../types/ExecutionTypes.js';
+import { collectToolExecution } from '../../../types/ToolResult.js';
+import { enterPlanModeTool } from '../EnterPlanModeTool.js';
+
+describe('EnterPlanMode Tool', () => {
+  it('passes the active tool signal to the confirmation handler', async () => {
+    const controller = new AbortController();
+    const requestConfirmation = vi.fn(async () => ({ approved: true }));
+    const invocation = enterPlanModeTool.build({});
+
+    const result = await collectToolExecution(
+      invocation.execute(controller.signal, {
+        signal: controller.signal,
+        confirmationHandler: { requestConfirmation },
+      } satisfies Partial<ExecutionContext>),
+    );
+
+    expect(requestConfirmation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'enterPlanMode',
+        abortSignal: controller.signal,
+      }),
+    );
+    expect(result.status).toBe('success');
+  });
+});

--- a/src/tools/builtin/plan/__tests__/ExitPlanModeTool.test.ts
+++ b/src/tools/builtin/plan/__tests__/ExitPlanModeTool.test.ts
@@ -45,6 +45,7 @@ async function executeWithContext(
 describe('ExitPlanMode Tool', () => {
   it('writes the plan file to bladeConfig.plansDirectory before requesting approval', async () => {
     const plansDirectory = await createTempDir('blade-plans-');
+    const controller = new AbortController();
     const requestConfirmation = vi.fn(async () => ({
       approved: true,
       targetMode: PermissionMode.DEFAULT,
@@ -53,6 +54,7 @@ describe('ExitPlanMode Tool', () => {
     const result = await executeWithContext({
       sessionId: SessionId('session-123'),
       bladeConfig: { plansDirectory } as BladeConfig,
+      signal: controller.signal,
       confirmationHandler: { requestConfirmation },
     });
 
@@ -61,6 +63,7 @@ describe('ExitPlanMode Tool', () => {
     expect(requestConfirmation).toHaveBeenCalledWith(
       expect.objectContaining({
         type: 'exitPlanMode',
+        abortSignal: controller.signal,
         planContent: '# Plan\n\n1. Add tests',
       })
     );

--- a/src/tools/builtin/system/__tests__/askUserQuestion.test.ts
+++ b/src/tools/builtin/system/__tests__/askUserQuestion.test.ts
@@ -225,7 +225,11 @@ describe('AskUserQuestion Tool', () => {
           })
         ),
       };
-      const context = createMockContext(mockHandler);
+      const controller = new AbortController();
+      const context = {
+        ...createMockContext(mockHandler),
+        signal: controller.signal,
+      };
 
       const questions = [
         {
@@ -244,6 +248,7 @@ describe('AskUserQuestion Tool', () => {
       expect(mockHandler.requestConfirmation).toHaveBeenCalledWith(
         expect.objectContaining({
           type: 'askUserQuestion',
+          abortSignal: controller.signal,
           questions,
         })
       );

--- a/src/tools/builtin/system/askUserQuestion.ts
+++ b/src/tools/builtin/system/askUserQuestion.ts
@@ -92,6 +92,7 @@ Usage notes:
       try {
         const response = await context.confirmationHandler.requestConfirmation({
           type: 'askUserQuestion',
+          abortSignal: context.signal,
           kind: ToolKind.ReadOnly, // 显式标记为只读，避免在 Plan 模式下被拒绝
           message: 'Please answer the following questions:',
           questions: params.questions,

--- a/src/tools/execution/ExecutionPipeline.ts
+++ b/src/tools/execution/ExecutionPipeline.ts
@@ -1031,6 +1031,10 @@ export class ExecutionPipeline {
       () => undefined,
       () => undefined,
     );
+    const trackCleanup = (): void => {
+      this.trackPendingPermissionCleanup(cleanup);
+    };
+    signal.addEventListener('abort', trackCleanup, { once: true });
 
     try {
       const result = await awaitWithAbortSignal(() => callback, signal);
@@ -1038,10 +1042,11 @@ export class ExecutionPipeline {
       return result;
     } catch (error) {
       if (signal.aborted) {
-        this.trackPendingPermissionCleanup(cleanup);
         throw getAbortSignalReason(signal);
       }
       throw error;
+    } finally {
+      signal.removeEventListener('abort', trackCleanup);
     }
   }
 

--- a/src/tools/execution/ExecutionPipeline.ts
+++ b/src/tools/execution/ExecutionPipeline.ts
@@ -25,6 +25,10 @@ import {
   type PermissionHandlerRequest,
   type PermissionUpdate,
 } from '../../types/permissions.js';
+import {
+  awaitWithAbortSignal,
+  getAbortSignalReason,
+} from '../../utils/abortPromise.js';
 import { getErrorMessage, getErrorName } from '../../utils/errorUtils.js';
 import type { ToolCatalog } from '../catalog/ToolCatalog.js';
 import type { ToolRegistry } from '../registry/ToolRegistry.js';
@@ -137,6 +141,7 @@ export class ExecutionPipeline {
   private readonly scheduler: ConcurrencyScheduler;
   private readonly resultArtifactStore = new ResultArtifactStore();
   private readonly pendingExecutionCleanups = new Set<Promise<void>>();
+  private readonly pendingPermissionCleanups = new Set<Promise<void>>();
 
   constructor(
     private registry: ToolRegistry,
@@ -182,6 +187,14 @@ export class ExecutionPipeline {
     return this.pendingExecutionCleanups.size > 0;
   }
 
+  hasPendingPermissionCleanup(): boolean {
+    return this.pendingPermissionCleanups.size > 0;
+  }
+
+  private hasPendingCleanup(): boolean {
+    return this.hasPendingExecutionCleanup() || this.hasPendingPermissionCleanup();
+  }
+
   /**
    * 执行工具
    */
@@ -190,7 +203,7 @@ export class ExecutionPipeline {
     params: JsonObject,
     context: ExecutionContext
   ): ToolExecution {
-    if (this.hasPendingExecutionCleanup()) {
+    if (this.hasPendingCleanup()) {
       return this.createPendingCleanupResult();
     }
     const startTime = Date.now();
@@ -473,7 +486,7 @@ export class ExecutionPipeline {
     let fileLease: FileLockLease | undefined;
 
     try {
-      if (this.hasPendingExecutionCleanup()) {
+      if (this.hasPendingCleanup()) {
         return this.createPendingCleanupResult();
       }
       fileLease = filePath
@@ -696,14 +709,22 @@ export class ExecutionPipeline {
         throw new Error(`Failed to build invocation for tool: ${state.tool.name}`);
       }
 
-      const validationError = await invocation.validate?.(state.context);
+      const validationError = invocation.validate
+        ? await this.awaitPermissionCallback(
+            () => invocation.validate?.(state.context),
+            state.context.signal,
+          )
+        : undefined;
       if (validationError) {
         state.result = validationErrorToToolResult(validationError);
         return;
       }
 
       const toolPermissionResult = state.tool.checkPermissions
-        ? await state.tool.checkPermissions(invocation.params, state.context)
+        ? await this.awaitPermissionCallback(
+            () => state.tool.checkPermissions?.(invocation.params, state.context),
+            state.context.signal,
+          )
         : undefined;
       const toolPermissionUpdatedInput =
         toolPermissionResult?.behavior === 'allow'
@@ -735,8 +756,11 @@ export class ExecutionPipeline {
         state.tool,
       );
 
-      let checkResult = await this.permissionRuleHandler(
-        this.buildPermissionRequest(state, state.affectedPaths),
+      let checkResult = await this.awaitPermissionCallback(
+        () => this.permissionRuleHandler(
+          this.buildPermissionRequest(state, state.affectedPaths),
+        ),
+        state.context.signal,
       );
 
       const hasRememberedApproval = Boolean(
@@ -777,14 +801,20 @@ export class ExecutionPipeline {
           break;
       }
 
-      const pathSafetyResult = await this.pathSafetyHandler(
-        this.buildPermissionRequest(state, state.affectedPaths),
+      const pathSafetyResult = await this.awaitPermissionCallback(
+        () => this.pathSafetyHandler(
+          this.buildPermissionRequest(state, state.affectedPaths),
+        ),
+        state.context.signal,
       );
       await this.handlePermissionHandlerResult(pathSafetyResult, state);
       if (state.result) {
         return;
       }
     } catch (error) {
+      if (state.context.signal?.aborted) {
+        throw getAbortSignalReason(state.context.signal);
+      }
       state.result = this.createAbortedResult(`Permission check failed: ${getErrorMessage(error)}`);
     }
   }
@@ -802,7 +832,10 @@ export class ExecutionPipeline {
     if (this.permissionHandlers.length > 0) {
       for (const permissionHandler of this.permissionHandlers) {
         const request = this.buildPermissionRequest(state, affectedPaths);
-        const result = await permissionHandler(request);
+        const result = await this.awaitPermissionCallback(
+          () => permissionHandler(request),
+          state.context.signal,
+        );
         await this.handlePermissionHandlerResult(result, state, request);
         if (state.result) {
           return;
@@ -827,7 +860,7 @@ export class ExecutionPipeline {
       );
       return;
     }
-    if (this.hasPendingExecutionCleanup()) {
+    if (this.hasPendingCleanup()) {
       state.result = this.createPendingCleanupResult();
       return;
     }
@@ -837,7 +870,7 @@ export class ExecutionPipeline {
       sideEffect: state.resolvedBehavior?.sideEffect ?? state.tool.sideEffect,
     });
     await state.context.assertExecutionLease?.();
-    if (this.hasPendingExecutionCleanup()) {
+    if (this.hasPendingCleanup()) {
       state.result = this.createPendingCleanupResult();
       return;
     }
@@ -981,6 +1014,41 @@ export class ExecutionPipeline {
     this.pendingExecutionCleanups.add(closing);
     void closing.finally(() => {
       this.pendingExecutionCleanups.delete(closing);
+    });
+  }
+
+  private async awaitPermissionCallback<T>(
+    operation: () => T | PromiseLike<T>,
+    signal: AbortSignal | undefined,
+  ): Promise<T> {
+    if (!signal) {
+      return await operation();
+    }
+
+    signal.throwIfAborted();
+    const callback = Promise.resolve().then(operation);
+    const cleanup = callback.then(
+      () => undefined,
+      () => undefined,
+    );
+
+    try {
+      const result = await awaitWithAbortSignal(() => callback, signal);
+      signal.throwIfAborted();
+      return result;
+    } catch (error) {
+      if (signal.aborted) {
+        this.trackPendingPermissionCleanup(cleanup);
+        throw getAbortSignalReason(signal);
+      }
+      throw error;
+    }
+  }
+
+  private trackPendingPermissionCleanup(cleanup: Promise<void>): void {
+    this.pendingPermissionCleanups.add(cleanup);
+    void cleanup.finally(() => {
+      this.pendingPermissionCleanups.delete(cleanup);
     });
   }
 
@@ -1231,6 +1299,7 @@ export class ExecutionPipeline {
       const confirmationDetails: ConfirmationDetails = {
         title: confirmationTitle,
         message: getConfirmationReason(state) || '此操作需要用户确认',
+        abortSignal: state.context.signal,
         kind: state.resolvedBehavior?.kind ?? state.tool.kind,
         details: this.generatePreviewForTool(state.tool.name, state.params),
         risks: this.extractRisksFromPermissionCheck(
@@ -1251,7 +1320,10 @@ export class ExecutionPipeline {
             structuredClone(state.params),
           );
         this.logger.info(`[ExecutionPipeline] Requesting confirmation for ${state.tool.name}`);
-        const response = await confirmationHandler.requestConfirmation(confirmationDetails);
+        const response = await this.awaitPermissionCallback(
+          () => confirmationHandler.requestConfirmation(confirmationDetails),
+          state.context.signal,
+        );
         this.logger.info(`[ExecutionPipeline] Confirmation response: approved=${response.approved}`);
         if (permissionRequestId) {
           resolutionAttempted = true;
@@ -1302,6 +1374,9 @@ export class ExecutionPipeline {
           );
         }
       }
+      if (state.context.signal?.aborted) {
+        throw failure;
+      }
       state.result = this.createAbortedResult(
         `User confirmation failed: ${getErrorMessage(failure)}`,
       );
@@ -1327,8 +1402,11 @@ export class ExecutionPipeline {
   }
 
   private createPendingCleanupResult(): ToolResult {
+    const source = this.hasPendingPermissionCleanup()
+      ? 'A permission callback'
+      : 'A tool execution';
     return this.createExecutionFailureResult(
-      'A tool execution is still cleaning up; refusing to start another tool',
+      `${source} is still cleaning up; refusing to start another tool`,
     );
   }
 

--- a/src/tools/execution/ExecutionPipeline.ts
+++ b/src/tools/execution/ExecutionPipeline.ts
@@ -141,7 +141,7 @@ export class ExecutionPipeline {
   private readonly scheduler: ConcurrencyScheduler;
   private readonly resultArtifactStore = new ResultArtifactStore();
   private readonly pendingExecutionCleanups = new Set<Promise<void>>();
-  private readonly pendingPermissionCleanups = new Set<Promise<void>>();
+  private readonly activePermissionCallbacks = new Map<Promise<void>, AbortSignal>();
 
   constructor(
     private registry: ToolRegistry,
@@ -188,7 +188,12 @@ export class ExecutionPipeline {
   }
 
   hasPendingPermissionCleanup(): boolean {
-    return this.pendingPermissionCleanups.size > 0;
+    for (const signal of this.activePermissionCallbacks.values()) {
+      if (signal.aborted) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private hasPendingCleanup(): boolean {
@@ -1031,10 +1036,10 @@ export class ExecutionPipeline {
       () => undefined,
       () => undefined,
     );
-    const trackCleanup = (): void => {
-      this.trackPendingPermissionCleanup(cleanup);
-    };
-    signal.addEventListener('abort', trackCleanup, { once: true });
+    this.activePermissionCallbacks.set(cleanup, signal);
+    void cleanup.finally(() => {
+      this.activePermissionCallbacks.delete(cleanup);
+    });
 
     try {
       const result = await awaitWithAbortSignal(() => callback, signal);
@@ -1045,16 +1050,7 @@ export class ExecutionPipeline {
         throw getAbortSignalReason(signal);
       }
       throw error;
-    } finally {
-      signal.removeEventListener('abort', trackCleanup);
     }
-  }
-
-  private trackPendingPermissionCleanup(cleanup: Promise<void>): void {
-    this.pendingPermissionCleanups.add(cleanup);
-    void cleanup.finally(() => {
-      this.pendingPermissionCleanups.delete(cleanup);
-    });
   }
 
   private createTimeoutError(toolName: string): Error {

--- a/src/tools/execution/__tests__/ExecutionPipeline.test.ts
+++ b/src/tools/execution/__tests__/ExecutionPipeline.test.ts
@@ -694,6 +694,11 @@ describe('ExecutionPipeline', () => {
         permissionHandler,
         canUseTool,
       });
+      let cleanupWasVisibleToEarlierAbortListener = false;
+      controller.signal.addEventListener('abort', () => {
+        cleanupWasVisibleToEarlierAbortListener =
+          pipeline.hasPendingPermissionCleanup();
+      }, { once: true });
 
       const internalHandler = (async (request) =>
         waitForRelease(request.signal, { behavior: 'allow' as const })) satisfies PermissionHandler;
@@ -737,6 +742,7 @@ describe('ExecutionPipeline', () => {
       await started.promise;
       expect(callbackSignal).toBe(controller.signal);
       controller.abort(cancellation);
+      expect(cleanupWasVisibleToEarlierAbortListener).toBe(true);
       expect(pipeline.hasPendingPermissionCleanup()).toBe(true);
 
       await expect(resultPromise).resolves.toMatchObject({

--- a/src/tools/execution/__tests__/ExecutionPipeline.test.ts
+++ b/src/tools/execution/__tests__/ExecutionPipeline.test.ts
@@ -737,6 +737,7 @@ describe('ExecutionPipeline', () => {
       await started.promise;
       expect(callbackSignal).toBe(controller.signal);
       controller.abort(cancellation);
+      expect(pipeline.hasPendingPermissionCleanup()).toBe(true);
 
       await expect(resultPromise).resolves.toMatchObject({
         status: 'error',
@@ -744,7 +745,6 @@ describe('ExecutionPipeline', () => {
           message: `${boundary} cancelled`,
         },
       });
-      expect(pipeline.hasPendingPermissionCleanup()).toBe(true);
       if (boundary === 'confirmationHandler') {
         expect(permissionResolutions).toEqual(['cancel']);
       }

--- a/src/tools/execution/__tests__/ExecutionPipeline.test.ts
+++ b/src/tools/execution/__tests__/ExecutionPipeline.test.ts
@@ -9,6 +9,7 @@ import { createTool } from '../../core/createTool.js';
 import { ToolRegistry } from '../../registry/ToolRegistry.js';
 import { PermissionRequestId, SessionId } from '../../../types/branded.js';
 import { type JsonObject, PermissionMode } from '../../../types/common.js';
+import type { PermissionHandler } from '../../../types/permissions.js';
 import {
   collectToolExecution,
   completeToolExecution,
@@ -612,6 +613,163 @@ describe('ExecutionPipeline', () => {
     expect(result.error?.message).toBe('Semantic validation failed');
     expect(executeSpy).not.toHaveBeenCalled();
   });
+
+  for (const boundary of [
+    'validateInput',
+    'checkPermissions',
+    'permissionRuleHandler',
+    'pathSafetyHandler',
+    'permissionHandler',
+    'canUseTool',
+    'confirmationHandler',
+  ] as const) {
+    it(`cancels and tracks an uncooperative ${boundary} callback`, async () => {
+      const registry = new ToolRegistry();
+      const started = deferred();
+      const release = deferred();
+      const controller = new AbortController();
+      const cancellation = new Error(`${boundary} cancelled`);
+      const executeSpy = vi.fn(() => completeToolExecution({
+        status: 'success',
+        model: 'unexpected',
+      }));
+      let callbackSignal: AbortSignal | undefined;
+
+      const waitForRelease = async <T>(signal: AbortSignal | undefined, result: T): Promise<T> => {
+        callbackSignal = signal;
+        started.resolve();
+        await release.promise;
+        return result;
+      };
+
+      registerTool(
+        registry,
+        createTool({
+          name: 'CancellationBoundaryTool',
+          displayName: 'Cancellation Boundary Tool',
+          kind: ToolKind.Execute,
+          sideEffect: 'non_idempotent',
+          description: { short: 'Permission cancellation boundary tool' },
+          schema: z.object({}),
+          ...(boundary === 'validateInput'
+            ? {
+                validateInput: (
+                  _params: JsonObject,
+                  context: ExecutionContext,
+                ) => waitForRelease(context.signal, undefined),
+              }
+            : {}),
+          ...(boundary === 'checkPermissions'
+            ? {
+                checkPermissions: (
+                  _params: JsonObject,
+                  context: ExecutionContext,
+                ) => waitForRelease(context.signal, { behavior: 'allow' as const }),
+              }
+            : boundary === 'confirmationHandler'
+              ? {
+                  checkPermissions: () => ({
+                    behavior: 'ask' as const,
+                    message: 'Confirm cancellation boundary tool',
+                  }),
+                }
+              : {}),
+          execute: executeSpy,
+        }),
+      );
+
+      const permissionHandler = boundary === 'permissionHandler'
+        ? (async (request) =>
+            waitForRelease(request.signal, { behavior: 'allow' as const })) satisfies PermissionHandler
+        : undefined;
+      const canUseTool = boundary === 'canUseTool'
+        ? async (
+            _toolName: string,
+            _input: JsonObject,
+            options: { signal: AbortSignal },
+          ) => waitForRelease(options.signal, { behavior: 'allow' as const })
+        : undefined;
+      const pipeline = new ExecutionPipeline(registry, {
+        permissionMode: PermissionMode.YOLO,
+        permissionHandler,
+        canUseTool,
+      });
+
+      const internalHandler = (async (request) =>
+        waitForRelease(request.signal, { behavior: 'allow' as const })) satisfies PermissionHandler;
+      if (boundary === 'permissionRuleHandler') {
+        (
+          pipeline as unknown as { permissionRuleHandler: PermissionHandler }
+        ).permissionRuleHandler = internalHandler;
+      }
+      if (boundary === 'pathSafetyHandler') {
+        (
+          pipeline as unknown as { pathSafetyHandler: PermissionHandler }
+        ).pathSafetyHandler = internalHandler;
+      }
+
+      const permissionResolutions: string[] = [];
+      const resultPromise = executePipeline(
+        pipeline,
+        'CancellationBoundaryTool',
+        {},
+        {
+          permissionMode: PermissionMode.YOLO,
+          signal: controller.signal,
+          ...(boundary === 'confirmationHandler'
+            ? {
+                confirmationHandler: {
+                  requestConfirmation: (details: { abortSignal?: AbortSignal }) =>
+                    waitForRelease(details.abortSignal, { approved: true }),
+                },
+                toolInvocationLifecycle: {
+                  onPermissionRequested: async () =>
+                    PermissionRequestId('permission-cancelled-by-request'),
+                  onPermissionResolved: async ({ decision }: { decision: string }) => {
+                    permissionResolutions.push(decision);
+                  },
+                },
+              }
+            : {}),
+        },
+      );
+
+      await started.promise;
+      expect(callbackSignal).toBe(controller.signal);
+      controller.abort(cancellation);
+
+      await expect(resultPromise).resolves.toMatchObject({
+        status: 'error',
+        error: {
+          message: `${boundary} cancelled`,
+        },
+      });
+      expect(pipeline.hasPendingPermissionCleanup()).toBe(true);
+      if (boundary === 'confirmationHandler') {
+        expect(permissionResolutions).toEqual(['cancel']);
+      }
+
+      await expect(
+        executePipeline(
+          pipeline,
+          'CancellationBoundaryTool',
+          {},
+          { permissionMode: PermissionMode.YOLO },
+        ),
+      ).resolves.toMatchObject({
+        status: 'error',
+        error: {
+          message: expect.stringContaining('permission callback is still cleaning up'),
+        },
+      });
+      expect(executeSpy).not.toHaveBeenCalled();
+
+      release.resolve();
+      await vi.waitFor(() => {
+        expect(pipeline.hasPendingPermissionCleanup()).toBe(false);
+      });
+    });
+  }
 
   it('lets tool-level checkPermissions deny before the external permission handler runs', async () => {
     const registry = new ToolRegistry();

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -9,6 +9,9 @@ export type {
 export { ToolCatalog } from './catalog/index.js';
 export { createTool, defineTool, toolFromDefinition } from './core/createTool.js';
 export type {
+  ConfirmationDetails,
+  ConfirmationHandler,
+  ConfirmationResponse,
   ExecutionContext,
   FunctionDeclaration,
   Tool,

--- a/src/tools/types/ExecutionTypes.ts
+++ b/src/tools/types/ExecutionTypes.ts
@@ -28,6 +28,8 @@ interface Question {
 
 export interface ConfirmationDetails {
   type?: 'permission' | 'enterPlanMode' | 'exitPlanMode' | 'maxTurnsExceeded' | 'askUserQuestion'; // 确认类型
+  /** Aborted when the owning request no longer accepts this confirmation. */
+  abortSignal?: AbortSignal;
   kind?: ToolKind; // 工具类型（readonly, write, execute），用于权限模式判断
   toolName?: string;
   args?: JsonObject;


### PR DESCRIPTION
## Summary

- race tool validation, tool permission checks, rule/path handlers, `permissionHandler`, `canUseTool`, and interactive confirmation against the active Request signal
- expose that signal as `ConfirmationDetails.abortSignal` and forward it from built-in confirmation tools
- track callbacks that ignore cancellation, reject later tool work, and keep Session close/handoff fail-closed until cleanup settles
- preserve durable permission cancellation and export the confirmation contracts from public entrypoints

## Semantics

Human approval remains intentionally free of a wall-clock timeout. Cancellation is cooperative: the Request can finish immediately, while an uncooperative callback remains tracked until its Promise settles.

## Verification

- `pnpm test` (`1607 passed`, `62 skipped`)
- `pnpm run type-check`
- `pnpm run lint`
- `pnpm run verify:entrypoints`
- `pnpm run docs:build`
- `pnpm run changelog:check`
- `pnpm run audit:prod`
