### PR TITLE
fix(hooks): terminate cancelled process trees

### DIFF
--- a/.changes/cancel-hook-process-trees.json
+++ b/.changes/cancel-hook-process-trees.json
@@ -1,5 +1,5 @@
 {
   "type": "fix",
-  "en": "Prevent cancelled file hooks from spawning, contain Windows hook commands in Job Objects, and wait for complete process trees to terminate before request cleanup finishes.",
-  "zh-CN": "阻止已取消的文件 Hook 启动进程，使用 Windows Job Object 纳管 Hook 命令，并在请求清理完成前等待完整进程树退出。"
+  "en": "Prevent cancelled file hooks from spawning and wait for their owned POSIX process groups or Windows Jobs to terminate before request cleanup finishes.",
+  "zh-CN": "阻止已取消的文件 Hook 启动进程，并在请求清理完成前等待其受管的 POSIX 进程组或 Windows Job 退出。"
 }

--- a/.changes/cancel-hook-process-trees.json
+++ b/.changes/cancel-hook-process-trees.json
@@ -1,0 +1,5 @@
+{
+  "type": "fix",
+  "en": "Prevent cancelled file hooks from spawning and wait for their complete process trees to terminate before request cleanup finishes.",
+  "zh-CN": "阻止已取消的文件 Hook 启动进程，并在请求清理完成前等待其完整进程树退出。"
+}

--- a/.changes/cancel-hook-process-trees.json
+++ b/.changes/cancel-hook-process-trees.json
@@ -1,5 +1,5 @@
 {
   "type": "fix",
-  "en": "Prevent cancelled file hooks from spawning and wait for their complete process trees to terminate before request cleanup finishes.",
-  "zh-CN": "阻止已取消的文件 Hook 启动进程，并在请求清理完成前等待其完整进程树退出。"
+  "en": "Prevent cancelled file hooks from spawning, contain Windows hook commands in Job Objects, and wait for complete process trees to terminate before request cleanup finishes.",
+  "zh-CN": "阻止已取消的文件 Hook 启动进程，使用 Windows Job Object 纳管 Hook 命令，并在请求清理完成前等待完整进程树退出。"
 }

--- a/.changes/cancel-hook-process-trees.json
+++ b/.changes/cancel-hook-process-trees.json
@@ -1,5 +1,5 @@
 {
   "type": "fix",
-  "en": "Prevent cancelled file hooks from spawning and wait for their owned POSIX process groups or Windows Jobs to terminate before request cleanup finishes.",
-  "zh-CN": "阻止已取消的文件 Hook 启动进程，并在请求清理完成前等待其受管的 POSIX 进程组或 Windows Job 退出。"
+  "en": "Prevent cancelled file hooks from spawning, contain descendants in owned POSIX process groups or Windows Jobs, and fail closed when cleanup cannot be proven.",
+  "zh-CN": "阻止已取消的文件 Hook 启动进程，将后代进程纳入 SDK 持有的 POSIX 进程组或 Windows Job，并在无法确认清理完成时保持 fail-closed。"
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,3 +97,4 @@ jobs:
           src/session/events/__tests__/JsonlDurableEventStoreUnavailableLock.test.ts
           src/agent/subagents/__tests__/AgentSessionStore.test.ts
           src/tools/builtin/shell/__tests__/BackgroundShellManager.test.ts
+          src/hooks/__tests__/SecureProcessExecutor.test.ts

--- a/docs/en/hooks.md
+++ b/docs/en/hooks.md
@@ -94,9 +94,9 @@ after `SIGTERM`, and escalates to `SIGKILL` when needed. On Windows, the command
 is admitted to a Job Object before it can spawn descendants and cancellation
 terminates the complete Job. The Hook does not settle until the owned process
 tree has exited. Windows command hooks fail closed before spawning when the
-optional `koffi` native binding is unavailable. The runtime checks the signal
-again after each file hook, so the default `ignore` failure policy cannot resume
-an already-cancelled Request.
+`koffi` native binding is unavailable. The runtime checks the signal again after
+each file hook, so the default `ignore` failure policy cannot resume an
+already-cancelled Request.
 
 `SessionEnd` callbacks are one-shot for a runtime shutdown attempt. A failed or
 timed-out callback is not invoked again when `close()` is retried; file hooks

--- a/docs/en/hooks.md
+++ b/docs/en/hooks.md
@@ -88,6 +88,13 @@ inline hook dispatches and Session close or handoff fail closed until it
 settles. These options do not replace the independent timeout configuration
 used by file hooks.
 
+File/command hooks check the Request signal before spawning. Cancellation or a
+file-hook timeout terminates the complete process tree, waits briefly after
+`SIGTERM`, escalates to `SIGKILL` when needed, and does not settle the Hook
+until the tree has exited. The runtime checks the signal again after each file
+hook, so the default `ignore` failure policy cannot resume an already-cancelled
+Request.
+
 `SessionEnd` callbacks are one-shot for a runtime shutdown attempt. A failed or
 timed-out callback is not invoked again when `close()` is retried; file hooks
 retain their existing retry behavior.

--- a/docs/en/hooks.md
+++ b/docs/en/hooks.md
@@ -92,11 +92,12 @@ File/command hooks check the Request signal before spawning. On POSIX,
 cancellation or a file-hook timeout terminates the process group, waits briefly
 after `SIGTERM`, and escalates to `SIGKILL` when needed. On Windows, the command
 is admitted to a Job Object before it can spawn descendants and cancellation
-terminates the complete Job. The Hook does not settle until the owned process
-tree has exited. Windows command hooks fail closed before spawning when the
-`koffi` native binding is unavailable. The runtime checks the signal again after
-each file hook, so the default `ignore` failure policy cannot resume an
-already-cancelled Request.
+terminates the complete Job. The Hook does not report successful cleanup until
+the owned process tree has exited; containment failures reject instead of
+following the configured Hook failure policy. Windows command hooks also fail
+closed before spawning when the `koffi` native binding is unavailable. The
+runtime checks the signal again after each file hook, so the default `ignore`
+failure policy cannot resume an already-cancelled Request.
 
 `SessionEnd` callbacks are one-shot for a runtime shutdown attempt. A failed or
 timed-out callback is not invoked again when `close()` is retried; file hooks

--- a/docs/en/hooks.md
+++ b/docs/en/hooks.md
@@ -88,12 +88,15 @@ inline hook dispatches and Session close or handoff fail closed until it
 settles. These options do not replace the independent timeout configuration
 used by file hooks.
 
-File/command hooks check the Request signal before spawning. Cancellation or a
-file-hook timeout terminates the complete process tree, waits briefly after
-`SIGTERM`, escalates to `SIGKILL` when needed, and does not settle the Hook
-until the tree has exited. The runtime checks the signal again after each file
-hook, so the default `ignore` failure policy cannot resume an already-cancelled
-Request.
+File/command hooks check the Request signal before spawning. On POSIX,
+cancellation or a file-hook timeout terminates the process group, waits briefly
+after `SIGTERM`, and escalates to `SIGKILL` when needed. On Windows, the command
+is admitted to a Job Object before it can spawn descendants and cancellation
+terminates the complete Job. The Hook does not settle until the owned process
+tree has exited. Windows command hooks fail closed before spawning when the
+optional `koffi` native binding is unavailable. The runtime checks the signal
+again after each file hook, so the default `ignore` failure policy cannot resume
+an already-cancelled Request.
 
 `SessionEnd` callbacks are one-shot for a runtime shutdown attempt. A failed or
 timed-out callback is not invoked again when `close()` is retried; file hooks

--- a/docs/en/hooks.md
+++ b/docs/en/hooks.md
@@ -98,6 +98,9 @@ following the configured Hook failure policy. Windows command hooks also fail
 closed before spawning when the `koffi` native binding is unavailable. The
 runtime checks the signal again after each file hook, so the default `ignore`
 failure policy cannot resume an already-cancelled Request.
+If a containment failure arrives after cancellation has already won an
+asynchronous tool or permission race, the execution pipeline is quarantined:
+later tool calls and Session close or handoff remain fail-closed.
 
 On POSIX, containment follows process-group semantics. A Hook command that
 deliberately creates a new session with `setsid()` leaves the SDK-owned process

--- a/docs/en/hooks.md
+++ b/docs/en/hooks.md
@@ -99,6 +99,10 @@ closed before spawning when the `koffi` native binding is unavailable. The
 runtime checks the signal again after each file hook, so the default `ignore`
 failure policy cannot resume an already-cancelled Request.
 
+On POSIX, containment follows process-group semantics. A Hook command that
+deliberately creates a new session with `setsid()` leaves the SDK-owned process
+group and is outside this portable cleanup boundary.
+
 `SessionEnd` callbacks are one-shot for a runtime shutdown attempt. A failed or
 timed-out callback is not invoked again when `close()` is retried; file hooks
 retain their existing retry behavior.

--- a/docs/en/session.md
+++ b/docs/en/session.md
@@ -200,8 +200,8 @@ Cancellation is cooperative at the JavaScript boundary: custom providers and
 tools must honor their `AbortSignal` and release resources in `finally`;
 otherwise the Promise remains pending until that operation settles.
 Built-in file/command hooks are process-tree managed: they do not spawn after
-cancellation and they wait for `SIGTERM`/`SIGKILL` cleanup before the Request
-finishes.
+cancellation and they wait for POSIX process-group or Windows Job Object
+cleanup before the Request finishes.
 
 An external `AbortSignal` can also cancel a request:
 

--- a/docs/en/session.md
+++ b/docs/en/session.md
@@ -199,6 +199,9 @@ differs from `priority: 'now'`, which steers the same request at a safe point.
 Cancellation is cooperative at the JavaScript boundary: custom providers and
 tools must honor their `AbortSignal` and release resources in `finally`;
 otherwise the Promise remains pending until that operation settles.
+Built-in file/command hooks are process-tree managed: they do not spawn after
+cancellation and they wait for `SIGTERM`/`SIGKILL` cleanup before the Request
+finishes.
 
 An external `AbortSignal` can also cancel a request:
 

--- a/docs/en/session.md
+++ b/docs/en/session.md
@@ -199,8 +199,8 @@ differs from `priority: 'now'`, which steers the same request at a safe point.
 Cancellation is cooperative at the JavaScript boundary: custom providers and
 tools must honor their `AbortSignal` and release resources in `finally`;
 otherwise the Promise remains pending until that operation settles.
-Built-in file/command hooks are process-tree managed: they do not spawn after
-cancellation and they wait for POSIX process-group or Windows Job Object
+Built-in file/command hooks are managed through a POSIX process group or Windows
+Job Object: they do not spawn after cancellation and wait for the corresponding
 cleanup before the Request finishes.
 
 An external `AbortSignal` can also cancel a request:

--- a/docs/en/session.md
+++ b/docs/en/session.md
@@ -201,7 +201,8 @@ tools must honor their `AbortSignal` and release resources in `finally`;
 otherwise the Promise remains pending until that operation settles.
 Built-in file/command hooks are managed through a POSIX process group or Windows
 Job Object: they do not spawn after cancellation and wait for the corresponding
-cleanup before the Request finishes.
+cleanup before the Request finishes. A late containment failure quarantines the
+execution pipeline, so later tool calls and Session close or handoff fail closed.
 
 An external `AbortSignal` can also cancel a request:
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -94,6 +94,8 @@ Hook 超时时会终止进程组，先发送 `SIGTERM` 并短暂等待，必要�
 不服从普通 Hook 的失败降级策略。Windows 原生依赖 `koffi` 不可用时，命令 Hook
 也会在启动前 fail-closed。Runtime 还会在每个文件 Hook 返回后再次检查信号，因此
 默认的 `ignore` 失败策略不会让已取消的 Request 继续执行。
+如果 containment failure 在取消已赢得异步工具或权限竞态后才到达，执行管道会
+进入隔离状态；后续工具调用以及 Session close/handoff 都会继续 fail-closed。
 
 POSIX containment 以进程组为边界。若 Hook 命令主动通过 `setsid()` 创建新会话，
 该进程会离开 SDK 管理的进程组，不属于可移植清理边界。

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -87,6 +87,11 @@ callback 必须监听 signal 并释放资源；如果取消后仍未结束，后
 dispatch 以及 Session close/handoff 都会 fail-closed，直至该 callback
 settle。上述选项不替代文件 Hook 自己的独立超时配置。
 
+文件/命令 Hook 会在启动子进程前检查 Request 信号。取消或文件 Hook 超时时，
+SDK 会终止完整进程树，先发送 `SIGTERM` 并短暂等待，必要时升级为 `SIGKILL`；
+在进程树退出前 Hook 不会结算。Runtime 还会在每个文件 Hook 返回后再次检查
+信号，因此默认的 `ignore` 失败策略不会让已取消的 Request 继续执行。
+
 `SessionEnd` callback 在一次 runtime 关闭流程中只执行一次；callback 失败或
 超时后，重试 `close()` 不会再次调用它；文件 Hook 保持原有重试行为。
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -90,9 +90,10 @@ settle。上述选项不替代文件 Hook 自己的独立超时配置。
 文件/命令 Hook 会在启动子进程前检查 Request 信号。在 POSIX 上，取消或文件
 Hook 超时时会终止进程组，先发送 `SIGTERM` 并短暂等待，必要时升级为
 `SIGKILL`。在 Windows 上，命令必须在启动后代前加入 Job Object，取消时会终止
-完整 Job；原生依赖 `koffi` 不可用时，命令 Hook 会在启动前 fail-closed。
-进程树退出前 Hook 不会结算。Runtime 还会在每个文件 Hook 返回后再次检查信号，
-因此默认的 `ignore` 失败策略不会让已取消的 Request 继续执行。
+完整 Job。进程树退出前 Hook 不会报告清理成功；containment 失败会直接拒绝，
+不服从普通 Hook 的失败降级策略。Windows 原生依赖 `koffi` 不可用时，命令 Hook
+也会在启动前 fail-closed。Runtime 还会在每个文件 Hook 返回后再次检查信号，因此
+默认的 `ignore` 失败策略不会让已取消的 Request 继续执行。
 
 `SessionEnd` callback 在一次 runtime 关闭流程中只执行一次；callback 失败或
 超时后，重试 `close()` 不会再次调用它；文件 Hook 保持原有重试行为。

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -87,10 +87,12 @@ callback 必须监听 signal 并释放资源；如果取消后仍未结束，后
 dispatch 以及 Session close/handoff 都会 fail-closed，直至该 callback
 settle。上述选项不替代文件 Hook 自己的独立超时配置。
 
-文件/命令 Hook 会在启动子进程前检查 Request 信号。取消或文件 Hook 超时时，
-SDK 会终止完整进程树，先发送 `SIGTERM` 并短暂等待，必要时升级为 `SIGKILL`；
-在进程树退出前 Hook 不会结算。Runtime 还会在每个文件 Hook 返回后再次检查
-信号，因此默认的 `ignore` 失败策略不会让已取消的 Request 继续执行。
+文件/命令 Hook 会在启动子进程前检查 Request 信号。在 POSIX 上，取消或文件
+Hook 超时时会终止进程组，先发送 `SIGTERM` 并短暂等待，必要时升级为
+`SIGKILL`。在 Windows 上，命令必须在启动后代前加入 Job Object，取消时会终止
+完整 Job；可选原生依赖 `koffi` 不可用时，命令 Hook 会在启动前 fail-closed。
+进程树退出前 Hook 不会结算。Runtime 还会在每个文件 Hook 返回后再次检查信号，
+因此默认的 `ignore` 失败策略不会让已取消的 Request 继续执行。
 
 `SessionEnd` callback 在一次 runtime 关闭流程中只执行一次；callback 失败或
 超时后，重试 `close()` 不会再次调用它；文件 Hook 保持原有重试行为。

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -95,6 +95,9 @@ Hook 超时时会终止进程组，先发送 `SIGTERM` 并短暂等待，必要�
 也会在启动前 fail-closed。Runtime 还会在每个文件 Hook 返回后再次检查信号，因此
 默认的 `ignore` 失败策略不会让已取消的 Request 继续执行。
 
+POSIX containment 以进程组为边界。若 Hook 命令主动通过 `setsid()` 创建新会话，
+该进程会离开 SDK 管理的进程组，不属于可移植清理边界。
+
 `SessionEnd` callback 在一次 runtime 关闭流程中只执行一次；callback 失败或
 超时后，重试 `close()` 不会再次调用它；文件 Hook 保持原有重试行为。
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -90,7 +90,7 @@ settle。上述选项不替代文件 Hook 自己的独立超时配置。
 文件/命令 Hook 会在启动子进程前检查 Request 信号。在 POSIX 上，取消或文件
 Hook 超时时会终止进程组，先发送 `SIGTERM` 并短暂等待，必要时升级为
 `SIGKILL`。在 Windows 上，命令必须在启动后代前加入 Job Object，取消时会终止
-完整 Job；可选原生依赖 `koffi` 不可用时，命令 Hook 会在启动前 fail-closed。
+完整 Job；原生依赖 `koffi` 不可用时，命令 Hook 会在启动前 fail-closed。
 进程树退出前 Hook 不会结算。Runtime 还会在每个文件 Hook 返回后再次检查信号，
 因此默认的 `ignore` 失败策略不会让已取消的 Request 继续执行。
 

--- a/docs/session.md
+++ b/docs/session.md
@@ -1437,7 +1437,7 @@ JavaScript 边界上的取消是协作式的：自定义 provider 与工具必�
 `AbortSignal`，并在 `finally` 中释放资源；否则 Promise 会保持 pending，
 直到该操作自行结束。
 内置文件/命令 Hook 由 SDK 管理完整进程树：取消后不会再启动 Hook，并会等待
-`SIGTERM` / `SIGKILL` 清理完成后再结束 Request。
+POSIX 进程组或 Windows Job Object 清理完成后再结束 Request。
 
 ### suspendForHandoff()
 

--- a/docs/session.md
+++ b/docs/session.md
@@ -1437,7 +1437,8 @@ JavaScript 边界上的取消是协作式的：自定义 provider 与工具必�
 `AbortSignal`，并在 `finally` 中释放资源；否则 Promise 会保持 pending，
 直到该操作自行结束。
 内置文件/命令 Hook 由 SDK 管理其 POSIX 进程组或 Windows Job：取消后不会再
-启动 Hook，并会等待对应清理完成后再结束 Request。
+启动 Hook，并会等待对应清理完成后再结束 Request。晚到的 containment failure
+会隔离执行管道，使后续工具调用以及 Session close/handoff 保持 fail-closed。
 
 ### suspendForHandoff()
 

--- a/docs/session.md
+++ b/docs/session.md
@@ -1436,6 +1436,8 @@ fencing 阻止新 Request 启动。
 JavaScript 边界上的取消是协作式的：自定义 provider 与工具必须监听
 `AbortSignal`，并在 `finally` 中释放资源；否则 Promise 会保持 pending，
 直到该操作自行结束。
+内置文件/命令 Hook 由 SDK 管理完整进程树：取消后不会再启动 Hook，并会等待
+`SIGTERM` / `SIGKILL` 清理完成后再结束 Request。
 
 ### suspendForHandoff()
 

--- a/docs/session.md
+++ b/docs/session.md
@@ -1436,8 +1436,8 @@ fencing 阻止新 Request 启动。
 JavaScript 边界上的取消是协作式的：自定义 provider 与工具必须监听
 `AbortSignal`，并在 `finally` 中释放资源；否则 Promise 会保持 pending，
 直到该操作自行结束。
-内置文件/命令 Hook 由 SDK 管理完整进程树：取消后不会再启动 Hook，并会等待
-POSIX 进程组或 Windows Job Object 清理完成后再结束 Request。
+内置文件/命令 Hook 由 SDK 管理其 POSIX 进程组或 Windows Job：取消后不会再
+启动 Hook，并会等待对应清理完成后再结束 Request。
 
 ### suspendForHandoff()
 

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "@ai-sdk/deepseek": "^2.0.29",
     "@ai-sdk/google": "^3.0.64",
     "@vscode/ripgrep": "^1.17.0",
+    "koffi": "3.1.6",
     "node-pty": "1.0.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -99,7 +99,6 @@
     "@ai-sdk/deepseek": "^2.0.29",
     "@ai-sdk/google": "^3.0.64",
     "@vscode/ripgrep": "^1.17.0",
-    "koffi": "3.1.6",
     "node-pty": "1.0.0"
   },
   "dependencies": {
@@ -115,6 +114,7 @@
     "fuse.js": "^7.3.0",
     "gray-matter": "^4.0.3",
     "js-tiktoken": "^1.0.21",
+    "koffi": "3.1.6",
     "lodash-es": "^4.18.1",
     "lru-cache": "^11.3.5",
     "nanoid": "^5.1.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,6 +139,9 @@ importers:
       '@vscode/ripgrep':
         specifier: ^1.17.0
         version: 1.17.1
+      koffi:
+        specifier: 3.1.6
+        version: 3.1.6
       node-pty:
         specifier: 1.0.0
         version: 1.0.0
@@ -712,6 +715,81 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@koromix/koffi-darwin-arm64@3.1.6':
+    resolution: {integrity: sha512-8FHyXGCZN7/iQf4f7W5BRysmtdlAFvSx6FpmX4u6wmkZiX/2e9hIRdGLiZYlHGudlcA18UmXB/cMiyhJ7fJkzA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@koromix/koffi-darwin-x64@3.1.6':
+    resolution: {integrity: sha512-uzx/jqFQuSHqgg1zaRidTBTCfj8Y9M0SDTO8HeoI9s9fJhiJ1mbB9TTwJO5c2hiMnuWg2m1byczC8BaIH6cG/w==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@koromix/koffi-freebsd-arm64@3.1.6':
+    resolution: {integrity: sha512-PjpTVrsCK5YTtixOw7VsseYXJOyoY6k0qBt+bf0T9h3wyV06y73rALsorFDDEoYpLUBZO7R6EIMs6CpUrEkNTQ==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@koromix/koffi-freebsd-ia32@3.1.6':
+    resolution: {integrity: sha512-ETYwL820HtFwYoOVzgyvmFmzTHRo9DJtGYTxa5Nb7ajaa5ldCum0jbmUJ3PMECxFTLxD5Q6PYZ8Xbp101bGeSg==}
+    cpu: [ia32]
+    os: [freebsd]
+
+  '@koromix/koffi-freebsd-x64@3.1.6':
+    resolution: {integrity: sha512-BkqxkNXhAAT9toU2stvLwx1iKHPDx7h08NCICyBbjYEXkCAEr84igTkpE5V3XJ9xZZ2gKll7VvdhxorHtHUqZw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@koromix/koffi-linux-arm64@3.1.6':
+    resolution: {integrity: sha512-cM4XPm9ljbCrcPgXjzFYjDNxDUvvuR7TCYaEoo1AKjwZT/vmWhu2xN3pomfbsHh6aVn80SFA3enufQnaETW1rQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@koromix/koffi-linux-ia32@3.1.6':
+    resolution: {integrity: sha512-l1SVTpO10iaQt8slbowJpzK4fbwQZ7ufj9tmCyAcIwWUpyAbPS83mJMctU72If6N9/gCS2wuRqwnYB2uPLLhLg==}
+    cpu: [ia32]
+    os: [linux]
+
+  '@koromix/koffi-linux-loong64@3.1.6':
+    resolution: {integrity: sha512-KpTJpMSbIdCVFU26ynt0xy4x15h+y6AwPJxj2+iVxJhCzJf4oisCPc0YH2VnutuLV2nVzSrFm7sL/WSOqPgkXw==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@koromix/koffi-linux-riscv64@3.1.6':
+    resolution: {integrity: sha512-YdFNpsywnXiYOYQlDAatf7TJLnspbGXdmfwIZhf82kbKSflYUsq4tI6NmoUOzM89oIWDGpYqd4Hz3xL7tsyXsw==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@koromix/koffi-linux-x64@3.1.6':
+    resolution: {integrity: sha512-Xx5mpr9VcaMCXfvbqIiLIWIL9Iuu6F4r3iMXg7+zZCqYUFZPFwJgiDQBLxctHv2OYgIfAoaaHMW0GC1cJkHfbA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@koromix/koffi-openbsd-ia32@3.1.6':
+    resolution: {integrity: sha512-39Np4QTxhTlTT6RRveIeP+TnbzrwuDJ0UMyHxEZ+oGtzmb9GqWhl9T1oyehG6v/O+c4BffafG2NwLkCZ7tDKWw==}
+    cpu: [ia32]
+    os: [openbsd]
+
+  '@koromix/koffi-openbsd-x64@3.1.6':
+    resolution: {integrity: sha512-3EynGn3ycQRqaMWGmUJ0tdtuQdStByqSy/tJ0ZGKWizbMGdFAE73YpgLsyd8BDvwnKWytVG/OLNb5nDHpfd9Dg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@koromix/koffi-win32-arm64@3.1.6':
+    resolution: {integrity: sha512-27FdPPRtT4xbO9bsd2OZa95M5YQ7bcJ8QjCRO57UUMI21REfkDegjqKwqo/CFlugxXlJf5IYtG2rq4BEYIrvxg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@koromix/koffi-win32-ia32@3.1.6':
+    resolution: {integrity: sha512-5mVelLKVDup4eoxZOpCzCyMPxoctsg+Qe4J9O5BP4KbBEdqoOEqaNEBBRgNzXcdr2g+GGfmIUo+oVR1NvIdiJw==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@koromix/koffi-win32-x64@3.1.6':
+    resolution: {integrity: sha512-lPKjAaHz0aoiZXT/wDVqH+joR5y3lCZj1s9Bk5qx/DGRq+0MK8Ib8VoqiBOrJ69NG5AsJSvn0tQDcSqfRgLmBQ==}
+    cpu: [x64]
+    os: [win32]
 
   '@modelcontextprotocol/sdk@1.30.0':
     resolution: {integrity: sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==}
@@ -2168,6 +2246,9 @@ packages:
   kind-of@6.0.3:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
     engines: {node: '>=0.10.0'}
+
+  koffi@3.1.6:
+    resolution: {integrity: sha512-ln60chEb3o7Du1ayjwl6BFiNN1wZK+3cTM2wWGiHLEzCY/FdTIN1ER5VWDwHq7J/j4tSnnrHaH5ABS1EO6+6ag==}
 
   lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
@@ -3879,6 +3960,51 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@koromix/koffi-darwin-arm64@3.1.6':
+    optional: true
+
+  '@koromix/koffi-darwin-x64@3.1.6':
+    optional: true
+
+  '@koromix/koffi-freebsd-arm64@3.1.6':
+    optional: true
+
+  '@koromix/koffi-freebsd-ia32@3.1.6':
+    optional: true
+
+  '@koromix/koffi-freebsd-x64@3.1.6':
+    optional: true
+
+  '@koromix/koffi-linux-arm64@3.1.6':
+    optional: true
+
+  '@koromix/koffi-linux-ia32@3.1.6':
+    optional: true
+
+  '@koromix/koffi-linux-loong64@3.1.6':
+    optional: true
+
+  '@koromix/koffi-linux-riscv64@3.1.6':
+    optional: true
+
+  '@koromix/koffi-linux-x64@3.1.6':
+    optional: true
+
+  '@koromix/koffi-openbsd-ia32@3.1.6':
+    optional: true
+
+  '@koromix/koffi-openbsd-x64@3.1.6':
+    optional: true
+
+  '@koromix/koffi-win32-arm64@3.1.6':
+    optional: true
+
+  '@koromix/koffi-win32-ia32@3.1.6':
+    optional: true
+
+  '@koromix/koffi-win32-x64@3.1.6':
+    optional: true
+
   '@modelcontextprotocol/sdk@1.30.0(zod@3.25.76)':
     dependencies:
       '@hono/node-server': 2.1.1(hono@4.13.3)
@@ -5420,6 +5546,25 @@ snapshots:
       graceful-fs: 4.2.11
 
   kind-of@6.0.3: {}
+
+  koffi@3.1.6:
+    optionalDependencies:
+      '@koromix/koffi-darwin-arm64': 3.1.6
+      '@koromix/koffi-darwin-x64': 3.1.6
+      '@koromix/koffi-freebsd-arm64': 3.1.6
+      '@koromix/koffi-freebsd-ia32': 3.1.6
+      '@koromix/koffi-freebsd-x64': 3.1.6
+      '@koromix/koffi-linux-arm64': 3.1.6
+      '@koromix/koffi-linux-ia32': 3.1.6
+      '@koromix/koffi-linux-loong64': 3.1.6
+      '@koromix/koffi-linux-riscv64': 3.1.6
+      '@koromix/koffi-linux-x64': 3.1.6
+      '@koromix/koffi-openbsd-ia32': 3.1.6
+      '@koromix/koffi-openbsd-x64': 3.1.6
+      '@koromix/koffi-win32-arm64': 3.1.6
+      '@koromix/koffi-win32-ia32': 3.1.6
+      '@koromix/koffi-win32-x64': 3.1.6
+    optional: true
 
   lilconfig@3.1.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       js-tiktoken:
         specifier: ^1.0.21
         version: 1.0.21
+      koffi:
+        specifier: 3.1.6
+        version: 3.1.6
       lodash-es:
         specifier: ^4.18.1
         version: 4.18.1
@@ -139,9 +142,6 @@ importers:
       '@vscode/ripgrep':
         specifier: ^1.17.0
         version: 1.17.1
-      koffi:
-        specifier: 3.1.6
-        version: 3.1.6
       node-pty:
         specifier: 1.0.0
         version: 1.0.0
@@ -5564,8 +5564,6 @@ snapshots:
       '@koromix/koffi-win32-arm64': 3.1.6
       '@koromix/koffi-win32-ia32': 3.1.6
       '@koromix/koffi-win32-x64': 3.1.6
-    optional: true
-
   lilconfig@3.1.3: {}
 
   lines-and-columns@1.2.4: {}

--- a/src/agent/AgentLoop.ts
+++ b/src/agent/AgentLoop.ts
@@ -6,6 +6,7 @@
  * 3. 使用 AsyncGenerator<AgentEvent, LoopResult> 统一输出
  */
 
+import { isHookProcessContainmentError } from '../hooks/WindowsProcessJob.js';
 import type { InternalLogger } from '../logging/Logger.js';
 import type { ChatResponse, Message, ToolCall } from '../services/ChatServiceInterface.js';
 import { FallbackTriggeredError } from '../services/RetryPolicy.js';
@@ -291,6 +292,9 @@ export async function* agentLoop(
       streamingExecutionResults = turnOutcome.streamingExecutionResults;
       modelAttemptId = turnOutcome.modelAttemptId;
     } catch (llmError) {
+      if (isHookProcessContainmentError(llmError)) {
+        throw llmError;
+      }
       const interruptInputId = getSteeringInterruptInputId(stepSignal);
       if (!signal?.aborted && interruptInputId && runControl) {
         yield {

--- a/src/agent/CompactionHandler.ts
+++ b/src/agent/CompactionHandler.ts
@@ -2,6 +2,7 @@ import { CompactionService } from '../context/CompactionService.js';
 import type { ContextManager } from '../context/ContextManager.js';
 import { softCompact } from '../context/strategies/SoftCompactionStrategy.js';
 import { TokenCounter } from '../context/TokenCounter.js';
+import type { HookRuntime } from '../hooks/HookRuntime.js';
 import { isHookProcessContainmentError } from '../hooks/WindowsProcessJob.js';
 import { type InternalLogger, LogCategory, NOOP_LOGGER } from '../logging/Logger.js';
 import type { IChatService } from '../services/ChatServiceInterface.js';
@@ -20,6 +21,7 @@ export interface CompactionRuntimeContext {
   signal?: AbortSignal;
   assertExecutionLease?: () => Promise<void>;
   runWithExecutionLease?: <T>(operation: () => Promise<T>) => Promise<T>;
+  hookRuntime?: HookRuntime;
 }
 
 export class CompactionHandler {
@@ -129,6 +131,7 @@ export class CompactionHandler {
           projectDir: runtimeCtx.projectDir,
           signal: runtimeCtx.signal,
           assertExecutionLease: runtimeCtx.assertExecutionLease,
+          hookRuntime: runtimeCtx.hookRuntime,
         });
         runtimeCtx.signal?.throwIfAborted();
         await runtimeCtx.assertExecutionLease?.();
@@ -271,6 +274,7 @@ export class CompactionHandler {
         projectDir: runtimeCtx.projectDir,
         signal: runtimeCtx.signal,
         assertExecutionLease: runtimeCtx.assertExecutionLease,
+        hookRuntime: runtimeCtx.hookRuntime,
       });
       runtimeCtx.signal?.throwIfAborted();
       await runtimeCtx.assertExecutionLease?.();

--- a/src/agent/CompactionHandler.ts
+++ b/src/agent/CompactionHandler.ts
@@ -2,6 +2,7 @@ import { CompactionService } from '../context/CompactionService.js';
 import type { ContextManager } from '../context/ContextManager.js';
 import { softCompact } from '../context/strategies/SoftCompactionStrategy.js';
 import { TokenCounter } from '../context/TokenCounter.js';
+import { isHookProcessContainmentError } from '../hooks/WindowsProcessJob.js';
 import { type InternalLogger, LogCategory, NOOP_LOGGER } from '../logging/Logger.js';
 import type { IChatService } from '../services/ChatServiceInterface.js';
 import { cloneMessage } from '../services/messageUtils.js';
@@ -169,6 +170,7 @@ export class CompactionHandler {
           if (
             runtimeCtx.signal?.aborted ||
             isExecutionLeaseFailure(saveError)
+            || isHookProcessContainmentError(saveError)
           ) {
             throw saveError;
           }
@@ -182,6 +184,7 @@ export class CompactionHandler {
         if (
           runtimeCtx.signal?.aborted ||
           isExecutionLeaseFailure(error)
+          || isHookProcessContainmentError(error)
         ) {
           throw error;
         }
@@ -297,6 +300,7 @@ export class CompactionHandler {
         if (
           runtimeCtx.signal?.aborted ||
           isExecutionLeaseFailure(saveError)
+          || isHookProcessContainmentError(saveError)
         ) {
           throw saveError;
         }
@@ -309,6 +313,7 @@ export class CompactionHandler {
       if (
         runtimeCtx.signal?.aborted ||
         isExecutionLeaseFailure(error)
+        || isHookProcessContainmentError(error)
       ) {
         throw error;
       }

--- a/src/agent/LoopHookBuilder.ts
+++ b/src/agent/LoopHookBuilder.ts
@@ -10,6 +10,7 @@ import { CompactionService } from '../context/CompactionService.js';
 import type { ContextManager } from '../context/ContextManager.js';
 import { SdkError } from '../errors/SdkError.js';
 import type { HookRuntime } from '../hooks/HookRuntime.js';
+import { isHookProcessContainmentError } from '../hooks/WindowsProcessJob.js';
 import type { InternalLogger } from '../logging/Logger.js';
 import type { Message } from '../services/ChatServiceInterface.js';
 import {
@@ -440,7 +441,10 @@ export function buildLoopConfig(deps: LoopHookBuilderDeps): AgentLoopConfig {
           };
         } catch (error) {
           requestSignal?.throwIfAborted();
-          if (isExecutionLeaseFailure(error)) {
+          if (
+            isExecutionLeaseFailure(error)
+            || isHookProcessContainmentError(error)
+          ) {
             throw error;
           }
           return { shouldStop: true };

--- a/src/agent/LoopHookBuilder.ts
+++ b/src/agent/LoopHookBuilder.ts
@@ -167,6 +167,7 @@ export function buildLoopConfig(deps: LoopHookBuilderDeps): AgentLoopConfig {
           signal: requestSignal,
           assertExecutionLease: context.assertExecutionLease,
           runWithExecutionLease: context.runWithExecutionLease,
+          hookRuntime,
         };
         const compactionStream = compactionHandler.checkAndCompactInLoop(
           loopState.conversationState, runtimeCtx, ctx.turn, ctx.lastPromptTokens,
@@ -193,6 +194,7 @@ export function buildLoopConfig(deps: LoopHookBuilderDeps): AgentLoopConfig {
               projectDir: context.snapshot?.cwd ?? defaultProjectPath,
               signal: requestSignal,
               assertExecutionLease: context.assertExecutionLease,
+              hookRuntime,
             },
           );
           requestSignal?.throwIfAborted();
@@ -417,6 +419,7 @@ export function buildLoopConfig(deps: LoopHookBuilderDeps): AgentLoopConfig {
               signal: requestSignal,
               assertExecutionLease: context.assertExecutionLease,
               runWithExecutionLease: context.runWithExecutionLease,
+              hookRuntime,
             };
             const compactStream = compactionHandler?.reactiveCompact(loopState.conversationState, runtimeCtx);
             if (!compactStream) return false;

--- a/src/agent/LoopHookBuilder.ts
+++ b/src/agent/LoopHookBuilder.ts
@@ -231,6 +231,7 @@ export function buildLoopConfig(deps: LoopHookBuilderDeps): AgentLoopConfig {
           if (
             context.signal?.aborted
             || isExecutionLeaseFailure(compactError)
+            || isHookProcessContainmentError(compactError)
           ) {
             throw compactError;
           }

--- a/src/agent/LoopHookBuilder.ts
+++ b/src/agent/LoopHookBuilder.ts
@@ -117,13 +117,13 @@ export function buildLoopConfig(deps: LoopHookBuilderDeps): AgentLoopConfig {
         }
         const hookContent = hookRuntime
           ? await hookRuntime.applyUserPromptSubmit(input.content, {
-              abortSignal: context.signal,
+              abortSignal: requestSignal,
             })
           : input.content;
         const content = options?.prepareInput
           ? await options.prepareInput(hookContent)
           : hookContent;
-        context.signal?.throwIfAborted();
+        requestSignal?.throwIfAborted();
         await context.assertExecutionLease?.();
         const messageId = await persistToJsonl(
           modelManager,
@@ -139,7 +139,7 @@ export function buildLoopConfig(deps: LoopHookBuilderDeps): AgentLoopConfig {
               context.subagentInfo,
             ),
           context.assertExecutionLease,
-          context.signal,
+          requestSignal,
           context.runWithExecutionLease,
         );
         if (messageId) {
@@ -164,7 +164,7 @@ export function buildLoopConfig(deps: LoopHookBuilderDeps): AgentLoopConfig {
         const runtimeCtx: CompactionRuntimeContext = {
           sessionId: context.sessionId,
           projectDir: context.snapshot?.cwd ?? defaultProjectPath,
-          signal: context.signal,
+          signal: requestSignal,
           assertExecutionLease: context.assertExecutionLease,
           runWithExecutionLease: context.runWithExecutionLease,
         };
@@ -191,11 +191,11 @@ export function buildLoopConfig(deps: LoopHookBuilderDeps): AgentLoopConfig {
               baseURL: cs.baseUrl,
               customHeaders: cs.customHeaders,
               projectDir: context.snapshot?.cwd ?? defaultProjectPath,
-              signal: context.signal,
+              signal: requestSignal,
               assertExecutionLease: context.assertExecutionLease,
             },
           );
-          context.signal?.throwIfAborted();
+          requestSignal?.throwIfAborted();
           await context.assertExecutionLease?.();
           const continueMessage: Message = {
             role: 'user',
@@ -218,7 +218,7 @@ export function buildLoopConfig(deps: LoopHookBuilderDeps): AgentLoopConfig {
               );
             },
             context.assertExecutionLease,
-            context.signal,
+            requestSignal,
             context.runWithExecutionLease,
           );
 
@@ -229,7 +229,7 @@ export function buildLoopConfig(deps: LoopHookBuilderDeps): AgentLoopConfig {
           };
         } catch (compactError) {
           if (
-            context.signal?.aborted
+            requestSignal?.aborted
             || isExecutionLeaseFailure(compactError)
             || isHookProcessContainmentError(compactError)
           ) {
@@ -284,7 +284,7 @@ export function buildLoopConfig(deps: LoopHookBuilderDeps): AgentLoopConfig {
             setLastUuid(uuid);
           },
           context.assertExecutionLease,
-          context.signal,
+          requestSignal,
           context.runWithExecutionLease,
         );
 
@@ -322,7 +322,7 @@ export function buildLoopConfig(deps: LoopHookBuilderDeps): AgentLoopConfig {
               }
             },
             context.assertExecutionLease,
-            context.signal,
+            requestSignal,
             context.runWithExecutionLease,
           );
         }
@@ -401,7 +401,7 @@ export function buildLoopConfig(deps: LoopHookBuilderDeps): AgentLoopConfig {
             }
           },
           context.assertExecutionLease,
-          context.signal,
+          requestSignal,
           context.runWithExecutionLease,
         );
       },
@@ -414,7 +414,7 @@ export function buildLoopConfig(deps: LoopHookBuilderDeps): AgentLoopConfig {
             const runtimeCtx: CompactionRuntimeContext = {
               sessionId: context.sessionId,
               projectDir: context.snapshot?.cwd ?? defaultProjectPath,
-              signal: context.signal,
+              signal: requestSignal,
               assertExecutionLease: context.assertExecutionLease,
               runWithExecutionLease: context.runWithExecutionLease,
             };

--- a/src/agent/LoopHookBuilder.ts
+++ b/src/agent/LoopHookBuilder.ts
@@ -441,13 +441,13 @@ export function buildLoopConfig(deps: LoopHookBuilderDeps): AgentLoopConfig {
             warning: stopResult.warning,
           };
         } catch (error) {
-          requestSignal?.throwIfAborted();
           if (
             isExecutionLeaseFailure(error)
             || isHookProcessContainmentError(error)
           ) {
             throw error;
           }
+          requestSignal?.throwIfAborted();
           return { shouldStop: true };
         }
       },

--- a/src/agent/LoopHookBuilder.ts
+++ b/src/agent/LoopHookBuilder.ts
@@ -100,6 +100,7 @@ export function buildLoopConfig(deps: LoopHookBuilderDeps): AgentLoopConfig {
   let pendingInjectedMessages: Message[] = [];
   let currentAssistantMessageId: string | null = null;
   const inputApplicationLifecycle = options?.inputApplicationLifecycle;
+  const requestSignal = options?.signal ?? context.signal;
 
   const hooks: AgentLoopHooks = {
     input: {
@@ -430,14 +431,18 @@ export function buildLoopConfig(deps: LoopHookBuilderDeps): AgentLoopConfig {
           }
           const stopResult = await hookRuntime.executeStopCheck({
             reason: ctx.content,
-            abortSignal: options?.signal,
+            abortSignal: requestSignal,
           });
           return {
             shouldStop: stopResult.shouldStop,
             continueReason: stopResult.continueReason,
             warning: stopResult.warning,
           };
-        } catch {
+        } catch (error) {
+          requestSignal?.throwIfAborted();
+          if (isExecutionLeaseFailure(error)) {
+            throw error;
+          }
           return { shouldStop: true };
         }
       },
@@ -452,7 +457,7 @@ export function buildLoopConfig(deps: LoopHookBuilderDeps): AgentLoopConfig {
     conversationState: loopState.conversationState,
     maxTurns,
     isYoloMode,
-    signal: options?.signal,
+    signal: requestSignal,
     tokenBudget,
     modelExecutionLifecycle: options?.modelExecutionLifecycle,
     initialInputPreparation: options?.initialInputPreparation,

--- a/src/agent/LoopRunner.ts
+++ b/src/agent/LoopRunner.ts
@@ -11,6 +11,7 @@
  */
 
 import type { HookRuntime } from '../hooks/HookRuntime.js';
+import { isHookProcessContainmentError } from '../hooks/WindowsProcessJob.js';
 import { type InternalLogger, LogCategory, NOOP_LOGGER } from '../logging/Logger.js';
 import { buildSystemPrompt } from '../prompts/index.js';
 import type { Message } from '../services/ChatServiceInterface.js';
@@ -261,7 +262,10 @@ export class LoopRunner {
       syncContextMessages(context, loopState.conversationState);
       return result;
     } catch (error) {
-      if (isExecutionLeaseFailure(error)) {
+      if (
+        isExecutionLeaseFailure(error)
+        || isHookProcessContainmentError(error)
+      ) {
         throw error;
       }
       if (isExecutionLeaseFailure(context.signal?.reason)) {

--- a/src/agent/LoopRunner.ts
+++ b/src/agent/LoopRunner.ts
@@ -132,18 +132,14 @@ export class LoopRunner {
     systemPrompt?: string,
   ): AsyncGenerator<AgentEvent, LoopResult> {
     const requestSignal = options?.signal ?? context.signal;
-    if (requestSignal?.aborted) {
-      if (
+    if (
+      requestSignal?.aborted
+      && (
         isExecutionLeaseFailure(requestSignal.reason)
         || isHookProcessContainmentError(requestSignal.reason)
-      ) {
-        throw requestSignal.reason;
-      }
-      return {
-        success: false,
-        error: { type: 'aborted', message: '任务已被用户中止' },
-        metadata: { turnsCount: 0, toolCallsCount: 0, duration: 0 },
-      };
+      )
+    ) {
+      throw requestSignal.reason;
     }
 
     // 1. 构建消息历史 — 入口归一化 + ConversationState 构造
@@ -186,7 +182,12 @@ export class LoopRunner {
     // 2. 保存用户消息到 JSONL
     let lastMessageUuid: string | null = null;
     const contextMgr = this.modelManager.getContextManager();
-    if (contextMgr && context.sessionId && options?.inputApplication) {
+    if (
+      !requestSignal?.aborted
+      && contextMgr
+      && context.sessionId
+      && options?.inputApplication
+    ) {
       const sessionId = context.sessionId;
       const inputApplication = options.inputApplication;
       try {
@@ -212,7 +213,7 @@ export class LoopRunner {
         // 与其他消息写入保持一致的 best-effort 策略：持久化失败不应中断请求。
         this.logger.warn('[LoopRunner] 保存已应用输入消息失败:', error);
       }
-    } else {
+    } else if (!requestSignal?.aborted) {
       try {
         if (contextMgr && context.sessionId && hasPersistableUserContent(message)) {
           const sessionId = context.sessionId;

--- a/src/agent/LoopRunner.ts
+++ b/src/agent/LoopRunner.ts
@@ -131,6 +131,21 @@ export class LoopRunner {
     options?: LoopOptions,
     systemPrompt?: string,
   ): AsyncGenerator<AgentEvent, LoopResult> {
+    const requestSignal = options?.signal ?? context.signal;
+    if (requestSignal?.aborted) {
+      if (
+        isExecutionLeaseFailure(requestSignal.reason)
+        || isHookProcessContainmentError(requestSignal.reason)
+      ) {
+        throw requestSignal.reason;
+      }
+      return {
+        success: false,
+        error: { type: 'aborted', message: '任务已被用户中止' },
+        metadata: { turnsCount: 0, toolCallsCount: 0, duration: 0 },
+      };
+    }
+
     // 1. 构建消息历史 — 入口归一化 + ConversationState 构造
     const rootPromptMessage: Message | null = systemPrompt
       ? {
@@ -176,7 +191,11 @@ export class LoopRunner {
       const inputApplication = options.inputApplication;
       try {
         lastMessageUuid = await runWithExecutionLeaseBoundary(
-          context,
+          {
+            signal: requestSignal,
+            assertExecutionLease: context.assertExecutionLease,
+            runWithExecutionLease: context.runWithExecutionLease,
+          },
           () => contextMgr.saveAppliedInputMessage(
             sessionId,
             inputApplication.inputId,
@@ -187,7 +206,7 @@ export class LoopRunner {
           ),
         );
       } catch (error) {
-        if (context.signal?.aborted || isExecutionLeaseFailure(error)) {
+        if (requestSignal?.aborted || isExecutionLeaseFailure(error)) {
           throw error;
         }
         // 与其他消息写入保持一致的 best-effort 策略：持久化失败不应中断请求。
@@ -198,7 +217,11 @@ export class LoopRunner {
         if (contextMgr && context.sessionId && hasPersistableUserContent(message)) {
           const sessionId = context.sessionId;
           lastMessageUuid = await runWithExecutionLeaseBoundary(
-            context,
+            {
+              signal: requestSignal,
+              assertExecutionLease: context.assertExecutionLease,
+              runWithExecutionLease: context.runWithExecutionLease,
+            },
             () => contextMgr.saveMessage(
               sessionId,
               'user',
@@ -210,7 +233,7 @@ export class LoopRunner {
           );
         }
       } catch (error) {
-        if (context.signal?.aborted || isExecutionLeaseFailure(error)) {
+        if (requestSignal?.aborted || isExecutionLeaseFailure(error)) {
           throw error;
         }
         this.logger.warn('[LoopRunner] 保存用户消息失败:', error);
@@ -268,8 +291,8 @@ export class LoopRunner {
       ) {
         throw error;
       }
-      if (isExecutionLeaseFailure(context.signal?.reason)) {
-        throw context.signal.reason;
+      if (isExecutionLeaseFailure(requestSignal?.reason)) {
+        throw requestSignal.reason;
       }
       if (error instanceof Error &&
         (error.name === 'AbortError' || error.message.includes('aborted'))) {

--- a/src/agent/StreamingToolExecutor.ts
+++ b/src/agent/StreamingToolExecutor.ts
@@ -1,4 +1,5 @@
 import type { JSONSchema7 } from 'json-schema';
+import { isHookProcessContainmentError } from '../hooks/WindowsProcessJob.js';
 import { type InternalLogger, LogCategory, NOOP_LOGGER } from '../logging/Logger.js';
 import type {
     ChatResponse,
@@ -235,8 +236,12 @@ export class StreamingToolExecutor {
         ),
       };
     } catch (error) {
-      if (isSteeringInterruptSignal(signal)) {
+      if (isHookProcessContainmentError(error)) {
         await Promise.allSettled(Array.from(inFlightExecutions.values()));
+        throw error;
+      }
+      if (isSteeringInterruptSignal(signal)) {
+        await this.settleInFlightExecutions(inFlightExecutions.values());
         await this.completeInterruptedToolCalls(
           toolCallAccumulator,
           executionResults,
@@ -262,11 +267,25 @@ export class StreamingToolExecutor {
       }
 
       if (hasDispatchedTools) {
-        await Promise.allSettled(Array.from(inFlightExecutions.values()));
+        await this.settleInFlightExecutions(inFlightExecutions.values());
         this.logger.warn('[Agent] 流式响应在工具派发后失败，已等待在途工具完成并继续抛出原始错误');
       }
 
       throw error;
+    }
+  }
+
+  private async settleInFlightExecutions(
+    executions: Iterable<Promise<void>>,
+  ): Promise<void> {
+    const settled = await Promise.allSettled(Array.from(executions));
+    const containmentFailure = settled.find(
+      (result): result is PromiseRejectedResult =>
+        result.status === 'rejected'
+        && isHookProcessContainmentError(result.reason),
+    );
+    if (containmentFailure) {
+      throw containmentFailure.reason;
     }
   }
 
@@ -460,6 +479,10 @@ export class StreamingToolExecutor {
         executionResults: input.executionResults,
         epoch: input.epoch,
       });
+      // The stream loop may not await this promise until a later chunk. Mark
+      // rejection as observed now; the original promise remains rejected and
+      // is inspected by the synchronization paths.
+      void execution.catch(() => {});
       input.inFlightExecutions.set(index, execution);
       if (input.serial) {
         await execution;

--- a/src/agent/__tests__/AgentLoop.test.ts
+++ b/src/agent/__tests__/AgentLoop.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, type Mock, vi } from 'vitest';
+import { HookProcessContainmentError } from '../../hooks/WindowsProcessJob.js';
 import type { Message } from '../../services/ChatServiceInterface.js';
 import { CannotRetryError } from '../../services/RetryPolicy.js';
 import { ActiveRequestController } from '../../session/ActiveRequestController.js';
@@ -1768,6 +1769,68 @@ describe('agentLoop', () => {
       );
       expect(onModelRequestStarting).toHaveBeenCalledTimes(2);
       expect(modelSettlements).toEqual(['aborted:steering', 'completed']);
+    });
+
+    it('does not downgrade a containment failure during a steering interrupt', async () => {
+      let resolveStarted!: () => void;
+      const started = new Promise<void>((resolve) => {
+        resolveStarted = resolve;
+      });
+      const containmentError = new HookProcessContainmentError(
+        'Hook process cleanup failed',
+      );
+      const chat = vi.fn(async (
+        _messages: readonly Message[],
+        _tools: unknown,
+        signal?: AbortSignal,
+      ) => {
+        resolveStarted();
+        return await new Promise<never>((_resolve, reject) => {
+          signal?.addEventListener(
+            'abort',
+            () => reject(containmentError),
+            { once: true },
+          );
+        });
+      });
+      const chatService = {
+        chat,
+        getConfig: () => ({
+          model: 'test-model',
+          maxContextTokens: 128000,
+        }),
+      } as unknown as TurnState['chatService'];
+      const inbox = new SessionInputInbox();
+      const requestId = RequestId('request-containment-steering');
+      const runControl = new ActiveRequestController(
+        requestId,
+        undefined,
+        inbox,
+        InputId('initial-input'),
+      );
+      const onInputApply = vi.fn(async ({ input }) => ({
+        role: 'user' as const,
+        content: input.content,
+      }));
+      const execution = collectEvents(agentLoop(baseConfig({
+        runControl,
+        turnState: { chatService },
+        onInputApply,
+      })));
+      const rejection = expect(execution).rejects.toBe(containmentError);
+
+      await started;
+      inbox.enqueue({
+        inputId: InputId('steer-now'),
+        content: 'Change direction',
+        priority: 'now',
+        targetRequestId: requestId,
+        acceptedAt: 1,
+      });
+      runControl.interruptStep(InputId('steer-now'));
+
+      await rejection;
+      expect(onInputApply).not.toHaveBeenCalled();
     });
 
     it('closes interrupted tool calls before applying now-priority input', async () => {

--- a/src/agent/__tests__/AgentLoop.test.ts
+++ b/src/agent/__tests__/AgentLoop.test.ts
@@ -1771,7 +1771,7 @@ describe('agentLoop', () => {
       expect(modelSettlements).toEqual(['aborted:steering', 'completed']);
     });
 
-    it('does not downgrade a containment failure during a steering interrupt', async () => {
+    it('does not downgrade an aggregated containment failure during a steering interrupt', async () => {
       let resolveStarted!: () => void;
       const started = new Promise<void>((resolve) => {
         resolveStarted = resolve;
@@ -1779,6 +1779,7 @@ describe('agentLoop', () => {
       const containmentError = new HookProcessContainmentError(
         'Hook process cleanup failed',
       );
+      const settlementError = new Error('durable settlement failed');
       const chat = vi.fn(async (
         _messages: readonly Message[],
         _tools: unknown,
@@ -1815,9 +1816,18 @@ describe('agentLoop', () => {
       const execution = collectEvents(agentLoop(baseConfig({
         runControl,
         turnState: { chatService },
+        modelExecutionLifecycle: {
+          onModelRequestStarting: async () => ({
+            onCompleted: async () => {},
+            onFailed: async () => {},
+            onAborted: async () => {
+              throw settlementError;
+            },
+          }),
+        },
         onInputApply,
       })));
-      const rejection = expect(execution).rejects.toBe(containmentError);
+      const failure = execution.catch((error: unknown) => error);
 
       await started;
       inbox.enqueue({
@@ -1829,7 +1839,12 @@ describe('agentLoop', () => {
       });
       runControl.interruptStep(InputId('steer-now'));
 
-      await rejection;
+      const error = await failure;
+      expect(error).toBeInstanceOf(AggregateError);
+      expect((error as AggregateError).errors).toEqual([
+        containmentError,
+        settlementError,
+      ]);
       expect(onInputApply).not.toHaveBeenCalled();
     });
 

--- a/src/agent/__tests__/CompactionHandler.test.ts
+++ b/src/agent/__tests__/CompactionHandler.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { HookProcessContainmentError } from '../../hooks/WindowsProcessJob.js';
 import type { Message } from '../../services/ChatServiceInterface.js';
 import { DurableExecutionLeaseError } from '../../session/events/DurableExecutionLeaseStore.js';
 import { SessionId } from '../../types/branded.js';
@@ -171,6 +172,74 @@ describe('CompactionHandler', () => {
     await expect(stream.next()).rejects.toBe(leaseLost);
     expect(mockCompact).toHaveBeenCalledOnce();
     expect(convState.getContextMessages()).toEqual(originalMessages);
+  });
+
+  it('propagates process-containment failures from automatic compaction hooks', async () => {
+    const containmentError = new HookProcessContainmentError(
+      'Windows Job Object support is unavailable',
+    );
+    mockCompact.mockRejectedValueOnce(containmentError);
+    const handler = new CompactionHandler(
+      () => ({
+        getConfig: () => ({
+          model: 'gpt-4o-mini',
+          provider: 'openai-compatible' as const,
+          maxContextTokens: 1000,
+          maxOutputTokens: 200,
+        }),
+      }) as never,
+      () => undefined,
+    );
+    const convState = new ConversationState(
+      null,
+      [{ role: 'user', content: 'context that requires compaction' }],
+      { role: 'assistant', content: 'continue' },
+    );
+    const stream = handler.checkAndCompactInLoop(
+      convState,
+      { sessionId: SessionId('containment-compaction-session') },
+      2,
+      700,
+    );
+
+    await expect(stream.next()).resolves.toMatchObject({
+      value: { type: 'compacting', isCompacting: true },
+      done: false,
+    });
+    await expect(stream.next()).rejects.toBe(containmentError);
+  });
+
+  it('propagates process-containment failures from reactive compaction hooks', async () => {
+    const containmentError = new HookProcessContainmentError(
+      'Windows Job Object support is unavailable',
+    );
+    mockCompact.mockRejectedValueOnce(containmentError);
+    const handler = new CompactionHandler(
+      () => ({
+        getConfig: () => ({
+          model: 'gpt-4o-mini',
+          provider: 'openai-compatible' as const,
+          maxContextTokens: 1000,
+          maxOutputTokens: 200,
+        }),
+      }) as never,
+      () => undefined,
+    );
+    const convState = new ConversationState(
+      null,
+      [{ role: 'user', content: 'context that requires compaction' }],
+      { role: 'assistant', content: 'continue' },
+    );
+    const stream = handler.reactiveCompact(
+      convState,
+      { sessionId: SessionId('containment-reactive-compaction-session') },
+    );
+
+    await expect(stream.next()).resolves.toMatchObject({
+      value: { type: 'compacting', isCompacting: true },
+      done: false,
+    });
+    await expect(stream.next()).rejects.toBe(containmentError);
   });
 
   it('falls back from the original messages when reactive compaction fails after microcompact', async () => {

--- a/src/agent/__tests__/LoopHookBuilder.test.ts
+++ b/src/agent/__tests__/LoopHookBuilder.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { HookRuntime } from '../../hooks/HookRuntime.js';
+import { DurableExecutionLeaseError } from '../../session/events/DurableExecutionLeaseStore.js';
+import { SessionId } from '../../types/branded.js';
+import { buildLoopConfig } from '../LoopHookBuilder.js';
+
+function createStopCheck(
+  executeStopCheck: HookRuntime['executeStopCheck'],
+  signal?: AbortSignal,
+) {
+  const config = buildLoopConfig({
+    context: {
+      messages: [],
+      userId: 'test-user',
+      sessionId: SessionId('loop-hook-builder-test'),
+      signal,
+    },
+    options: { signal },
+    loopState: { conversationState: {} } as never,
+    maxTurns: 1,
+    isYoloMode: false,
+    getLastUuid: () => null,
+    setLastUuid: () => {},
+    executionPipeline: {} as never,
+    logger: {} as never,
+    hookRuntime: { executeStopCheck } as HookRuntime,
+    modelManager: {} as never,
+    runtimePatchManager: {} as never,
+  });
+  const stopCheck = config.hooks?.stop?.check;
+  if (!stopCheck) {
+    throw new Error('Stop check was not configured');
+  }
+  return stopCheck;
+}
+
+describe('LoopHookBuilder stop hook', () => {
+  it('propagates request cancellation from a running Stop hook', async () => {
+    const controller = new AbortController();
+    const cancellation = new Error('request cancelled');
+    const stopCheck = createStopCheck(vi.fn(async () => {
+      controller.abort(cancellation);
+      controller.signal.throwIfAborted();
+      return { shouldStop: true };
+    }), controller.signal);
+
+    await expect(
+      stopCheck({ content: 'done', turn: 1 }),
+    ).rejects.toBe(cancellation);
+  });
+
+  it('propagates execution lease failures from a Stop hook', async () => {
+    const leaseError = new DurableExecutionLeaseError(
+      'DURABLE_EXECUTION_LEASE_LOST',
+      'worker is stale',
+    );
+    const stopCheck = createStopCheck(vi.fn(async () => {
+      throw leaseError;
+    }));
+
+    await expect(
+      stopCheck({ content: 'done', turn: 1 }),
+    ).rejects.toBe(leaseError);
+  });
+
+  it('preserves the fail-safe stop fallback for ordinary Hook errors', async () => {
+    const stopCheck = createStopCheck(vi.fn(async () => {
+      throw new Error('hook failed');
+    }));
+
+    await expect(
+      stopCheck({ content: 'done', turn: 1 }),
+    ).resolves.toEqual({ shouldStop: true });
+  });
+});

--- a/src/agent/__tests__/LoopHookBuilder.test.ts
+++ b/src/agent/__tests__/LoopHookBuilder.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
+import { CompactionService } from '../../context/CompactionService.js';
 import type { HookRuntime } from '../../hooks/HookRuntime.js';
 import { HookProcessContainmentError } from '../../hooks/WindowsProcessJob.js';
 import { DurableExecutionLeaseError } from '../../session/events/DurableExecutionLeaseStore.js';
-import { SessionId } from '../../types/branded.js';
+import { InputId, RequestId, SessionId } from '../../types/branded.js';
 import { buildLoopConfig } from '../LoopHookBuilder.js';
 
 function createStopCheck(
@@ -85,5 +86,159 @@ describe('LoopHookBuilder stop hook', () => {
     await expect(
       stopCheck({ content: 'done', turn: 1 }),
     ).resolves.toEqual({ shouldStop: true });
+  });
+});
+
+describe('LoopHookBuilder request signal', () => {
+  it('uses the explicit request signal for steering input hooks and persistence', async () => {
+    const contextController = new AbortController();
+    const requestController = new AbortController();
+    contextController.abort(new Error('stale context signal'));
+    const applyUserPromptSubmit = vi.fn<HookRuntime['applyUserPromptSubmit']>(async (
+      content,
+      options = {},
+    ) => {
+      options.abortSignal?.throwIfAborted();
+      return content;
+    });
+    const getContextManager = vi.fn(() => undefined);
+    const config = buildLoopConfig({
+      context: {
+        messages: [],
+        userId: 'test-user',
+        sessionId: SessionId('loop-hook-builder-input-signal'),
+        signal: contextController.signal,
+      },
+      options: { signal: requestController.signal },
+      loopState: { conversationState: {} } as never,
+      maxTurns: 1,
+      isYoloMode: false,
+      getLastUuid: () => null,
+      setLastUuid: () => {},
+      executionPipeline: {} as never,
+      logger: { warn: vi.fn() } as never,
+      hookRuntime: { applyUserPromptSubmit } as unknown as HookRuntime,
+      modelManager: { getContextManager } as never,
+      runtimePatchManager: {} as never,
+      runControl: {
+        requestId: RequestId('request-input-signal'),
+      } as never,
+    });
+    const applyInput = config.hooks?.input?.apply;
+    if (!applyInput) {
+      throw new Error('Input hook was not configured');
+    }
+
+    await expect(applyInput({
+      input: {
+        inputId: InputId('steering-input'),
+        content: 'Apply this input',
+        priority: 'next',
+        acceptedAt: 1,
+      },
+      turn: 1,
+    })).resolves.toMatchObject({
+      role: 'user',
+      content: 'Apply this input',
+    });
+
+    expect(applyUserPromptSubmit).toHaveBeenCalledWith(
+      'Apply this input',
+      { abortSignal: requestController.signal },
+    );
+    expect(getContextManager).toHaveBeenCalledOnce();
+  });
+
+  it('uses the explicit request signal for every compaction path', async () => {
+    const contextController = new AbortController();
+    const requestController = new AbortController();
+    contextController.abort(new Error('stale context signal'));
+    const observedSignals: Array<AbortSignal | undefined> = [];
+    const checkAndCompactInLoop = vi.fn(async function* (
+      _conversationState,
+      runtimeContext: { signal?: AbortSignal },
+    ) {
+      observedSignals.push(runtimeContext.signal);
+      yield* [] as never[];
+      return false;
+    });
+    const reactiveCompact = vi.fn(async function* (
+      _conversationState,
+      runtimeContext: { signal?: AbortSignal },
+    ) {
+      observedSignals.push(runtimeContext.signal);
+      yield* [] as never[];
+      return false;
+    });
+    const compact = vi.spyOn(CompactionService, 'compact').mockImplementation(
+      async (_messages, options) => {
+        observedSignals.push(options.signal);
+        return {
+          success: true,
+          summary: 'summary',
+          preTokens: 10,
+          postTokens: 5,
+          filesIncluded: [],
+          compactedMessages: [],
+          boundaryMessage: { role: 'system', content: '' },
+          summaryMessage: { role: 'user', content: 'summary' },
+        };
+      },
+    );
+    const config = buildLoopConfig({
+      context: {
+        messages: [],
+        userId: 'test-user',
+        sessionId: SessionId('loop-hook-builder-compaction-signal'),
+        signal: contextController.signal,
+      },
+      options: { signal: requestController.signal },
+      loopState: {
+        conversationState: {
+          getContextMessages: () => [],
+        },
+        getChatService: () => ({
+          getConfig: () => ({
+            model: 'test-model',
+            maxContextTokens: 128000,
+          }),
+        }),
+      } as never,
+      maxTurns: 1,
+      isYoloMode: false,
+      getLastUuid: () => null,
+      setLastUuid: () => {},
+      executionPipeline: {} as never,
+      logger: { error: vi.fn(), warn: vi.fn() } as never,
+      compactionHandler: {
+        checkAndCompactInLoop,
+        reactiveCompact,
+      } as never,
+      modelManager: {
+        getContextManager: () => undefined,
+      } as never,
+      runtimePatchManager: {} as never,
+    });
+    const beforeTurn = config.hooks?.turn?.beforeTurn;
+    const turnLimitCompact = config.hooks?.turn?.onTurnLimitCompact;
+    const recover = config.hooks?.recovery?.reactiveCompact;
+    if (!beforeTurn || !turnLimitCompact || !recover) {
+      throw new Error('Compaction hooks were not configured');
+    }
+
+    await beforeTurn({
+      turn: 1,
+      messages: [],
+      lastPromptTokens: 100,
+    }).next();
+    await turnLimitCompact({ contextMessages: [] });
+    await recover({ messages: [] }).next();
+
+    expect(observedSignals).toEqual([
+      requestController.signal,
+      requestController.signal,
+      requestController.signal,
+    ]);
+    compact.mockRestore();
   });
 });

--- a/src/agent/__tests__/LoopHookBuilder.test.ts
+++ b/src/agent/__tests__/LoopHookBuilder.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { HookRuntime } from '../../hooks/HookRuntime.js';
+import { HookProcessContainmentError } from '../../hooks/WindowsProcessJob.js';
 import { DurableExecutionLeaseError } from '../../session/events/DurableExecutionLeaseStore.js';
 import { SessionId } from '../../types/branded.js';
 import { buildLoopConfig } from '../LoopHookBuilder.js';
@@ -61,6 +62,19 @@ describe('LoopHookBuilder stop hook', () => {
     await expect(
       stopCheck({ content: 'done', turn: 1 }),
     ).rejects.toBe(leaseError);
+  });
+
+  it('propagates process-containment failures from a Stop hook', async () => {
+    const containmentError = new HookProcessContainmentError(
+      'Windows Job Object support is unavailable',
+    );
+    const stopCheck = createStopCheck(vi.fn(async () => {
+      throw containmentError;
+    }));
+
+    await expect(
+      stopCheck({ content: 'done', turn: 1 }),
+    ).rejects.toBe(containmentError);
   });
 
   it('preserves the fail-safe stop fallback for ordinary Hook errors', async () => {

--- a/src/agent/__tests__/LoopHookBuilder.test.ts
+++ b/src/agent/__tests__/LoopHookBuilder.test.ts
@@ -78,6 +78,21 @@ describe('LoopHookBuilder stop hook', () => {
     ).rejects.toBe(containmentError);
   });
 
+  it('preserves a containment failure when Stop hook cancellation races cleanup', async () => {
+    const controller = new AbortController();
+    const containmentError = new HookProcessContainmentError(
+      'Hook process cleanup failed',
+    );
+    const stopCheck = createStopCheck(vi.fn(async () => {
+      controller.abort(new Error('request cancelled'));
+      throw containmentError;
+    }), controller.signal);
+
+    await expect(
+      stopCheck({ content: 'done', turn: 1 }),
+    ).rejects.toBe(containmentError);
+  });
+
   it('preserves the fail-safe stop fallback for ordinary Hook errors', async () => {
     const stopCheck = createStopCheck(vi.fn(async () => {
       throw new Error('hook failed');

--- a/src/agent/__tests__/LoopRunner.test.ts
+++ b/src/agent/__tests__/LoopRunner.test.ts
@@ -249,6 +249,27 @@ describe('LoopRunner', () => {
       expect(mm._contextMgr.saveMessage).toHaveBeenCalled();
     });
 
+    it('does not persist input after the explicit request signal is cancelled', async () => {
+      const mm = createMockModelManager();
+      const pipeline = createMockPipeline();
+      const runner = new LoopRunner(baseConfig, baseOptions, mm, pipeline);
+      const controller = new AbortController();
+      const cancellation = new Error('request cancelled');
+      controller.abort(cancellation);
+
+      await expect(
+        runner.runLoop('Cancelled input', createContext(), {
+          signal: controller.signal,
+        }),
+      ).resolves.toMatchObject({
+        success: false,
+        error: { type: 'aborted' },
+      });
+      expect(mm._contextMgr.saveMessage).not.toHaveBeenCalled();
+      expect(mm._contextMgr.saveAppliedInputMessage).not.toHaveBeenCalled();
+      expect(mm._chat).not.toHaveBeenCalled();
+    });
+
     it('fences the initial transcript write before model execution', async () => {
       const mm = createMockModelManager();
       const pipeline = createMockPipeline();

--- a/src/agent/__tests__/LoopRunner.test.ts
+++ b/src/agent/__tests__/LoopRunner.test.ts
@@ -6,6 +6,7 @@ import { z } from 'zod';
 import { ContextManager } from '../../context/ContextManager.js';
 import * as FileAnalyzerModule from '../../context/FileAnalyzer.js';
 import { HookRuntime } from '../../hooks/HookRuntime.js';
+import { HookProcessContainmentError } from '../../hooks/WindowsProcessJob.js';
 import type { RuntimeContextPatch } from '../../runtime/RuntimeContextPatch.js';
 import type { RuntimePatch } from '../../runtime/RuntimePatch.js';
 import type { Message } from '../../services/ChatServiceInterface.js';
@@ -303,6 +304,32 @@ describe('LoopRunner', () => {
         }),
       ).rejects.toBe(leaseError);
       expect(mm._chat).toHaveBeenCalledOnce();
+    });
+
+    it('propagates process-containment failures from the agent loop', async () => {
+      const mm = createMockModelManager();
+      mm._chat.mockResolvedValueOnce({
+        content: '',
+        toolCalls: [{
+          id: 'containment-tool',
+          type: 'function',
+          function: { name: 'Task', arguments: '{}' },
+        }],
+        usage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 },
+      });
+      const containmentError = new HookProcessContainmentError(
+        'Hook process cleanup failed',
+      );
+      const pipeline = createMockPipeline();
+      pipeline.execute = vi.fn(async function* () {
+        yield* [] as never[];
+        throw containmentError;
+      });
+      const runner = new LoopRunner(baseConfig, baseOptions, mm, pipeline);
+
+      await expect(
+        runner.runLoop('Run a tool', createContext()),
+      ).rejects.toBe(containmentError);
     });
 
     it('persists streaming tool turns in provider-compatible order', async () => {

--- a/src/agent/__tests__/StreamingToolExecutor.test.ts
+++ b/src/agent/__tests__/StreamingToolExecutor.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { HookProcessContainmentError } from '../../hooks/WindowsProcessJob.js';
 import type { ChatResponse, StreamChunk } from '../../services/ChatServiceInterface.js';
 import { ActiveRequestController } from '../../session/ActiveRequestController.js';
 import type { ToolExecution, ToolResult } from '../../tools/types/index.js';
@@ -1033,6 +1034,66 @@ describe('StreamingToolExecutor', () => {
         message: 'cancelled',
       },
     });
+  });
+
+  it('does not downgrade containment failure during a steering interrupt', async () => {
+    const toolStarted = deferred<void>();
+    const runControl = new ActiveRequestController(RequestId('request-containment'));
+    const containmentError = new HookProcessContainmentError(
+      'Windows Job Object cleanup failed',
+    );
+    const { executor, execute } = createExecutor({
+      streamChat: async function* () {
+        yield {
+          toolCalls: [
+            {
+              index: 0,
+              id: 'tool-1',
+              function: {
+                name: 'CancelableTool',
+                arguments: '{}',
+              },
+            },
+          ],
+        };
+        while (!runControl.stepSignal.aborted) {
+          await tick();
+        }
+      },
+      execute: async (_toolName, _params, context) => {
+        const signal = (context as { signal?: AbortSignal } | undefined)?.signal;
+        toolStarted.resolve();
+        await new Promise<void>((_resolve) => {
+          signal?.addEventListener('abort', () => _resolve(), { once: true });
+        });
+        throw containmentError;
+      },
+      toolInterruptBehaviors: {
+        CancelableTool: 'cancel',
+      },
+    });
+
+    const promise = executor.collectAndExecute(
+      [{ role: 'user', content: 'run cancelable tool' }],
+      [{ name: 'CancelableTool', description: 'cancel', parameters: {} }],
+      runControl.stepSignal,
+      {
+        executionPipeline: executionPipelineFromMock(execute, {
+          CancelableTool: { interruptBehavior: 'cancel' },
+        }),
+        executionContext: {
+          sessionId: SessionId('session-1'),
+          userId: 'user-1',
+        },
+        requestSignal: runControl.requestSignal,
+        steeringSignal: runControl.steeringSignal,
+      },
+    );
+    const rejection = expect(promise).rejects.toBe(containmentError);
+    await toolStarted.promise;
+
+    runControl.interruptStep(InputId('input-now'));
+    await rejection;
   });
 
   it('forwards skillActivationPaths through the streaming execution path', async () => {

--- a/src/agent/loop/__tests__/executeToolCalls.test.ts
+++ b/src/agent/loop/__tests__/executeToolCalls.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { HookProcessContainmentError } from '../../../hooks/WindowsProcessJob.js';
 import { createContextSnapshot } from '../../../runtime/index.js';
 import { DurableExecutionLeaseError } from '../../../session/events/DurableExecutionLeaseStore.js';
 import { completeToolExecution, type ExecutionContext } from '../../../tools/types/index.js';
@@ -243,6 +244,46 @@ describe('executeToolCalls', () => {
         },
       }),
     ).rejects.toBe(leaseError);
+    expect(onToolSettled).not.toHaveBeenCalled();
+  });
+
+  it('propagates Hook process containment failures instead of creating a tool result', async () => {
+    const containmentError = new HookProcessContainmentError(
+      'Windows Job Object support is unavailable',
+    );
+    const onToolSettled = vi.fn(async () => {});
+
+    await expect(
+      executeToolCalls({
+        plan: {
+          mode: 'serial',
+          calls: [
+            {
+              id: 'tool-without-hook-containment',
+              type: 'function',
+              function: {
+                name: 'Write',
+                arguments: '{}',
+              },
+            },
+          ],
+        },
+        executionPipeline: {
+          // biome-ignore lint/correctness/useYield: generator fails before producing output
+          execute: vi.fn(async function* () {
+            throw containmentError;
+          }),
+          getRegistry: () => ({
+            get: () => undefined,
+          }),
+        } as never,
+        executionContext: {
+          sessionId: SessionId('session-without-hook-containment'),
+          userId: 'user-1',
+          lifecycle: { onToolSettled },
+        },
+      }),
+    ).rejects.toBe(containmentError);
     expect(onToolSettled).not.toHaveBeenCalled();
   });
 

--- a/src/agent/loop/__tests__/executeToolCalls.test.ts
+++ b/src/agent/loop/__tests__/executeToolCalls.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
-import { HookProcessContainmentError } from '../../../hooks/WindowsProcessJob.js';
+import {
+  HookProcessContainmentError,
+  isHookProcessContainmentError,
+} from '../../../hooks/WindowsProcessJob.js';
 import { createContextSnapshot } from '../../../runtime/index.js';
 import { DurableExecutionLeaseError } from '../../../session/events/DurableExecutionLeaseStore.js';
 import { completeToolExecution, type ExecutionContext } from '../../../tools/types/index.js';
@@ -285,6 +288,105 @@ describe('executeToolCalls', () => {
       }),
     ).rejects.toBe(containmentError);
     expect(onToolSettled).not.toHaveBeenCalled();
+  });
+
+  it('prioritizes a late containment failure across parallel tool calls', async () => {
+    const secondStarted = Promise.withResolvers<void>();
+    const releaseSecond = Promise.withResolvers<void>();
+    const containmentError = new HookProcessContainmentError(
+      'Hook process cleanup failed',
+    );
+
+    const execution = executeToolCalls({
+      plan: {
+        mode: 'parallel',
+        calls: [
+          {
+            id: 'ordinary-failure',
+            type: 'function',
+            function: { name: 'OrdinaryFailure', arguments: '{}' },
+          },
+          {
+            id: 'containment-failure',
+            type: 'function',
+            function: { name: 'ContainmentFailure', arguments: '{}' },
+          },
+        ],
+      },
+      executionPipeline: {
+        execute: vi.fn(async function* (toolName: string) {
+          yield* [] as never[];
+          if (toolName === 'OrdinaryFailure') {
+            await secondStarted.promise;
+            throw new Error('ordinary failure');
+          }
+          secondStarted.resolve();
+          await releaseSecond.promise;
+          throw containmentError;
+        }),
+        getRegistry: () => ({
+          get: () => undefined,
+        }),
+      } as never,
+      executionContext: {
+        sessionId: SessionId('session-parallel-containment'),
+        userId: 'user-1',
+      },
+    });
+    const rejection = expect(execution).rejects.toBe(containmentError);
+
+    await secondStarted.promise;
+    await Promise.resolve();
+    releaseSecond.resolve();
+
+    await rejection;
+  });
+
+  it('preserves containment failure raised while closing a tool generator', async () => {
+    const containmentError = new HookProcessContainmentError(
+      'Hook process cleanup failed',
+    );
+    const execution = executeToolCalls({
+      plan: {
+        mode: 'serial',
+        calls: [
+          {
+            id: 'close-containment-failure',
+            type: 'function',
+            function: { name: 'CloseContainmentFailure', arguments: '{}' },
+          },
+        ],
+      },
+      executionPipeline: {
+        execute: vi.fn(async function* () {
+          try {
+            yield { kind: 'progress', message: 'started' };
+            return { status: 'success', model: 'unexpected' };
+          } finally {
+            // biome-ignore lint/correctness/noUnsafeFinally: simulates a fatal cleanup failure
+            throw containmentError;
+          }
+        }),
+        getRegistry: () => ({
+          get: () => undefined,
+        }),
+      } as never,
+      executionContext: {
+        sessionId: SessionId('session-close-containment'),
+        userId: 'user-1',
+      },
+      hooks: {
+        onUpdate: async (update) => {
+          if (update.type === 'tool_progress') {
+            throw new Error('event consumer failed');
+          }
+        },
+      },
+    }).catch((error: unknown) => error);
+
+    const error = await execution;
+    expect(error).toBeInstanceOf(AggregateError);
+    expect(isHookProcessContainmentError(error)).toBe(true);
   });
 
   it('emits a unified ready-progress-message-effect-result-completed update sequence for each tool call', async () => {

--- a/src/agent/loop/executeToolCalls.ts
+++ b/src/agent/loop/executeToolCalls.ts
@@ -1,19 +1,21 @@
+import { isHookProcessContainmentError } from '../../hooks/WindowsProcessJob.js';
 import type { InternalLogger } from '../../logging/Logger.js';
+import { isExecutionLeaseFailure } from '../../session/events/DurableExecutionLeaseStore.js';
 import type { ExecutionPipeline } from '../../tools/execution/ExecutionPipeline.js';
 import type { PermissionMode } from '../../types/common.js';
 import type { ToolExecutionPlan } from './planToolExecution.js';
 import type {
-  ToolExecutionContext,
-  ToolExecutionHooks,
-  ToolExecutionOutcome,
+    ToolExecutionContext,
+    ToolExecutionHooks,
+    ToolExecutionOutcome,
 } from './runToolCall.js';
 import { runToolCall } from './runToolCall.js';
 import type { FunctionToolCall } from './types.js';
 
 export type {
-  ToolExecutionContext,
-  ToolExecutionHooks,
-  ToolExecutionOutcome,
+    ToolExecutionContext,
+    ToolExecutionHooks,
+    ToolExecutionOutcome
 } from './runToolCall.js';
 
 interface ExecuteToolCallsInput {
@@ -39,7 +41,32 @@ export async function executeToolCalls(
     return results;
   }
 
-  return Promise.all(plan.calls.map((toolCall) => executeToolCall(toolCall, input)));
+  const settled = await Promise.allSettled(
+    plan.calls.map((toolCall) => executeToolCall(toolCall, input)),
+  );
+  const criticalFailure = settled.find(
+    (result): result is PromiseRejectedResult =>
+      result.status === 'rejected'
+      && (
+        isHookProcessContainmentError(result.reason)
+        || isExecutionLeaseFailure(result.reason)
+      ),
+  );
+  if (criticalFailure) {
+    throw criticalFailure.reason;
+  }
+  const failure = settled.find(
+    (result): result is PromiseRejectedResult => result.status === 'rejected',
+  );
+  if (failure) {
+    throw failure.reason;
+  }
+  return settled.map((result) => {
+    if (result.status === 'rejected') {
+      throw result.reason;
+    }
+    return result.value;
+  });
 }
 
 async function executeToolCall(

--- a/src/agent/loop/runToolCall.ts
+++ b/src/agent/loop/runToolCall.ts
@@ -201,10 +201,13 @@ export async function runToolCall(input: RunToolCallInput): Promise<ToolExecutio
       toolUseUuid,
     });
 
-    let result: ToolResult;
+    let result: ToolResult | undefined;
     const effects: ToolEffect[] = [];
     let execution: ReturnType<ExecutionPipeline['execute']> | undefined;
     let executionCompleted = false;
+    let executionFailed = false;
+    let executionFailure: unknown;
+    let closeFailure: unknown;
     try {
       execution = input.executionPipeline.execute(input.toolCall.function.name, params, {
         sessionId: input.executionContext.sessionId,
@@ -239,30 +242,52 @@ export async function runToolCall(input: RunToolCallInput): Promise<ToolExecutio
           mapToolYieldToExecutionUpdate(input.toolCall, step.value),
         );
       }
-      if (
-        result.status === 'error' &&
-        interruptBehavior === 'cancel' &&
-        isSteeringInterruptSignal(input.steeringSignal)
-      ) {
-        result = {
-          ...result,
-          error: {
-            ...result.error,
-            type: ToolErrorType.INTERRUPTED,
-          },
-        };
-      }
+    } catch (error) {
+      executionFailed = true;
+      executionFailure = error;
     } finally {
       if (execution && !executionCompleted) {
         try {
           await execution.return(undefined as never);
-        } catch {
-          // Preserve the original execution or event-consumer failure.
+        } catch (error) {
+          if (
+            isExecutionLeaseFailure(error)
+            || isHookProcessContainmentError(error)
+          ) {
+            closeFailure = error;
+          }
         }
       }
       interruptSignal.cleanup();
     }
 
+    if (closeFailure !== undefined) {
+      throw executionFailed
+        ? new AggregateError(
+            [executionFailure, closeFailure],
+            'Tool execution and cleanup both failed',
+          )
+        : closeFailure;
+    }
+    if (executionFailed) {
+      throw executionFailure;
+    }
+    if (!result) {
+      throw new Error('Tool execution completed without a result');
+    }
+    if (
+      result.status === 'error' &&
+      interruptBehavior === 'cancel' &&
+      isSteeringInterruptSignal(input.steeringSignal)
+    ) {
+      result = {
+        ...result,
+        error: {
+          ...result.error,
+          type: ToolErrorType.INTERRUPTED,
+        },
+      };
+    }
     outcome = { toolCall: input.toolCall, result, effects, toolUseUuid };
   } catch (error) {
     if (

--- a/src/agent/loop/runToolCall.ts
+++ b/src/agent/loop/runToolCall.ts
@@ -1,3 +1,4 @@
+import { isHookProcessContainmentError } from '../../hooks/WindowsProcessJob.js';
 import { type InternalLogger, LogCategory, NOOP_LOGGER } from '../../logging/Logger.js';
 import type { ContextSnapshot } from '../../runtime/index.js';
 import {
@@ -264,7 +265,10 @@ export async function runToolCall(input: RunToolCallInput): Promise<ToolExecutio
 
     outcome = { toolCall: input.toolCall, result, effects, toolUseUuid };
   } catch (error) {
-    if (isExecutionLeaseFailure(error)) {
+    if (
+      isExecutionLeaseFailure(error)
+      || isHookProcessContainmentError(error)
+    ) {
       throw error;
     }
     logger.error(`Tool execution failed for ${input.toolCall.function.name}:`, error);

--- a/src/context/CompactionService.ts
+++ b/src/context/CompactionService.ts
@@ -302,13 +302,13 @@ export async function compact(
       summaryMessage,
     };
   } catch (error) {
-    options.signal?.throwIfAborted();
     if (
       isExecutionLeaseFailure(error)
       || isHookProcessContainmentError(error)
     ) {
       throw error;
     }
+    options.signal?.throwIfAborted();
     console.error('[CompactionService] 压缩失败，使用降级策略', error);
     return fallbackCompact(messages, options, preTokens, error);
   }

--- a/src/context/CompactionService.ts
+++ b/src/context/CompactionService.ts
@@ -5,6 +5,7 @@
 
 import { nanoid } from 'nanoid';
 import { HookManager } from '../hooks/HookManager.js';
+import type { HookRuntime } from '../hooks/HookRuntime.js';
 import { isHookProcessContainmentError } from '../hooks/WindowsProcessJob.js';
 import { NOOP_LOGGER } from '../logging/Logger.js';
 import { createChatServiceAsync, type Message } from '../services/ChatServiceInterface.js';
@@ -50,6 +51,8 @@ export interface CompactionOptions {
   signal?: AbortSignal;
   /** @internal Validates execution ownership around compaction side effects. */
   assertExecutionLease?: () => Promise<void>;
+  /** @internal Applies the owning Session's file-Hook quarantine boundary. */
+  hookRuntime?: Pick<HookRuntime, 'runFileHookOperation'>;
 }
 
 /**
@@ -130,21 +133,28 @@ export async function compact(
     options.actualPreTokens ?? TokenCounter.countTokens(messages, options.modelName);
   const tokenSource = options.actualPreTokens ? 'actual (from LLM usage)' : 'estimated';
   console.log(`[CompactionService] preTokens source: ${tokenSource}`);
+  const runFileHook = <T>(operation: () => Promise<T>): Promise<T> =>
+    options.hookRuntime
+      ? options.hookRuntime.runFileHookOperation(options.signal, operation)
+      : operation();
+  const projectDir = options.projectDir;
 
-  if (options.projectDir) {
+  if (projectDir) {
     try {
       const hookManager = HookManager.getInstance();
 
-      const preCompactResult = await hookManager.executePreCompactHooks(
-        {
-          trigger: options.trigger,
-          messages_before: messages.length,
-          tokens_before: preTokens,
-        },
-        options.projectDir,
-        options.sessionId || SessionId('unknown'),
-        options.permissionMode || PermissionMode.DEFAULT,
-        options.signal,
+      const preCompactResult = await runFileHook(
+        () => hookManager.executePreCompactHooks(
+          {
+            trigger: options.trigger,
+            messages_before: messages.length,
+            tokens_before: preTokens,
+          },
+          projectDir,
+          options.sessionId || SessionId('unknown'),
+          options.permissionMode || PermissionMode.DEFAULT,
+          options.signal,
+        ),
       );
       options.signal?.throwIfAborted();
       await options.assertExecutionLease?.();
@@ -169,14 +179,16 @@ export async function compact(
         console.warn(`[CompactionService] PreCompact hook warning: ${preCompactResult.warning}`);
       }
 
-      const hookResult = await hookManager.executeCompactionHooks(options.trigger, {
-        projectDir: options.projectDir,
-        sessionId: options.sessionId || SessionId('unknown'),
-        permissionMode: options.permissionMode || PermissionMode.DEFAULT,
-        messagesBefore: messages.length,
-        tokensBefore: preTokens,
-        abortSignal: options.signal,
-      });
+      const hookResult = await runFileHook(
+        () => hookManager.executeCompactionHooks(options.trigger, {
+          projectDir,
+          sessionId: options.sessionId || SessionId('unknown'),
+          permissionMode: options.permissionMode || PermissionMode.DEFAULT,
+          messagesBefore: messages.length,
+          tokensBefore: preTokens,
+          abortSignal: options.signal,
+        }),
+      );
       options.signal?.throwIfAborted();
       await options.assertExecutionLease?.();
 
@@ -254,24 +266,26 @@ export async function compact(
       `(-${((1 - postTokens / preTokens) * 100).toFixed(1)}%)`,
     );
 
-    if (options.projectDir) {
+    if (projectDir) {
       try {
         options.signal?.throwIfAborted();
         await options.assertExecutionLease?.();
         const postHookManager = HookManager.getInstance();
-        const postHookResult = await postHookManager.executePostCompactHooks(
-          {
-            trigger: options.trigger,
-            messages_before: messages.length,
-            messages_after: compactedMessages.length,
-            tokens_before: preTokens,
-            tokens_after: postTokens,
-            summary,
-          },
-          options.projectDir,
-          options.sessionId || SessionId('unknown'),
-          options.permissionMode || PermissionMode.DEFAULT,
-          options.signal,
+        const postHookResult = await runFileHook(
+          () => postHookManager.executePostCompactHooks(
+            {
+              trigger: options.trigger,
+              messages_before: messages.length,
+              messages_after: compactedMessages.length,
+              tokens_before: preTokens,
+              tokens_after: postTokens,
+              summary,
+            },
+            projectDir,
+            options.sessionId || SessionId('unknown'),
+            options.permissionMode || PermissionMode.DEFAULT,
+            options.signal,
+          ),
         );
         options.signal?.throwIfAborted();
         await options.assertExecutionLease?.();

--- a/src/context/CompactionService.ts
+++ b/src/context/CompactionService.ts
@@ -5,6 +5,7 @@
 
 import { nanoid } from 'nanoid';
 import { HookManager } from '../hooks/HookManager.js';
+import { isHookProcessContainmentError } from '../hooks/WindowsProcessJob.js';
 import { NOOP_LOGGER } from '../logging/Logger.js';
 import { createChatServiceAsync, type Message } from '../services/ChatServiceInterface.js';
 import { wrapChatServiceWithTimeouts } from '../services/ChatServiceTimeout.js';
@@ -200,7 +201,11 @@ export async function compact(
         console.warn(`[CompactionService] Compaction hook warning: ${hookResult.warning}`);
       }
     } catch (hookError) {
-      if (options.signal?.aborted || isExecutionLeaseFailure(hookError)) {
+      if (
+        options.signal?.aborted
+        || isExecutionLeaseFailure(hookError)
+        || isHookProcessContainmentError(hookError)
+      ) {
         throw hookError;
       }
       console.warn('[CompactionService] Compaction hook execution failed:', hookError);
@@ -274,7 +279,11 @@ export async function compact(
           console.warn(`[CompactionService] PostCompact hook warning: ${postHookResult.warning}`);
         }
       } catch (hookError) {
-        if (options.signal?.aborted || isExecutionLeaseFailure(hookError)) {
+        if (
+          options.signal?.aborted
+          || isExecutionLeaseFailure(hookError)
+          || isHookProcessContainmentError(hookError)
+        ) {
           throw hookError;
         }
         console.warn('[CompactionService] PostCompact hook execution failed:', hookError);
@@ -294,7 +303,10 @@ export async function compact(
     };
   } catch (error) {
     options.signal?.throwIfAborted();
-    if (isExecutionLeaseFailure(error)) {
+    if (
+      isExecutionLeaseFailure(error)
+      || isHookProcessContainmentError(error)
+    ) {
       throw error;
     }
     console.error('[CompactionService] 压缩失败，使用降级策略', error);

--- a/src/context/__tests__/CompactionService.test.ts
+++ b/src/context/__tests__/CompactionService.test.ts
@@ -1,4 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { HookManager } from '../../hooks/HookManager.js';
+import { HookProcessContainmentError } from '../../hooks/WindowsProcessJob.js';
 import type { ChatConfig, Message } from '../../services/ChatServiceInterface.js';
 
 const mockChat = vi.fn(async () => ({
@@ -92,6 +94,31 @@ describe('CompactionService', () => {
         signal: controller.signal,
       }),
     ).rejects.toBe(abortError);
+  });
+
+  it('preserves a hook containment failure when cancellation races cleanup', async () => {
+    const controller = new AbortController();
+    const containmentError = new HookProcessContainmentError(
+      'Hook process cleanup failed',
+    );
+    const preCompactHook = vi.spyOn(
+      HookManager.getInstance(),
+      'executePreCompactHooks',
+    ).mockImplementationOnce(async () => {
+      controller.abort(new Error('request cancelled'));
+      throw containmentError;
+    });
+
+    await expect(
+      compact([{ role: 'user', content: 'hello' }], {
+        trigger: 'manual',
+        modelName: 'gpt-5',
+        maxContextTokens: 128000,
+        projectDir: '/tmp',
+        signal: controller.signal,
+      }),
+    ).rejects.toBe(containmentError);
+    preCompactHook.mockRestore();
   });
 
   it('retainRecentMessages drops orphan tool results outside the retained window', () => {

--- a/src/context/__tests__/CompactionService.test.ts
+++ b/src/context/__tests__/CompactionService.test.ts
@@ -121,6 +121,28 @@ describe('CompactionService', () => {
     preCompactHook.mockRestore();
   });
 
+  it('routes session-owned compaction hooks through the runtime boundary', async () => {
+    const controller = new AbortController();
+    const runFileHookOperation = vi.fn(async (
+      signal: AbortSignal | undefined,
+      operation: () => Promise<unknown>,
+    ) => {
+      expect(signal).toBe(controller.signal);
+      return operation();
+    });
+
+    await compact([{ role: 'user', content: 'hello' }], {
+      trigger: 'manual',
+      modelName: 'gpt-5',
+      maxContextTokens: 128000,
+      projectDir: '/tmp',
+      signal: controller.signal,
+      hookRuntime: { runFileHookOperation } as never,
+    });
+
+    expect(runFileHookOperation).toHaveBeenCalledTimes(3);
+  });
+
   it('retainRecentMessages drops orphan tool results outside the retained window', () => {
     const messages: Message[] = [
       {

--- a/src/hooks/HookExecutor.ts
+++ b/src/hooks/HookExecutor.ts
@@ -7,7 +7,10 @@
 import type { JsonObject, JsonValue } from '../types/common.js';
 import { OutputParser } from './OutputParser.js';
 import { SecureProcessExecutor } from './SecureProcessExecutor.js';
-import { getRecoverableHookErrorMessage } from './WindowsProcessJob.js';
+import {
+  getRecoverableHookErrorMessage,
+  isHookProcessContainmentError,
+} from './WindowsProcessJob.js';
 import {
   type CommandHook,
   type CompactionHookResult,
@@ -1207,12 +1210,17 @@ export class HookExecutor {
   ): Promise<HookExecutionResult[]> {
     const results: Promise<HookExecutionResult>[] = [];
     const executing = new Set<Promise<void>>();
+    let containmentFailure: unknown;
 
     for (const hook of hooks) {
       // 如果达到并发限制,等待一个完成
       if (executing.size >= maxConcurrent) {
         // 等待任意一个 Promise 完成
         await Promise.race(executing);
+        if (containmentFailure) {
+          await Promise.all(executing);
+          throw containmentFailure;
+        }
       }
 
       // 创建新的 hook 执行 Promise
@@ -1227,8 +1235,11 @@ export class HookExecutor {
         .then(() => {
           executing.delete(tracker);
         })
-        .catch(() => {
+        .catch((error) => {
           executing.delete(tracker);
+          if (isHookProcessContainmentError(error)) {
+            containmentFailure ??= error;
+          }
         });
 
       executing.add(tracker);
@@ -1236,6 +1247,10 @@ export class HookExecutor {
     }
 
     // 等待所有剩余的 hooks 完成
+    await Promise.all(executing);
+    if (containmentFailure) {
+      throw containmentFailure;
+    }
     return Promise.all(results);
   }
 }

--- a/src/hooks/HookExecutor.ts
+++ b/src/hooks/HookExecutor.ts
@@ -7,6 +7,7 @@
 import type { JsonObject, JsonValue } from '../types/common.js';
 import { OutputParser } from './OutputParser.js';
 import { SecureProcessExecutor } from './SecureProcessExecutor.js';
+import { getRecoverableHookErrorMessage } from './WindowsProcessJob.js';
 import {
   type CommandHook,
   type CompactionHookResult,
@@ -127,7 +128,7 @@ export class HookExecutor {
         }
       } catch (err) {
         // Hook 执行异常,根据 failureBehavior 处理
-        const errorMsg = err instanceof Error ? err.message : String(err);
+        const errorMsg = getRecoverableHookErrorMessage(err);
         warnings.push(`Hook failed: ${errorMsg}`);
 
         if (context.config.failureBehavior === 'deny') {
@@ -251,7 +252,7 @@ export class HookExecutor {
           };
         }
       } catch (err) {
-        const errorMsg = err instanceof Error ? err.message : String(err);
+        const errorMsg = getRecoverableHookErrorMessage(err);
         warnings.push(`Hook failed: ${errorMsg}`);
       }
     }
@@ -299,7 +300,7 @@ export class HookExecutor {
           additionalContexts.push(specific.additionalContext);
         }
       } catch (err) {
-        const errorMsg = err instanceof Error ? err.message : String(err);
+        const errorMsg = getRecoverableHookErrorMessage(err);
         warnings.push(`Hook failed: ${errorMsg}`);
       }
     }
@@ -352,7 +353,7 @@ export class HookExecutor {
           }
         }
       } catch (err) {
-        const errorMsg = err instanceof Error ? err.message : String(err);
+        const errorMsg = getRecoverableHookErrorMessage(err);
         warnings.push(`Hook failed: ${errorMsg}`);
       }
     }
@@ -408,7 +409,7 @@ export class HookExecutor {
           };
         }
       } catch (err) {
-        const errorMsg = err instanceof Error ? err.message : String(err);
+        const errorMsg = getRecoverableHookErrorMessage(err);
         warnings.push(`Hook failed: ${errorMsg}`);
       }
     }
@@ -458,7 +459,7 @@ export class HookExecutor {
           }
         }
       } catch (err) {
-        const errorMsg = err instanceof Error ? err.message : String(err);
+        const errorMsg = getRecoverableHookErrorMessage(err);
         warnings.push(`Hook failed: ${errorMsg}`);
       }
     }
@@ -520,7 +521,7 @@ export class HookExecutor {
           }
         }
       } catch (err) {
-        const errorMsg = err instanceof Error ? err.message : String(err);
+        const errorMsg = getRecoverableHookErrorMessage(err);
         warnings.push(`Hook failed: ${errorMsg}`);
       }
     }
@@ -573,7 +574,7 @@ export class HookExecutor {
           Object.assign(env, specific.env);
         }
       } catch (err) {
-        const errorMsg = err instanceof Error ? err.message : String(err);
+        const errorMsg = getRecoverableHookErrorMessage(err);
         warnings.push(`Hook failed: ${errorMsg}`);
       }
     }
@@ -701,7 +702,7 @@ export class HookExecutor {
           message = result.stdout.trim();
         }
       } catch (err) {
-        const errorMsg = err instanceof Error ? err.message : String(err);
+        const errorMsg = getRecoverableHookErrorMessage(err);
         warnings.push(`Hook failed: ${errorMsg}`);
       }
     }
@@ -747,7 +748,7 @@ export class HookExecutor {
           };
         }
       } catch (err) {
-        const errorMsg = err instanceof Error ? err.message : String(err);
+        const errorMsg = getRecoverableHookErrorMessage(err);
         warnings.push(`Hook failed: ${errorMsg}`);
       }
     }
@@ -794,7 +795,7 @@ export class HookExecutor {
           };
         }
       } catch (err) {
-        const errorMsg = err instanceof Error ? err.message : String(err);
+        const errorMsg = getRecoverableHookErrorMessage(err);
         warnings.push(`Hook failed: ${errorMsg}`);
       }
     }
@@ -841,7 +842,7 @@ export class HookExecutor {
           };
         }
       } catch (err) {
-        const errorMsg = err instanceof Error ? err.message : String(err);
+        const errorMsg = getRecoverableHookErrorMessage(err);
         warnings.push(`Hook failed: ${errorMsg}`);
       }
     }
@@ -888,7 +889,7 @@ export class HookExecutor {
           };
         }
       } catch (err) {
-        const errorMsg = err instanceof Error ? err.message : String(err);
+        const errorMsg = getRecoverableHookErrorMessage(err);
         warnings.push(`Hook failed: ${errorMsg}`);
       }
     }
@@ -921,7 +922,7 @@ export class HookExecutor {
           warnings.push(result.warning);
         }
       } catch (err) {
-        const errorMsg = err instanceof Error ? err.message : String(err);
+        const errorMsg = getRecoverableHookErrorMessage(err);
         warnings.push(`Hook failed: ${errorMsg}`);
       }
     }
@@ -967,7 +968,7 @@ export class HookExecutor {
           };
         }
       } catch (err) {
-        const errorMsg = err instanceof Error ? err.message : String(err);
+        const errorMsg = getRecoverableHookErrorMessage(err);
         warnings.push(`Hook failed: ${errorMsg}`);
       }
     }
@@ -1011,7 +1012,7 @@ export class HookExecutor {
           action = specific.action as 'reload' | 'ignore';
         }
       } catch (err) {
-        const errorMsg = err instanceof Error ? err.message : String(err);
+        const errorMsg = getRecoverableHookErrorMessage(err);
         warnings.push(`Hook failed: ${errorMsg}`);
       }
     }
@@ -1055,7 +1056,7 @@ export class HookExecutor {
           modified_instructions = specific.modified_instructions;
         }
       } catch (err) {
-        const errorMsg = err instanceof Error ? err.message : String(err);
+        const errorMsg = getRecoverableHookErrorMessage(err);
         warnings.push(`Hook failed: ${errorMsg}`);
       }
     }
@@ -1189,7 +1190,7 @@ export class HookExecutor {
     } catch (err) {
       return {
         status: 'warning',
-        warning: err instanceof Error ? err.message : String(err),
+        warning: getRecoverableHookErrorMessage(err),
         hook,
       };
     }
@@ -1217,7 +1218,7 @@ export class HookExecutor {
       // 创建新的 hook 执行 Promise
       const promise = this.executeHook(hook, input, context).catch((err) => ({
         status: 'warning' as const,
-        warning: err instanceof Error ? err.message : String(err),
+        warning: getRecoverableHookErrorMessage(err),
         hook,
       }));
 

--- a/src/hooks/HookManager.ts
+++ b/src/hooks/HookManager.ts
@@ -13,55 +13,56 @@ import { DEFAULT_HOOK_CONFIG, mergeHookConfig, parseEnvConfig } from './HookConf
 import { HookExecutionGuard } from './HookExecutionGuard.js';
 import { HookExecutor } from './HookExecutor.js';
 import { Matcher } from './Matcher.js';
+import { getRecoverableHookErrorMessage } from './WindowsProcessJob.js';
 import type {
-  CompactionHookResult,
-  CompactionInput,
-  ConfigChangeHookResult,
-  ConfigChangeInput,
-  CwdChangedHookResult,
-  CwdChangedInput,
-  ElicitationHookResult,
-  ElicitationInput,
-  ElicitationResultHookResult,
-  ElicitationResultInput,
-  FileChangedHookResult,
-  FileChangedInput,
-  Hook,
-  HookConfig,
-  HookExecutionContext,
-  InstructionsLoadedHookResult,
-  InstructionsLoadedInput,
-  MatchContext,
-  NotificationHookResult,
-  NotificationInput,
-  PermissionRequestHookResult,
-  PermissionRequestInput,
-  PostCompactHookResult,
-  PostCompactInput,
-  PostToolHookResult,
-  PostToolUseFailureHookResult,
-  PostToolUseFailureInput,
-  PostToolUseInput,
-  PreCompactHookResult,
-  PreCompactInput,
-  PreToolHookResult,
-  PreToolUseInput,
-  SessionEndHookResult,
-  SessionEndInput,
-  SessionStartHookResult,
-  SessionStartInput,
-  StopFailureHookResult,
-  StopFailureInput,
-  StopHookResult,
-  StopInput,
-  SubagentStartHookResult,
-  SubagentStartInput,
-  SubagentStopHookResult,
-  SubagentStopInput,
-  TaskCompletedHookResult,
-  TaskCompletedInput,
-  UserPromptSubmitHookResult,
-  UserPromptSubmitInput
+    CompactionHookResult,
+    CompactionInput,
+    ConfigChangeHookResult,
+    ConfigChangeInput,
+    CwdChangedHookResult,
+    CwdChangedInput,
+    ElicitationHookResult,
+    ElicitationInput,
+    ElicitationResultHookResult,
+    ElicitationResultInput,
+    FileChangedHookResult,
+    FileChangedInput,
+    Hook,
+    HookConfig,
+    HookExecutionContext,
+    InstructionsLoadedHookResult,
+    InstructionsLoadedInput,
+    MatchContext,
+    NotificationHookResult,
+    NotificationInput,
+    PermissionRequestHookResult,
+    PermissionRequestInput,
+    PostCompactHookResult,
+    PostCompactInput,
+    PostToolHookResult,
+    PostToolUseFailureHookResult,
+    PostToolUseFailureInput,
+    PostToolUseInput,
+    PreCompactHookResult,
+    PreCompactInput,
+    PreToolHookResult,
+    PreToolUseInput,
+    SessionEndHookResult,
+    SessionEndInput,
+    SessionStartHookResult,
+    SessionStartInput,
+    StopFailureHookResult,
+    StopFailureInput,
+    StopHookResult,
+    StopInput,
+    SubagentStartHookResult,
+    SubagentStartInput,
+    SubagentStopHookResult,
+    SubagentStopInput,
+    TaskCompletedHookResult,
+    TaskCompletedInput,
+    UserPromptSubmitHookResult,
+    UserPromptSubmitInput
 } from './types/HookTypes.js';
 
 /**
@@ -270,7 +271,7 @@ export class HookManager {
       console.error('[HookManager] Error executing PreToolUse hooks:', err);
       return {
         decision: 'allow',
-        warning: `Hook execution failed: ${err instanceof Error ? err.message : String(err)}`,
+        warning: `Hook execution failed: ${getRecoverableHookErrorMessage(err)}`,
       };
     }
   }
@@ -353,7 +354,7 @@ export class HookManager {
     } catch (err) {
       console.error('[HookManager] Error executing PostToolUse hooks:', err);
       return {
-        warning: `Hook execution failed: ${err instanceof Error ? err.message : String(err)}`,
+        warning: `Hook execution failed: ${getRecoverableHookErrorMessage(err)}`,
       };
     } finally {
       // 清理完成的工具
@@ -413,7 +414,7 @@ export class HookManager {
       console.error('[HookManager] Error executing Stop hooks:', err);
       return {
         shouldStop: true,
-        warning: `Hook execution failed: ${err instanceof Error ? err.message : String(err)}`,
+        warning: `Hook execution failed: ${getRecoverableHookErrorMessage(err)}`,
       };
     }
   }
@@ -475,7 +476,7 @@ export class HookManager {
       console.error('[HookManager] Error executing SubagentStart hooks:', err);
       return {
         proceed: true,
-        warning: `Hook execution failed: ${err instanceof Error ? err.message : String(err)}`,
+        warning: `Hook execution failed: ${getRecoverableHookErrorMessage(err)}`,
       };
     }
   }
@@ -542,7 +543,7 @@ export class HookManager {
       console.error('[HookManager] Error executing SubagentStop hooks:', err);
       return {
         shouldStop: true,
-        warning: `Hook execution failed: ${err instanceof Error ? err.message : String(err)}`,
+        warning: `Hook execution failed: ${getRecoverableHookErrorMessage(err)}`,
       };
     }
   }
@@ -604,7 +605,7 @@ export class HookManager {
       console.error('[HookManager] Error executing TaskCompleted hooks:', err);
       return {
         allowCompletion: true,
-        warning: `Hook execution failed: ${err instanceof Error ? err.message : String(err)}`,
+        warning: `Hook execution failed: ${getRecoverableHookErrorMessage(err)}`,
       };
     }
   }
@@ -668,7 +669,7 @@ export class HookManager {
       console.error('[HookManager] Error executing PermissionRequest hooks:', err);
       return {
         decision: 'ask',
-        warning: `Hook execution failed: ${err instanceof Error ? err.message : String(err)}`,
+        warning: `Hook execution failed: ${getRecoverableHookErrorMessage(err)}`,
       };
     }
   }
@@ -731,7 +732,7 @@ export class HookManager {
       console.error('[HookManager] Error executing UserPromptSubmit hooks:', err);
       return {
         proceed: true,
-        warning: `Hook execution failed: ${err instanceof Error ? err.message : String(err)}`,
+        warning: `Hook execution failed: ${getRecoverableHookErrorMessage(err)}`,
       };
     }
   }
@@ -790,7 +791,7 @@ export class HookManager {
       console.error('[HookManager] Error executing SessionStart hooks:', err);
       return {
         proceed: true,
-        warning: `Hook execution failed: ${err instanceof Error ? err.message : String(err)}`,
+        warning: `Hook execution failed: ${getRecoverableHookErrorMessage(err)}`,
       };
     }
   }
@@ -845,7 +846,7 @@ export class HookManager {
     } catch (err) {
       console.error('[HookManager] Error executing SessionEnd hooks:', err);
       return {
-        warning: `Hook execution failed: ${err instanceof Error ? err.message : String(err)}`,
+        warning: `Hook execution failed: ${getRecoverableHookErrorMessage(err)}`,
       };
     }
   }
@@ -919,7 +920,7 @@ export class HookManager {
     } catch (err) {
       console.error('[HookManager] Error executing PostToolUseFailure hooks:', err);
       return {
-        warning: `Hook execution failed: ${err instanceof Error ? err.message : String(err)}`,
+        warning: `Hook execution failed: ${getRecoverableHookErrorMessage(err)}`,
       };
     }
   }
@@ -983,7 +984,7 @@ export class HookManager {
       return {
         suppress: false,
         message,
-        warning: `Hook execution failed: ${err instanceof Error ? err.message : String(err)}`,
+        warning: `Hook execution failed: ${getRecoverableHookErrorMessage(err)}`,
       };
     }
   }
@@ -1046,7 +1047,7 @@ export class HookManager {
       console.error('[HookManager] Error executing Compaction hooks:', err);
       return {
         blockCompaction: false,
-        warning: `Hook execution failed: ${err instanceof Error ? err.message : String(err)}`,
+        warning: `Hook execution failed: ${getRecoverableHookErrorMessage(err)}`,
       };
     }
   }
@@ -1102,7 +1103,7 @@ export class HookManager {
       console.error('[HookManager] Error executing StopFailure hooks:', err);
       return {
         shouldRetry: false,
-        warning: `Hook execution failed: ${err instanceof Error ? err.message : String(err)}`,
+        warning: `Hook execution failed: ${getRecoverableHookErrorMessage(err)}`,
       };
     }
   }
@@ -1158,7 +1159,7 @@ export class HookManager {
       console.error('[HookManager] Error executing PreCompact hooks:', err);
       return {
         blockCompaction: false,
-        warning: `Hook execution failed: ${err instanceof Error ? err.message : String(err)}`,
+        warning: `Hook execution failed: ${getRecoverableHookErrorMessage(err)}`,
       };
     }
   }
@@ -1223,7 +1224,7 @@ export class HookManager {
     } catch (err) {
       console.error('[HookManager] Error executing PostCompact hooks:', err);
       return {
-        warning: `Hook execution failed: ${err instanceof Error ? err.message : String(err)}`,
+        warning: `Hook execution failed: ${getRecoverableHookErrorMessage(err)}`,
       };
     }
   }
@@ -1279,7 +1280,7 @@ export class HookManager {
       console.error('[HookManager] Error executing Elicitation hooks:', err);
       return {
         proceed: true,
-        warning: `Hook execution failed: ${err instanceof Error ? err.message : String(err)}`,
+        warning: `Hook execution failed: ${getRecoverableHookErrorMessage(err)}`,
       };
     }
   }
@@ -1335,7 +1336,7 @@ export class HookManager {
       console.error('[HookManager] Error executing ElicitationResult hooks:', err);
       return {
         proceed: true,
-        warning: `Hook execution failed: ${err instanceof Error ? err.message : String(err)}`,
+        warning: `Hook execution failed: ${getRecoverableHookErrorMessage(err)}`,
       };
     }
   }
@@ -1390,7 +1391,7 @@ export class HookManager {
       console.error('[HookManager] Error executing ConfigChange hooks:', err);
       return {
         proceed: true,
-        warning: `Hook execution failed: ${err instanceof Error ? err.message : String(err)}`,
+        warning: `Hook execution failed: ${getRecoverableHookErrorMessage(err)}`,
       };
     }
   }
@@ -1445,7 +1446,7 @@ export class HookManager {
       console.error('[HookManager] Error executing CwdChanged hooks:', err);
       return {
         proceed: true,
-        warning: `Hook execution failed: ${err instanceof Error ? err.message : String(err)}`,
+        warning: `Hook execution failed: ${getRecoverableHookErrorMessage(err)}`,
       };
     }
   }
@@ -1502,7 +1503,7 @@ export class HookManager {
       console.error('[HookManager] Error executing FileChanged hooks:', err);
       return {
         action: 'reload',
-        warning: `Hook execution failed: ${err instanceof Error ? err.message : String(err)}`,
+        warning: `Hook execution failed: ${getRecoverableHookErrorMessage(err)}`,
       };
     }
   }
@@ -1557,7 +1558,7 @@ export class HookManager {
       console.error('[HookManager] Error executing InstructionsLoaded hooks:', err);
       return {
         proceed: true,
-        warning: `Hook execution failed: ${err instanceof Error ? err.message : String(err)}`,
+        warning: `Hook execution failed: ${getRecoverableHookErrorMessage(err)}`,
       };
     }
   }

--- a/src/hooks/HookManager.ts
+++ b/src/hooks/HookManager.ts
@@ -13,7 +13,10 @@ import { DEFAULT_HOOK_CONFIG, mergeHookConfig, parseEnvConfig } from './HookConf
 import { HookExecutionGuard } from './HookExecutionGuard.js';
 import { HookExecutor } from './HookExecutor.js';
 import { Matcher } from './Matcher.js';
-import { getRecoverableHookErrorMessage } from './WindowsProcessJob.js';
+import {
+    getRecoverableHookErrorMessage,
+    isHookProcessContainmentError,
+} from './WindowsProcessJob.js';
 import type {
     CompactionHookResult,
     CompactionInput,
@@ -165,16 +168,18 @@ export class HookManager {
         // 触发 ConfigChange hook
         const changedKeys = Object.keys(settings.hooks);
         if (changedKeys.length > 0) {
-          // 异步触发，不阻塞 reloadConfig
-          void this.executeConfigChangeHooks(
+          await this.executeConfigChangeHooks(
             { changed_keys: changedKeys, source: 'file' },
             '',
             SessionId(''),
             PermissionMode.DEFAULT,
-          ).catch(() => {});
+          );
         }
       }
-    } catch {
+    } catch (error) {
+      if (isHookProcessContainmentError(error)) {
+        throw error;
+      }
       // 文件不存在或读取失败，保持当前配置
     }
   }

--- a/src/hooks/HookRuntime.ts
+++ b/src/hooks/HookRuntime.ts
@@ -121,6 +121,14 @@ export class HookRuntime {
     return this.terminalContainmentFailure;
   }
 
+  /** @internal Runs a Session-owned file Hook through the quarantine boundary. */
+  runFileHookOperation<T>(
+    abortSignal: AbortSignal | undefined,
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    return this.runFileHooks(abortSignal, operation);
+  }
+
   setTraceCollector(traceCollector: HookTraceCollector | undefined): void {
     this.traceCollector = traceCollector;
   }

--- a/src/hooks/HookRuntime.ts
+++ b/src/hooks/HookRuntime.ts
@@ -676,6 +676,7 @@ export class HookRuntime {
     abortSignal?.throwIfAborted();
     try {
       const result = await operation();
+      this.throwIfTerminalContainmentFailed();
       abortSignal?.throwIfAborted();
       return result;
     } catch (error) {
@@ -685,6 +686,7 @@ export class HookRuntime {
       ) {
         this.terminalContainmentFailure = error;
       }
+      this.throwIfTerminalContainmentFailed();
       throw error;
     }
   }

--- a/src/hooks/HookRuntime.ts
+++ b/src/hooks/HookRuntime.ts
@@ -13,6 +13,7 @@ import type { HookCallback, HookInput } from '../session/types.js';
 import type { HookTraceCollector } from '../observability/index.js';
 import { HookManager } from './HookManager.js';
 import { HookBus } from './HookBus.js';
+import { isHookProcessContainmentError } from './WindowsProcessJob.js';
 
 interface HookRuntimeOptions {
   sessionId: SessionId;
@@ -80,6 +81,7 @@ export class HookRuntime {
   private readonly hookTimeoutMs: number;
   private readonly sessionEndHookTimeoutMs: number;
   private sessionEndCallbacksAttempted = false;
+  private terminalContainmentFailure: unknown;
   private traceCollector?: HookTraceCollector;
   private readonly runtimeHookRegistrations = new Map<string, {
     event: HookEvent;
@@ -113,6 +115,10 @@ export class HookRuntime {
 
   hasPendingCallbackCleanup(): boolean {
     return this.bus.hasPendingCallbackCleanup();
+  }
+
+  getTerminalContainmentFailure(): unknown {
+    return this.terminalContainmentFailure;
   }
 
   setTraceCollector(traceCollector: HookTraceCollector | undefined): void {
@@ -166,6 +172,7 @@ export class HookRuntime {
       abortSignal?: AbortSignal;
     } = {},
   ): Promise<PreToolUseRuntimeResult> {
+    this.throwIfTerminalContainmentFailed();
     options.abortSignal?.throwIfAborted();
     const toolUseId = options.toolUseId ?? `tool_${nanoid()}` as ToolUseId;
     let nextInput = { ...input };
@@ -252,6 +259,7 @@ export class HookRuntime {
       abortSignal?: AbortSignal;
     } = {},
   ): Promise<PostToolUseRuntimeResult> {
+    this.throwIfTerminalContainmentFailed();
     options.abortSignal?.throwIfAborted();
     const toolUseId = options.toolUseId ?? `tool_${nanoid()}` as ToolUseId;
     let nextResult = result;
@@ -300,6 +308,7 @@ export class HookRuntime {
       abortSignal?: AbortSignal;
     } = {},
   ): Promise<PostToolUseRuntimeResult> {
+    this.throwIfTerminalContainmentFailed();
     options.abortSignal?.throwIfAborted();
     const toolUseId = options.toolUseId ?? `tool_${nanoid()}` as ToolUseId;
     let nextResult = result;
@@ -358,6 +367,7 @@ export class HookRuntime {
     updatedInput: JsonObject;
     decision?: PermissionResult;
   }> {
+    this.throwIfTerminalContainmentFailed();
     options.abortSignal?.throwIfAborted();
     let nextInput = input;
 
@@ -434,6 +444,7 @@ export class HookRuntime {
     message: UserMessageContent,
     options: { abortSignal?: AbortSignal } = {},
   ): Promise<UserMessageContent> {
+    this.throwIfTerminalContainmentFailed();
     options.abortSignal?.throwIfAborted();
     let nextMessage = message;
 
@@ -504,6 +515,7 @@ export class HookRuntime {
   async runSessionStart(
     payload: { isResume: boolean; resumeSessionId?: string; abortSignal?: AbortSignal },
   ): Promise<void> {
+    this.throwIfTerminalContainmentFailed();
     await this.runCallbackGroup(HookEvent.SessionStart, payload, payload.abortSignal);
 
     const projectDir = this.options.resolveProjectDir();
@@ -537,6 +549,7 @@ export class HookRuntime {
       [key: string]: unknown;
     },
   ): Promise<void> {
+    this.throwIfTerminalContainmentFailed();
     await this.runCallbackGroup(HookEvent.TaskCompleted, payload, payload.abortSignal);
 
     const projectDir = this.options.resolveProjectDir();
@@ -576,6 +589,7 @@ export class HookRuntime {
       abortSignal?: AbortSignal;
     },
   ): Promise<void> {
+    this.throwIfTerminalContainmentFailed();
     payload.abortSignal?.throwIfAborted();
     if (!this.sessionEndCallbacksAttempted) {
       this.bus.assertNoPendingCallbackCleanup();
@@ -610,6 +624,7 @@ export class HookRuntime {
       abortSignal?: AbortSignal;
     },
   ): Promise<{ shouldStop: boolean; continueReason?: string; warning?: string }> {
+    this.throwIfTerminalContainmentFailed();
     payload.abortSignal?.throwIfAborted();
     const projectDir = this.options.resolveProjectDir();
     if (!projectDir) {
@@ -657,10 +672,27 @@ export class HookRuntime {
     abortSignal: AbortSignal | undefined,
     operation: () => Promise<T>,
   ): Promise<T> {
+    this.throwIfTerminalContainmentFailed();
     abortSignal?.throwIfAborted();
-    const result = await operation();
-    abortSignal?.throwIfAborted();
-    return result;
+    try {
+      const result = await operation();
+      abortSignal?.throwIfAborted();
+      return result;
+    } catch (error) {
+      if (
+        this.terminalContainmentFailure === undefined
+        && isHookProcessContainmentError(error)
+      ) {
+        this.terminalContainmentFailure = error;
+      }
+      throw error;
+    }
+  }
+
+  private throwIfTerminalContainmentFailed(): void {
+    if (this.terminalContainmentFailure !== undefined) {
+      throw this.terminalContainmentFailure;
+    }
   }
 
   private applyManagerPostToolResult(result: ToolResult, hookResult: {

--- a/src/hooks/HookRuntime.ts
+++ b/src/hooks/HookRuntime.ts
@@ -166,6 +166,7 @@ export class HookRuntime {
       abortSignal?: AbortSignal;
     } = {},
   ): Promise<PreToolUseRuntimeResult> {
+    options.abortSignal?.throwIfAborted();
     const toolUseId = options.toolUseId ?? `tool_${nanoid()}` as ToolUseId;
     let nextInput = { ...input };
 
@@ -200,16 +201,19 @@ export class HookRuntime {
       return { toolUseId, updatedInput: nextInput };
     }
 
-    const managerResult = await this.hookManager.executePreToolHooks(
-      toolName,
-      toolUseId,
-      nextInput,
-      {
-        projectDir,
-        sessionId: this.options.sessionId,
-        permissionMode: options.permissionMode ?? this.options.permissionMode,
-        abortSignal: options.abortSignal,
-      },
+    const managerResult = await this.runFileHooks(
+      options.abortSignal,
+      () => this.hookManager.executePreToolHooks(
+        toolName,
+        toolUseId,
+        nextInput,
+        {
+          projectDir,
+          sessionId: this.options.sessionId,
+          permissionMode: options.permissionMode ?? this.options.permissionMode,
+          abortSignal: options.abortSignal,
+        },
+      ),
     );
 
     if (managerResult.modifiedInput) {
@@ -248,22 +252,26 @@ export class HookRuntime {
       abortSignal?: AbortSignal;
     } = {},
   ): Promise<PostToolUseRuntimeResult> {
+    options.abortSignal?.throwIfAborted();
     const toolUseId = options.toolUseId ?? `tool_${nanoid()}` as ToolUseId;
     let nextResult = result;
 
     const projectDir = this.options.resolveProjectDir();
     if (projectDir) {
-      const managerResult = await this.hookManager.executePostToolHooks(
-        toolName,
-        toolUseId,
-        input,
-        nextResult,
-        {
-          projectDir,
-          sessionId: this.options.sessionId,
-          permissionMode: options.permissionMode ?? this.options.permissionMode,
-          abortSignal: options.abortSignal,
-        },
+      const managerResult = await this.runFileHooks(
+        options.abortSignal,
+        () => this.hookManager.executePostToolHooks(
+          toolName,
+          toolUseId,
+          input,
+          nextResult,
+          {
+            projectDir,
+            sessionId: this.options.sessionId,
+            permissionMode: options.permissionMode ?? this.options.permissionMode,
+            abortSignal: options.abortSignal,
+          },
+        ),
       );
 
       nextResult = this.applyManagerPostToolResult(nextResult, managerResult);
@@ -292,25 +300,29 @@ export class HookRuntime {
       abortSignal?: AbortSignal;
     } = {},
   ): Promise<PostToolUseRuntimeResult> {
+    options.abortSignal?.throwIfAborted();
     const toolUseId = options.toolUseId ?? `tool_${nanoid()}` as ToolUseId;
     let nextResult = result;
 
     const projectDir = this.options.resolveProjectDir();
     if (projectDir) {
-      const managerResult = await this.hookManager.executePostToolUseFailureHooks(
-        toolName,
-        toolUseId,
-        input,
-        result.error?.message || `Tool "${toolName}" failed`,
-        {
-          projectDir,
-          sessionId: this.options.sessionId,
-          permissionMode: options.permissionMode ?? this.options.permissionMode,
-          errorType: options.errorType,
-          isInterrupt: options.isInterrupt ?? false,
-          isTimeout: options.isTimeout ?? false,
-          abortSignal: options.abortSignal,
-        },
+      const managerResult = await this.runFileHooks(
+        options.abortSignal,
+        () => this.hookManager.executePostToolUseFailureHooks(
+          toolName,
+          toolUseId,
+          input,
+          result.error?.message || `Tool "${toolName}" failed`,
+          {
+            projectDir,
+            sessionId: this.options.sessionId,
+            permissionMode: options.permissionMode ?? this.options.permissionMode,
+            errorType: options.errorType,
+            isInterrupt: options.isInterrupt ?? false,
+            isTimeout: options.isTimeout ?? false,
+            abortSignal: options.abortSignal,
+          },
+        ),
       );
 
       if (managerResult.additionalContext) {
@@ -346,6 +358,7 @@ export class HookRuntime {
     updatedInput: JsonObject;
     decision?: PermissionResult;
   }> {
+    options.abortSignal?.throwIfAborted();
     let nextInput = input;
 
     if (this.bus.has(HookEvent.PermissionRequest)) {
@@ -382,16 +395,19 @@ export class HookRuntime {
       return { updatedInput: nextInput };
     }
 
-    const managerResult = await this.hookManager.executePermissionRequestHooks(
-      toolName,
-      ToolUseId(`permission_${toolName}_${Date.now()}`),
-      nextInput,
-      {
-        projectDir,
-        sessionId: this.options.sessionId,
-        permissionMode: this.options.permissionMode,
-        abortSignal: options.abortSignal,
-      },
+    const managerResult = await this.runFileHooks(
+      options.abortSignal,
+      () => this.hookManager.executePermissionRequestHooks(
+        toolName,
+        ToolUseId(`permission_${toolName}_${Date.now()}`),
+        nextInput,
+        {
+          projectDir,
+          sessionId: this.options.sessionId,
+          permissionMode: this.options.permissionMode,
+          abortSignal: options.abortSignal,
+        },
+      ),
     );
 
     if (managerResult.decision === 'deny') {
@@ -418,6 +434,7 @@ export class HookRuntime {
     message: UserMessageContent,
     options: { abortSignal?: AbortSignal } = {},
   ): Promise<UserMessageContent> {
+    options.abortSignal?.throwIfAborted();
     let nextMessage = message;
 
     if (this.bus.has(HookEvent.UserPromptSubmit)) {
@@ -454,16 +471,19 @@ export class HookRuntime {
     }
 
     const imageMeta = this.getImageMetadata(nextMessage);
-    const managerResult = await this.hookManager.executeUserPromptSubmitHooks(
-      this.getTextContent(nextMessage),
-      {
-        projectDir,
-        sessionId: this.options.sessionId,
-        permissionMode: this.options.permissionMode,
-        hasImages: imageMeta.hasImages,
-        imageCount: imageMeta.imageCount,
-        abortSignal: options.abortSignal,
-      },
+    const managerResult = await this.runFileHooks(
+      options.abortSignal,
+      () => this.hookManager.executeUserPromptSubmitHooks(
+        this.getTextContent(nextMessage),
+        {
+          projectDir,
+          sessionId: this.options.sessionId,
+          permissionMode: this.options.permissionMode,
+          hasImages: imageMeta.hasImages,
+          imageCount: imageMeta.imageCount,
+          abortSignal: options.abortSignal,
+        },
+      ),
     );
 
     if (!managerResult.proceed) {
@@ -491,14 +511,17 @@ export class HookRuntime {
       return;
     }
 
-    const result = await this.hookManager.executeSessionStartHooks({
-      projectDir,
-      sessionId: this.options.sessionId,
-      permissionMode: this.options.permissionMode,
-      isResume: payload.isResume,
-      resumeSessionId: payload.resumeSessionId,
-      abortSignal: payload.abortSignal,
-    });
+    const result = await this.runFileHooks(
+      payload.abortSignal,
+      () => this.hookManager.executeSessionStartHooks({
+        projectDir,
+        sessionId: this.options.sessionId,
+        permissionMode: this.options.permissionMode,
+        isResume: payload.isResume,
+        resumeSessionId: payload.resumeSessionId,
+        abortSignal: payload.abortSignal,
+      }),
+    );
     if (!result.proceed) {
       throw new Error(result.warning || 'Session start aborted by hook manager');
     }
@@ -521,15 +544,18 @@ export class HookRuntime {
       return;
     }
 
-    const result = await this.hookManager.executeTaskCompletedHooks(payload.taskId, {
-      projectDir,
-      sessionId: this.options.sessionId,
-      permissionMode: this.options.permissionMode,
-      taskDescription: payload.taskDescription,
-      resultSummary: payload.resultSummary,
-      success: payload.success,
-      abortSignal: payload.abortSignal,
-    });
+    const result = await this.runFileHooks(
+      payload.abortSignal,
+      () => this.hookManager.executeTaskCompletedHooks(payload.taskId, {
+        projectDir,
+        sessionId: this.options.sessionId,
+        permissionMode: this.options.permissionMode,
+        taskDescription: payload.taskDescription,
+        resultSummary: payload.resultSummary,
+        success: payload.success,
+        abortSignal: payload.abortSignal,
+      }),
+    );
     if (!result.allowCompletion) {
       throw new Error(result.blockReason || 'Task completion blocked by hook manager');
     }
@@ -550,6 +576,7 @@ export class HookRuntime {
       abortSignal?: AbortSignal;
     },
   ): Promise<void> {
+    payload.abortSignal?.throwIfAborted();
     if (!this.sessionEndCallbacksAttempted) {
       this.bus.assertNoPendingCallbackCleanup();
       this.sessionEndCallbacksAttempted = true;
@@ -566,12 +593,15 @@ export class HookRuntime {
       return;
     }
 
-    await this.hookManager.executeSessionEndHooks(payload.reason, {
-      projectDir,
-      sessionId: this.options.sessionId,
-      permissionMode: this.options.permissionMode,
-      abortSignal: payload.abortSignal,
-    });
+    await this.runFileHooks(
+      payload.abortSignal,
+      () => this.hookManager.executeSessionEndHooks(payload.reason, {
+        projectDir,
+        sessionId: this.options.sessionId,
+        permissionMode: this.options.permissionMode,
+        abortSignal: payload.abortSignal,
+      }),
+    );
   }
 
   async executeStopCheck(
@@ -580,18 +610,22 @@ export class HookRuntime {
       abortSignal?: AbortSignal;
     },
   ): Promise<{ shouldStop: boolean; continueReason?: string; warning?: string }> {
+    payload.abortSignal?.throwIfAborted();
     const projectDir = this.options.resolveProjectDir();
     if (!projectDir) {
       return { shouldStop: true };
     }
 
-    return this.hookManager.executeStopHooks({
-      projectDir,
-      sessionId: this.options.sessionId,
-      permissionMode: this.options.permissionMode,
-      reason: payload.reason,
-      abortSignal: payload.abortSignal,
-    });
+    return this.runFileHooks(
+      payload.abortSignal,
+      () => this.hookManager.executeStopHooks({
+        projectDir,
+        sessionId: this.options.sessionId,
+        permissionMode: this.options.permissionMode,
+        reason: payload.reason,
+        abortSignal: payload.abortSignal,
+      }),
+    );
   }
 
   private async runCallbackGroup(
@@ -600,6 +634,7 @@ export class HookRuntime {
     abortSignal?: AbortSignal,
     timeoutMs = this.hookTimeoutMs,
   ): Promise<void> {
+    abortSignal?.throwIfAborted();
     if (!this.bus.has(event)) {
       return;
     }
@@ -615,6 +650,17 @@ export class HookRuntime {
         throw new Error(output.reason || `Hook ${event} aborted`);
       }
     }
+    abortSignal?.throwIfAborted();
+  }
+
+  private async runFileHooks<T>(
+    abortSignal: AbortSignal | undefined,
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    abortSignal?.throwIfAborted();
+    const result = await operation();
+    abortSignal?.throwIfAborted();
+    return result;
   }
 
   private applyManagerPostToolResult(result: ToolResult, hookResult: {

--- a/src/hooks/SecureProcessExecutor.ts
+++ b/src/hooks/SecureProcessExecutor.ts
@@ -4,7 +4,10 @@
  * 安全地执行 Hook 子进程
  */
 
-import { spawn } from 'node:child_process';
+import {
+  type ChildProcessWithoutNullStreams,
+  spawn,
+} from 'node:child_process';
 import {
   shellProcessSpawnOptions,
   terminateProcessTree,
@@ -15,8 +18,61 @@ import {
   type HookInput,
   type ProcessResult,
 } from './types/HookTypes.js';
+import { WindowsProcessJob } from './WindowsProcessJob.js';
 
 const DEFAULT_HOOK_PROCESS_TERMINATION_GRACE_MS = 1_000;
+const WINDOWS_HOOK_RUNNER = `
+const { spawn } = require('node:child_process');
+
+let envelope = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', (chunk) => {
+  envelope += chunk;
+});
+process.stdin.once('error', (error) => {
+  process.stderr.write(String(error));
+  process.exitCode = 1;
+});
+process.stdin.once('end', () => {
+  let payload;
+  try {
+    payload = JSON.parse(envelope);
+  } catch (error) {
+    process.stderr.write(String(error));
+    process.exitCode = 1;
+    return;
+  }
+
+  const child = spawn(payload.command, [], {
+    shell: true,
+    cwd: process.cwd(),
+    env: process.env,
+    windowsHide: true,
+    stdio: ['pipe', 'inherit', 'inherit'],
+  });
+  let failed = false;
+  child.once('error', (error) => {
+    failed = true;
+    process.stderr.write(String(error));
+    process.exitCode = 1;
+  });
+  child.once('close', (code) => {
+    if (!failed) {
+      process.exitCode = code ?? 1;
+    }
+  });
+  child.stdin.on('error', (error) => {
+    if (error?.code === 'EPIPE') {
+      return;
+    }
+    failed = true;
+    process.exitCode = 1;
+    process.stderr.write(String(error));
+    child.kill();
+  });
+  child.stdin.end(payload.input);
+});
+`;
 
 function isBrokenPipeError(error: unknown): boolean {
   return (
@@ -95,12 +151,53 @@ export class SecureProcessExecutor {
     const env = this.createSafeEnv(input);
 
     // 3. 启动子进程
-    const child = spawn(command, [], {
-      shell: true,
-      env,
-      cwd: context.projectDir,
-      ...shellProcessSpawnOptions(),
-    });
+    const windowsJob = process.platform === 'win32'
+      ? await WindowsProcessJob.create()
+      : undefined;
+    if (context.abortSignal?.aborted) {
+      windowsJob?.close();
+      return this.createCancelledResult();
+    }
+    let child: ChildProcessWithoutNullStreams;
+    try {
+      child = windowsJob
+        ? spawn(process.execPath, ['-e', WINDOWS_HOOK_RUNNER], {
+            env,
+            cwd: context.projectDir,
+            windowsHide: true,
+          })
+        : spawn(command, [], {
+            shell: true,
+            env,
+            cwd: context.projectDir,
+            ...shellProcessSpawnOptions(),
+          });
+    } catch (error) {
+      windowsJob?.close();
+      throw error;
+    }
+
+    if (windowsJob) {
+      try {
+        if (!child.pid) {
+          throw new Error('Hook process did not expose a process identifier');
+        }
+        windowsJob.assign(child.pid);
+      } catch (error) {
+        await terminateProcessTree(
+          child.pid,
+          child,
+          this.terminationGraceMs,
+        );
+        windowsJob.close();
+        throw new Error('Failed to contain the Windows Hook process', {
+          cause: error,
+        });
+      }
+    }
+    const processInput = windowsJob
+      ? JSON.stringify({ command, input: inputJson })
+      : inputJson;
 
     // 4. 流量控制
     const stdout = new StreamLimiter(this.MAX_STDOUT_SIZE);
@@ -120,7 +217,12 @@ export class SecureProcessExecutor {
     // 5. 等待完成、取消或超时
     return new Promise((resolve, reject) => {
       let settled = false;
-      let termination: 'abort' | 'timeout' | 'input-error' | undefined;
+      let termination:
+        | 'abort'
+        | 'timeout'
+        | 'input-error'
+        | 'process-error'
+        | undefined;
       let timeout: ReturnType<typeof setTimeout> | undefined;
       let abortHandler: (() => void) | null = null;
 
@@ -147,7 +249,7 @@ export class SecureProcessExecutor {
         reject(error);
       };
       const stop = (
-        reason: 'abort' | 'timeout' | 'input-error',
+        reason: 'abort' | 'timeout' | 'input-error' | 'process-error',
         cause?: unknown,
       ): void => {
         if (settled || termination) {
@@ -155,12 +257,19 @@ export class SecureProcessExecutor {
         }
         termination = reason;
         cleanup();
-        void terminateProcessTree(
-          child.pid,
-          child,
-          this.terminationGraceMs,
-        ).then(
+        const processCleanup = windowsJob
+          ? windowsJob.terminateAndWait()
+          : terminateProcessTree(
+              child.pid,
+              child,
+              this.terminationGraceMs,
+            );
+        void processCleanup.then(
           () => {
+            if (reason === 'process-error') {
+              rejectOnce(cause);
+              return;
+            }
             if (reason === 'input-error') {
               rejectOnce(
                 new Error(`Failed to write hook input: ${String(cause)}`, {
@@ -186,19 +295,23 @@ export class SecureProcessExecutor {
 
       child.on('close', (code) => {
         if (termination) return;
-        resolveOnce({
-          stdout: stdout.getContent(),
-          stderr: stderr.getContent(),
-          exitCode: code ?? 1,
-          timedOut: false,
-        });
+        cleanup();
+        const processCleanup = windowsJob
+          ? windowsJob.terminateAndWait()
+          : Promise.resolve();
+        void processCleanup.then(() => {
+          if (termination) return;
+          resolveOnce({
+            stdout: stdout.getContent(),
+            stderr: stderr.getContent(),
+            exitCode: code ?? 1,
+            timedOut: false,
+          });
+        }, rejectOnce);
       });
 
       child.on('error', (error) => {
-        if (termination && child.pid) {
-          return;
-        }
-        rejectOnce(error);
+        stop('process-error', error);
       });
       child.stdin.on('error', (error) => {
         if (isBrokenPipeError(error)) {
@@ -221,7 +334,7 @@ export class SecureProcessExecutor {
 
       if (!termination) {
         try {
-          child.stdin.write(inputJson);
+          child.stdin.write(processInput);
           child.stdin.end();
         } catch (error) {
           if (isBrokenPipeError(error)) {

--- a/src/hooks/SecureProcessExecutor.ts
+++ b/src/hooks/SecureProcessExecutor.ts
@@ -25,6 +25,7 @@ import {
 } from './WindowsProcessJob.js';
 
 const DEFAULT_HOOK_PROCESS_TERMINATION_GRACE_MS = 1_000;
+const WINDOWS_HOOK_PROCESS_TERMINATION_TIMEOUT_MS = 5_000;
 const WINDOWS_HOOK_RUNNER = `
 const { spawn } = require('node:child_process');
 
@@ -274,7 +275,9 @@ export class SecureProcessExecutor {
         termination = reason;
         cleanup();
         const processCleanup = windowsJob
-          ? windowsJob.terminateAndWait()
+          ? windowsJob.terminateAndWait(
+              WINDOWS_HOOK_PROCESS_TERMINATION_TIMEOUT_MS,
+            )
           : terminateProcessTree(
               child.pid,
               child,
@@ -316,7 +319,9 @@ export class SecureProcessExecutor {
         if (termination) return;
         cleanup();
         const processCleanup = windowsJob
-          ? windowsJob.terminateAndWait()
+          ? windowsJob.terminateAndWait(
+              WINDOWS_HOOK_PROCESS_TERMINATION_TIMEOUT_MS,
+            )
           : terminateProcessTree(
               child.pid,
               child,

--- a/src/hooks/SecureProcessExecutor.ts
+++ b/src/hooks/SecureProcessExecutor.ts
@@ -18,7 +18,10 @@ import {
   type HookInput,
   type ProcessResult,
 } from './types/HookTypes.js';
-import { WindowsProcessJob } from './WindowsProcessJob.js';
+import {
+  HookProcessContainmentError,
+  WindowsProcessJob,
+} from './WindowsProcessJob.js';
 
 const DEFAULT_HOOK_PROCESS_TERMINATION_GRACE_MS = 1_000;
 const WINDOWS_HOOK_RUNNER = `
@@ -160,8 +163,17 @@ export class SecureProcessExecutor {
           });
     } catch (error) {
       windowsJob?.close();
-      throw error;
+      throw windowsJob
+        ? new HookProcessContainmentError(
+            'Failed to spawn the contained Windows Hook process',
+            { cause: error },
+          )
+        : error;
     }
+    child.once('error', () => {
+      // Keep spawn failures observed if containment setup rejects before the
+      // main lifecycle listeners are installed.
+    });
 
     if (windowsJob) {
       try {
@@ -176,9 +188,10 @@ export class SecureProcessExecutor {
           this.terminationGraceMs,
         );
         windowsJob.close();
-        throw new Error('Failed to contain the Windows Hook process', {
-          cause: error,
-        });
+        throw new HookProcessContainmentError(
+          'Failed to contain the Windows Hook process',
+          { cause: error },
+        );
       }
     }
     const processInput = windowsJob
@@ -252,7 +265,14 @@ export class SecureProcessExecutor {
         void processCleanup.then(
           () => {
             if (reason === 'process-error') {
-              rejectOnce(cause);
+              rejectOnce(
+                windowsJob
+                  ? new HookProcessContainmentError(
+                      'The contained Windows Hook process failed',
+                      { cause },
+                    )
+                  : cause,
+              );
               return;
             }
             resolveOnce(

--- a/src/hooks/SecureProcessExecutor.ts
+++ b/src/hooks/SecureProcessExecutor.ts
@@ -62,26 +62,12 @@ process.stdin.once('end', () => {
     }
   });
   child.stdin.on('error', (error) => {
-    if (error?.code === 'EPIPE') {
-      return;
-    }
-    failed = true;
-    process.exitCode = 1;
-    process.stderr.write(String(error));
-    child.kill();
+    // The command may close stdin without consuming the payload. Its final
+    // exit status remains authoritative.
   });
   child.stdin.end(payload.input);
 });
 `;
-
-function isBrokenPipeError(error: unknown): boolean {
-  return (
-    typeof error === 'object'
-    && error !== null
-    && 'code' in error
-    && error.code === 'EPIPE'
-  );
-}
 
 /**
  * 流量限制器
@@ -220,7 +206,6 @@ export class SecureProcessExecutor {
       let termination:
         | 'abort'
         | 'timeout'
-        | 'input-error'
         | 'process-error'
         | undefined;
       let timeout: ReturnType<typeof setTimeout> | undefined;
@@ -249,7 +234,7 @@ export class SecureProcessExecutor {
         reject(error);
       };
       const stop = (
-        reason: 'abort' | 'timeout' | 'input-error' | 'process-error',
+        reason: 'abort' | 'timeout' | 'process-error',
         cause?: unknown,
       ): void => {
         if (settled || termination) {
@@ -268,14 +253,6 @@ export class SecureProcessExecutor {
           () => {
             if (reason === 'process-error') {
               rejectOnce(cause);
-              return;
-            }
-            if (reason === 'input-error') {
-              rejectOnce(
-                new Error(`Failed to write hook input: ${String(cause)}`, {
-                  cause,
-                }),
-              );
               return;
             }
             resolveOnce(
@@ -313,13 +290,9 @@ export class SecureProcessExecutor {
       child.on('error', (error) => {
         stop('process-error', error);
       });
-      child.stdin.on('error', (error) => {
-        if (isBrokenPipeError(error)) {
-          // Fast hooks may close stdin before the write completes. Their exit
-          // status remains authoritative.
-          return;
-        }
-        stop('input-error', error);
+      child.stdin.on('error', () => {
+        // Fast hooks may close stdin before the write completes. Their exit
+        // status remains authoritative.
       });
 
       timeout = setTimeout(() => stop('timeout'), timeoutMs);
@@ -336,11 +309,8 @@ export class SecureProcessExecutor {
         try {
           child.stdin.write(processInput);
           child.stdin.end();
-        } catch (error) {
-          if (isBrokenPipeError(error)) {
-            return;
-          }
-          stop('input-error', error);
+        } catch {
+          // Wait for close or timeout; the process exit status is authoritative.
         }
       }
     });

--- a/src/hooks/SecureProcessExecutor.ts
+++ b/src/hooks/SecureProcessExecutor.ts
@@ -20,6 +20,7 @@ import {
 } from './types/HookTypes.js';
 import {
   HookProcessContainmentError,
+  isHookProcessContainmentError,
   WindowsProcessJob,
 } from './WindowsProcessJob.js';
 
@@ -71,6 +72,15 @@ process.stdin.once('end', () => {
   child.stdin.end(payload.input);
 });
 `;
+
+function toContainmentError(
+  message: string,
+  error: unknown,
+): HookProcessContainmentError {
+  return isHookProcessContainmentError(error)
+    ? error
+    : new HookProcessContainmentError(message, { cause: error });
+}
 
 /**
  * 流量限制器
@@ -182,12 +192,20 @@ export class SecureProcessExecutor {
         }
         windowsJob.assign(child.pid);
       } catch (error) {
-        await terminateProcessTree(
-          child.pid,
-          child,
-          this.terminationGraceMs,
-        );
-        windowsJob.close();
+        try {
+          await terminateProcessTree(
+            child.pid,
+            child,
+            this.terminationGraceMs,
+          );
+        } catch (cleanupError) {
+          throw new HookProcessContainmentError(
+            'Failed to contain or terminate the Windows Hook process',
+            { cause: new AggregateError([error, cleanupError]) },
+          );
+        } finally {
+          windowsJob.close();
+        }
         throw new HookProcessContainmentError(
           'Failed to contain the Windows Hook process',
           { cause: error },
@@ -286,7 +304,11 @@ export class SecureProcessExecutor {
                 : this.createCancelledResult(stdout.getContent()),
             );
           },
-          rejectOnce,
+          (error) => {
+            rejectOnce(
+              toContainmentError('Failed to terminate the Hook process tree', error),
+            );
+          },
         );
       };
 
@@ -295,7 +317,11 @@ export class SecureProcessExecutor {
         cleanup();
         const processCleanup = windowsJob
           ? windowsJob.terminateAndWait()
-          : Promise.resolve();
+          : terminateProcessTree(
+              child.pid,
+              child,
+              this.terminationGraceMs,
+            );
         void processCleanup.then(() => {
           if (termination) return;
           resolveOnce({
@@ -304,7 +330,11 @@ export class SecureProcessExecutor {
             exitCode: code ?? 1,
             timedOut: false,
           });
-        }, rejectOnce);
+        }, (error) => {
+          rejectOnce(
+            toContainmentError('Failed to reap the Hook process tree', error),
+          );
+        });
       });
 
       child.on('error', (error) => {

--- a/src/hooks/SecureProcessExecutor.ts
+++ b/src/hooks/SecureProcessExecutor.ts
@@ -18,6 +18,15 @@ import {
 
 const DEFAULT_HOOK_PROCESS_TERMINATION_GRACE_MS = 1_000;
 
+function isBrokenPipeError(error: unknown): boolean {
+  return (
+    typeof error === 'object'
+    && error !== null
+    && 'code' in error
+    && error.code === 'EPIPE'
+  );
+}
+
 /**
  * 流量限制器
  */
@@ -192,6 +201,11 @@ export class SecureProcessExecutor {
         rejectOnce(error);
       });
       child.stdin.on('error', (error) => {
+        if (isBrokenPipeError(error)) {
+          // Fast hooks may close stdin before the write completes. Their exit
+          // status remains authoritative.
+          return;
+        }
         stop('input-error', error);
       });
 
@@ -210,6 +224,9 @@ export class SecureProcessExecutor {
           child.stdin.write(inputJson);
           child.stdin.end();
         } catch (error) {
+          if (isBrokenPipeError(error)) {
+            return;
+          }
           stop('input-error', error);
         }
       }

--- a/src/hooks/SecureProcessExecutor.ts
+++ b/src/hooks/SecureProcessExecutor.ts
@@ -6,11 +6,17 @@
 
 import { spawn } from 'node:child_process';
 import {
+  shellProcessSpawnOptions,
+  terminateProcessTree,
+} from '../tools/builtin/shell/processTree.js';
+import {
   HookExitCode,
   type HookExecutionContext,
   type HookInput,
   type ProcessResult,
 } from './types/HookTypes.js';
+
+const DEFAULT_HOOK_PROCESS_TERMINATION_GRACE_MS = 1_000;
 
 /**
  * 流量限制器
@@ -47,6 +53,14 @@ export class SecureProcessExecutor {
   private readonly MAX_STDERR_SIZE = 1 * 1024 * 1024; // 1MB
   private readonly MAX_INPUT_SIZE = 100 * 1024; // 100KB
 
+  constructor(
+    private readonly terminationGraceMs = DEFAULT_HOOK_PROCESS_TERMINATION_GRACE_MS,
+  ) {
+    if (!Number.isSafeInteger(terminationGraceMs) || terminationGraceMs <= 0) {
+      throw new TypeError('Hook process termination grace must be a positive safe integer');
+    }
+  }
+
   /**
    * 执行命令
    */
@@ -56,6 +70,10 @@ export class SecureProcessExecutor {
     context: HookExecutionContext,
     timeoutMs: number
   ): Promise<ProcessResult> {
+    if (context.abortSignal?.aborted) {
+      return this.createCancelledResult();
+    }
+
     // 1. 验证输入大小
     const inputJson = JSON.stringify(input);
     if (inputJson.length > this.MAX_INPUT_SIZE) {
@@ -72,7 +90,7 @@ export class SecureProcessExecutor {
       shell: true,
       env,
       cwd: context.projectDir,
-      timeout: timeoutMs,
+      ...shellProcessSpawnOptions(),
     });
 
     // 4. 流量控制
@@ -90,76 +108,121 @@ export class SecureProcessExecutor {
       stderr.append(data);
     });
 
-    // 5. 写入输入
-    try {
-      child.stdin.write(inputJson);
-      child.stdin.end();
-    } catch (err) {
-      child.kill('SIGTERM');
-      throw new Error(`Failed to write hook input: ${err}`);
-    }
-
-    // 6. 等待完成或超时
+    // 5. 等待完成、取消或超时
     return new Promise((resolve, reject) => {
-      let timedOut = false;
-      let resolved = false;
-
-      // 保存 abort handler 引用，以便后续移除
+      let settled = false;
+      let termination: 'abort' | 'timeout' | 'input-error' | undefined;
+      let timeout: ReturnType<typeof setTimeout> | undefined;
       let abortHandler: (() => void) | null = null;
 
-      const cleanup = () => {
-        // 移除 abort 监听器，避免内存泄漏
+      const cleanup = (): void => {
+        if (timeout) {
+          clearTimeout(timeout);
+          timeout = undefined;
+        }
         if (abortHandler && context.abortSignal) {
           context.abortSignal.removeEventListener('abort', abortHandler);
           abortHandler = null;
         }
       };
-
-      const timer = setTimeout(() => {
-        timedOut = true;
-        child.kill('SIGKILL');
-      }, timeoutMs);
+      const resolveOnce = (result: ProcessResult): void => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        resolve(result);
+      };
+      const rejectOnce = (error: unknown): void => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        reject(error);
+      };
+      const stop = (
+        reason: 'abort' | 'timeout' | 'input-error',
+        cause?: unknown,
+      ): void => {
+        if (settled || termination) {
+          return;
+        }
+        termination = reason;
+        cleanup();
+        void terminateProcessTree(
+          child.pid,
+          child,
+          this.terminationGraceMs,
+        ).then(
+          () => {
+            if (reason === 'input-error') {
+              rejectOnce(
+                new Error(`Failed to write hook input: ${String(cause)}`, {
+                  cause,
+                }),
+              );
+              return;
+            }
+            resolveOnce(
+              reason === 'timeout'
+                ? {
+                    stdout: stdout.getContent(),
+                    stderr: stderr.getContent(),
+                    exitCode: HookExitCode.TIMEOUT,
+                    timedOut: true,
+                  }
+                : this.createCancelledResult(stdout.getContent()),
+            );
+          },
+          rejectOnce,
+        );
+      };
 
       child.on('close', (code) => {
-        if (resolved) return;
-        resolved = true;
-        clearTimeout(timer);
-        cleanup();
-
-        resolve({
+        if (termination) return;
+        resolveOnce({
           stdout: stdout.getContent(),
           stderr: stderr.getContent(),
-          exitCode: timedOut ? HookExitCode.TIMEOUT : (code ?? 1),
-          timedOut,
+          exitCode: code ?? 1,
+          timedOut: false,
         });
       });
 
-      child.on('error', (err) => {
-        if (resolved) return;
-        resolved = true;
-        clearTimeout(timer);
-        cleanup();
-        reject(err);
+      child.on('error', (error) => {
+        if (termination && child.pid) {
+          return;
+        }
+        rejectOnce(error);
+      });
+      child.stdin.on('error', (error) => {
+        stop('input-error', error);
       });
 
-      // 处理中止信号
+      timeout = setTimeout(() => stop('timeout'), timeoutMs);
+
       if (context.abortSignal) {
-        abortHandler = () => {
-          if (resolved) return;
-          resolved = true;
-          clearTimeout(timer);
-          cleanup();
-          child.kill('SIGTERM');
-          resolve({
-            stdout: stdout.getContent(),
-            stderr: 'Hook cancelled by abort signal',
-            exitCode: 1,
-            timedOut: false,
-          });
-        };
-        context.abortSignal.addEventListener('abort', abortHandler);
+        abortHandler = () => stop('abort');
+        context.abortSignal.addEventListener('abort', abortHandler, { once: true });
+        if (context.abortSignal.aborted) {
+          abortHandler();
+        }
+      }
+
+      if (!termination) {
+        try {
+          child.stdin.write(inputJson);
+          child.stdin.end();
+        } catch (error) {
+          stop('input-error', error);
+        }
       }
     });
+  }
+
+  private createCancelledResult(stdout = ''): ProcessResult {
+    return {
+      stdout,
+      stderr: 'Hook cancelled by abort signal',
+      exitCode: HookExitCode.NON_BLOCKING_ERROR,
+      timedOut: false,
+    };
   }
 
   /**

--- a/src/hooks/SecureProcessExecutor.ts
+++ b/src/hooks/SecureProcessExecutor.ts
@@ -20,7 +20,6 @@ import {
 } from './types/HookTypes.js';
 import {
   HookProcessContainmentError,
-  isHookProcessContainmentError,
   WindowsProcessJob,
 } from './WindowsProcessJob.js';
 
@@ -78,7 +77,7 @@ function toContainmentError(
   message: string,
   error: unknown,
 ): HookProcessContainmentError {
-  return isHookProcessContainmentError(error)
+  return error instanceof HookProcessContainmentError
     ? error
     : new HookProcessContainmentError(message, { cause: error });
 }

--- a/src/hooks/WindowsProcessJob.ts
+++ b/src/hooks/WindowsProcessJob.ts
@@ -1,3 +1,5 @@
+import { SdkError } from '../errors/SdkError.js';
+
 const JOB_OBJECT_BASIC_ACCOUNTING_INFORMATION = 1;
 const JOB_OBJECT_EXTENDED_LIMIT_INFORMATION = 9;
 const JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x0000_2000;
@@ -8,25 +10,15 @@ const WINDOWS_JOB_POLL_INTERVAL_MS = 20;
 type NativeHandle = unknown;
 
 interface WindowsJobBindings {
-  createJobObject: (
-    attributes: null,
-    name: null,
-  ) => NativeHandle;
+  createJobObject: (attributes: null, name: null) => NativeHandle;
   setInformationJobObject: (
     job: NativeHandle,
     informationClass: number,
     information: Buffer,
     informationLength: number,
   ) => number;
-  openProcess: (
-    desiredAccess: number,
-    inheritHandle: number,
-    processId: number,
-  ) => NativeHandle;
-  assignProcessToJobObject: (
-    job: NativeHandle,
-    process: NativeHandle,
-  ) => number;
+  openProcess: (desiredAccess: number, inheritHandle: number, processId: number) => NativeHandle;
+  assignProcessToJobObject: (job: NativeHandle, process: NativeHandle) => number;
   terminateJobObject: (job: NativeHandle, exitCode: number) => number;
   queryInformationJobObject: (
     job: NativeHandle,
@@ -41,11 +33,35 @@ interface WindowsJobBindings {
 
 let bindingsPromise: Promise<WindowsJobBindings> | undefined;
 
-function win32Error(
-  bindings: WindowsJobBindings,
-  operation: string,
-): Error {
-  return new Error(`${operation} failed (Win32 error ${bindings.getLastError()})`);
+export class HookProcessContainmentError extends SdkError {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super('HOOK_PROCESS_CONTAINMENT_FAILED', message, options);
+  }
+}
+
+export function isHookProcessContainmentError(
+  error: unknown,
+): error is HookProcessContainmentError {
+  return (
+    error instanceof HookProcessContainmentError ||
+    (typeof error === 'object' &&
+      error !== null &&
+      'code' in error &&
+      error.code === 'HOOK_PROCESS_CONTAINMENT_FAILED')
+  );
+}
+
+export function getRecoverableHookErrorMessage(error: unknown): string {
+  if (isHookProcessContainmentError(error)) {
+    throw error;
+  }
+  return error instanceof Error ? error.message : String(error);
+}
+
+function win32Error(bindings: WindowsJobBindings, operation: string): HookProcessContainmentError {
+  return new HookProcessContainmentError(
+    `${operation} failed (Win32 error ${bindings.getLastError()})`,
+  );
 }
 
 async function loadWindowsJobBindings(): Promise<WindowsJobBindings> {
@@ -53,40 +69,38 @@ async function loadWindowsJobBindings(): Promise<WindowsJobBindings> {
     throw new Error('Windows Job Objects are only available on Windows');
   }
   if (!bindingsPromise) {
-    bindingsPromise = import('koffi').then(({ default: koffi }) => {
-      const kernel32 = koffi.load('kernel32.dll');
-      return {
-        createJobObject: kernel32.func(
-          'void * __stdcall CreateJobObjectW(void *attributes, const char16_t *name)',
-        ),
-        setInformationJobObject: kernel32.func(
-          'int32_t __stdcall SetInformationJobObject(void *job, int32_t informationClass, void *information, uint32_t informationLength)',
-        ),
-        openProcess: kernel32.func(
-          'void * __stdcall OpenProcess(uint32_t desiredAccess, int32_t inheritHandle, uint32_t processId)',
-        ),
-        assignProcessToJobObject: kernel32.func(
-          'int32_t __stdcall AssignProcessToJobObject(void *job, void *process)',
-        ),
-        terminateJobObject: kernel32.func(
-          'int32_t __stdcall TerminateJobObject(void *job, uint32_t exitCode)',
-        ),
-        queryInformationJobObject: kernel32.func(
-          'int32_t __stdcall QueryInformationJobObject(void *job, int32_t informationClass, void *information, uint32_t informationLength, void *returnLength)',
-        ),
-        closeHandle: kernel32.func(
-          'int32_t __stdcall CloseHandle(void *handle)',
-        ),
-        getLastError: kernel32.func(
-          'uint32_t __stdcall GetLastError()',
-        ),
-      };
-    }).catch((error) => {
-      bindingsPromise = undefined;
-      throw new Error('Windows Job Object support is unavailable', {
-        cause: error,
+    bindingsPromise = import('koffi')
+      .then(({ default: koffi }) => {
+        const kernel32 = koffi.load('kernel32.dll');
+        return {
+          createJobObject: kernel32.func(
+            'void * __stdcall CreateJobObjectW(void *attributes, const char16_t *name)',
+          ),
+          setInformationJobObject: kernel32.func(
+            'int32_t __stdcall SetInformationJobObject(void *job, int32_t informationClass, void *information, uint32_t informationLength)',
+          ),
+          openProcess: kernel32.func(
+            'void * __stdcall OpenProcess(uint32_t desiredAccess, int32_t inheritHandle, uint32_t processId)',
+          ),
+          assignProcessToJobObject: kernel32.func(
+            'int32_t __stdcall AssignProcessToJobObject(void *job, void *process)',
+          ),
+          terminateJobObject: kernel32.func(
+            'int32_t __stdcall TerminateJobObject(void *job, uint32_t exitCode)',
+          ),
+          queryInformationJobObject: kernel32.func(
+            'int32_t __stdcall QueryInformationJobObject(void *job, int32_t informationClass, void *information, uint32_t informationLength, void *returnLength)',
+          ),
+          closeHandle: kernel32.func('int32_t __stdcall CloseHandle(void *handle)'),
+          getLastError: kernel32.func('uint32_t __stdcall GetLastError()'),
+        };
+      })
+      .catch((error) => {
+        bindingsPromise = undefined;
+        throw new HookProcessContainmentError('Windows Job Object support is unavailable', {
+          cause: error,
+        });
       });
-    });
   }
   return bindingsPromise;
 }
@@ -119,12 +133,14 @@ export class WindowsProcessJob {
     }
 
     const information = createExtendedLimitInformation();
-    if (!bindings.setInformationJobObject(
-      handle,
-      JOB_OBJECT_EXTENDED_LIMIT_INFORMATION,
-      information,
-      information.byteLength,
-    )) {
+    if (
+      !bindings.setInformationJobObject(
+        handle,
+        JOB_OBJECT_EXTENDED_LIMIT_INFORMATION,
+        information,
+        information.byteLength,
+      )
+    ) {
       const error = win32Error(bindings, 'SetInformationJobObject');
       bindings.closeHandle(handle);
       throw error;
@@ -135,7 +151,9 @@ export class WindowsProcessJob {
 
   assign(processId: number): void {
     if (this.closed) {
-      throw new Error('Cannot assign a process to a closed Windows Job Object');
+      throw new HookProcessContainmentError(
+        'Cannot assign a process to a closed Windows Job Object',
+      );
     }
     const processHandle = this.bindings.openProcess(
       PROCESS_TERMINATE | PROCESS_SET_QUOTA,
@@ -147,10 +165,7 @@ export class WindowsProcessJob {
     }
 
     try {
-      if (!this.bindings.assignProcessToJobObject(
-        this.handle,
-        processHandle,
-      )) {
+      if (!this.bindings.assignProcessToJobObject(this.handle, processHandle)) {
         throw win32Error(this.bindings, 'AssignProcessToJobObject');
       }
     } finally {
@@ -178,30 +193,42 @@ export class WindowsProcessJob {
       return;
     }
 
-    while (this.getActiveProcessCount() !== 0) {
-      if (!this.bindings.terminateJobObject(this.handle, 1)) {
+    try {
+      if (this.getActiveProcessCount() > 0 && !this.bindings.terminateJobObject(this.handle, 1)) {
+        throw win32Error(this.bindings, 'TerminateJobObject');
+      }
+
+      while (this.getActiveProcessCount() > 0) {
         await new Promise<void>((resolve) => {
           setTimeout(resolve, WINDOWS_JOB_POLL_INTERVAL_MS);
         });
-        continue;
       }
-      await new Promise<void>((resolve) => {
-        setTimeout(resolve, WINDOWS_JOB_POLL_INTERVAL_MS);
-      });
+      this.close();
+    } catch (error) {
+      try {
+        this.close();
+      } catch (closeError) {
+        throw new HookProcessContainmentError(
+          'Failed to close the Windows Job Object after cleanup failed',
+          { cause: new AggregateError([error, closeError]) },
+        );
+      }
+      throw error;
     }
-    this.close();
   }
 
-  private getActiveProcessCount(): number | undefined {
+  private getActiveProcessCount(): number {
     const information = Buffer.alloc(48);
-    if (!this.bindings.queryInformationJobObject(
-      this.handle,
-      JOB_OBJECT_BASIC_ACCOUNTING_INFORMATION,
-      information,
-      information.byteLength,
-      null,
-    )) {
-      return undefined;
+    if (
+      !this.bindings.queryInformationJobObject(
+        this.handle,
+        JOB_OBJECT_BASIC_ACCOUNTING_INFORMATION,
+        information,
+        information.byteLength,
+        null,
+      )
+    ) {
+      throw win32Error(this.bindings, 'QueryInformationJobObject');
     }
     return information.readUInt32LE(40);
   }

--- a/src/hooks/WindowsProcessJob.ts
+++ b/src/hooks/WindowsProcessJob.ts
@@ -1,0 +1,205 @@
+const JOB_OBJECT_BASIC_ACCOUNTING_INFORMATION = 1;
+const JOB_OBJECT_EXTENDED_LIMIT_INFORMATION = 9;
+const JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x0000_2000;
+const PROCESS_TERMINATE = 0x0001;
+const PROCESS_SET_QUOTA = 0x0100;
+const WINDOWS_JOB_POLL_INTERVAL_MS = 20;
+
+type NativeHandle = unknown;
+
+interface WindowsJobBindings {
+  createJobObject: () => NativeHandle;
+  setInformationJobObject: (
+    job: NativeHandle,
+    informationClass: number,
+    information: Buffer,
+    informationLength: number,
+  ) => number;
+  openProcess: (
+    desiredAccess: number,
+    inheritHandle: number,
+    processId: number,
+  ) => NativeHandle;
+  assignProcessToJobObject: (
+    job: NativeHandle,
+    process: NativeHandle,
+  ) => number;
+  terminateJobObject: (job: NativeHandle, exitCode: number) => number;
+  queryInformationJobObject: (
+    job: NativeHandle,
+    informationClass: number,
+    information: Buffer,
+    informationLength: number,
+    returnLength: null,
+  ) => number;
+  closeHandle: (handle: NativeHandle) => number;
+  getLastError: () => number;
+}
+
+let bindingsPromise: Promise<WindowsJobBindings> | undefined;
+
+function win32Error(
+  bindings: WindowsJobBindings,
+  operation: string,
+): Error {
+  return new Error(`${operation} failed (Win32 error ${bindings.getLastError()})`);
+}
+
+async function loadWindowsJobBindings(): Promise<WindowsJobBindings> {
+  if (process.platform !== 'win32') {
+    throw new Error('Windows Job Objects are only available on Windows');
+  }
+  if (!bindingsPromise) {
+    bindingsPromise = import('koffi').then(({ default: koffi }) => {
+      const kernel32 = koffi.load('kernel32.dll');
+      return {
+        createJobObject: kernel32.func(
+          'void * __stdcall CreateJobObjectW(void *attributes, const char16_t *name)',
+        ),
+        setInformationJobObject: kernel32.func(
+          'int32_t __stdcall SetInformationJobObject(void *job, int32_t informationClass, void *information, uint32_t informationLength)',
+        ),
+        openProcess: kernel32.func(
+          'void * __stdcall OpenProcess(uint32_t desiredAccess, int32_t inheritHandle, uint32_t processId)',
+        ),
+        assignProcessToJobObject: kernel32.func(
+          'int32_t __stdcall AssignProcessToJobObject(void *job, void *process)',
+        ),
+        terminateJobObject: kernel32.func(
+          'int32_t __stdcall TerminateJobObject(void *job, uint32_t exitCode)',
+        ),
+        queryInformationJobObject: kernel32.func(
+          'int32_t __stdcall QueryInformationJobObject(void *job, int32_t informationClass, void *information, uint32_t informationLength, void *returnLength)',
+        ),
+        closeHandle: kernel32.func(
+          'int32_t __stdcall CloseHandle(void *handle)',
+        ),
+        getLastError: kernel32.func(
+          'uint32_t __stdcall GetLastError()',
+        ),
+      };
+    }).catch((error) => {
+      bindingsPromise = undefined;
+      throw new Error('Windows Job Object support is unavailable', {
+        cause: error,
+      });
+    });
+  }
+  return bindingsPromise;
+}
+
+function createExtendedLimitInformation(): Buffer {
+  const size = process.arch === 'ia32' ? 112 : 144;
+  const information = Buffer.alloc(size);
+  information.writeUInt32LE(JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE, 16);
+  return information;
+}
+
+/**
+ * Owns one Windows process tree. The root must be assigned before it receives
+ * permission to spawn, so every descendant inherits the Job membership.
+ */
+export class WindowsProcessJob {
+  private cleanupPromise: Promise<void> | undefined;
+  private closed = false;
+
+  private constructor(
+    private readonly bindings: WindowsJobBindings,
+    private readonly handle: NativeHandle,
+  ) {}
+
+  static async create(): Promise<WindowsProcessJob> {
+    const bindings = await loadWindowsJobBindings();
+    const handle = bindings.createJobObject();
+    if (!handle) {
+      throw win32Error(bindings, 'CreateJobObjectW');
+    }
+
+    const information = createExtendedLimitInformation();
+    if (!bindings.setInformationJobObject(
+      handle,
+      JOB_OBJECT_EXTENDED_LIMIT_INFORMATION,
+      information,
+      information.byteLength,
+    )) {
+      const error = win32Error(bindings, 'SetInformationJobObject');
+      bindings.closeHandle(handle);
+      throw error;
+    }
+
+    return new WindowsProcessJob(bindings, handle);
+  }
+
+  assign(processId: number): void {
+    if (this.closed) {
+      throw new Error('Cannot assign a process to a closed Windows Job Object');
+    }
+    const processHandle = this.bindings.openProcess(
+      PROCESS_TERMINATE | PROCESS_SET_QUOTA,
+      0,
+      processId,
+    );
+    if (!processHandle) {
+      throw win32Error(this.bindings, 'OpenProcess');
+    }
+
+    try {
+      if (!this.bindings.assignProcessToJobObject(
+        this.handle,
+        processHandle,
+      )) {
+        throw win32Error(this.bindings, 'AssignProcessToJobObject');
+      }
+    } finally {
+      this.bindings.closeHandle(processHandle);
+    }
+  }
+
+  terminateAndWait(): Promise<void> {
+    this.cleanupPromise ??= this.terminateAndWaitOnce();
+    return this.cleanupPromise;
+  }
+
+  close(): void {
+    if (this.closed) {
+      return;
+    }
+    if (!this.bindings.closeHandle(this.handle)) {
+      throw win32Error(this.bindings, 'CloseHandle');
+    }
+    this.closed = true;
+  }
+
+  private async terminateAndWaitOnce(): Promise<void> {
+    if (this.closed) {
+      return;
+    }
+
+    while (this.getActiveProcessCount() !== 0) {
+      if (!this.bindings.terminateJobObject(this.handle, 1)) {
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, WINDOWS_JOB_POLL_INTERVAL_MS);
+        });
+        continue;
+      }
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, WINDOWS_JOB_POLL_INTERVAL_MS);
+      });
+    }
+    this.close();
+  }
+
+  private getActiveProcessCount(): number | undefined {
+    const information = Buffer.alloc(48);
+    if (!this.bindings.queryInformationJobObject(
+      this.handle,
+      JOB_OBJECT_BASIC_ACCOUNTING_INFORMATION,
+      information,
+      information.byteLength,
+      null,
+    )) {
+      return undefined;
+    }
+    return information.readUInt32LE(40);
+  }
+}

--- a/src/hooks/WindowsProcessJob.ts
+++ b/src/hooks/WindowsProcessJob.ts
@@ -8,7 +8,10 @@ const WINDOWS_JOB_POLL_INTERVAL_MS = 20;
 type NativeHandle = unknown;
 
 interface WindowsJobBindings {
-  createJobObject: () => NativeHandle;
+  createJobObject: (
+    attributes: null,
+    name: null,
+  ) => NativeHandle;
   setInformationJobObject: (
     job: NativeHandle,
     informationClass: number,
@@ -110,7 +113,7 @@ export class WindowsProcessJob {
 
   static async create(): Promise<WindowsProcessJob> {
     const bindings = await loadWindowsJobBindings();
-    const handle = bindings.createJobObject();
+    const handle = bindings.createJobObject(null, null);
     if (!handle) {
       throw win32Error(bindings, 'CreateJobObjectW');
     }

--- a/src/hooks/WindowsProcessJob.ts
+++ b/src/hooks/WindowsProcessJob.ts
@@ -41,13 +41,37 @@ export class HookProcessContainmentError extends SdkError {
 
 export function isHookProcessContainmentError(
   error: unknown,
-): error is HookProcessContainmentError {
+): boolean {
+  return containsHookProcessContainmentError(error, new Set());
+}
+
+function containsHookProcessContainmentError(
+  error: unknown,
+  seen: Set<object>,
+): boolean {
+  if (typeof error !== 'object' || error === null) {
+    return false;
+  }
+  if (
+    error instanceof HookProcessContainmentError
+    || ('code' in error && error.code === 'HOOK_PROCESS_CONTAINMENT_FAILED')
+  ) {
+    return true;
+  }
+  if (seen.has(error)) {
+    return false;
+  }
+  seen.add(error);
+  if (
+    error instanceof AggregateError
+    && error.errors.some((nestedError) =>
+      containsHookProcessContainmentError(nestedError, seen))
+  ) {
+    return true;
+  }
   return (
-    error instanceof HookProcessContainmentError ||
-    (typeof error === 'object' &&
-      error !== null &&
-      'code' in error &&
-      error.code === 'HOOK_PROCESS_CONTAINMENT_FAILED')
+    'cause' in error
+    && containsHookProcessContainmentError(error.cause, seen)
   );
 }
 

--- a/src/hooks/WindowsProcessJob.ts
+++ b/src/hooks/WindowsProcessJob.ts
@@ -64,6 +64,16 @@ function win32Error(bindings: WindowsJobBindings, operation: string): HookProces
   );
 }
 
+function closeNativeHandle(
+  bindings: WindowsJobBindings,
+  handle: NativeHandle,
+  operation: string,
+): void {
+  if (!bindings.closeHandle(handle)) {
+    throw win32Error(bindings, operation);
+  }
+}
+
 async function loadWindowsJobBindings(): Promise<WindowsJobBindings> {
   if (process.platform !== 'win32') {
     throw new Error('Windows Job Objects are only available on Windows');
@@ -141,9 +151,19 @@ export class WindowsProcessJob {
         information.byteLength,
       )
     ) {
-      const error = win32Error(bindings, 'SetInformationJobObject');
-      bindings.closeHandle(handle);
-      throw error;
+      const configurationError = win32Error(
+        bindings,
+        'SetInformationJobObject',
+      );
+      try {
+        closeNativeHandle(bindings, handle, 'CloseHandle(Job)');
+      } catch (closeError) {
+        throw new HookProcessContainmentError(
+          'Failed to configure and close the Windows Job Object',
+          { cause: new AggregateError([configurationError, closeError]) },
+        );
+      }
+      throw configurationError;
     }
 
     return new WindowsProcessJob(bindings, handle);
@@ -164,17 +184,36 @@ export class WindowsProcessJob {
       throw win32Error(this.bindings, 'OpenProcess');
     }
 
+    const assigned = this.bindings.assignProcessToJobObject(
+      this.handle,
+      processHandle,
+    );
+    const assignmentError = assigned
+      ? undefined
+      : win32Error(this.bindings, 'AssignProcessToJobObject');
     try {
-      if (!this.bindings.assignProcessToJobObject(this.handle, processHandle)) {
-        throw win32Error(this.bindings, 'AssignProcessToJobObject');
-      }
-    } finally {
-      this.bindings.closeHandle(processHandle);
+      closeNativeHandle(
+        this.bindings,
+        processHandle,
+        'CloseHandle(Process)',
+      );
+    } catch (closeError) {
+      throw new HookProcessContainmentError(
+        'Failed to close the Windows Hook process handle',
+        {
+          cause: assignmentError
+            ? new AggregateError([assignmentError, closeError])
+            : closeError,
+        },
+      );
+    }
+    if (assignmentError) {
+      throw assignmentError;
     }
   }
 
-  terminateAndWait(): Promise<void> {
-    this.cleanupPromise ??= this.terminateAndWaitOnce();
+  terminateAndWait(timeoutMs: number): Promise<void> {
+    this.cleanupPromise ??= this.terminateAndWaitOnce(timeoutMs);
     return this.cleanupPromise;
   }
 
@@ -182,13 +221,11 @@ export class WindowsProcessJob {
     if (this.closed) {
       return;
     }
-    if (!this.bindings.closeHandle(this.handle)) {
-      throw win32Error(this.bindings, 'CloseHandle');
-    }
+    closeNativeHandle(this.bindings, this.handle, 'CloseHandle(Job)');
     this.closed = true;
   }
 
-  private async terminateAndWaitOnce(): Promise<void> {
+  private async terminateAndWaitOnce(timeoutMs: number): Promise<void> {
     if (this.closed) {
       return;
     }
@@ -198,9 +235,19 @@ export class WindowsProcessJob {
         throw win32Error(this.bindings, 'TerminateJobObject');
       }
 
+      const deadline = Date.now() + timeoutMs;
       while (this.getActiveProcessCount() > 0) {
+        const remainingMs = deadline - Date.now();
+        if (remainingMs <= 0) {
+          throw new HookProcessContainmentError(
+            `Windows Hook Job did not terminate within ${timeoutMs}ms`,
+          );
+        }
         await new Promise<void>((resolve) => {
-          setTimeout(resolve, WINDOWS_JOB_POLL_INTERVAL_MS);
+          setTimeout(
+            resolve,
+            Math.min(WINDOWS_JOB_POLL_INTERVAL_MS, remainingMs),
+          );
         });
       }
       this.close();

--- a/src/hooks/__tests__/HookInfrastructureFailure.test.ts
+++ b/src/hooks/__tests__/HookInfrastructureFailure.test.ts
@@ -11,6 +11,7 @@ import { SecureProcessExecutor } from '../SecureProcessExecutor.js';
 import { HookType } from '../types/HookTypes.js';
 import {
   HookProcessContainmentError,
+  isHookProcessContainmentError,
   WindowsProcessJob,
 } from '../WindowsProcessJob.js';
 
@@ -33,6 +34,19 @@ afterEach(async () => {
 });
 
 describe('Hook infrastructure failures', () => {
+  it('recognizes containment failures through aggregate and cause wrappers', () => {
+    const containmentError = new HookProcessContainmentError(
+      'Windows Job Object cleanup failed',
+    );
+    const aggregate = new AggregateError([
+      new Error('durable settlement failed'),
+      new Error('wrapped', { cause: containmentError }),
+    ]);
+
+    expect(isHookProcessContainmentError(aggregate)).toBe(true);
+    expect(isHookProcessContainmentError(new Error('ordinary failure'))).toBe(false);
+  });
+
   it('does not downgrade a process-containment failure to ignore', async () => {
     const containmentError = new HookProcessContainmentError(
       'Windows Job Object support is unavailable',

--- a/src/hooks/__tests__/HookInfrastructureFailure.test.ts
+++ b/src/hooks/__tests__/HookInfrastructureFailure.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ToolUseId, SessionId } from '../../types/branded.js';
+import { PermissionMode } from '../../types/common.js';
+import { DEFAULT_HOOK_CONFIG } from '../HookConfig.js';
+import { HookManager } from '../HookManager.js';
+import { SecureProcessExecutor } from '../SecureProcessExecutor.js';
+import { HookType } from '../types/HookTypes.js';
+import { HookProcessContainmentError } from '../WindowsProcessJob.js';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  HookManager.getInstance().loadConfig(DEFAULT_HOOK_CONFIG);
+});
+
+describe('Hook infrastructure failures', () => {
+  it('does not downgrade a process-containment failure to ignore', async () => {
+    const containmentError = new HookProcessContainmentError(
+      'Windows Job Object support is unavailable',
+    );
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(SecureProcessExecutor.prototype, 'execute').mockRejectedValue(containmentError);
+    const manager = HookManager.getInstance();
+    manager.loadConfig({
+      ...DEFAULT_HOOK_CONFIG,
+      enabled: true,
+      failureBehavior: 'ignore',
+      PreToolUse: [
+        {
+          hooks: [{ type: HookType.Command, command: 'echo guarded' }],
+        },
+      ],
+    });
+
+    await expect(
+      manager.executePreToolHooks(
+        'Bash',
+        ToolUseId('containment-failure'),
+        {},
+        {
+          projectDir: process.cwd(),
+          sessionId: SessionId('containment-failure'),
+          permissionMode: PermissionMode.DEFAULT,
+        },
+      ),
+    ).rejects.toBe(containmentError);
+  });
+
+  it('keeps ordinary Hook failures recoverable under ignore policy', async () => {
+    vi.spyOn(SecureProcessExecutor.prototype, 'execute').mockRejectedValue(
+      new Error('hook command failed'),
+    );
+    const manager = HookManager.getInstance();
+    manager.loadConfig({
+      ...DEFAULT_HOOK_CONFIG,
+      enabled: true,
+      failureBehavior: 'ignore',
+      PreToolUse: [
+        {
+          hooks: [{ type: HookType.Command, command: 'echo optional' }],
+        },
+      ],
+    });
+
+    await expect(
+      manager.executePreToolHooks(
+        'Bash',
+        ToolUseId('recoverable-hook-failure'),
+        {},
+        {
+          projectDir: process.cwd(),
+          sessionId: SessionId('recoverable-hook-failure'),
+          permissionMode: PermissionMode.DEFAULT,
+        },
+      ),
+    ).resolves.toMatchObject({
+      decision: 'allow',
+      warning: 'hook command failed',
+    });
+  });
+});

--- a/src/hooks/__tests__/HookInfrastructureFailure.test.ts
+++ b/src/hooks/__tests__/HookInfrastructureFailure.test.ts
@@ -1,7 +1,11 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ToolUseId, SessionId } from '../../types/branded.js';
 import { PermissionMode } from '../../types/common.js';
 import { DEFAULT_HOOK_CONFIG } from '../HookConfig.js';
+import { HookExecutor } from '../HookExecutor.js';
 import { HookManager } from '../HookManager.js';
 import { SecureProcessExecutor } from '../SecureProcessExecutor.js';
 import { HookType } from '../types/HookTypes.js';
@@ -9,6 +13,8 @@ import {
   HookProcessContainmentError,
   WindowsProcessJob,
 } from '../WindowsProcessJob.js';
+
+const roots: string[] = [];
 
 function createWindowsJob(bindings: Record<string, unknown>): WindowsProcessJob {
   const Constructor = WindowsProcessJob as unknown as new (
@@ -18,9 +24,12 @@ function createWindowsJob(bindings: Record<string, unknown>): WindowsProcessJob 
   return new Constructor(bindings, {});
 }
 
-afterEach(() => {
+afterEach(async () => {
   vi.restoreAllMocks();
   HookManager.getInstance().loadConfig(DEFAULT_HOOK_CONFIG);
+  await Promise.all(roots.splice(0).map((root) =>
+    rm(root, { recursive: true, force: true })
+  ));
 });
 
 describe('Hook infrastructure failures', () => {
@@ -87,6 +96,73 @@ describe('Hook infrastructure failures', () => {
       decision: 'allow',
       warning: 'hook command failed',
     });
+  });
+
+  it('propagates containment failure from a ConfigChange Hook reload', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'hook-config-reload-'));
+    roots.push(root);
+    const configPath = join(root, 'settings.json');
+    await writeFile(configPath, JSON.stringify({
+      hooks: { enabled: true },
+    }));
+    const containmentError = new HookProcessContainmentError(
+      'Windows Job Object support is unavailable',
+    );
+    const manager = HookManager.getInstance();
+    vi.spyOn(manager, 'executeConfigChangeHooks')
+      .mockRejectedValueOnce(containmentError);
+
+    await expect(manager.reloadConfig(configPath)).rejects.toBe(
+      containmentError,
+    );
+  });
+
+  it('stops scheduling concurrent Hooks after a containment failure', async () => {
+    const containmentError = new HookProcessContainmentError(
+      'Windows Job Object cleanup failed',
+    );
+    const execute = vi.spyOn(SecureProcessExecutor.prototype, 'execute')
+      .mockRejectedValueOnce(containmentError)
+      .mockResolvedValue({
+        stdout: '',
+        stderr: '',
+        exitCode: 0,
+        timedOut: false,
+      });
+    const executor = new HookExecutor();
+
+    await expect(executor.executePostToolHooks(
+      [
+        { type: HookType.Command, command: 'first' },
+        { type: HookType.Command, command: 'second' },
+      ],
+      {
+        hook_event_name: 'PostToolUse',
+        hook_execution_id: 'containment-concurrency',
+        timestamp: new Date().toISOString(),
+        project_dir: process.cwd(),
+        session_id: 'containment-concurrency',
+        permission_mode: PermissionMode.DEFAULT,
+        tool_name: 'Bash',
+        tool_use_id: 'containment-concurrency',
+        tool_input: {},
+        tool_response: {
+          status: 'success',
+          model: 'ok',
+        },
+      },
+      {
+        projectDir: process.cwd(),
+        sessionId: SessionId('containment-concurrency'),
+        permissionMode: PermissionMode.DEFAULT,
+        config: {
+          ...DEFAULT_HOOK_CONFIG,
+          enabled: true,
+          maxConcurrentHooks: 1,
+        },
+      },
+    )).rejects.toBe(containmentError);
+    expect(execute).toHaveBeenCalledOnce();
   });
 
   it('bounds Windows Job termination and closes the kill-on-close handle', async () => {

--- a/src/hooks/__tests__/HookInfrastructureFailure.test.ts
+++ b/src/hooks/__tests__/HookInfrastructureFailure.test.ts
@@ -5,7 +5,18 @@ import { DEFAULT_HOOK_CONFIG } from '../HookConfig.js';
 import { HookManager } from '../HookManager.js';
 import { SecureProcessExecutor } from '../SecureProcessExecutor.js';
 import { HookType } from '../types/HookTypes.js';
-import { HookProcessContainmentError } from '../WindowsProcessJob.js';
+import {
+  HookProcessContainmentError,
+  WindowsProcessJob,
+} from '../WindowsProcessJob.js';
+
+function createWindowsJob(bindings: Record<string, unknown>): WindowsProcessJob {
+  const Constructor = WindowsProcessJob as unknown as new (
+    bindings: Record<string, unknown>,
+    handle: object,
+  ) => WindowsProcessJob;
+  return new Constructor(bindings, {});
+}
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -76,5 +87,41 @@ describe('Hook infrastructure failures', () => {
       decision: 'allow',
       warning: 'hook command failed',
     });
+  });
+
+  it('bounds Windows Job termination and closes the kill-on-close handle', async () => {
+    const closeHandle = vi.fn(() => 1);
+    const job = createWindowsJob({
+      queryInformationJobObject: vi.fn((
+        _job,
+        _informationClass,
+        information: Buffer,
+      ) => {
+        information.writeUInt32LE(1, 40);
+        return 1;
+      }),
+      terminateJobObject: vi.fn(() => 1),
+      closeHandle,
+      getLastError: vi.fn(() => 0),
+    });
+
+    await expect(job.terminateAndWait(1)).rejects.toMatchObject({
+      code: 'HOOK_PROCESS_CONTAINMENT_FAILED',
+    });
+    expect(closeHandle).toHaveBeenCalledOnce();
+  });
+
+  it('reports a native process-handle close failure during assignment', () => {
+    const processHandle = {};
+    const job = createWindowsJob({
+      openProcess: vi.fn(() => processHandle),
+      assignProcessToJobObject: vi.fn(() => 1),
+      closeHandle: vi.fn(() => 0),
+      getLastError: vi.fn(() => 6),
+    });
+
+    expect(() => job.assign(42_424)).toThrow(
+      'Failed to close the Windows Hook process handle',
+    );
   });
 });

--- a/src/hooks/__tests__/HookRuntime.test.ts
+++ b/src/hooks/__tests__/HookRuntime.test.ts
@@ -7,6 +7,7 @@ import { SessionId, ToolUseId } from '../../types/branded.js';
 import { PermissionMode } from '../../types/common.js';
 import { HookEvent } from '../../types/constants.js';
 import { HookRuntime } from '../HookRuntime.js';
+import { HookProcessContainmentError } from '../WindowsProcessJob.js';
 
 function deferred(): { promise: Promise<void>; resolve: () => void } {
   let resolve!: () => void;
@@ -259,6 +260,32 @@ describe('HookRuntime', () => {
     release.resolve();
 
     await cancellationResult;
+    expect(executeUserPromptSubmitHooks).toHaveBeenCalledOnce();
+  });
+
+  it('quarantines file hooks after a containment failure', async () => {
+    const containmentError = new HookProcessContainmentError(
+      'Hook process cleanup failed',
+    );
+    const executeUserPromptSubmitHooks = vi.fn()
+      .mockRejectedValueOnce(containmentError)
+      .mockResolvedValue({ proceed: true });
+    const runtime = new HookRuntime({
+      sessionId: SessionId('session-file-hook-containment'),
+      permissionMode: PermissionMode.DEFAULT,
+      resolveProjectDir: () => '/tmp/project',
+      hookManager: {
+        executeUserPromptSubmitHooks,
+      } as never,
+    });
+
+    await expect(
+      runtime.applyUserPromptSubmit('first'),
+    ).rejects.toBe(containmentError);
+    expect(runtime.getTerminalContainmentFailure()).toBe(containmentError);
+    await expect(
+      runtime.applyUserPromptSubmit('second'),
+    ).rejects.toBe(containmentError);
     expect(executeUserPromptSubmitHooks).toHaveBeenCalledOnce();
   });
 

--- a/src/hooks/__tests__/HookRuntime.test.ts
+++ b/src/hooks/__tests__/HookRuntime.test.ts
@@ -207,6 +207,61 @@ describe('HookRuntime', () => {
     expect(runtime.hasPendingCallbackCleanup()).toBe(false);
   });
 
+  it('does not invoke file hooks for an already-aborted event', async () => {
+    const cancellation = new Error('cancel before file hook');
+    const controller = new AbortController();
+    const executeUserPromptSubmitHooks = vi.fn(async () => ({
+      proceed: true,
+    }));
+    const runtime = new HookRuntime({
+      sessionId: SessionId('session-file-hook-pre-abort'),
+      permissionMode: PermissionMode.DEFAULT,
+      resolveProjectDir: () => '/tmp/project',
+      hookManager: {
+        executeUserPromptSubmitHooks,
+      } as never,
+    });
+    controller.abort(cancellation);
+
+    await expect(
+      runtime.applyUserPromptSubmit('prompt', {
+        abortSignal: controller.signal,
+      }),
+    ).rejects.toBe(cancellation);
+    expect(executeUserPromptSubmitHooks).not.toHaveBeenCalled();
+  });
+
+  it('preserves cancellation that arrives while a file hook is running', async () => {
+    const started = deferred();
+    const release = deferred();
+    const cancellation = new Error('cancel running file hook');
+    const controller = new AbortController();
+    const executeUserPromptSubmitHooks = vi.fn(async () => {
+      started.resolve();
+      await release.promise;
+      return { proceed: true };
+    });
+    const runtime = new HookRuntime({
+      sessionId: SessionId('session-file-hook-cancel'),
+      permissionMode: PermissionMode.DEFAULT,
+      resolveProjectDir: () => '/tmp/project',
+      hookManager: {
+        executeUserPromptSubmitHooks,
+      } as never,
+    });
+
+    const dispatch = runtime.applyUserPromptSubmit('prompt', {
+      abortSignal: controller.signal,
+    });
+    const cancellationResult = expect(dispatch).rejects.toBe(cancellation);
+    await started.promise;
+    controller.abort(cancellation);
+    release.resolve();
+
+    await cancellationResult;
+    expect(executeUserPromptSubmitHooks).toHaveBeenCalledOnce();
+  });
+
   it('rejects invalid inline hook timeout configuration', () => {
     for (const [name, value] of [
       ['hookTimeoutMs', 0],

--- a/src/hooks/__tests__/HookRuntime.test.ts
+++ b/src/hooks/__tests__/HookRuntime.test.ts
@@ -289,6 +289,48 @@ describe('HookRuntime', () => {
     expect(executeUserPromptSubmitHooks).toHaveBeenCalledOnce();
   });
 
+  it('rejects an in-flight file hook that completes after quarantine', async () => {
+    const firstStarted = deferred();
+    const secondStarted = deferred();
+    const releaseFirst = deferred();
+    const releaseSecond = deferred();
+    const containmentError = new HookProcessContainmentError(
+      'Hook process cleanup failed',
+    );
+    let callCount = 0;
+    const executeUserPromptSubmitHooks = vi.fn(async () => {
+      callCount += 1;
+      if (callCount === 1) {
+        firstStarted.resolve();
+        await releaseFirst.promise;
+        throw containmentError;
+      }
+      secondStarted.resolve();
+      await releaseSecond.promise;
+      return { proceed: true };
+    });
+    const runtime = new HookRuntime({
+      sessionId: SessionId('session-concurrent-file-hook-containment'),
+      permissionMode: PermissionMode.DEFAULT,
+      resolveProjectDir: () => '/tmp/project',
+      hookManager: {
+        executeUserPromptSubmitHooks,
+      } as never,
+    });
+    const firstDispatch = runtime.applyUserPromptSubmit('first');
+    const firstRejection = expect(firstDispatch).rejects.toBe(containmentError);
+    await firstStarted.promise;
+    const secondDispatch = runtime.applyUserPromptSubmit('second');
+    const secondRejection = expect(secondDispatch).rejects.toBe(containmentError);
+    await secondStarted.promise;
+
+    releaseFirst.resolve();
+    await firstRejection;
+    releaseSecond.resolve();
+
+    await secondRejection;
+  });
+
   it('rejects invalid inline hook timeout configuration', () => {
     for (const [name, value] of [
       ['hookTimeoutMs', 0],

--- a/src/hooks/__tests__/SecureProcessExecutor.test.ts
+++ b/src/hooks/__tests__/SecureProcessExecutor.test.ts
@@ -61,7 +61,10 @@ function createContext(
   };
 }
 
-async function createProcessTreeFixture(root: string): Promise<{
+async function createProcessTreeFixture(
+  root: string,
+  parentExits = false,
+): Promise<{
   command: string;
   markerPath: string;
   readyPath: string;
@@ -87,13 +90,17 @@ async function createProcessTreeFixture(root: string): Promise<{
       "import { spawn } from 'node:child_process';",
       "import { execFileSync } from 'node:child_process';",
       "import { writeFileSync } from 'node:fs';",
+      "const parentExits = process.argv[5] === 'exit';",
       'const child = spawn(process.execPath, [process.argv[2], process.argv[3]], {',
-      "  stdio: 'ignore',",
+      "  stdio: parentExits ? ['ignore', 'inherit', 'inherit'] : 'ignore',",
       '});',
       "const groupPid = process.platform === 'win32'",
       '  ? process.pid',
       "  : Number(execFileSync('ps', ['-o', 'pgid=', '-p', String(process.pid)], { encoding: 'utf8' }).trim());",
-      'writeFileSync(process.argv[4], JSON.stringify({ groupPid, childPid: child.pid }));',
+      'writeFileSync(process.argv[4], JSON.stringify({ groupPid, parentPid: process.pid, childPid: child.pid }));',
+      'if (parentExits) {',
+      '  process.exit(0);',
+      '}',
       "process.on('SIGTERM', () => {});",
       'setInterval(() => {}, 1_000);',
     ].join('\n'),
@@ -105,6 +112,7 @@ async function createProcessTreeFixture(root: string): Promise<{
       quoteShellArgument(childPath),
       quoteShellArgument(markerPath),
       quoteShellArgument(readyPath),
+      quoteShellArgument(parentExits ? 'exit' : 'wait'),
     ].join(' '),
     markerPath,
     readyPath,
@@ -254,5 +262,45 @@ describe('SecureProcessExecutor', () => {
       expect(() => process.kill(childPid, 0)).toThrow();
     }, { timeout: 2_000 });
     processGroups.delete(groupPid);
+  });
+
+  it('terminates descendants after the hook parent has exited', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'hook-exited-parent-'));
+    roots.push(root);
+    const fixture = await createProcessTreeFixture(root, true);
+    const controller = new AbortController();
+    const executor = new SecureProcessExecutor(50);
+    const execution = executor.execute(
+      fixture.command,
+      createInput(root),
+      createContext(root, controller.signal),
+      5_000,
+    );
+
+    await vi.waitFor(async () => {
+      expect(await pathExists(fixture.readyPath)).toBe(true);
+    }, { timeout: 2_000 });
+    const { groupPid, parentPid, childPid } = JSON.parse(
+      await readFile(fixture.readyPath, 'utf8'),
+    ) as { groupPid: number; parentPid: number; childPid: number };
+    processGroups.add(groupPid);
+    processGroups.add(childPid);
+    await vi.waitFor(() => {
+      expect(() => process.kill(parentPid, 0)).toThrow();
+    }, { timeout: 2_000 });
+
+    controller.abort(new Error('request cancelled'));
+    await expect(execution).resolves.toMatchObject({
+      exitCode: 1,
+      timedOut: false,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 550));
+
+    expect(await pathExists(fixture.markerPath)).toBe(false);
+    await vi.waitFor(() => {
+      expect(() => process.kill(childPid, 0)).toThrow();
+    }, { timeout: 2_000 });
+    processGroups.delete(groupPid);
+    processGroups.delete(childPid);
   });
 });

--- a/src/hooks/__tests__/SecureProcessExecutor.test.ts
+++ b/src/hooks/__tests__/SecureProcessExecutor.test.ts
@@ -57,6 +57,7 @@ function createContext(projectDir: string, abortSignal?: AbortSignal): HookExecu
 async function createProcessTreeFixture(
   root: string,
   parentExits = false,
+  markerDelayMs = 500,
 ): Promise<{
   command: string;
   markerPath: string;
@@ -74,7 +75,7 @@ async function createProcessTreeFixture(
       'setTimeout(() => {',
       "  writeFileSync(process.argv[2], 'survived');",
       '  process.exit(0);',
-      '}, 500);',
+      '}, Number(process.argv[3]));',
     ].join('\n'),
   );
   await writeFile(
@@ -84,7 +85,7 @@ async function createProcessTreeFixture(
       "import { execFileSync } from 'node:child_process';",
       "import { writeFileSync } from 'node:fs';",
       "const parentExits = process.argv[5] === 'exit';",
-      'const child = spawn(process.execPath, [process.argv[2], process.argv[3]], {',
+      'const child = spawn(process.execPath, [process.argv[2], process.argv[3], process.argv[6]], {',
       "  stdio: 'ignore',",
       '});',
       "const groupPid = process.platform === 'win32'",
@@ -106,6 +107,7 @@ async function createProcessTreeFixture(
       quoteShellArgument(markerPath),
       quoteShellArgument(readyPath),
       quoteShellArgument(parentExits ? 'exit' : 'wait'),
+      quoteShellArgument(String(markerDelayMs)),
     ].join(' '),
     markerPath,
     readyPath,
@@ -209,21 +211,29 @@ describe('SecureProcessExecutor', () => {
   ])('terminates and reaps the hook process tree on $mode', async ({ mode, expectedTimeout }) => {
     const root = await mkdtemp(join(tmpdir(), `hook-${mode}-tree-`));
     roots.push(root);
-    const fixture = await createProcessTreeFixture(root);
+    const fixture = await createProcessTreeFixture(
+      root,
+      false,
+      mode === 'timeout' && process.platform === 'win32' ? 5_000 : 500,
+    );
     const controller = new AbortController();
     const executor = new SecureProcessExecutor(50);
     const execution = executor.execute(
       fixture.command,
       createInput(root),
       createContext(root, controller.signal),
-      mode === 'timeout' ? 200 : 5_000,
+      mode === 'timeout'
+        ? process.platform === 'win32'
+          ? 2_000
+          : 200
+        : 5_000,
     );
 
     await vi.waitFor(
       async () => {
         expect(await pathExists(fixture.readyPath)).toBe(true);
       },
-      { timeout: 2_000 },
+      { timeout: 5_000 },
     );
     const { groupPid, childPid } = JSON.parse(await readFile(fixture.readyPath, 'utf8')) as {
       groupPid: number;

--- a/src/hooks/__tests__/SecureProcessExecutor.test.ts
+++ b/src/hooks/__tests__/SecureProcessExecutor.test.ts
@@ -1,0 +1,232 @@
+import { access, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { SessionId } from '../../types/branded.js';
+import { PermissionMode } from '../../types/common.js';
+import { HookEvent } from '../../types/constants.js';
+import { signalProcessTree } from '../../tools/builtin/shell/processTree.js';
+import { DEFAULT_HOOK_CONFIG } from '../HookConfig.js';
+import { SecureProcessExecutor } from '../SecureProcessExecutor.js';
+import type {
+  HookExecutionContext,
+  HookInput,
+} from '../types/HookTypes.js';
+
+const roots: string[] = [];
+const processGroups = new Set<number>();
+
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function quoteShellArgument(value: string): string {
+  if (process.platform === 'win32') {
+    return `"${value.replaceAll('"', '\\"')}"`;
+  }
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+function createInput(projectDir: string): HookInput {
+  return {
+    hook_event_name: HookEvent.PreToolUse,
+    hook_execution_id: 'hook-execution-1',
+    timestamp: new Date().toISOString(),
+    project_dir: projectDir,
+    session_id: 'session-hook-process',
+    permission_mode: PermissionMode.DEFAULT,
+    tool_name: 'TestTool',
+    tool_use_id: 'tool-use-1',
+    tool_input: {},
+  };
+}
+
+function createContext(
+  projectDir: string,
+  abortSignal?: AbortSignal,
+): HookExecutionContext {
+  return {
+    projectDir,
+    sessionId: SessionId('session-hook-process'),
+    permissionMode: PermissionMode.DEFAULT,
+    config: DEFAULT_HOOK_CONFIG,
+    abortSignal,
+  };
+}
+
+async function createProcessTreeFixture(root: string): Promise<{
+  command: string;
+  markerPath: string;
+  readyPath: string;
+}> {
+  const childPath = join(root, 'child.mjs');
+  const parentPath = join(root, 'parent.mjs');
+  const markerPath = join(root, 'grandchild-survived');
+  const readyPath = join(root, 'parent-ready');
+  await writeFile(
+    childPath,
+    [
+      "import { writeFileSync } from 'node:fs';",
+      "process.on('SIGTERM', () => {});",
+      "setTimeout(() => {",
+      "  writeFileSync(process.argv[2], 'survived');",
+      '  process.exit(0);',
+      '}, 500);',
+    ].join('\n'),
+  );
+  await writeFile(
+    parentPath,
+    [
+      "import { spawn } from 'node:child_process';",
+      "import { execFileSync } from 'node:child_process';",
+      "import { writeFileSync } from 'node:fs';",
+      'const child = spawn(process.execPath, [process.argv[2], process.argv[3]], {',
+      "  stdio: 'ignore',",
+      '});',
+      "const groupPid = process.platform === 'win32'",
+      '  ? process.pid',
+      "  : Number(execFileSync('ps', ['-o', 'pgid=', '-p', String(process.pid)], { encoding: 'utf8' }).trim());",
+      'writeFileSync(process.argv[4], JSON.stringify({ groupPid, childPid: child.pid }));',
+      "process.on('SIGTERM', () => {});",
+      'setInterval(() => {}, 1_000);',
+    ].join('\n'),
+  );
+  return {
+    command: [
+      quoteShellArgument(process.execPath),
+      quoteShellArgument(parentPath),
+      quoteShellArgument(childPath),
+      quoteShellArgument(markerPath),
+      quoteShellArgument(readyPath),
+    ].join(' '),
+    markerPath,
+    readyPath,
+  };
+}
+
+afterEach(async () => {
+  for (const pid of processGroups) {
+    try {
+      signalProcessTree(pid, 'SIGKILL');
+    } catch {
+      // The process group was already reaped.
+    }
+  }
+  processGroups.clear();
+  await Promise.all(roots.splice(0).map((root) =>
+    rm(root, { recursive: true, force: true })
+  ));
+});
+
+describe('SecureProcessExecutor', () => {
+  it('rejects an invalid process termination grace period', () => {
+    expect(() => new SecureProcessExecutor(0)).toThrow(
+      'Hook process termination grace must be a positive safe integer',
+    );
+  });
+
+  it('preserves normal completion and removes the abort listener', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'hook-complete-'));
+    roots.push(root);
+    const controller = new AbortController();
+    const removeEventListener = vi.spyOn(controller.signal, 'removeEventListener');
+    const executor = new SecureProcessExecutor(50);
+
+    const result = await executor.execute(
+      `${quoteShellArgument(process.execPath)} -e ${
+        quoteShellArgument("process.stdout.write('ok')")
+      }`,
+      createInput(root),
+      createContext(root, controller.signal),
+      5_000,
+    );
+
+    expect(result).toEqual({
+      stdout: 'ok',
+      stderr: '',
+      exitCode: 0,
+      timedOut: false,
+    });
+    expect(removeEventListener).toHaveBeenCalledWith(
+      'abort',
+      expect.any(Function),
+    );
+  });
+
+  it('does not spawn a command for an already-aborted hook', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'hook-pre-abort-'));
+    roots.push(root);
+    const markerPath = join(root, 'should-not-exist');
+    const controller = new AbortController();
+    controller.abort(new Error('request cancelled'));
+    const executor = new SecureProcessExecutor(50);
+
+    const result = await executor.execute(
+      `${quoteShellArgument(process.execPath)} -e ${
+        quoteShellArgument(
+          `require('node:fs').writeFileSync(${JSON.stringify(markerPath)}, 'spawned')`,
+        )
+      }`,
+      createInput(root),
+      createContext(root, controller.signal),
+      5_000,
+    );
+
+    expect(result).toMatchObject({
+      exitCode: 1,
+      timedOut: false,
+      stderr: 'Hook cancelled by abort signal',
+    });
+    expect(await pathExists(markerPath)).toBe(false);
+  });
+
+  it.each([
+    { mode: 'abort' as const, expectedTimeout: false },
+    { mode: 'timeout' as const, expectedTimeout: true },
+  ])('terminates and reaps the hook process tree on $mode', async ({
+    mode,
+    expectedTimeout,
+  }) => {
+    const root = await mkdtemp(join(tmpdir(), `hook-${mode}-tree-`));
+    roots.push(root);
+    const fixture = await createProcessTreeFixture(root);
+    const controller = new AbortController();
+    const executor = new SecureProcessExecutor(50);
+    const execution = executor.execute(
+      fixture.command,
+      createInput(root),
+      createContext(root, controller.signal),
+      mode === 'timeout' ? 200 : 5_000,
+    );
+
+    await vi.waitFor(async () => {
+      expect(await pathExists(fixture.readyPath)).toBe(true);
+    }, { timeout: 2_000 });
+    const { groupPid, childPid } = JSON.parse(
+      await readFile(fixture.readyPath, 'utf8'),
+    ) as { groupPid: number; childPid: number };
+    expect(groupPid).toBeGreaterThan(0);
+    expect(groupPid).not.toBe(process.pid);
+    processGroups.add(groupPid);
+    if (mode === 'abort') {
+      controller.abort(new Error('request cancelled'));
+    }
+
+    await expect(execution).resolves.toMatchObject({
+      exitCode: expectedTimeout ? 124 : 1,
+      timedOut: expectedTimeout,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 550));
+
+    expect(await pathExists(fixture.markerPath)).toBe(false);
+    await vi.waitFor(() => {
+      expect(() => process.kill(childPid, 0)).toThrow();
+    }, { timeout: 2_000 });
+    processGroups.delete(groupPid);
+  });
+});

--- a/src/hooks/__tests__/SecureProcessExecutor.test.ts
+++ b/src/hooks/__tests__/SecureProcessExecutor.test.ts
@@ -9,6 +9,7 @@ import { signalProcessTree } from '../../tools/builtin/shell/processTree.js';
 import { DEFAULT_HOOK_CONFIG } from '../HookConfig.js';
 import { SecureProcessExecutor } from '../SecureProcessExecutor.js';
 import type { HookExecutionContext, HookInput } from '../types/HookTypes.js';
+import { HookProcessContainmentError } from '../WindowsProcessJob.js';
 
 const roots: string[] = [];
 const processGroups = new Set<number>();
@@ -298,6 +299,24 @@ describe('SecureProcessExecutor', () => {
       );
       processGroups.delete(groupPid);
       processGroups.delete(childPid);
+    },
+  );
+
+  it.runIf(process.platform === 'win32')(
+    'fails closed when the contained wrapper cannot spawn',
+    async () => {
+      const root = await mkdtemp(join(tmpdir(), 'hook-invalid-cwd-'));
+      roots.push(root);
+      const executor = new SecureProcessExecutor(50);
+
+      await expect(
+        executor.execute(
+          'echo should-not-run',
+          createInput(root),
+          createContext(join(root, 'missing')),
+          5_000,
+        ),
+      ).rejects.toBeInstanceOf(HookProcessContainmentError);
     },
   );
 });

--- a/src/hooks/__tests__/SecureProcessExecutor.test.ts
+++ b/src/hooks/__tests__/SecureProcessExecutor.test.ts
@@ -214,7 +214,7 @@ describe('SecureProcessExecutor', () => {
     const fixture = await createProcessTreeFixture(
       root,
       false,
-      mode === 'timeout' && process.platform === 'win32' ? 5_000 : 500,
+      mode === 'timeout' ? 5_000 : 500,
     );
     const controller = new AbortController();
     const executor = new SecureProcessExecutor(50);
@@ -222,11 +222,7 @@ describe('SecureProcessExecutor', () => {
       fixture.command,
       createInput(root),
       createContext(root, controller.signal),
-      mode === 'timeout'
-        ? process.platform === 'win32'
-          ? 2_000
-          : 200
-        : 5_000,
+      mode === 'timeout' ? 2_000 : 5_000,
     );
 
     await vi.waitFor(

--- a/src/hooks/__tests__/SecureProcessExecutor.test.ts
+++ b/src/hooks/__tests__/SecureProcessExecutor.test.ts
@@ -8,10 +8,7 @@ import { HookEvent } from '../../types/constants.js';
 import { signalProcessTree } from '../../tools/builtin/shell/processTree.js';
 import { DEFAULT_HOOK_CONFIG } from '../HookConfig.js';
 import { SecureProcessExecutor } from '../SecureProcessExecutor.js';
-import type {
-  HookExecutionContext,
-  HookInput,
-} from '../types/HookTypes.js';
+import type { HookExecutionContext, HookInput } from '../types/HookTypes.js';
 
 const roots: string[] = [];
 const processGroups = new Set<number>();
@@ -42,16 +39,11 @@ function createInput(projectDir: string, payloadSize = 0): HookInput {
     permission_mode: PermissionMode.DEFAULT,
     tool_name: 'TestTool',
     tool_use_id: 'tool-use-1',
-    tool_input: payloadSize > 0
-      ? { payload: 'x'.repeat(payloadSize) }
-      : {},
+    tool_input: payloadSize > 0 ? { payload: 'x'.repeat(payloadSize) } : {},
   };
 }
 
-function createContext(
-  projectDir: string,
-  abortSignal?: AbortSignal,
-): HookExecutionContext {
+function createContext(projectDir: string, abortSignal?: AbortSignal): HookExecutionContext {
   return {
     projectDir,
     sessionId: SessionId('session-hook-process'),
@@ -78,7 +70,7 @@ async function createProcessTreeFixture(
     [
       "import { writeFileSync } from 'node:fs';",
       "process.on('SIGTERM', () => {});",
-      "setTimeout(() => {",
+      'setTimeout(() => {',
       "  writeFileSync(process.argv[2], 'survived');",
       '  process.exit(0);',
       '}, 500);',
@@ -92,7 +84,7 @@ async function createProcessTreeFixture(
       "import { writeFileSync } from 'node:fs';",
       "const parentExits = process.argv[5] === 'exit';",
       'const child = spawn(process.execPath, [process.argv[2], process.argv[3]], {',
-      "  stdio: parentExits ? ['ignore', 'inherit', 'inherit'] : 'ignore',",
+      "  stdio: 'ignore',",
       '});',
       "const groupPid = process.platform === 'win32'",
       '  ? process.pid',
@@ -128,9 +120,7 @@ afterEach(async () => {
     }
   }
   processGroups.clear();
-  await Promise.all(roots.splice(0).map((root) =>
-    rm(root, { recursive: true, force: true })
-  ));
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
 });
 
 describe('SecureProcessExecutor', () => {
@@ -148,9 +138,9 @@ describe('SecureProcessExecutor', () => {
     const executor = new SecureProcessExecutor(50);
 
     const result = await executor.execute(
-      `${quoteShellArgument(process.execPath)} -e ${
-        quoteShellArgument("process.stdout.write('ok')")
-      }`,
+      `${quoteShellArgument(process.execPath)} -e ${quoteShellArgument(
+        "process.stdout.write('ok')",
+      )}`,
       createInput(root),
       createContext(root, controller.signal),
       5_000,
@@ -162,10 +152,7 @@ describe('SecureProcessExecutor', () => {
       exitCode: 0,
       timedOut: false,
     });
-    expect(removeEventListener).toHaveBeenCalledWith(
-      'abort',
-      expect.any(Function),
-    );
+    expect(removeEventListener).toHaveBeenCalledWith('abort', expect.any(Function));
   });
 
   it('preserves a successful exit when the hook closes stdin early', async () => {
@@ -174,11 +161,9 @@ describe('SecureProcessExecutor', () => {
     const executor = new SecureProcessExecutor(50);
 
     const result = await executor.execute(
-      `${quoteShellArgument(process.execPath)} -e ${
-        quoteShellArgument(
-          "require('node:fs').closeSync(0); process.stdout.write('ok'); setTimeout(() => process.exit(0), 50)",
-        )
-      }`,
+      `${quoteShellArgument(process.execPath)} -e ${quoteShellArgument(
+        "require('node:fs').closeSync(0); process.stdout.write('ok'); setTimeout(() => process.exit(0), 50)",
+      )}`,
       createInput(root, 96 * 1024),
       createContext(root),
       5_000,
@@ -201,11 +186,9 @@ describe('SecureProcessExecutor', () => {
     const executor = new SecureProcessExecutor(50);
 
     const result = await executor.execute(
-      `${quoteShellArgument(process.execPath)} -e ${
-        quoteShellArgument(
-          `require('node:fs').writeFileSync(${JSON.stringify(markerPath)}, 'spawned')`,
-        )
-      }`,
+      `${quoteShellArgument(process.execPath)} -e ${quoteShellArgument(
+        `require('node:fs').writeFileSync(${JSON.stringify(markerPath)}, 'spawned')`,
+      )}`,
       createInput(root),
       createContext(root, controller.signal),
       5_000,
@@ -222,10 +205,7 @@ describe('SecureProcessExecutor', () => {
   it.each([
     { mode: 'abort' as const, expectedTimeout: false },
     { mode: 'timeout' as const, expectedTimeout: true },
-  ])('terminates and reaps the hook process tree on $mode', async ({
-    mode,
-    expectedTimeout,
-  }) => {
+  ])('terminates and reaps the hook process tree on $mode', async ({ mode, expectedTimeout }) => {
     const root = await mkdtemp(join(tmpdir(), `hook-${mode}-tree-`));
     roots.push(root);
     const fixture = await createProcessTreeFixture(root);
@@ -238,12 +218,16 @@ describe('SecureProcessExecutor', () => {
       mode === 'timeout' ? 200 : 5_000,
     );
 
-    await vi.waitFor(async () => {
-      expect(await pathExists(fixture.readyPath)).toBe(true);
-    }, { timeout: 2_000 });
-    const { groupPid, childPid } = JSON.parse(
-      await readFile(fixture.readyPath, 'utf8'),
-    ) as { groupPid: number; childPid: number };
+    await vi.waitFor(
+      async () => {
+        expect(await pathExists(fixture.readyPath)).toBe(true);
+      },
+      { timeout: 2_000 },
+    );
+    const { groupPid, childPid } = JSON.parse(await readFile(fixture.readyPath, 'utf8')) as {
+      groupPid: number;
+      childPid: number;
+    };
     expect(groupPid).toBeGreaterThan(0);
     expect(groupPid).not.toBe(process.pid);
     processGroups.add(groupPid);
@@ -258,49 +242,62 @@ describe('SecureProcessExecutor', () => {
     await new Promise((resolve) => setTimeout(resolve, 550));
 
     expect(await pathExists(fixture.markerPath)).toBe(false);
-    await vi.waitFor(() => {
-      expect(() => process.kill(childPid, 0)).toThrow();
-    }, { timeout: 2_000 });
-    processGroups.delete(groupPid);
-  });
-
-  it('terminates descendants after the hook parent has exited', async () => {
-    const root = await mkdtemp(join(tmpdir(), 'hook-exited-parent-'));
-    roots.push(root);
-    const fixture = await createProcessTreeFixture(root, true);
-    const controller = new AbortController();
-    const executor = new SecureProcessExecutor(50);
-    const execution = executor.execute(
-      fixture.command,
-      createInput(root),
-      createContext(root, controller.signal),
-      5_000,
+    await vi.waitFor(
+      () => {
+        expect(() => process.kill(childPid, 0)).toThrow();
+      },
+      { timeout: 2_000 },
     );
-
-    await vi.waitFor(async () => {
-      expect(await pathExists(fixture.readyPath)).toBe(true);
-    }, { timeout: 2_000 });
-    const { groupPid, parentPid, childPid } = JSON.parse(
-      await readFile(fixture.readyPath, 'utf8'),
-    ) as { groupPid: number; parentPid: number; childPid: number };
-    processGroups.add(groupPid);
-    processGroups.add(childPid);
-    await vi.waitFor(() => {
-      expect(() => process.kill(parentPid, 0)).toThrow();
-    }, { timeout: 2_000 });
-
-    controller.abort(new Error('request cancelled'));
-    await expect(execution).resolves.toMatchObject({
-      exitCode: 1,
-      timedOut: false,
-    });
-    await new Promise((resolve) => setTimeout(resolve, 550));
-
-    expect(await pathExists(fixture.markerPath)).toBe(false);
-    await vi.waitFor(() => {
-      expect(() => process.kill(childPid, 0)).toThrow();
-    }, { timeout: 2_000 });
     processGroups.delete(groupPid);
-    processGroups.delete(childPid);
   });
+
+  it.runIf(process.platform === 'win32')(
+    'reaps descendants after the hook command parent has exited',
+    async () => {
+      const root = await mkdtemp(join(tmpdir(), 'hook-exited-parent-'));
+      roots.push(root);
+      const fixture = await createProcessTreeFixture(root, true);
+      const executor = new SecureProcessExecutor(50);
+      const execution = executor.execute(
+        fixture.command,
+        createInput(root),
+        createContext(root),
+        5_000,
+      );
+
+      await vi.waitFor(
+        async () => {
+          expect(await pathExists(fixture.readyPath)).toBe(true);
+        },
+        { timeout: 2_000 },
+      );
+      const { groupPid, parentPid, childPid } = JSON.parse(
+        await readFile(fixture.readyPath, 'utf8'),
+      ) as { groupPid: number; parentPid: number; childPid: number };
+      processGroups.add(groupPid);
+      processGroups.add(childPid);
+      await vi.waitFor(
+        () => {
+          expect(() => process.kill(parentPid, 0)).toThrow();
+        },
+        { timeout: 2_000 },
+      );
+
+      await expect(execution).resolves.toMatchObject({
+        exitCode: 0,
+        timedOut: false,
+      });
+      await new Promise((resolve) => setTimeout(resolve, 550));
+
+      expect(await pathExists(fixture.markerPath)).toBe(false);
+      await vi.waitFor(
+        () => {
+          expect(() => process.kill(childPid, 0)).toThrow();
+        },
+        { timeout: 2_000 },
+      );
+      processGroups.delete(groupPid);
+      processGroups.delete(childPid);
+    },
+  );
 });

--- a/src/hooks/__tests__/SecureProcessExecutor.test.ts
+++ b/src/hooks/__tests__/SecureProcessExecutor.test.ts
@@ -32,7 +32,7 @@ function quoteShellArgument(value: string): string {
   return `'${value.replaceAll("'", "'\\''")}'`;
 }
 
-function createInput(projectDir: string): HookInput {
+function createInput(projectDir: string, payloadSize = 0): HookInput {
   return {
     hook_event_name: HookEvent.PreToolUse,
     hook_execution_id: 'hook-execution-1',
@@ -42,7 +42,9 @@ function createInput(projectDir: string): HookInput {
     permission_mode: PermissionMode.DEFAULT,
     tool_name: 'TestTool',
     tool_use_id: 'tool-use-1',
-    tool_input: {},
+    tool_input: payloadSize > 0
+      ? { payload: 'x'.repeat(payloadSize) }
+      : {},
   };
 }
 
@@ -156,6 +158,30 @@ describe('SecureProcessExecutor', () => {
       'abort',
       expect.any(Function),
     );
+  });
+
+  it('preserves a successful exit when the hook closes stdin early', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'hook-stdin-close-'));
+    roots.push(root);
+    const executor = new SecureProcessExecutor(50);
+
+    const result = await executor.execute(
+      `${quoteShellArgument(process.execPath)} -e ${
+        quoteShellArgument(
+          "require('node:fs').closeSync(0); process.stdout.write('ok'); setTimeout(() => process.exit(0), 50)",
+        )
+      }`,
+      createInput(root, 96 * 1024),
+      createContext(root),
+      5_000,
+    );
+
+    expect(result).toEqual({
+      stdout: 'ok',
+      stderr: '',
+      exitCode: 0,
+      timedOut: false,
+    });
   });
 
   it('does not spawn a command for an already-aborted hook', async () => {

--- a/src/hooks/__tests__/SecureProcessExecutor.test.ts
+++ b/src/hooks/__tests__/SecureProcessExecutor.test.ts
@@ -262,7 +262,7 @@ describe('SecureProcessExecutor', () => {
     processGroups.delete(groupPid);
   });
 
-  it.runIf(process.platform === 'win32')(
+  it(
     'reaps descendants after the hook command parent has exited',
     async () => {
       const root = await mkdtemp(join(tmpdir(), 'hook-exited-parent-'));

--- a/src/session/Session.ts
+++ b/src/session/Session.ts
@@ -8,6 +8,7 @@ import {
 import type { ChatContext, LoopResult, UserMessageContent } from '../agent/types.js';
 import { SessionHandoffError } from '../errors/SessionHandoffError.js';
 import { SessionInputError } from '../errors/SessionInputError.js';
+import { isHookProcessContainmentError } from '../hooks/WindowsProcessJob.js';
 import { type CleanupHandle, registerCleanup } from '../lifecycle/CleanupRegistry.js';
 import { createRootLogger, type InternalLogger, LogCategory } from '../logging/Logger.js';
 import { type AgentTrace, TraceRecorder } from '../observability/index.js';
@@ -895,11 +896,12 @@ class Session implements ISession {
       const handingOff = isHandoffRequested();
       const leaseFailure = this.executionLeaseFailure;
       const requestAborted = signal.aborted;
+      const containmentFailure = isHookProcessContainmentError(error);
       let terminalError = error;
       if (!handingOff && !leaseFailure) {
         try {
           await finishDurableRequest(
-            requestAborted
+            requestAborted && !containmentFailure
               ? {
                   status: 'interrupted',
                   reason: this.getDurableInterruptReason(requestController),
@@ -913,18 +915,41 @@ class Session implements ISession {
           );
         }
       }
-      const errorMessage =
+      let errorMessage =
         terminalError instanceof Error ? terminalError.message : String(terminalError);
-      await finishTrace(handingOff || leaseFailure || requestAborted ? 'aborted' : 'error', {
-        ...(handingOff
-          ? { reason: 'session_handoff' }
-          : leaseFailure
-            ? { reason: 'process_restart' }
-            : requestAborted
-              ? { reason: this.getDurableInterruptReason(requestController) }
-              : { error: errorMessage }),
-      });
+      let terminalContainmentFailure =
+        isHookProcessContainmentError(terminalError);
       try {
+        await finishTrace(
+          !terminalContainmentFailure && (handingOff || leaseFailure || requestAborted)
+            ? 'aborted'
+            : 'error',
+          {
+            ...(terminalContainmentFailure
+              ? { error: errorMessage }
+              : handingOff
+                ? { reason: 'session_handoff' }
+                : leaseFailure
+                  ? { reason: 'process_restart' }
+                  : requestAborted
+                    ? { reason: this.getDurableInterruptReason(requestController) }
+                    : { error: errorMessage }),
+          },
+        );
+      } catch (traceError) {
+        const combinedError = new AggregateError(
+          [terminalError, traceError],
+          'Request setup and trace finalization both failed',
+        );
+        terminalError = combinedError;
+        errorMessage = combinedError.message;
+        terminalContainmentFailure =
+          isHookProcessContainmentError(terminalError);
+      }
+      try {
+        if (terminalContainmentFailure) {
+          throw terminalError;
+        }
         if (handingOff) {
           return;
         }
@@ -1324,11 +1349,12 @@ class Session implements ISession {
       const handingOff = isHandoffRequested();
       const leaseFailure = this.executionLeaseFailure;
       const requestAborted = signal.aborted;
+      const containmentFailure = isHookProcessContainmentError(error);
       let terminalError = error;
       if (!handingOff && !leaseFailure && !durableFinishAttempted) {
         try {
           await finishDurableRequest(
-            requestAborted
+            requestAborted && !containmentFailure
               ? {
                   status: 'interrupted',
                   reason: this.getDurableInterruptReason(requestController),
@@ -1342,17 +1368,40 @@ class Session implements ISession {
           );
         }
       }
-      const errorMessage =
+      let errorMessage =
         terminalError instanceof Error ? terminalError.message : String(terminalError);
-      await finishTrace(handingOff || leaseFailure || requestAborted ? 'aborted' : 'error', {
-        ...(handingOff
-          ? { reason: 'session_handoff' }
-          : leaseFailure
-            ? { reason: 'process_restart' }
-            : requestAborted
-              ? { reason: this.getDurableInterruptReason(requestController) }
-              : { error: errorMessage }),
-      });
+      let terminalContainmentFailure =
+        isHookProcessContainmentError(terminalError);
+      try {
+        await finishTrace(
+          !terminalContainmentFailure && (handingOff || leaseFailure || requestAborted)
+            ? 'aborted'
+            : 'error',
+          {
+            ...(terminalContainmentFailure
+              ? { error: errorMessage }
+              : handingOff
+                ? { reason: 'session_handoff' }
+                : leaseFailure
+                  ? { reason: 'process_restart' }
+                  : requestAborted
+                    ? { reason: this.getDurableInterruptReason(requestController) }
+                    : { error: errorMessage }),
+          },
+        );
+      } catch (traceError) {
+        const combinedError = new AggregateError(
+          [terminalError, traceError],
+          'Request execution and trace finalization both failed',
+        );
+        terminalError = combinedError;
+        errorMessage = combinedError.message;
+        terminalContainmentFailure =
+          isHookProcessContainmentError(terminalError);
+      }
+      if (terminalContainmentFailure) {
+        throw terminalError;
+      }
       if (handingOff) {
         return;
       }

--- a/src/session/Session.ts
+++ b/src/session/Session.ts
@@ -1537,7 +1537,7 @@ class Session implements ISession {
     disposition: 'terminal' | 'detached',
     abortReason: RequestAbortReason = { kind: 'session_close' },
   ): Promise<void> {
-    this.runtime?.assertNoPendingCleanup();
+    this.runtime?.assertNoPendingCleanup({ includeTerminalFailures: false });
     const recordDurableClose = disposition === 'terminal';
     // 关闭时对 executionState 的读写走 inputMutex，避免与并发 send()/stream()
     // 交错（例如 send() 在 await 处让出后用 pending 覆盖 closed）。
@@ -1607,7 +1607,7 @@ class Session implements ISession {
       });
     }
 
-    this.runtime?.assertNoPendingCleanup();
+    this.runtime?.assertNoPendingCleanup({ includeTerminalFailures: false });
     if (this.runtime) {
       closeErrors.push(...(await this.releaseLocalRuntime()));
     }

--- a/src/session/SessionRuntime.ts
+++ b/src/session/SessionRuntime.ts
@@ -275,26 +275,12 @@ export class SessionRuntime {
     });
   }
 
-  assertNoPendingCleanup(): void {
-    const errors: Error[] = [];
-    const terminalCleanupFailure =
-      this.executionPipeline.getTerminalCleanupFailure();
-    if (terminalCleanupFailure !== undefined) {
-      errors.push(
-        terminalCleanupFailure instanceof Error
-          ? terminalCleanupFailure
-          : new Error(String(terminalCleanupFailure)),
-      );
-    }
-    const hookContainmentFailure =
-      this.hookRuntime.getTerminalContainmentFailure();
-    if (hookContainmentFailure !== undefined) {
-      errors.push(
-        hookContainmentFailure instanceof Error
-          ? hookContainmentFailure
-          : new Error(String(hookContainmentFailure)),
-      );
-    }
+  assertNoPendingCleanup(
+    options: { includeTerminalFailures?: boolean } = {},
+  ): void {
+    const errors = options.includeTerminalFailures === false
+      ? []
+      : this.getTerminalCleanupFailures();
     if (this.executionPipeline.hasPendingExecutionCleanup()) {
       errors.push(
         new Error(
@@ -324,8 +310,23 @@ export class SessionRuntime {
     }
   }
 
+  private getTerminalCleanupFailures(): Error[] {
+    const terminalCleanupFailure =
+      this.executionPipeline.getTerminalCleanupFailure();
+    const hookContainmentFailure =
+      this.hookRuntime.getTerminalContainmentFailure();
+    return Array.from(new Set([
+      terminalCleanupFailure,
+      hookContainmentFailure,
+    ]))
+      .filter((error) => error !== undefined)
+      .map((error) =>
+        error instanceof Error ? error : new Error(String(error)));
+  }
+
   async close(executionFence?: DurableExecutionFence): Promise<void> {
-    this.assertNoPendingCleanup();
+    this.assertNoPendingCleanup({ includeTerminalFailures: false });
+    const errors: unknown[] = this.getTerminalCleanupFailures();
     const shellManager = BackgroundShellManager.getInstance();
     const shutdownResults = await Promise.allSettled([
       this.backgroundAgentManager.sealCancelAndWait(),
@@ -333,16 +334,16 @@ export class SessionRuntime {
         ? shellManager.terminateExecutionFence(this.sessionId, executionFence)
         : shellManager.terminateSession(this.sessionId),
     ]);
-    const errors = shutdownResults.flatMap((result) =>
+    errors.push(...shutdownResults.flatMap((result) =>
       result.status === 'rejected' ? [result.reason] : [],
-    );
+    ));
     try {
       await this.mcpRegistry.disconnectAll();
     } catch (error) {
       errors.push(error);
     }
     try {
-      this.assertNoPendingCleanup();
+      this.assertNoPendingCleanup({ includeTerminalFailures: false });
     } catch (error) {
       errors.push(error);
     }

--- a/src/session/SessionRuntime.ts
+++ b/src/session/SessionRuntime.ts
@@ -277,6 +277,24 @@ export class SessionRuntime {
 
   assertNoPendingCleanup(): void {
     const errors: Error[] = [];
+    const terminalCleanupFailure =
+      this.executionPipeline.getTerminalCleanupFailure();
+    if (terminalCleanupFailure !== undefined) {
+      errors.push(
+        terminalCleanupFailure instanceof Error
+          ? terminalCleanupFailure
+          : new Error(String(terminalCleanupFailure)),
+      );
+    }
+    const hookContainmentFailure =
+      this.hookRuntime.getTerminalContainmentFailure();
+    if (hookContainmentFailure !== undefined) {
+      errors.push(
+        hookContainmentFailure instanceof Error
+          ? hookContainmentFailure
+          : new Error(String(hookContainmentFailure)),
+      );
+    }
     if (this.executionPipeline.hasPendingExecutionCleanup()) {
       errors.push(
         new Error(

--- a/src/session/__tests__/SessionRuntime.test.ts
+++ b/src/session/__tests__/SessionRuntime.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
 import { assertDefined } from '../../__tests__/helpers/assertDefined.js';
 import { HookManager } from '../../hooks/HookManager.js';
+import { HookProcessContainmentError } from '../../hooks/WindowsProcessJob.js';
 import { NOOP_LOGGER } from '../../logging/Logger.js';
 import { MemoryManager } from '../../memory/MemoryManager.js';
 import { createContextSnapshot, type RuntimeContext } from '../../runtime/index.js';
@@ -426,6 +427,58 @@ describe('SessionRuntime', () => {
     });
 
     await runtime.close();
+  });
+
+  it('remains fail closed after permission cleanup reports a containment failure', async () => {
+    const started = deferred();
+    const release = Promise.withResolvers<void>();
+    const controller = new AbortController();
+    const containmentError = new HookProcessContainmentError(
+      'Permission Hook process cleanup failed',
+    );
+    const runtime = new SessionRuntime(
+      SessionId('session-permission-containment-failure'),
+      createOptions({
+        tools: [customTool],
+        allowedTools: ['CustomTool'],
+        permissionHandler: async () => {
+          started.resolve();
+          await release.promise;
+          throw containmentError;
+        },
+      }),
+      {
+        models: [],
+      },
+      PermissionMode.YOLO,
+      createFilesystemContext(workspaceRoot),
+      NOOP_LOGGER,
+    );
+
+    await runtime.initialize();
+    const executionPipeline = runtime.getAgentRuntimeDeps().executionPipeline;
+    assertDefined(executionPipeline);
+    const resultPromise = collectToolExecution(
+      executionPipeline.execute('CustomTool', {}, {
+        permissionMode: PermissionMode.YOLO,
+        signal: controller.signal,
+      }),
+    );
+
+    await started.promise;
+    controller.abort(new Error('request cancelled'));
+    await expect(resultPromise).resolves.toMatchObject({
+      status: 'error',
+      error: { message: 'request cancelled' },
+    });
+    release.reject(containmentError);
+    await vi.waitFor(() => {
+      expect(executionPipeline.getTerminalCleanupFailure()).toBe(
+        containmentError,
+      );
+    });
+
+    await expect(runtime.close()).rejects.toBe(containmentError);
   });
 
   it('should install plugin tools and tool middleware through one declarative entry', async () => {

--- a/src/session/__tests__/SessionRuntime.test.ts
+++ b/src/session/__tests__/SessionRuntime.test.ts
@@ -478,7 +478,12 @@ describe('SessionRuntime', () => {
       );
     });
 
+    const cancelBackgroundAgents = vi.spyOn(
+      runtime.getBackgroundAgentManager(),
+      'sealCancelAndWait',
+    );
     await expect(runtime.close()).rejects.toBe(containmentError);
+    expect(cancelBackgroundAgents).toHaveBeenCalledOnce();
   });
 
   it('should install plugin tools and tool middleware through one declarative entry', async () => {

--- a/src/session/__tests__/SessionSteeringResilience.test.ts
+++ b/src/session/__tests__/SessionSteeringResilience.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { JSONLStore } from '../../context/storage/JSONLStore.js';
 import { getSessionFilePathFromStorageRoot } from '../../context/storage/pathUtils.js';
 import type { SessionEvent } from '../../context/types.js';
+import { HookProcessContainmentError } from '../../hooks/WindowsProcessJob.js';
 import { SessionId } from '../../types/branded.js';
 import { HookEvent } from '../../types/constants.js';
 
@@ -153,6 +154,37 @@ describe('Session steering resilience', () => {
     for await (const _event of stream) {
       // drain
     }
+    await session.close();
+  });
+
+  it('does not hide a containment failure behind request cancellation', async () => {
+    const started = Promise.withResolvers<void>();
+    const containmentError = new HookProcessContainmentError(
+      'Hook process cleanup failed',
+    );
+    streamChatImpl = async function* containmentFailureStream(
+      _message,
+      context,
+    ) {
+      const signal = (context as { signal: AbortSignal }).signal;
+      started.resolve();
+      await new Promise<void>((resolve) => {
+        signal.addEventListener('abort', () => resolve(), { once: true });
+      });
+      yield* [] as never[];
+      throw containmentError;
+    };
+    const session = await createSession(baseOptions(createWorkspaceRoot()));
+    const controller = new AbortController();
+    await session.send('cancel during cleanup', { signal: controller.signal });
+    const stream = session.stream();
+    const firstEvent = stream.next();
+    const rejection = expect(firstEvent).rejects.toBe(containmentError);
+
+    await started.promise;
+    controller.abort(new Error('request cancelled'));
+
+    await rejection;
     await session.close();
   });
 

--- a/src/tools/builtin/shell/__tests__/processTree.test.ts
+++ b/src/tools/builtin/shell/__tests__/processTree.test.ts
@@ -1,12 +1,36 @@
-import type { ChildProcess } from 'node:child_process';
+import { type ChildProcess, spawnSync } from 'node:child_process';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { terminateProcessTree } from '../processTree.js';
+import { signalProcessTree, terminateProcessTree } from '../processTree.js';
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const original = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...original,
+    spawnSync: vi.fn(original.spawnSync),
+  };
+});
 
 afterEach(() => {
   vi.restoreAllMocks();
 });
 
 describe('terminateProcessTree', () => {
+  it('bounds the Windows taskkill fallback', () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
+    vi.mocked(spawnSync).mockReturnValue({ status: 0 } as never);
+
+    expect(signalProcessTree(42_424, 'SIGTERM')).toBe(true);
+    expect(spawnSync).toHaveBeenCalledWith(
+      'taskkill',
+      ['/pid', '42424', '/t', '/f'],
+      {
+        stdio: 'ignore',
+        windowsHide: true,
+        timeout: 5_000,
+      },
+    );
+  });
+
   it('rejects after bounded force-kill attempts when the tree stays alive', async () => {
     const permissionError = Object.assign(new Error('operation not permitted'), {
       code: 'EPERM',

--- a/src/tools/builtin/shell/__tests__/processTree.test.ts
+++ b/src/tools/builtin/shell/__tests__/processTree.test.ts
@@ -1,0 +1,30 @@
+import type { ChildProcess } from 'node:child_process';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { terminateProcessTree } from '../processTree.js';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('terminateProcessTree', () => {
+  it('rejects after bounded force-kill attempts when the tree stays alive', async () => {
+    const permissionError = Object.assign(new Error('operation not permitted'), {
+      code: 'EPERM',
+    });
+    vi.spyOn(process, 'kill').mockImplementation(() => {
+      throw permissionError;
+    });
+    const child = {
+      exitCode: null,
+      signalCode: null,
+      kill: vi.fn(() => false),
+    } as unknown as ChildProcess;
+
+    await expect(
+      terminateProcessTree(42_424, child, 1),
+    ).rejects.toThrow(
+      'Failed to terminate process tree 42424 after 3 force-kill attempts',
+    );
+    expect(child.kill).toHaveBeenCalledTimes(4);
+  });
+});

--- a/src/tools/builtin/shell/__tests__/processTree.test.ts
+++ b/src/tools/builtin/shell/__tests__/processTree.test.ts
@@ -31,6 +31,22 @@ describe('terminateProcessTree', () => {
     );
   });
 
+  it('does not report root-only fallback as Windows tree cleanup', () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
+    vi.mocked(spawnSync).mockReturnValue({
+      status: null,
+      error: Object.assign(new Error('taskkill timed out'), {
+        code: 'ETIMEDOUT',
+      }),
+    } as never);
+    const child = {
+      kill: vi.fn(() => true),
+    } as unknown as ChildProcess;
+
+    expect(signalProcessTree(42_424, 'SIGKILL', child)).toBe(false);
+    expect(child.kill).not.toHaveBeenCalled();
+  });
+
   it('rejects after bounded force-kill attempts when the tree stays alive', async () => {
     const permissionError = Object.assign(new Error('operation not permitted'), {
       code: 'EPERM',

--- a/src/tools/builtin/shell/processTree.ts
+++ b/src/tools/builtin/shell/processTree.ts
@@ -2,6 +2,7 @@ import { type ChildProcess, spawnSync } from 'node:child_process';
 
 const PROCESS_TREE_POLL_INTERVAL_MS = 20;
 const PROCESS_TREE_FORCE_KILL_ATTEMPTS = 3;
+const WINDOWS_TASKKILL_TIMEOUT_MS = 5_000;
 
 function isMissingProcess(error: unknown): boolean {
   return (
@@ -26,6 +27,7 @@ export function signalProcessTree(
   pid: number | undefined,
   signal: NodeJS.Signals,
   child?: ChildProcess,
+  taskkillTimeoutMs = WINDOWS_TASKKILL_TIMEOUT_MS,
 ): boolean {
   if (!pid) {
     return child?.kill(signal) ?? false;
@@ -45,6 +47,7 @@ export function signalProcessTree(
       {
         stdio: 'ignore',
         windowsHide: true,
+        timeout: taskkillTimeoutMs,
       },
     );
     if (result.status === 0) {
@@ -114,7 +117,7 @@ export async function terminateProcessTree(
   let lastSignalError: unknown;
   const signalSafely = (signal: NodeJS.Signals): void => {
     try {
-      if (!signalProcessTree(pid, signal, child)) {
+      if (!signalProcessTree(pid, signal, child, gracePeriodMs)) {
         lastSignalError = new Error(
           `Process tree ${pid ?? 'unknown'} did not accept ${signal}`,
         );

--- a/src/tools/builtin/shell/processTree.ts
+++ b/src/tools/builtin/shell/processTree.ts
@@ -1,6 +1,7 @@
 import { type ChildProcess, spawnSync } from 'node:child_process';
 
 const PROCESS_TREE_POLL_INTERVAL_MS = 20;
+const PROCESS_TREE_FORCE_KILL_ATTEMPTS = 3;
 
 function isMissingProcess(error: unknown): boolean {
   return (
@@ -104,17 +105,22 @@ export async function waitForProcessTreeExit(
   return true;
 }
 
-/** Escalates process-tree termination and remains pending until the tree exits. */
+/** Escalates process-tree termination and rejects if the tree remains alive. */
 export async function terminateProcessTree(
   pid: number | undefined,
   child: ChildProcess | undefined,
   gracePeriodMs: number,
 ): Promise<void> {
+  let lastSignalError: unknown;
   const signalSafely = (signal: NodeJS.Signals): void => {
     try {
-      signalProcessTree(pid, signal, child);
-    } catch {
-      // Keep escalating and polling; returning while the tree is alive is unsafe.
+      if (!signalProcessTree(pid, signal, child)) {
+        lastSignalError = new Error(
+          `Process tree ${pid ?? 'unknown'} did not accept ${signal}`,
+        );
+      }
+    } catch (error) {
+      lastSignalError = error;
     }
   };
 
@@ -128,10 +134,19 @@ export async function terminateProcessTree(
     return;
   }
 
-  while (true) {
+  for (
+    let attempt = 0;
+    attempt < PROCESS_TREE_FORCE_KILL_ATTEMPTS;
+    attempt += 1
+  ) {
     signalSafely('SIGKILL');
     if (await waitForProcessTreeExit(pid, child, gracePeriodMs)) {
       return;
     }
   }
+
+  throw new Error(
+    `Failed to terminate process tree ${pid} after ${PROCESS_TREE_FORCE_KILL_ATTEMPTS} force-kill attempts`,
+    { cause: lastSignalError },
+  );
 }

--- a/src/tools/builtin/shell/processTree.ts
+++ b/src/tools/builtin/shell/processTree.ts
@@ -53,7 +53,7 @@ export function signalProcessTree(
     if (result.status === 0) {
       return true;
     }
-    return child?.kill(signal) ?? false;
+    return false;
   }
 
   try {
@@ -115,15 +115,18 @@ export async function terminateProcessTree(
   gracePeriodMs: number,
 ): Promise<void> {
   let lastSignalError: unknown;
-  const signalSafely = (signal: NodeJS.Signals): void => {
+  const signalSafely = (signal: NodeJS.Signals): boolean => {
     try {
-      if (!signalProcessTree(pid, signal, child, gracePeriodMs)) {
+      const accepted = signalProcessTree(pid, signal, child, gracePeriodMs);
+      if (!accepted) {
         lastSignalError = new Error(
           `Process tree ${pid ?? 'unknown'} did not accept ${signal}`,
         );
       }
+      return accepted;
     } catch (error) {
       lastSignalError = error;
+      return false;
     }
   };
 
@@ -132,8 +135,11 @@ export async function terminateProcessTree(
     return;
   }
 
-  signalSafely('SIGTERM');
-  if (await waitForProcessTreeExit(pid, child, gracePeriodMs)) {
+  let signalAccepted = signalSafely('SIGTERM');
+  if (
+    await waitForProcessTreeExit(pid, child, gracePeriodMs)
+    && (process.platform !== 'win32' || signalAccepted)
+  ) {
     return;
   }
 
@@ -142,8 +148,11 @@ export async function terminateProcessTree(
     attempt < PROCESS_TREE_FORCE_KILL_ATTEMPTS;
     attempt += 1
   ) {
-    signalSafely('SIGKILL');
-    if (await waitForProcessTreeExit(pid, child, gracePeriodMs)) {
+    signalAccepted = signalSafely('SIGKILL');
+    if (
+      await waitForProcessTreeExit(pid, child, gracePeriodMs)
+      && (process.platform !== 'win32' || signalAccepted)
+    ) {
       return;
     }
   }

--- a/src/tools/builtin/shell/processTree.ts
+++ b/src/tools/builtin/shell/processTree.ts
@@ -103,3 +103,35 @@ export async function waitForProcessTreeExit(
   }
   return true;
 }
+
+/** Escalates process-tree termination and remains pending until the tree exits. */
+export async function terminateProcessTree(
+  pid: number | undefined,
+  child: ChildProcess | undefined,
+  gracePeriodMs: number,
+): Promise<void> {
+  const signalSafely = (signal: NodeJS.Signals): void => {
+    try {
+      signalProcessTree(pid, signal, child);
+    } catch {
+      // Keep escalating and polling; returning while the tree is alive is unsafe.
+    }
+  };
+
+  if (!pid) {
+    signalSafely('SIGTERM');
+    return;
+  }
+
+  signalSafely('SIGTERM');
+  if (await waitForProcessTreeExit(pid, child, gracePeriodMs)) {
+    return;
+  }
+
+  while (true) {
+    signalSafely('SIGKILL');
+    if (await waitForProcessTreeExit(pid, child, gracePeriodMs)) {
+      return;
+    }
+  }
+}

--- a/src/tools/builtin/task/__tests__/taskTools.test.ts
+++ b/src/tools/builtin/task/__tests__/taskTools.test.ts
@@ -7,6 +7,7 @@ import { BackgroundAgentManager } from '../../../../agent/subagents/BackgroundAg
 import { SubagentRegistry } from '../../../../agent/subagents/SubagentRegistry.js';
 import { AgentId, SessionId } from '../../../../types/branded.js';
 import { DurableExecutionLeaseError } from '../../../../session/events/DurableExecutionLeaseStore.js';
+import { HookManager } from '../../../../hooks/HookManager.js';
 import {
   collectToolExecution,
   type ExecutionContext,
@@ -88,6 +89,7 @@ describe('task tools', () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     manager.killAll();
   });
 
@@ -345,5 +347,52 @@ describe('task tools', () => {
         } as never,
       ),
     ).rejects.toBe(leaseError);
+  });
+
+  it('propagates cancellation through a running SubagentStop file hook', async () => {
+    const registry = new SubagentRegistry();
+    registry.register(subagentConfig);
+    const taskTool = createTaskTool({ registry });
+    const controller = new AbortController();
+    const cancellation = new Error('cancel subagent stop hook');
+    const started = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const stopHook = vi.spyOn(
+      HookManager.getInstance(),
+      'executeSubagentStopHooks',
+    ).mockImplementation(async (_agentType, context) => {
+      expect(context.abortSignal).toBe(controller.signal);
+      started.resolve();
+      await release.promise;
+      return { shouldStop: true };
+    });
+    runAgenticLoop.mockResolvedValueOnce({
+      success: true,
+      finalMessage: 'done',
+      metadata: { duration: 1 },
+    });
+
+    const execution = executeWithContext(
+      taskTool,
+      {
+        subagent_type: subagentConfig.name,
+        description: 'Inspect repository',
+        prompt: 'inspect code',
+        run_in_background: false,
+      },
+      {
+        sessionId: SessionId('cancelled-task-session'),
+        bladeConfig,
+        signal: controller.signal,
+        contextSnapshot: { cwd: '/tmp' },
+      } as never,
+    );
+    const cancellationResult = expect(execution).rejects.toBe(cancellation);
+    await started.promise;
+    controller.abort(cancellation);
+    release.resolve();
+
+    await cancellationResult;
+    expect(stopHook).toHaveBeenCalledOnce();
   });
 });

--- a/src/tools/builtin/task/__tests__/taskTools.test.ts
+++ b/src/tools/builtin/task/__tests__/taskTools.test.ts
@@ -8,6 +8,7 @@ import { SubagentRegistry } from '../../../../agent/subagents/SubagentRegistry.j
 import { AgentId, SessionId } from '../../../../types/branded.js';
 import { DurableExecutionLeaseError } from '../../../../session/events/DurableExecutionLeaseStore.js';
 import { HookManager } from '../../../../hooks/HookManager.js';
+import { HookProcessContainmentError } from '../../../../hooks/WindowsProcessJob.js';
 import {
   collectToolExecution,
   type ExecutionContext,
@@ -393,6 +394,47 @@ describe('task tools', () => {
     release.resolve();
 
     await cancellationResult;
+    expect(stopHook).toHaveBeenCalledOnce();
+  });
+
+  it('preserves a SubagentStop containment failure during cancellation', async () => {
+    const registry = new SubagentRegistry();
+    registry.register(subagentConfig);
+    const taskTool = createTaskTool({ registry });
+    const controller = new AbortController();
+    const containmentError = new HookProcessContainmentError(
+      'Hook process cleanup failed',
+    );
+    const stopHook = vi.spyOn(
+      HookManager.getInstance(),
+      'executeSubagentStopHooks',
+    ).mockImplementation(async () => {
+      controller.abort(new Error('request cancelled'));
+      throw containmentError;
+    });
+    runAgenticLoop.mockResolvedValueOnce({
+      success: true,
+      finalMessage: 'done',
+      metadata: { duration: 1 },
+    });
+
+    await expect(
+      executeWithContext(
+        taskTool,
+        {
+          subagent_type: subagentConfig.name,
+          description: 'Inspect repository',
+          prompt: 'inspect code',
+          run_in_background: false,
+        },
+        {
+          sessionId: SessionId('containment-task-session'),
+          bladeConfig,
+          signal: controller.signal,
+          contextSnapshot: { cwd: '/tmp' },
+        } as never,
+      ),
+    ).rejects.toBe(containmentError);
     expect(stopHook).toHaveBeenCalledOnce();
   });
 });

--- a/src/tools/builtin/task/task.ts
+++ b/src/tools/builtin/task/task.ts
@@ -331,25 +331,25 @@ export function createTaskTool({ registry }: { registry: SubagentRegistry }) {
             console.warn(`[Task] SubagentStop hook warning: ${stopResult.warning}`);
           }
         } catch (hookError) {
-          context.signal?.throwIfAborted();
           if (
             isExecutionLeaseFailure(hookError)
             || isHookProcessContainmentError(hookError)
           ) {
             throw hookError;
           }
+          context.signal?.throwIfAborted();
           console.warn('[Task] SubagentStop hook execution failed:', hookError);
         }
 
         return buildTaskResult(result, subagent_type, description, duration, subagentSessionId);
       } catch (error) {
-        context.signal?.throwIfAborted();
         if (
           isExecutionLeaseFailure(error)
           || isHookProcessContainmentError(error)
         ) {
           throw error;
         }
+        context.signal?.throwIfAborted();
         const _errorMessage = extractUserFriendlyError(
           error instanceof Error ? error : new Error(getErrorMessage(error))
         );

--- a/src/tools/builtin/task/task.ts
+++ b/src/tools/builtin/task/task.ts
@@ -19,6 +19,7 @@ import type {
   SubagentResult,
 } from '../../../agent/subagents/types.js';
 import { HookManager } from '../../../hooks/HookManager.js';
+import { isHookProcessContainmentError } from '../../../hooks/WindowsProcessJob.js';
 import { isExecutionLeaseFailure } from '../../../session/events/DurableExecutionLeaseStore.js';
 import { AgentId, SessionId } from '../../../types/branded.js';
 import { PermissionMode } from '../../../types/common.js';
@@ -331,7 +332,10 @@ export function createTaskTool({ registry }: { registry: SubagentRegistry }) {
           }
         } catch (hookError) {
           context.signal?.throwIfAborted();
-          if (isExecutionLeaseFailure(hookError)) {
+          if (
+            isExecutionLeaseFailure(hookError)
+            || isHookProcessContainmentError(hookError)
+          ) {
             throw hookError;
           }
           console.warn('[Task] SubagentStop hook execution failed:', hookError);
@@ -340,7 +344,10 @@ export function createTaskTool({ registry }: { registry: SubagentRegistry }) {
         return buildTaskResult(result, subagent_type, description, duration, subagentSessionId);
       } catch (error) {
         context.signal?.throwIfAborted();
-        if (isExecutionLeaseFailure(error)) {
+        if (
+          isExecutionLeaseFailure(error)
+          || isHookProcessContainmentError(error)
+        ) {
           throw error;
         }
         const _errorMessage = extractUserFriendlyError(

--- a/src/tools/builtin/task/task.ts
+++ b/src/tools/builtin/task/task.ts
@@ -300,7 +300,9 @@ export function createTaskTool({ registry }: { registry: SubagentRegistry }) {
             success: result.success,
             resultSummary: result.message.slice(0, 500),
             error: result.error,
+            abortSignal: context.signal,
           });
+          context.signal?.throwIfAborted();
 
           if (!stopResult.shouldStop && stopResult.continueReason) {
             console.log(
@@ -328,11 +330,16 @@ export function createTaskTool({ registry }: { registry: SubagentRegistry }) {
             console.warn(`[Task] SubagentStop hook warning: ${stopResult.warning}`);
           }
         } catch (hookError) {
+          context.signal?.throwIfAborted();
+          if (isExecutionLeaseFailure(hookError)) {
+            throw hookError;
+          }
           console.warn('[Task] SubagentStop hook execution failed:', hookError);
         }
 
         return buildTaskResult(result, subagent_type, description, duration, subagentSessionId);
       } catch (error) {
+        context.signal?.throwIfAborted();
         if (isExecutionLeaseFailure(error)) {
           throw error;
         }

--- a/src/tools/execution/ExecutionPipeline.ts
+++ b/src/tools/execution/ExecutionPipeline.ts
@@ -1,5 +1,6 @@
 import { ConfigError } from '../../errors/ConfigError.js';
 import type { HookRuntime } from '../../hooks/HookRuntime.js';
+import { isHookProcessContainmentError } from '../../hooks/WindowsProcessJob.js';
 import { type InternalLogger, LogCategory, NOOP_LOGGER } from '../../logging/Logger.js';
 import { composeMiddleware } from '../../middleware/composeMiddleware.js';
 import type {
@@ -349,6 +350,9 @@ export class ExecutionPipeline {
           if (isExecutionLeaseFailure(error)) {
             throw error;
           }
+          if (isHookProcessContainmentError(error)) {
+            throw error;
+          }
           if (isExecutionLeaseFailure(protectedContext.signal?.reason)) {
             throw protectedContext.signal.reason;
           }
@@ -521,6 +525,9 @@ export class ExecutionPipeline {
       if (isExecutionLeaseFailure(error)) {
         throw error;
       }
+      if (isHookProcessContainmentError(error)) {
+        throw error;
+      }
       if (isExecutionLeaseFailure(state.context.signal?.reason)) {
         throw state.context.signal.reason;
       }
@@ -591,6 +598,9 @@ export class ExecutionPipeline {
         if (isExecutionLeaseFailure(error)) {
           throw error;
         }
+        if (isHookProcessContainmentError(error)) {
+          throw error;
+        }
         if (isTimeout) {
           this.logger.warn(
             `Post-execution hooks failed after ${state.toolName} timed out; preserving the timeout`,
@@ -607,6 +617,9 @@ export class ExecutionPipeline {
       );
     } catch (error) {
       if (isExecutionLeaseFailure(error)) {
+        throw error;
+      }
+      if (isHookProcessContainmentError(error)) {
         throw error;
       }
       const errorMsg = getErrorMessage(error);
@@ -647,6 +660,9 @@ export class ExecutionPipeline {
         );
       } catch (hookError) {
         if (isExecutionLeaseFailure(hookError)) {
+          throw hookError;
+        }
+        if (isHookProcessContainmentError(hookError)) {
           throw hookError;
         }
         // Hook 执行失败不应阻止错误处理

--- a/src/tools/execution/ExecutionPipeline.ts
+++ b/src/tools/execution/ExecutionPipeline.ts
@@ -1150,7 +1150,7 @@ export class ExecutionPipeline {
       isInterrupt?: boolean;
     } = {},
   ): Promise<ToolResult> {
-    if (!this.hookRuntime) {
+    if (!this.hookRuntime || context.signal?.aborted) {
       return result;
     }
 

--- a/src/tools/execution/ExecutionPipeline.ts
+++ b/src/tools/execution/ExecutionPipeline.ts
@@ -513,6 +513,7 @@ export class ExecutionPipeline {
         toolKind,
         state.context.signal,
       );
+      this.throwIfTerminalCleanupFailed();
       state.context.signal?.throwIfAborted();
       if (this.hasPendingCleanup()) {
         return this.createPendingCleanupResult();
@@ -524,11 +525,13 @@ export class ExecutionPipeline {
             state.context.signal,
           )
         : undefined;
+      this.throwIfTerminalCleanupFailed();
       state.context.signal?.throwIfAborted();
       if (this.hasPendingCleanup()) {
         return this.createPendingCleanupResult();
       }
       await state.context.assertExecutionLease?.();
+      this.throwIfTerminalCleanupFailed();
       state.context.signal?.throwIfAborted();
       return yield* this.executeWithPipeline(state, executionId);
     } catch (error) {
@@ -568,6 +571,7 @@ export class ExecutionPipeline {
   ): ToolExecution {
     try {
       await this.applyPreToolUseHooks(state, executionId);
+      this.throwIfTerminalCleanupFailed();
       if (!state.result && state.context.signal?.aborted) {
         state.interrupted = isSteeringInterruptSignal(state.context.signal);
         state.result = this.createAbortedResult(
@@ -581,9 +585,11 @@ export class ExecutionPipeline {
       }
       if (!state.result) {
         await this.prepareExecution(state);
+        this.throwIfTerminalCleanupFailed();
       }
       if (!state.result) {
         await this.resolveConfirmation(state);
+        this.throwIfTerminalCleanupFailed();
       }
       if (!state.result) {
         yield* this.executeInvocation(state);
@@ -944,6 +950,7 @@ export class ExecutionPipeline {
       sideEffect: state.resolvedBehavior?.sideEffect ?? state.tool.sideEffect,
     });
     await state.context.assertExecutionLease?.();
+    this.throwIfTerminalCleanupFailed();
     if (this.hasPendingCleanup()) {
       state.result = this.createPendingCleanupResult();
       return;

--- a/src/tools/execution/ExecutionPipeline.ts
+++ b/src/tools/execution/ExecutionPipeline.ts
@@ -147,6 +147,7 @@ export class ExecutionPipeline {
   private readonly resultArtifactStore = new ResultArtifactStore();
   private readonly pendingExecutionCleanups = new Set<Promise<void>>();
   private readonly activePermissionCallbacks = new Map<Promise<void>, AbortSignal>();
+  private terminalCleanupFailure: unknown;
 
   constructor(
     private registry: ToolRegistry,
@@ -201,6 +202,10 @@ export class ExecutionPipeline {
     return false;
   }
 
+  getTerminalCleanupFailure(): unknown {
+    return this.terminalCleanupFailure;
+  }
+
   private hasPendingCleanup(): boolean {
     return this.hasPendingExecutionCleanup() || this.hasPendingPermissionCleanup();
   }
@@ -213,6 +218,7 @@ export class ExecutionPipeline {
     params: JsonObject,
     context: ExecutionContext
   ): ToolExecution {
+    this.throwIfTerminalCleanupFailed();
     if (this.hasPendingCleanup()) {
       return this.createPendingCleanupResult();
     }
@@ -403,9 +409,13 @@ export class ExecutionPipeline {
           effectiveRequest,
         );
       }
+      this.throwIfTerminalCleanupFailed();
       await protectedContext.assertExecutionLease?.();
       completed = true;
       return result;
+    } catch (error) {
+      this.rememberTerminalCleanupFailure(error);
+      throw error;
     } finally {
       if (completed && result) {
         this.addToHistory({
@@ -870,6 +880,12 @@ export class ExecutionPipeline {
         return;
       }
     } catch (error) {
+      if (
+        isExecutionLeaseFailure(error)
+        || isHookProcessContainmentError(error)
+      ) {
+        throw error;
+      }
       if (state.context.signal?.aborted) {
         throw getAbortSignalReason(state.context.signal);
       }
@@ -937,6 +953,7 @@ export class ExecutionPipeline {
       return;
     }
     let completed = false;
+    let lateCriticalFailure: unknown;
     let timedOut = false;
     const timeoutController = new AbortController();
     const timeoutError = this.createTimeoutError(state.toolName);
@@ -957,7 +974,19 @@ export class ExecutionPipeline {
 
     try {
       while (true) {
-        const step = await this.nextExecutionStep(execution, executionSignal);
+        const step = await this.nextExecutionStep(
+          execution,
+          executionSignal,
+          (error) => {
+            if (
+              isExecutionLeaseFailure(error)
+              || isHookProcessContainmentError(error)
+            ) {
+              lateCriticalFailure ??= error;
+              this.rememberTerminalCleanupFailure(error);
+            }
+          },
+        );
         timeoutController.signal.throwIfAborted();
         if (step.done) {
           state.result = step.value;
@@ -975,11 +1004,17 @@ export class ExecutionPipeline {
             };
           }
           completed = true;
-          return;
+          break;
         }
         yield step.value;
       }
     } catch (error) {
+      if (
+        isExecutionLeaseFailure(error)
+        || isHookProcessContainmentError(error)
+      ) {
+        throw error;
+      }
       timedOut =
         timeoutController.signal.aborted
         || getErrorName(error) === 'TimeoutError';
@@ -1002,17 +1037,30 @@ export class ExecutionPipeline {
         }
         const closing = Promise.resolve(execution.return(undefined as never)).then(
           () => undefined,
-          () => undefined,
+          (error) => {
+            if (
+              isExecutionLeaseFailure(error)
+              || isHookProcessContainmentError(error)
+            ) {
+              lateCriticalFailure ??= error;
+              this.rememberTerminalCleanupFailure(error);
+              throw error;
+            }
+          },
         );
         this.trackPendingExecutionCleanup(closing);
         await this.waitForExecutionClose(closing);
       }
+    }
+    if (lateCriticalFailure) {
+      throw lateCriticalFailure;
     }
   }
 
   private async nextExecutionStep(
     execution: ToolExecution,
     signal: AbortSignal,
+    onLateFailure: (error: unknown) => void,
   ): Promise<IteratorResult<ToolYield, ToolResult>> {
     if (signal.aborted) {
       throw signal.reason;
@@ -1045,17 +1093,20 @@ export class ExecutionPipeline {
       };
 
       signal.addEventListener('abort', onAbort, { once: true });
-      execution.next().then(
-        resolveOnce,
-        rejectOnce,
-      );
+      execution.next().then(resolveOnce, (error) => {
+        if (settled) {
+          onLateFailure(error);
+          return;
+        }
+        rejectOnce(error);
+      });
     });
   }
 
   private async waitForExecutionClose(
     closing: PromiseLike<unknown>,
   ): Promise<void> {
-    await new Promise<void>((resolve) => {
+    await new Promise<void>((resolve, reject) => {
       let settled = false;
       const finish = (): void => {
         if (settled) return;
@@ -1063,16 +1114,28 @@ export class ExecutionPipeline {
         clearTimeout(timeout);
         resolve();
       };
+      const fail = (error: unknown): void => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeout);
+        reject(error);
+      };
       const timeout = setTimeout(finish, MAX_TOOL_CLEANUP_WAIT_MS);
-      closing.then(finish, finish);
+      closing.then(finish, fail);
     });
   }
 
   private trackPendingExecutionCleanup(closing: Promise<void>): void {
     this.pendingExecutionCleanups.add(closing);
-    void closing.finally(() => {
-      this.pendingExecutionCleanups.delete(closing);
-    });
+    void closing.then(
+      () => {
+        this.pendingExecutionCleanups.delete(closing);
+      },
+      (error) => {
+        this.pendingExecutionCleanups.delete(closing);
+        this.rememberTerminalCleanupFailure(error);
+      },
+    );
   }
 
   private async awaitPermissionCallback<T>(
@@ -1087,7 +1150,9 @@ export class ExecutionPipeline {
     const callback = Promise.resolve().then(operation);
     const cleanup = callback.then(
       () => undefined,
-      () => undefined,
+      (error) => {
+        this.rememberTerminalCleanupFailure(error);
+      },
     );
     this.activePermissionCallbacks.set(cleanup, signal);
     void cleanup.finally(() => {
@@ -1099,10 +1164,34 @@ export class ExecutionPipeline {
       signal.throwIfAborted();
       return result;
     } catch (error) {
+      if (
+        isExecutionLeaseFailure(error)
+        || isHookProcessContainmentError(error)
+      ) {
+        throw error;
+      }
       if (signal.aborted) {
         throw getAbortSignalReason(signal);
       }
       throw error;
+    }
+  }
+
+  private rememberTerminalCleanupFailure(error: unknown): void {
+    if (
+      this.terminalCleanupFailure === undefined
+      && (
+        isExecutionLeaseFailure(error)
+        || isHookProcessContainmentError(error)
+      )
+    ) {
+      this.terminalCleanupFailure = error;
+    }
+  }
+
+  private throwIfTerminalCleanupFailed(): void {
+    if (this.terminalCleanupFailure !== undefined) {
+      throw this.terminalCleanupFailure;
     }
   }
 
@@ -1427,6 +1516,12 @@ export class ExecutionPipeline {
             'Permission handling and durable resolution both failed',
           );
         }
+      }
+      if (
+        isExecutionLeaseFailure(failure)
+        || isHookProcessContainmentError(failure)
+      ) {
+        throw failure;
       }
       if (state.context.signal?.aborted) {
         throw failure;

--- a/src/tools/execution/__tests__/ExecutionPipeline.test.ts
+++ b/src/tools/execution/__tests__/ExecutionPipeline.test.ts
@@ -866,6 +866,88 @@ describe('ExecutionPipeline', () => {
     expect(executeSpy).not.toHaveBeenCalled();
   });
 
+  it('blocks an in-flight tool before its side effect after quarantine', async () => {
+    const registry = new ToolRegistry();
+    const firstPermissionStarted = deferred();
+    const secondExecutionReady = deferred();
+    const releaseFirstPermission = deferred();
+    const releaseSecondExecution = deferred();
+    const firstController = new AbortController();
+    const containmentError = new HookProcessContainmentError(
+      'Permission Hook process cleanup failed',
+    );
+    const executeSpy = vi.fn(() => completeToolExecution({
+      status: 'success',
+      model: 'unexpected',
+    }));
+    registerTool(
+      registry,
+      createTool({
+        name: 'ConcurrentContainmentTool',
+        displayName: 'Concurrent Containment Tool',
+        kind: ToolKind.Execute,
+        sideEffect: 'non_idempotent',
+        description: { short: 'Concurrent containment tool' },
+        schema: z.object({ id: z.string() }),
+        execute: executeSpy,
+      }),
+    );
+    const permissionHandler = vi.fn(async (request) => {
+      if (request.input.id === 'first') {
+        firstPermissionStarted.resolve();
+        await releaseFirstPermission.promise;
+        throw containmentError;
+      }
+      return { behavior: 'allow' as const };
+    });
+    const pipeline = new ExecutionPipeline(registry, {
+      permissionMode: PermissionMode.YOLO,
+      permissionHandler,
+      concurrencyLimits: { execute: 2 },
+    });
+    const firstExecution = executePipeline(
+      pipeline,
+      'ConcurrentContainmentTool',
+      { id: 'first' },
+      {
+        permissionMode: PermissionMode.YOLO,
+        signal: firstController.signal,
+      },
+    );
+    await firstPermissionStarted.promise;
+
+    const secondExecution = executePipeline(
+      pipeline,
+      'ConcurrentContainmentTool',
+      { id: 'second' },
+      {
+        permissionMode: PermissionMode.YOLO,
+        toolInvocationLifecycle: {
+          onExecutionStarted: async () => {
+            secondExecutionReady.resolve();
+            await releaseSecondExecution.promise;
+          },
+        },
+      },
+    );
+    const secondRejection = expect(secondExecution).rejects.toBe(containmentError);
+    await secondExecutionReady.promise;
+
+    firstController.abort(new Error('request cancelled'));
+    await expect(firstExecution).resolves.toMatchObject({
+      status: 'error',
+      error: { message: 'request cancelled' },
+    });
+    releaseFirstPermission.resolve();
+    await vi.waitFor(() => {
+      expect(pipeline.getTerminalCleanupFailure()).toBe(containmentError);
+    });
+    releaseSecondExecution.resolve();
+
+    await secondRejection;
+    expect(executeSpy).not.toHaveBeenCalled();
+  });
+
   it('uses resolved readonly behavior for plan-mode execution', async () => {
     const registry = new ToolRegistry();
 

--- a/src/tools/execution/__tests__/ExecutionPipeline.test.ts
+++ b/src/tools/execution/__tests__/ExecutionPipeline.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
 import { ConfigError } from '../../../errors/ConfigError.js';
 import type { HookRuntime } from '../../../hooks/HookRuntime.js';
+import { HookProcessContainmentError } from '../../../hooks/WindowsProcessJob.js';
 import { DurableExecutionLeaseError } from '../../../session/events/DurableExecutionLeaseStore.js';
 import { createTool } from '../../core/createTool.js';
 import { ToolRegistry } from '../../registry/ToolRegistry.js';
@@ -710,6 +711,159 @@ describe('ExecutionPipeline', () => {
         message: 'boom',
       },
     });
+  });
+
+  it('does not normalize a tool containment failure into a ToolResult', async () => {
+    const registry = new ToolRegistry();
+    const containmentError = new HookProcessContainmentError(
+      'Hook process cleanup failed',
+    );
+
+    registerTool(
+      registry,
+      createTool({
+        name: 'ContainmentFailureTool',
+        displayName: 'Containment Failure Tool',
+        kind: ToolKind.Execute,
+        sideEffect: 'non_idempotent',
+        description: { short: 'Containment failure tool' },
+        schema: z.object({}),
+        // biome-ignore lint/correctness/useYield: exercises a terminal execution failure
+        async *execute() {
+          throw containmentError;
+        },
+      }),
+    );
+
+    await expect(
+      executePipeline(
+        new ExecutionPipeline(registry, {
+          permissionMode: PermissionMode.YOLO,
+        }),
+        'ContainmentFailureTool',
+        {},
+        { permissionMode: PermissionMode.YOLO },
+      ),
+    ).rejects.toBe(containmentError);
+  });
+
+  it('preserves a late containment failure after cancellation wins the tool race', async () => {
+    vi.useFakeTimers();
+    const registry = new ToolRegistry();
+    const controller = new AbortController();
+    const started = deferred();
+    const releaseCleanup = deferred();
+    const containmentError = new HookProcessContainmentError(
+      'Hook process cleanup failed',
+    );
+
+    registerTool(
+      registry,
+      createTool({
+        name: 'LateContainmentFailureTool',
+        displayName: 'Late Containment Failure Tool',
+        kind: ToolKind.Execute,
+        sideEffect: 'non_idempotent',
+        description: { short: 'Late containment failure tool' },
+        schema: z.object({}),
+        async *execute(_params, context) {
+          started.resolve();
+          await new Promise<void>((resolve) => {
+            context.signal?.addEventListener('abort', () => resolve(), {
+              once: true,
+            });
+          });
+          await releaseCleanup.promise;
+          throw containmentError;
+        },
+      }),
+    );
+    const pipeline = new ExecutionPipeline(registry, {
+      permissionMode: PermissionMode.YOLO,
+    });
+    const execution = executePipeline(
+      pipeline,
+      'LateContainmentFailureTool',
+      {},
+      {
+        permissionMode: PermissionMode.YOLO,
+        signal: controller.signal,
+      },
+    );
+    const rejection = expect(execution).rejects.toBe(containmentError);
+
+    await started.promise;
+    controller.abort(new Error('request cancelled'));
+    await vi.advanceTimersByTimeAsync(0);
+    releaseCleanup.resolve();
+
+    await rejection;
+    expect(pipeline.getTerminalCleanupFailure()).toBe(containmentError);
+  });
+
+  it('quarantines the pipeline after a late permission containment failure', async () => {
+    const registry = new ToolRegistry();
+    const controller = new AbortController();
+    const started = deferred();
+    const releaseCleanup = Promise.withResolvers<void>();
+    const containmentError = new HookProcessContainmentError(
+      'Permission Hook process cleanup failed',
+    );
+    const executeSpy = vi.fn(() => completeToolExecution({
+      status: 'success',
+      model: 'unexpected',
+    }));
+    registerTool(
+      registry,
+      createTool({
+        name: 'PermissionContainmentFailureTool',
+        displayName: 'Permission Containment Failure Tool',
+        kind: ToolKind.Execute,
+        sideEffect: 'non_idempotent',
+        description: { short: 'Permission containment failure tool' },
+        schema: z.object({}),
+        execute: executeSpy,
+      }),
+    );
+    const permissionHandler = vi.fn(async () => {
+      started.resolve();
+      await releaseCleanup.promise;
+      throw containmentError;
+    });
+    const pipeline = new ExecutionPipeline(registry, {
+      permissionMode: PermissionMode.YOLO,
+      permissionHandler,
+    });
+    const firstExecution = executePipeline(
+      pipeline,
+      'PermissionContainmentFailureTool',
+      {},
+      {
+        permissionMode: PermissionMode.YOLO,
+        signal: controller.signal,
+      },
+    );
+
+    await started.promise;
+    controller.abort(new Error('request cancelled'));
+    await expect(firstExecution).resolves.toMatchObject({
+      status: 'error',
+      error: { message: 'request cancelled' },
+    });
+    releaseCleanup.reject(containmentError);
+    await vi.waitFor(() => {
+      expect(pipeline.getTerminalCleanupFailure()).toBe(containmentError);
+    });
+
+    await expect(
+      executePipeline(
+        pipeline,
+        'PermissionContainmentFailureTool',
+        {},
+        { permissionMode: PermissionMode.YOLO },
+      ),
+    ).rejects.toBe(containmentError);
+    expect(executeSpy).not.toHaveBeenCalled();
   });
 
   it('uses resolved readonly behavior for plan-mode execution', async () => {


### PR DESCRIPTION
## Summary

- prevent pre-cancelled file/command hooks from spawning child processes
- preserve Request cancellation before and after every file-hook dispatch, including `SubagentStop`
- run hook commands in isolated process groups and terminate the complete tree on cancellation or timeout
- escalate from SIGTERM to SIGKILL and keep the Hook pending until the process tree is gone

## Reference alignment

- Claude Code checks combined abort signals before hook execution
- Codex uses process groups and kill-on-drop cleanup
- Grok tracks process groups and explicitly reaps child trees

## Verification

- `pnpm test` (`1628 passed`, `62 skipped`)
- real parent/grandchild process tests for cancellation and timeout
- `pnpm run type-check`
- `pnpm run lint`
- `pnpm run verify:entrypoints`
- `pnpm run docs:build`
- `pnpm run changelog:check`
- `pnpm run audit:prod`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cancelled or timed-out file and command hooks now clean up complete process trees before requests finish.
  * Windows hooks contain descendant processes and fail safely when containment or cleanup cannot be confirmed.
  * Containment failures are preserved and reported instead of being downgraded or converted into normal tool results.
  * Late cleanup failures quarantine execution, preventing subsequent tool calls and session close or handoff from proceeding.
  * Improved handling of hook cancellation, timeouts, broken pipes, and termination failures.

* **Documentation**
  * Clarified platform-specific cancellation, timeout, escalation, and cleanup behavior.

* **Tests**
  * Added comprehensive coverage for containment and fail-closed behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->