### PR TITLE
fix(tools): cancel queued admission waits

### DIFF
--- a/.changes/cancel-tool-admission-waits.json
+++ b/.changes/cancel-tool-admission-waits.json
@@ -1,0 +1,5 @@
+{
+  "type": "fix",
+  "en": "Cancel queued tool concurrency and same-file lock waits with the active Request signal without leaking leases or disturbing FIFO order.",
+  "zh-CN": "工具等待并发槽位或同文件锁时现在响应当前 Request 的取消信号，且不会泄漏 lease 或破坏 FIFO 顺序。"
+}

--- a/docs/en/session.md
+++ b/docs/en/session.md
@@ -618,6 +618,11 @@ retains its runtime and durable execution lease, rejects new tool work, and
 makes `close()` or `suspendForHandoff()` retryable only after that callback
 settles.
 
+Waiting for a tool concurrency slot or same-file lock is also outside
+`toolTimeoutMs`, but is cancellation-aware. Aborting the Request removes its
+waiter immediately; a slot or lock granted concurrently with cancellation is
+released before tool hooks, permission checks, or side effects can start.
+
 See [Tools](./tools), [Permissions](./permissions), and [Hooks](./hooks).
 
 ## MCP

--- a/docs/en/tools.md
+++ b/docs/en/tools.md
@@ -223,6 +223,13 @@ close/handoff fail closed until the callback Promise settles. A durable
 permission request is resolved with `decision: 'cancel'` before cancellation
 completes.
 
+Concurrency-slot and same-file lock waits also occur before the tool timeout
+starts, but both observe the active Request signal. Cancellation removes a
+queued waiter without consuming capacity or disturbing FIFO order. If resource
+grant and cancellation happen in the same turn, the pipeline rechecks the
+signal and releases every acquired lease before returning the cancellation
+result.
+
 `interruptBehavior` belongs to the `ToolConfig` accepted by `createTool()`;
 `defineTool()` / `ToolDefinition` does not expose it. Use `createTool()` with
 `cancel` when a custom Session tool can safely stop for a `now` input.

--- a/docs/session.md
+++ b/docs/session.md
@@ -1244,6 +1244,10 @@ type PermissionResult =
 会保留 Runtime 和 durable execution lease、拒绝新的工具执行，并让 `close()`
 或 `suspendForHandoff()` 保持可重试失败，直至该回调结束。
 
+等待工具并发槽位或同文件锁也不计入 `toolTimeoutMs`，但会响应 Request 取消。
+Request 中止后，对应 waiter 会立即从队列移除；若资源授予与取消同时发生，SDK
+会在任何 Hook、权限检查或工具副作用开始前释放已取得的槽位与锁。
+
 ## 子 Agent
 
 通过 `agents` 字段定义命名子代理，供内置任务工具（如 Task）在运行时调度：

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -451,6 +451,11 @@ generator 退出。JavaScript 无法强制抢占忽略取消信号的自定义�
 仍会完成取消，但新的工具调用以及 Session close/handoff 会 fail-closed，直至
 该回调 Promise 结束。已持久化的权限请求会先以 `decision: 'cancel'` 完成解析。
 
+并发槽位与同文件锁的等待也发生在工具时限开始之前，但都会监听当前 Request
+信号。取消会从 FIFO 队列中移除 waiter，不占用配额，也不打乱其他请求的顺序。
+若资源授予与取消发生在同一轮事件循环，pipeline 会再次检查信号，并在返回取消
+结果前释放已取得的所有 lease。
+
 `interruptBehavior` 属于 `createTool()` 的 `ToolConfig`，轻量
 `defineTool()` / `ToolDefinition` 不暴露该字段。需要让 Session 中的自定义
 工具响应 `now` 转向时，应使用 `createTool()` 并声明 `cancel`。

--- a/src/tools/execution/ConcurrencyScheduler.ts
+++ b/src/tools/execution/ConcurrencyScheduler.ts
@@ -15,6 +15,7 @@
  * 调用方应直接提交所有已就绪任务,不要再叠加独立的数值并发限制。
  */
 
+import { getAbortSignalReason } from '../../utils/abortPromise.js';
 import { ToolKind } from '../types/ToolKind.js';
 
 export interface ConcurrencyLease {
@@ -23,6 +24,9 @@ export interface ConcurrencyLease {
 
 interface PendingLease {
   resolve: (lease: ConcurrencyLease) => void;
+  reject: (reason?: unknown) => void;
+  signal?: AbortSignal;
+  onAbort?: () => void;
 };
 
 interface BucketState {
@@ -80,7 +84,11 @@ export class ConcurrencyScheduler {
     ConcurrencyScheduler.instance = null;
   }
 
-  async acquire(kind: ToolKind): Promise<ConcurrencyLease> {
+  async acquire(
+    kind: ToolKind,
+    signal?: AbortSignal,
+  ): Promise<ConcurrencyLease> {
+    signal?.throwIfAborted();
     const bucket = this.buckets[kind];
     if (!bucket) {
       return { release() {} };
@@ -91,14 +99,35 @@ export class ConcurrencyScheduler {
       return this.createLease(bucket);
     }
 
-    return new Promise<ConcurrencyLease>((resolve) => {
-      bucket.queue.push({ resolve });
+    return new Promise<ConcurrencyLease>((resolve, reject) => {
+      const pending: PendingLease = {
+        resolve,
+        reject,
+        signal,
+      };
+      if (signal) {
+        pending.onAbort = () => {
+          const index = bucket.queue.indexOf(pending);
+          if (index < 0) {
+            return;
+          }
+          bucket.queue.splice(index, 1);
+          reject(getAbortSignalReason(signal));
+        };
+        signal.addEventListener('abort', pending.onAbort, { once: true });
+      }
+      bucket.queue.push(pending);
     });
   }
 
-  async schedule<T>(kind: ToolKind, fn: () => Promise<T>): Promise<T> {
-    const lease = await this.acquire(kind);
+  async schedule<T>(
+    kind: ToolKind,
+    fn: () => Promise<T>,
+    signal?: AbortSignal,
+  ): Promise<T> {
+    const lease = await this.acquire(kind, signal);
     try {
+      signal?.throwIfAborted();
       return await fn();
     } finally {
       lease.release();
@@ -138,6 +167,13 @@ export class ConcurrencyScheduler {
     while (bucket.inFlight < bucket.maxConcurrent && bucket.queue.length > 0) {
       const pending = bucket.queue.shift();
       if (!pending) break;
+      if (pending.onAbort && pending.signal) {
+        pending.signal.removeEventListener('abort', pending.onAbort);
+      }
+      if (pending.signal?.aborted) {
+        pending.reject(getAbortSignalReason(pending.signal));
+        continue;
+      }
       bucket.inFlight++;
       pending.resolve(this.createLease(bucket));
     }

--- a/src/tools/execution/ExecutionPipeline.ts
+++ b/src/tools/execution/ExecutionPipeline.ts
@@ -515,6 +515,7 @@ export class ExecutionPipeline {
         return this.createPendingCleanupResult();
       }
       await state.context.assertExecutionLease?.();
+      state.context.signal?.throwIfAborted();
       return yield* this.executeWithPipeline(state, executionId);
     } catch (error) {
       if (isExecutionLeaseFailure(error)) {

--- a/src/tools/execution/ExecutionPipeline.ts
+++ b/src/tools/execution/ExecutionPipeline.ts
@@ -53,7 +53,11 @@ import {
   ToolErrorType,
   validationErrorToToolResult,
 } from '../types/ToolResult.js';
-import { type ConcurrencyLimits, ConcurrencyScheduler } from './ConcurrencyScheduler.js';
+import {
+  type ConcurrencyLease,
+  type ConcurrencyLimits,
+  ConcurrencyScheduler,
+} from './ConcurrencyScheduler.js';
 import { DenialTracker } from './DenialTracker.js';
 import { type FileLockLease, FileLockManager } from './FileLockManager.js';
 import { ResultArtifactStore } from './ResultArtifactStore.js';
@@ -487,21 +491,53 @@ export class ExecutionPipeline {
         : 'write';
 
     const toolKind = resolvedBehavior?.kind ?? tool.kind ?? ToolKind.Execute;
-    const concurrencyLease = await this.scheduler.acquire(toolKind);
+    let concurrencyLease: ConcurrencyLease | undefined;
     let fileLease: FileLockLease | undefined;
 
     try {
+      concurrencyLease = await this.scheduler.acquire(
+        toolKind,
+        state.context.signal,
+      );
+      state.context.signal?.throwIfAborted();
       if (this.hasPendingCleanup()) {
         return this.createPendingCleanupResult();
       }
       fileLease = filePath
-        ? await FileLockManager.getInstance(this.logger).acquire(filePath, lockMode)
+        ? await FileLockManager.getInstance(this.logger).acquire(
+            filePath,
+            lockMode,
+            state.context.signal,
+          )
         : undefined;
+      state.context.signal?.throwIfAborted();
+      if (this.hasPendingCleanup()) {
+        return this.createPendingCleanupResult();
+      }
       await state.context.assertExecutionLease?.();
       return yield* this.executeWithPipeline(state, executionId);
+    } catch (error) {
+      if (isExecutionLeaseFailure(error)) {
+        throw error;
+      }
+      if (isExecutionLeaseFailure(state.context.signal?.reason)) {
+        throw state.context.signal.reason;
+      }
+      if (state.context.signal?.aborted) {
+        const isInterrupt = isSteeringInterruptSignal(state.context.signal);
+        return this.createAbortedResult(
+          isInterrupt ? '工具执行被新的用户输入中断' : '任务已被用户中止',
+          {
+            errorType: isInterrupt
+              ? ToolErrorType.INTERRUPTED
+              : ToolErrorType.EXECUTION_ERROR,
+          },
+        );
+      }
+      throw error;
     } finally {
       fileLease?.release();
-      concurrencyLease.release();
+      concurrencyLease?.release();
     }
   }
 

--- a/src/tools/execution/FileLockManager.ts
+++ b/src/tools/execution/FileLockManager.ts
@@ -130,8 +130,8 @@ export class FileLockManager {
             return;
           }
           state.queue.splice(index, 1);
-          this.cleanupState(filePath, state);
           reject(getAbortSignalReason(signal));
+          this.drainQueue(filePath, state);
         };
         signal.addEventListener('abort', request.onAbort, { once: true });
       }
@@ -243,12 +243,15 @@ export class FileLockManager {
   }
 
   private drainQueue(filePath: string, state: FileLockState): void {
-    if (state.activeWriter || state.activeReaders > 0) {
+    if (state.activeWriter) {
       return;
     }
 
     while (state.queue.length > 0) {
       const next = state.queue[0];
+      if (state.activeReaders > 0 && next?.mode === 'write') {
+        return;
+      }
       if (next?.mode === 'read') {
         let grantedReader = false;
         while (state.queue[0]?.mode === 'read') {

--- a/src/tools/execution/FileLockManager.ts
+++ b/src/tools/execution/FileLockManager.ts
@@ -8,6 +8,7 @@
  */
 
 import { type InternalLogger, LogCategory, NOOP_LOGGER } from '../../logging/Logger.js';
+import { getAbortSignalReason } from '../../utils/abortPromise.js';
 
 type FileLockMode = 'read' | 'write';
 
@@ -18,6 +19,9 @@ export interface FileLockLease {
 interface QueuedLockRequest {
   mode: FileLockMode;
   resolve: (lease: FileLockLease) => void;
+  reject: (reason?: unknown) => void;
+  signal?: AbortSignal;
+  onAbort?: () => void;
 }
 
 interface FileLockState {
@@ -60,39 +64,77 @@ export class FileLockManager {
    * @param filePath 文件绝对路径
    * @param mode 锁模式，默认 write
    * @param operation 要执行的操作
+   * @param signal 可选的排队取消信号
    * @returns 操作结果
    */
-  acquireLock<T>(filePath: string, operation: () => Promise<T>): Promise<T>;
-  acquireLock<T>(filePath: string, mode: FileLockMode, operation: () => Promise<T>): Promise<T>;
+  acquireLock<T>(
+    filePath: string,
+    operation: () => Promise<T>,
+    signal?: AbortSignal,
+  ): Promise<T>;
+  acquireLock<T>(
+    filePath: string,
+    mode: FileLockMode,
+    operation: () => Promise<T>,
+    signal?: AbortSignal,
+  ): Promise<T>;
   acquireLock<T>(
     filePath: string,
     modeOrOperation: FileLockMode | (() => Promise<T>),
-    maybeOperation?: () => Promise<T>,
+    operationOrSignal?: (() => Promise<T>) | AbortSignal,
+    signal?: AbortSignal,
   ): Promise<T> {
     const mode = typeof modeOrOperation === 'function' ? 'write' : modeOrOperation;
     const operation = typeof modeOrOperation === 'function'
       ? modeOrOperation
-      : maybeOperation;
+      : operationOrSignal;
+    const resolvedSignal = typeof modeOrOperation === 'function'
+      ? operationOrSignal as AbortSignal | undefined
+      : signal;
 
-    if (!operation) {
+    if (typeof operation !== 'function') {
       throw new TypeError('FileLockManager.acquireLock requires an operation');
     }
 
-    return this.runWithLock(filePath, mode, operation);
+    return this.runWithLock(filePath, mode, operation, resolvedSignal);
   }
 
-  acquire(filePath: string, mode: FileLockMode = 'write'): Promise<FileLockLease> {
+  async acquire(
+    filePath: string,
+    mode: FileLockMode = 'write',
+    signal?: AbortSignal,
+  ): Promise<FileLockLease> {
+    signal?.throwIfAborted();
     const state = this.getOrCreateState(filePath);
-    return new Promise<FileLockLease>((resolve) => {
-      const request: QueuedLockRequest = { mode, resolve };
+    return new Promise<FileLockLease>((resolve, reject) => {
+      const request: QueuedLockRequest = {
+        mode,
+        resolve,
+        reject,
+        signal,
+      };
 
       if (this.canGrantImmediately(state, mode)) {
-        this.grant(filePath, state, request);
+        if (!this.grant(filePath, state, request)) {
+          this.cleanupState(filePath, state);
+        }
         return;
       }
 
       this.logger.debug(`排队等待${mode === 'read' ? '读' : '写'}锁: ${filePath}`);
       state.queue.push(request);
+      if (signal) {
+        request.onAbort = () => {
+          const index = state.queue.indexOf(request);
+          if (index < 0) {
+            return;
+          }
+          state.queue.splice(index, 1);
+          this.cleanupState(filePath, state);
+          reject(getAbortSignalReason(signal));
+        };
+        signal.addEventListener('abort', request.onAbort, { once: true });
+      }
     });
   }
 
@@ -172,7 +214,15 @@ export class FileLockManager {
     filePath: string,
     state: FileLockState,
     request: QueuedLockRequest,
-  ): void {
+  ): boolean {
+    if (request.onAbort && request.signal) {
+      request.signal.removeEventListener('abort', request.onAbort);
+    }
+    if (request.signal?.aborted) {
+      request.reject(getAbortSignalReason(request.signal));
+      return false;
+    }
+
     if (request.mode === 'read') {
       state.activeReaders += 1;
       this.logger.debug(`获取文件读锁: ${filePath} (activeReaders=${state.activeReaders})`);
@@ -189,6 +239,7 @@ export class FileLockManager {
         this.releaseRequest(filePath, state, request.mode);
       },
     });
+    return true;
   }
 
   private drainQueue(filePath: string, state: FileLockState): void {
@@ -196,25 +247,28 @@ export class FileLockManager {
       return;
     }
 
-    if (state.queue.length === 0) {
-      this.cleanupState(filePath, state);
-      return;
-    }
-
-    const next = state.queue[0];
-    if (next?.mode === 'read') {
-      while (state.queue[0]?.mode === 'read') {
-        const request = state.queue.shift();
-        if (!request) break;
-        this.grant(filePath, state, request);
+    while (state.queue.length > 0) {
+      const next = state.queue[0];
+      if (next?.mode === 'read') {
+        let grantedReader = false;
+        while (state.queue[0]?.mode === 'read') {
+          const request = state.queue.shift();
+          if (!request) break;
+          grantedReader = this.grant(filePath, state, request) || grantedReader;
+        }
+        if (grantedReader) {
+          return;
+        }
+        continue;
       }
-      return;
+
+      const request = state.queue.shift();
+      if (request && this.grant(filePath, state, request)) {
+        return;
+      }
     }
 
-    const request = state.queue.shift();
-    if (request) {
-      this.grant(filePath, state, request);
-    }
+    this.cleanupState(filePath, state);
   }
 
   private cleanupState(filePath: string, state: FileLockState): void {
@@ -243,9 +297,11 @@ export class FileLockManager {
     filePath: string,
     mode: FileLockMode,
     operation: () => Promise<T>,
+    signal?: AbortSignal,
   ): Promise<T> {
-    const lease = await this.acquire(filePath, mode);
+    const lease = await this.acquire(filePath, mode, signal);
     try {
+      signal?.throwIfAborted();
       return await operation();
     } finally {
       lease.release();

--- a/src/tools/execution/__tests__/ConcurrencyScheduler.test.ts
+++ b/src/tools/execution/__tests__/ConcurrencyScheduler.test.ts
@@ -134,6 +134,102 @@ describe('ConcurrencyScheduler', () => {
     });
   });
 
+  describe('取消排队', () => {
+    it('拒绝已取消的请求且不占用配额', async () => {
+      const scheduler = new ConcurrencyScheduler({ execute: 1 });
+      const controller = new AbortController();
+      const reason = new Error('cancelled before acquire');
+      controller.abort(reason);
+
+      await expect(
+        scheduler.acquire(ToolKind.Execute, controller.signal),
+      ).rejects.toBe(reason);
+      expect(scheduler.getStats()[ToolKind.Execute]).toEqual({
+        inFlight: 0,
+        queued: 0,
+      });
+    });
+
+    it('从 FIFO 队列移除已取消的 waiter', async () => {
+      const scheduler = new ConcurrencyScheduler({ execute: 1 });
+      const holder = await scheduler.acquire(ToolKind.Execute);
+      const controller = new AbortController();
+      const reason = new Error('cancelled while queued');
+      const cancelled = scheduler.acquire(ToolKind.Execute, controller.signal);
+      const next = scheduler.acquire(ToolKind.Execute);
+      const cancelledResult = expect(cancelled).rejects.toBe(reason);
+
+      expect(scheduler.getStats()[ToolKind.Execute]).toEqual({
+        inFlight: 1,
+        queued: 2,
+      });
+      controller.abort(reason);
+      await cancelledResult;
+      expect(scheduler.getStats()[ToolKind.Execute]).toEqual({
+        inFlight: 1,
+        queued: 1,
+      });
+
+      holder.release();
+      const nextLease = await next;
+      expect(scheduler.getStats()[ToolKind.Execute]).toEqual({
+        inFlight: 1,
+        queued: 0,
+      });
+      nextLease.release();
+      expect(scheduler.getStats()[ToolKind.Execute].inFlight).toBe(0);
+    });
+
+    it('skips an aborted waiter when an earlier abort listener releases the slot', async () => {
+      const scheduler = new ConcurrencyScheduler({ execute: 1 });
+      const holder = await scheduler.acquire(ToolKind.Execute);
+      const controller = new AbortController();
+      const reason = new Error('cancelled during release');
+      controller.signal.addEventListener('abort', () => holder.release(), {
+        once: true,
+      });
+      const cancelled = scheduler.acquire(ToolKind.Execute, controller.signal);
+      const next = scheduler.acquire(ToolKind.Execute);
+      const cancelledResult = expect(cancelled).rejects.toBe(reason);
+
+      controller.abort(reason);
+      await cancelledResult;
+      const nextLease = await next;
+
+      expect(scheduler.getStats()[ToolKind.Execute]).toEqual({
+        inFlight: 1,
+        queued: 0,
+      });
+      nextLease.release();
+    });
+
+    it('does not run scheduled work when cancellation wins after grant', async () => {
+      const scheduler = new ConcurrencyScheduler({ execute: 1 });
+      const holder = await scheduler.acquire(ToolKind.Execute);
+      const controller = new AbortController();
+      const reason = new Error('cancelled after grant');
+      let invoked = false;
+      const scheduled = scheduler.schedule(
+        ToolKind.Execute,
+        async () => {
+          invoked = true;
+        },
+        controller.signal,
+      );
+      const cancelledResult = expect(scheduled).rejects.toBe(reason);
+
+      holder.release();
+      controller.abort(reason);
+      await cancelledResult;
+
+      expect(invoked).toBe(false);
+      expect(scheduler.getStats()[ToolKind.Execute]).toEqual({
+        inFlight: 0,
+        queued: 0,
+      });
+    });
+  });
+
   describe('桶隔离', () => {
     it('execute 桶打满不影响 readonly', async () => {
       const scheduler = new ConcurrencyScheduler({ execute: 1 });

--- a/src/tools/execution/__tests__/ExecutionPipeline.test.ts
+++ b/src/tools/execution/__tests__/ExecutionPipeline.test.ts
@@ -7,7 +7,7 @@ import { ConfigError } from '../../../errors/ConfigError.js';
 import { DurableExecutionLeaseError } from '../../../session/events/DurableExecutionLeaseStore.js';
 import { createTool } from '../../core/createTool.js';
 import { ToolRegistry } from '../../registry/ToolRegistry.js';
-import { PermissionRequestId, SessionId } from '../../../types/branded.js';
+import { InputId, PermissionRequestId, SessionId } from '../../../types/branded.js';
 import { type JsonObject, PermissionMode } from '../../../types/common.js';
 import type { PermissionHandler } from '../../../types/permissions.js';
 import {
@@ -114,6 +114,172 @@ describe('ExecutionPipeline', () => {
     gates[1].resolve();
     gates[2].resolve();
     await Promise.all(executions);
+  });
+
+  it('cancels a tool while it is queued for a concurrency slot', async () => {
+    const registry = new ToolRegistry();
+    const scheduler = new ConcurrencyScheduler({ execute: 1 });
+    const firstStarted = deferred();
+    const releaseFirst = deferred();
+    const started: number[] = [];
+
+    registerTool(
+      registry,
+      createTool({
+        name: 'QueuedExecutionTool',
+        displayName: 'Queued Execution Tool',
+        kind: ToolKind.Execute,
+        sideEffect: 'non_idempotent',
+        description: { short: 'Concurrency queue cancellation tool' },
+        schema: z.object({ id: z.number() }),
+        async *execute({ id }) {
+          started.push(id);
+          yield { kind: 'progress', data: { id } };
+          if (id === 1) {
+            firstStarted.resolve();
+            await releaseFirst.promise;
+          }
+          return { status: 'success', model: String(id) };
+        },
+      }),
+    );
+
+    const pipeline = new ExecutionPipeline(registry, {
+      permissionMode: PermissionMode.YOLO,
+      scheduler,
+    });
+    const first = executePipeline(
+      pipeline,
+      'QueuedExecutionTool',
+      { id: 1 },
+      { permissionMode: PermissionMode.YOLO },
+    );
+    await firstStarted.promise;
+
+    const controller = new AbortController();
+    const second = executePipeline(
+      pipeline,
+      'QueuedExecutionTool',
+      { id: 2 },
+      {
+        permissionMode: PermissionMode.YOLO,
+        signal: controller.signal,
+      },
+    );
+    await vi.waitFor(() => {
+      expect(scheduler.getStats()[ToolKind.Execute].queued).toBe(1);
+    });
+
+    controller.abort({
+      kind: 'steering',
+      inputId: InputId('queued-steering'),
+    });
+    await expect(second).resolves.toMatchObject({
+      status: 'error',
+      error: {
+        type: ToolErrorType.INTERRUPTED,
+        message: '工具执行被新的用户输入中断',
+      },
+    });
+    expect(started).toEqual([1]);
+    expect(scheduler.getStats()[ToolKind.Execute]).toEqual({
+      inFlight: 1,
+      queued: 0,
+    });
+
+    releaseFirst.resolve();
+    await expect(first).resolves.toMatchObject({
+      status: 'success',
+      model: '1',
+    });
+    expect(scheduler.getStats()[ToolKind.Execute].inFlight).toBe(0);
+  });
+
+  it('cancels a tool while it is queued for a file lock', async () => {
+    const registry = new ToolRegistry();
+    const scheduler = new ConcurrencyScheduler({ write: 2 });
+    const firstStarted = deferred();
+    const releaseFirst = deferred();
+    const started: number[] = [];
+    const filePath = '/tmp/file-lock-cancellation.txt';
+
+    registerTool(
+      registry,
+      createTool({
+        name: 'FileLockCancellationTool',
+        displayName: 'File Lock Cancellation Tool',
+        kind: ToolKind.Write,
+        sideEffect: 'idempotent',
+        description: { short: 'File lock cancellation tool' },
+        schema: z.object({
+          id: z.number(),
+          file_path: z.string(),
+        }),
+        async *execute({ id }) {
+          started.push(id);
+          yield { kind: 'progress', data: { id } };
+          if (id === 1) {
+            firstStarted.resolve();
+            await releaseFirst.promise;
+          }
+          return { status: 'success', model: String(id) };
+        },
+      }),
+    );
+
+    const pipeline = new ExecutionPipeline(registry, {
+      permissionMode: PermissionMode.YOLO,
+      scheduler,
+    });
+    const first = executePipeline(
+      pipeline,
+      'FileLockCancellationTool',
+      { id: 1, file_path: filePath },
+      { permissionMode: PermissionMode.YOLO },
+    );
+    await firstStarted.promise;
+
+    const controller = new AbortController();
+    const addAbortListener = vi.spyOn(controller.signal, 'addEventListener');
+    const second = executePipeline(
+      pipeline,
+      'FileLockCancellationTool',
+      { id: 2, file_path: filePath },
+      {
+        permissionMode: PermissionMode.YOLO,
+        signal: controller.signal,
+      },
+    );
+    await vi.waitFor(() => {
+      expect(addAbortListener).toHaveBeenCalledWith(
+        'abort',
+        expect.any(Function),
+        { once: true },
+      );
+    });
+
+    controller.abort(new Error('cancel file lock wait'));
+    await expect(second).resolves.toMatchObject({
+      status: 'error',
+      error: {
+        type: ToolErrorType.EXECUTION_ERROR,
+        message: '任务已被用户中止',
+      },
+    });
+    expect(started).toEqual([1]);
+    expect(scheduler.getStats()[ToolKind.Write]).toEqual({
+      inFlight: 1,
+      queued: 0,
+    });
+    expect(FileLockManager.getInstance().isLocked(filePath)).toBe(true);
+
+    releaseFirst.resolve();
+    await expect(first).resolves.toMatchObject({
+      status: 'success',
+      model: '1',
+    });
+    expect(scheduler.getStats()[ToolKind.Write].inFlight).toBe(0);
+    expect(FileLockManager.getInstance().isLocked(filePath)).toBe(false);
   });
 
   it('releases execution leases when an event consumer stops the stream', async () => {

--- a/src/tools/execution/__tests__/ExecutionPipeline.test.ts
+++ b/src/tools/execution/__tests__/ExecutionPipeline.test.ts
@@ -4,6 +4,7 @@ import * as path from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
 import { ConfigError } from '../../../errors/ConfigError.js';
+import type { HookRuntime } from '../../../hooks/HookRuntime.js';
 import { DurableExecutionLeaseError } from '../../../session/events/DurableExecutionLeaseStore.js';
 import { createTool } from '../../core/createTool.js';
 import { ToolRegistry } from '../../registry/ToolRegistry.js';
@@ -280,6 +281,67 @@ describe('ExecutionPipeline', () => {
     });
     expect(scheduler.getStats()[ToolKind.Write].inFlight).toBe(0);
     expect(FileLockManager.getInstance().isLocked(filePath)).toBe(false);
+  });
+
+  it('does not start pre-tool hooks when cancellation wins during the final lease check', async () => {
+    const registry = new ToolRegistry();
+    const leaseCheckStarted = deferred();
+    const releaseLeaseCheck = deferred();
+    const preToolUse = vi.fn();
+    let leaseCheckCount = 0;
+
+    registerTool(
+      registry,
+      createTool({
+        name: 'LeaseCheckCancellationTool',
+        displayName: 'Lease Check Cancellation Tool',
+        kind: ToolKind.Execute,
+        sideEffect: 'non_idempotent',
+        description: { short: 'Lease check cancellation tool' },
+        schema: z.object({}),
+        execute: () => completeToolExecution({
+          status: 'success',
+          model: 'unexpected',
+        }),
+      }),
+    );
+
+    const pipeline = new ExecutionPipeline(registry, {
+      permissionMode: PermissionMode.YOLO,
+      hookRuntime: {
+        applyPreToolUse: preToolUse,
+      } as unknown as HookRuntime,
+    });
+    const controller = new AbortController();
+    const resultPromise = executePipeline(
+      pipeline,
+      'LeaseCheckCancellationTool',
+      {},
+      {
+        permissionMode: PermissionMode.YOLO,
+        signal: controller.signal,
+        assertExecutionLease: async () => {
+          leaseCheckCount += 1;
+          if (leaseCheckCount === 3) {
+            leaseCheckStarted.resolve();
+            await releaseLeaseCheck.promise;
+          }
+        },
+      },
+    );
+
+    await leaseCheckStarted.promise;
+    controller.abort(new Error('cancel final lease check'));
+    releaseLeaseCheck.resolve();
+
+    await expect(resultPromise).resolves.toMatchObject({
+      status: 'error',
+      error: {
+        type: ToolErrorType.EXECUTION_ERROR,
+        message: '任务已被用户中止',
+      },
+    });
+    expect(preToolUse).not.toHaveBeenCalled();
   });
 
   it('releases execution leases when an event consumer stops the stream', async () => {

--- a/src/tools/execution/__tests__/FileLockManager.test.ts
+++ b/src/tools/execution/__tests__/FileLockManager.test.ts
@@ -281,6 +281,33 @@ describe('FileLockManager', () => {
       expect(manager.isLocked(filePath)).toBe(false);
     });
 
+    it('admits a queued reader when the writer ahead of it is cancelled', async () => {
+      const manager = FileLockManager.getInstance();
+      const filePath = '/tmp/cancelled-writer.ts';
+      const activeReader = await manager.acquire(filePath, 'read');
+      const controller = new AbortController();
+      const reason = new Error('cancelled writer');
+      const writer = manager.acquire(filePath, 'write', controller.signal);
+      const queuedReader = manager.acquire(filePath, 'read');
+      const writerResult = expect(writer).rejects.toBe(reason);
+      let readerAcquired = false;
+      void queuedReader.then(() => {
+        readerAcquired = true;
+      });
+
+      await Promise.resolve();
+      expect(readerAcquired).toBe(false);
+      controller.abort(reason);
+      await writerResult;
+      const secondReader = await queuedReader;
+
+      expect(readerAcquired).toBe(true);
+      activeReader.release();
+      expect(manager.isLocked(filePath)).toBe(true);
+      secondReader.release();
+      expect(manager.isLocked(filePath)).toBe(false);
+    });
+
     it('does not run acquireLock work when cancellation wins after grant', async () => {
       const manager = FileLockManager.getInstance();
       const holder = await manager.acquire('/tmp/grant-race.ts');

--- a/src/tools/execution/__tests__/FileLockManager.test.ts
+++ b/src/tools/execution/__tests__/FileLockManager.test.ts
@@ -220,6 +220,115 @@ describe('FileLockManager', () => {
     });
   });
 
+  describe('cancellable acquisition', () => {
+    it('rejects an already-aborted request without creating lock state', async () => {
+      const manager = FileLockManager.getInstance();
+      const controller = new AbortController();
+      const reason = new Error('cancelled before lock');
+      controller.abort(reason);
+
+      await expect(
+        manager.acquire('/tmp/cancelled.ts', 'write', controller.signal),
+      ).rejects.toBe(reason);
+      expect(manager.isLocked('/tmp/cancelled.ts')).toBe(false);
+    });
+
+    it('removes an aborted waiter and preserves FIFO progress', async () => {
+      const manager = FileLockManager.getInstance();
+      const holder = await manager.acquire('/tmp/queued.ts');
+      const controller = new AbortController();
+      const reason = new Error('cancelled while waiting for lock');
+      const cancelled = manager.acquire(
+        '/tmp/queued.ts',
+        'write',
+        controller.signal,
+      );
+      const next = manager.acquire('/tmp/queued.ts');
+      const cancelledResult = expect(cancelled).rejects.toBe(reason);
+
+      controller.abort(reason);
+      await cancelledResult;
+      expect(manager.isLocked('/tmp/queued.ts')).toBe(true);
+
+      holder.release();
+      const nextLease = await next;
+      nextLease.release();
+      expect(manager.isLocked('/tmp/queued.ts')).toBe(false);
+    });
+
+    it('skips an aborted waiter when an earlier abort listener releases the lock', async () => {
+      const manager = FileLockManager.getInstance();
+      const filePath = '/tmp/listener-order.ts';
+      const holder = await manager.acquire(filePath);
+      const controller = new AbortController();
+      const reason = new Error('cancelled during lock release');
+      controller.signal.addEventListener('abort', () => holder.release(), {
+        once: true,
+      });
+      const cancelled = manager.acquire(
+        filePath,
+        'write',
+        controller.signal,
+      );
+      const next = manager.acquire(filePath);
+      const cancelledResult = expect(cancelled).rejects.toBe(reason);
+
+      controller.abort(reason);
+      await cancelledResult;
+      const nextLease = await next;
+      nextLease.release();
+
+      expect(manager.isLocked(filePath)).toBe(false);
+    });
+
+    it('does not run acquireLock work when cancellation wins after grant', async () => {
+      const manager = FileLockManager.getInstance();
+      const holder = await manager.acquire('/tmp/grant-race.ts');
+      const controller = new AbortController();
+      const reason = new Error('cancelled after lock grant');
+      let invoked = false;
+      const scheduled = manager.acquireLock(
+        '/tmp/grant-race.ts',
+        async () => {
+          invoked = true;
+        },
+        controller.signal,
+      );
+      const cancelledResult = expect(scheduled).rejects.toBe(reason);
+
+      holder.release();
+      controller.abort(reason);
+      await cancelledResult;
+
+      expect(invoked).toBe(false);
+      expect(manager.isLocked('/tmp/grant-race.ts')).toBe(false);
+    });
+
+    it('passes a cancellation signal through the explicit lock mode overload', async () => {
+      const manager = FileLockManager.getInstance();
+      const holder = await manager.acquire('/tmp/read-mode.ts', 'write');
+      const controller = new AbortController();
+      const reason = new Error('cancelled read');
+      let invoked = false;
+      const scheduled = manager.acquireLock(
+        '/tmp/read-mode.ts',
+        'read',
+        async () => {
+          invoked = true;
+        },
+        controller.signal,
+      );
+      const cancelledResult = expect(scheduled).rejects.toBe(reason);
+
+      controller.abort(reason);
+      await cancelledResult;
+      holder.release();
+
+      expect(invoked).toBe(false);
+      expect(manager.isLocked('/tmp/read-mode.ts')).toBe(false);
+    });
+  });
+
   describe('isLocked', () => {
     it('should return false for a file that has never been locked', () => {
       const manager = FileLockManager.getInstance();


### PR DESCRIPTION
## Summary

- make concurrency-slot and same-file lock waiters cancellable with the active Request signal
- remove cancelled waiters from FIFO queues without consuming capacity or blocking later compatible readers
- recheck cancellation after resource grant and the final execution-lease assertion, releasing every acquired lease before hooks or side effects
- preserve steering interruption classification at the ExecutionPipeline boundary

## Reference alignment

- Claude Code races blocked permission/tool work against abort signals
- Codex uses cancellation-selectable async waits
- Grok registers cancellation before admission so cancel cannot queue behind work

## Verification

- `pnpm test` (`1620 passed`, `62 skipped`)
- `pnpm run type-check`
- `pnpm run lint`
- `pnpm run verify:entrypoints`
- `pnpm run docs:build`
- `pnpm run changelog:check`
- `pnpm run audit:prod`
