### PR TITLE
fix(provider): preserve model provenance across history

### DIFF
--- a/.changes/provider-aware-history.json
+++ b/.changes/provider-aware-history.json
@@ -1,0 +1,5 @@
+{
+  "type": "fix",
+  "en": "Persist provider, API adapter, and model provenance for assistant history, and safely downgrade reasoning when replaying across providers or models.",
+  "zh-CN": "持久化 assistant 历史的 Provider、API adapter 与模型来源，并在跨 Provider 或模型回放时安全降级 reasoning。"
+}

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -242,6 +242,7 @@ Node-local 能力外，这些函数都从根入口导出；实际 subpath 以“
 |------|------|
 | `ProviderConfig` | Provider 配置 |
 | `ProviderType` | Provider 类型字面量 |
+| `ModelIdentity` | 生成 assistant 消息的 Provider、API adapter 与模型身份 |
 | `ModelInfo` | 模型信息 |
 | `TokenUsage` | Token 用量 |
 

--- a/docs/durable-events.md
+++ b/docs/durable-events.md
@@ -82,7 +82,7 @@ interface DurableEventEnvelope<TType extends DurableEventType> {
 | `turn_started` | `requestId`、`turnId` | `turn`、`model?` |
 | `turn_completed` | `requestId`、`turnId` | `turn`、`hasToolCalls` |
 | `turn_aborted` | `requestId`、`turnId` | `turn`、`reason` |
-| `model_request_started` | Request、Turn、`modelAttemptId` | `model`、`streaming` |
+| `model_request_started` | Request、Turn、`modelAttemptId` | `model`、可选 `provider` / `api`、`streaming` |
 | `model_request_completed` | Request、Turn、`modelAttemptId` | 完整模型 `response` |
 | `model_request_failed` | Request、Turn、`modelAttemptId` | `error` |
 | `model_request_aborted` | Request、Turn、`modelAttemptId` | `reason` |
@@ -352,6 +352,8 @@ Turn 结束；进程崩溃留下 started attempt 时，plan 返回
 一次 model attempt 表示包含内部 HTTP 重试的一次逻辑模型调用；反应式压缩后的
 重新调用会创建新的 attempt。高频 token delta 仍是临时流，完整响应在任何后续
 Turn 终态前持久化。
+新的 model attempt event 会保留逻辑 Provider 和 API adapter，避免恢复时丢失
+模型来源；缺少这些可选字段的旧事件仍然有效。
 活动 model attempt 的对账优先于同一 Turn 的权限和工具结果；模型终态提交后，
 plan 会继续暴露尚未消解的下一层恢复动作。
 

--- a/docs/durable-events.md
+++ b/docs/durable-events.md
@@ -43,7 +43,7 @@ import {
 
 ```ts
 interface DurableEventEnvelope<TType extends DurableEventType> {
-  schemaVersion: 2 | 3;
+  schemaVersion: 2 | 3 | 4;
   eventId: EventId;
   sequence: EventSequence;
   sessionId: SessionId;
@@ -82,7 +82,7 @@ interface DurableEventEnvelope<TType extends DurableEventType> {
 | `turn_started` | `requestId`、`turnId` | `turn`、`model?` |
 | `turn_completed` | `requestId`、`turnId` | `turn`、`hasToolCalls` |
 | `turn_aborted` | `requestId`、`turnId` | `turn`、`reason` |
-| `model_request_started` | Request、Turn、`modelAttemptId` | `model`、可选 `provider` / `api`、`streaming` |
+| `model_request_started` | Request、Turn、`modelAttemptId` | `model`、可选 `modelIdentity`、`streaming` |
 | `model_request_completed` | Request、Turn、`modelAttemptId` | 完整模型 `response` |
 | `model_request_failed` | Request、Turn、`modelAttemptId` | `error` |
 | `model_request_aborted` | Request、Turn、`modelAttemptId` | `reason` |
@@ -567,16 +567,17 @@ provenance 还要求前置 synthetic `turn_started`。`requestId` 和 `turnId` �
 `DURABLE_RECOVERY_UNSAFE_ROLLOVER`，必须保持 fail-closed；该 API 不使用提示词
 绕过未知副作用。
 
-当前 writer 使用 schema v3，并为模型调用增加 `modelAttemptId` 及完整生命周期
-事件。v3 的 `tool_scheduled.modelAttemptId` 显式绑定产生该工具调用的 Model
-Attempt，`modelInput` 保存 provider 原始参数，`input` 保存参数修复后的执行值；
-projector 以 canonical JSON 校验工具 ID、名称和原始参数与已确认模型响应完全
-一致。即使流式工具在
+当前 writer 使用 schema v4。Schema v3 为模型调用增加了 `modelAttemptId` 和完整
+生命周期事件；v3 及后续版本的 `tool_scheduled.modelAttemptId` 显式绑定产生该
+工具调用的 Model Attempt，`modelInput` 保存 provider 原始参数，`input` 保存参数
+修复后的执行值。Schema v4 在 `model_request_started` 中增加可选的
+`modelIdentity` 对象。projector 以 canonical JSON 校验工具 ID、
+名称和原始参数与已确认模型响应完全一致。即使流式工具在
 `model_request_completed` 前开始调度，模型终态到达时也会反向校验已调度工具。
-Reader 可继续读取没有这些字段的 schema v2 日志，并允许在同一 Session 后续追加
-v3 batch；schema 版本只能单调升级，不能在 v3 后降回 v2，且 v2 batch 不允许
-伪装包含 v3 模型事件。Schema v1 不会被静默推断，需要显式迁移后才能由当前
-runtime 恢复。
+Reader 可继续读取 schema v2 和 v3 日志，并允许在同一 Session 后续追加 v4
+batch；schema 版本只能单调升级，旧版本 batch 不能追加到新版本之后，v2 不允许
+包含 v3 模型事件，v2/v3 也不允许包含 v4 Provider 身份。Schema v1 不会被静默
+推断，需要显式迁移后才能由当前 runtime 恢复。
 
 ### Store deadline 与协作取消
 

--- a/docs/en/api-reference.md
+++ b/docs/en/api-reference.md
@@ -32,7 +32,7 @@ Types:
 
 `AgentDefinition`, `ExecutionContext`, `ForkOptions`, `ForkSessionOptions`,
 `ForkSessionResult`, `HookCallback`, `HookInput`, `HookOutput`,
-`InputSubmission`, `ISession`, `McpServerStatus`, `McpToolInfo`, `ModelInfo`,
+`InputSubmission`, `ISession`, `McpServerStatus`, `McpToolInfo`, `ModelIdentity`, `ModelInfo`,
 `PendingSessionInput`, `PromptResult`, `ProviderConfig`, `ProviderType`,
 `ResumeOptions`, `SendOptions`, `SessionHandoffErrorCode`,
 `SessionHandoffResult`, `SessionOptions`, `SessionTool`, `StreamMessage`,

--- a/docs/en/durable-events.md
+++ b/docs/en/durable-events.md
@@ -87,7 +87,7 @@ are rejected before append.
 | `turn_started` | `requestId`, `turnId` | `turn`, `model?` |
 | `turn_completed` | `requestId`, `turnId` | `turn`, `hasToolCalls` |
 | `turn_aborted` | `requestId`, `turnId` | `turn`, `reason` |
-| `model_request_started` | Request, Turn, `modelAttemptId` | `model`, `streaming` |
+| `model_request_started` | Request, Turn, `modelAttemptId` | `model`, optional `provider` / `api`, `streaming` |
 | `model_request_completed` | Request, Turn, `modelAttemptId` | Complete model `response` |
 | `model_request_failed` | Request, Turn, `modelAttemptId` | `error` |
 | `model_request_aborted` | Request, Turn, `modelAttemptId` | `reason` |
@@ -372,6 +372,9 @@ A model attempt is one logical model operation and may contain internal HTTP
 retries. A reactive-compaction retry creates a new attempt. High-frequency
 token deltas remain transient, while the complete response is durable before
 any later Turn terminal event.
+New model-attempt events retain the logical provider and API adapter so
+recovery does not lose model provenance. Older events without those optional
+fields remain valid.
 Active model reconciliation takes precedence over permission and tool outcomes
 in the same Turn. After the model terminal event commits, the plan exposes the
 next unresolved recovery action.

--- a/docs/en/durable-events.md
+++ b/docs/en/durable-events.md
@@ -47,7 +47,7 @@ import {
 
 ```ts
 interface DurableEventEnvelope<TType extends DurableEventType> {
-  schemaVersion: 2 | 3;
+  schemaVersion: 2 | 3 | 4;
   eventId: EventId;
   sequence: EventSequence;
   sessionId: SessionId;
@@ -87,7 +87,7 @@ are rejected before append.
 | `turn_started` | `requestId`, `turnId` | `turn`, `model?` |
 | `turn_completed` | `requestId`, `turnId` | `turn`, `hasToolCalls` |
 | `turn_aborted` | `requestId`, `turnId` | `turn`, `reason` |
-| `model_request_started` | Request, Turn, `modelAttemptId` | `model`, optional `provider` / `api`, `streaming` |
+| `model_request_started` | Request, Turn, `modelAttemptId` | `model`, optional `modelIdentity`, `streaming` |
 | `model_request_completed` | Request, Turn, `modelAttemptId` | Complete model `response` |
 | `model_request_failed` | Request, Turn, `modelAttemptId` | `error` |
 | `model_request_aborted` | Request, Turn, `modelAttemptId` | `reason` |
@@ -608,18 +608,21 @@ execution started raises
 `DURABLE_RECOVERY_UNSAFE_ROLLOVER` and remains fail-closed; the API does not use
 prompting to bypass an unknown side effect.
 
-The current writer uses schema v3, which adds `modelAttemptId` and the complete
-model-request lifecycle. In v3, `tool_scheduled.modelAttemptId` explicitly
-identifies the Model Attempt that produced the call, `modelInput` preserves the
-provider's original arguments, and `input` holds repaired execution input. The
-projector uses canonical JSON to match the tool ID, name, and original
-arguments to the confirmed model response. If streaming dispatches a tool before
+The current writer uses schema v4. Schema v3 added `modelAttemptId` and the
+complete model-request lifecycle. In v3 and later,
+`tool_scheduled.modelAttemptId` explicitly identifies the Model Attempt that
+produced the call, `modelInput` preserves the provider's original arguments,
+and `input` holds repaired execution input. Schema v4 adds the optional
+`modelIdentity` object to `model_request_started`. The projector
+uses canonical JSON to match the tool ID, name, and original arguments to the
+confirmed model response. If streaming dispatches a tool before
 `model_request_completed`, the terminal model event validates all previously
-scheduled tools when it arrives. Readers remain compatible with schema-v2 logs
-that lack these fields and may append later v3 batches to the same Session. Schema
-versions may only increase: a v2 batch after v3 is corrupt, and a v2 batch
-cannot masquerade as containing v3 model events. Version 1 logs are not
-inferred silently and must be migrated before this runtime can resume them.
+scheduled tools when it arrives. Readers remain compatible with schema-v2 and
+schema-v3 logs and may append later v4 batches to the same Session. Schema
+versions may only increase: an older batch after a newer one is corrupt, v2
+cannot contain v3 model events, and v2/v3 cannot contain v4 provider identity.
+Version 1 logs are not inferred silently and must be migrated before this
+runtime can resume them.
 
 ### Store deadlines and cooperative cancellation
 

--- a/docs/en/providers.md
+++ b/docs/en/providers.md
@@ -38,7 +38,8 @@ interface ProviderConfig {
 
 `type` selects the wire-protocol adapter. `id` identifies the logical provider
 and defaults to `type`. Set `id` for OpenAI-compatible gateways when provider
-identity must survive model switches or persisted-session resume:
+identity must survive model switches or persisted-session resume. `id` never
+changes adapter selection:
 
 ```ts
 provider: {

--- a/docs/en/providers.md
+++ b/docs/en/providers.md
@@ -17,6 +17,7 @@ Provider adapters are loaded lazily. Optional adapters only need to be installed
 
 ```ts
 interface ProviderConfig {
+  id?: string;
   type:
     | 'openai'
     | 'anthropic'
@@ -32,6 +33,19 @@ interface ProviderConfig {
   projectId?: string;
   requestTimeoutMs?: number;
   streamIdleTimeoutMs?: number;
+}
+```
+
+`type` selects the wire-protocol adapter. `id` identifies the logical provider
+and defaults to `type`. Set `id` for OpenAI-compatible gateways when provider
+identity must survive model switches or persisted-session resume:
+
+```ts
+provider: {
+  id: 'openrouter',
+  type: 'openai-compatible',
+  apiKey: process.env.OPENROUTER_API_KEY!,
+  baseUrl: 'https://openrouter.ai/api/v1',
 }
 ```
 
@@ -122,6 +136,7 @@ These helpers are lower-level APIs and do not replace the Session interface.
 ```ts
 const session = await createSession({
   provider: {
+    id: 'provider-name',
     type: 'openai-compatible',
     apiKey: process.env.PROVIDER_API_KEY!,
     baseUrl: 'https://provider.example.com/v1',
@@ -170,6 +185,13 @@ for (const model of models) {
 ```
 
 Changing the model affects later model calls in the same Session.
+
+Assistant history records the logical provider ID, API adapter, and model that
+produced each response. Native reasoning blocks are replayed only to that same
+provider, adapter, and model. When any identity component changes, or when
+legacy history has no identity, reasoning is converted to ordinary assistant
+text while tool-call relationships are preserved. This prevents
+provider-specific reasoning payloads from being sent to an incompatible API.
 
 ## Logging
 

--- a/docs/en/session.md
+++ b/docs/en/session.md
@@ -744,6 +744,8 @@ Payload capture is opt-in because prompts and tool data may be sensitive.
 `ProviderConfig.requestTimeoutMs` defaults to `600000`, and
 `ProviderConfig.streamIdleTimeoutMs` defaults to `300000`. See
 [Providers and Logging](./providers) for timeout semantics.
+`ProviderConfig.id` optionally identifies the logical provider independently
+from its wire-protocol `type`.
 
 ## ISession
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -30,7 +30,7 @@ interface ProviderConfig {
 
 `type` 选择 wire protocol adapter；`id` 标识逻辑 Provider，默认等于
 `type`。OpenAI-compatible 网关如需在模型切换和持久化 Session 恢复后保留
-真实 Provider 身份，应显式设置 `id`：
+真实 Provider 身份，应显式设置 `id`；`id` 不会改变 adapter 选择：
 
 ```ts
 provider: {

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -15,6 +15,7 @@
 
 ```ts
 interface ProviderConfig {
+  id?: string;
   type: ProviderType;
   apiKey?: string;
   baseUrl?: string;
@@ -27,11 +28,30 @@ interface ProviderConfig {
 }
 ```
 
+`type` 选择 wire protocol adapter；`id` 标识逻辑 Provider，默认等于
+`type`。OpenAI-compatible 网关如需在模型切换和持久化 Session 恢复后保留
+真实 Provider 身份，应显式设置 `id`：
+
+```ts
+provider: {
+  id: 'openrouter',
+  type: 'openai-compatible',
+  apiKey: process.env.OPENROUTER_API_KEY!,
+  baseUrl: 'https://openrouter.ai/api/v1',
+}
+```
+
 `requestTimeoutMs` 限制一次非流式模型操作的总时长（包括重试等待），默认
 10 分钟。`streamIdleTimeoutMs` 限制等待下一个流式 chunk 的时长，默认
 5 分钟。两者都必须是以毫秒为单位的正整数。超时会主动中止底层 provider
 请求，并抛出 `ModelTimeoutError`；错误码分别为
 `MODEL_REQUEST_TIMEOUT` 和 `MODEL_STREAM_IDLE_TIMEOUT`，不会伪装成用户取消。
+
+assistant 历史会记录生成响应时的逻辑 Provider ID、API adapter 和模型。
+只有来源三元组完全相同时，原生 reasoning block 才会按原格式回放。切换
+Provider、adapter、模型，或恢复不含来源信息的旧历史时，reasoning 会降级为
+普通 assistant 文本，同时保留 tool call 关联，避免把 Provider 专属 payload
+发送给不兼容的 API。
 
 ## 配置示例
 

--- a/docs/session.md
+++ b/docs/session.md
@@ -119,6 +119,7 @@ const session = await createSession(options);
 
 ```ts
 interface ProviderConfig {
+  id?: string;              // 逻辑 Provider ID；默认等于 type
   type: ProviderType;
   apiKey?: string;
   baseUrl?: string;

--- a/src/__tests__/rootExports.test.ts
+++ b/src/__tests__/rootExports.test.ts
@@ -144,7 +144,7 @@ describe('root exports', () => {
     expect(new SessionInputError('TEST', 'message')).toBeInstanceOf(Error);
     expect(ToolErrorType.INTERRUPTED).toBe('interrupted');
     expect(ToolSideEffect.NON_IDEMPOTENT).toBe('non_idempotent');
-    expect(DURABLE_EVENT_SCHEMA_VERSION).toBe(3);
+    expect(DURABLE_EVENT_SCHEMA_VERSION).toBe(4);
     expect(DURABLE_EVENT_CURSOR_VERSION).toBe(1);
     expect(DurableEventType.REQUEST_ACCEPTED).toBe('request_accepted');
     expect(DurableEventType.MODEL_REQUEST_STARTED).toBe('model_request_started');
@@ -266,8 +266,8 @@ describe('root exports', () => {
     expectTypeOf<DurableModelAttemptProjection['modelAttemptId']>().toEqualTypeOf<
       ReturnType<typeof ModelAttemptId>
     >();
-    expectTypeOf<DurableModelAttemptProjection['provider']>().toEqualTypeOf<
-      string | undefined
+    expectTypeOf<DurableModelAttemptProjection['modelIdentity']>().toEqualTypeOf<
+      ModelIdentity | undefined
     >();
     expectTypeOf<DurableModelOutcomeReconciliationCommand['modelAttemptId']>().toEqualTypeOf<
       ReturnType<typeof ModelAttemptId>

--- a/src/__tests__/rootExports.test.ts
+++ b/src/__tests__/rootExports.test.ts
@@ -35,6 +35,7 @@ import type {
   ExecutionContext,
   InputSubmission,
   ISession,
+  ModelIdentity,
   PendingSessionInput,
   RuntimePatch,
   SessionHandoffErrorCode,
@@ -230,6 +231,9 @@ describe('root exports', () => {
     expectTypeOf<ToolSettledLifecycle['result']>().toEqualTypeOf<ToolResult>();
     expectTypeOf<InputSubmission['status']>().toEqualTypeOf<'started' | 'steered' | 'queued'>();
     expectTypeOf<PendingSessionInput['priority']>().toEqualTypeOf<'now' | 'next' | 'later'>();
+    expectTypeOf<ModelIdentity['api']>().toEqualTypeOf<
+      'anthropic' | 'openai' | 'azure-openai' | 'gemini' | 'deepseek' | 'openai-compatible'
+    >();
     expectTypeOf<ReturnType<typeof createMemoryReadTool>>().toMatchTypeOf<SessionTool>();
     expectTypeOf<DurableEventEnvelope['sequence']>().toEqualTypeOf<EventSequence>();
     expectTypeOf<DurableEventCursor['eventId']>().toEqualTypeOf<EventId>();
@@ -261,6 +265,9 @@ describe('root exports', () => {
     expectTypeOf<DurableRequestRecoveryKind>().toEqualTypeOf<'turn' | 'pre_turn_request'>();
     expectTypeOf<DurableModelAttemptProjection['modelAttemptId']>().toEqualTypeOf<
       ReturnType<typeof ModelAttemptId>
+    >();
+    expectTypeOf<DurableModelAttemptProjection['provider']>().toEqualTypeOf<
+      string | undefined
     >();
     expectTypeOf<DurableModelOutcomeReconciliationCommand['modelAttemptId']>().toEqualTypeOf<
       ReturnType<typeof ModelAttemptId>

--- a/src/agent/AgentLoop.ts
+++ b/src/agent/AgentLoop.ts
@@ -8,7 +8,12 @@
 
 import { isHookProcessContainmentError } from '../hooks/WindowsProcessJob.js';
 import type { InternalLogger } from '../logging/Logger.js';
-import type { ChatResponse, Message, ToolCall } from '../services/ChatServiceInterface.js';
+import type {
+  ChatResponse,
+  Message,
+  ModelIdentity,
+  ToolCall,
+} from '../services/ChatServiceInterface.js';
 import { FallbackTriggeredError } from '../services/RetryPolicy.js';
 import type { ExecutionPipeline } from '../tools/execution/ExecutionPipeline.js';
 import type { ToolEffect, ToolResult } from '../tools/types/index.js';
@@ -95,6 +100,7 @@ export interface AgentLoopHooks {
       content: string;
       reasoningContent?: string;
       toolCalls?: ToolCall[];
+      modelIdentity: ModelIdentity;
       turn: number;
     }) => Promise<void>;
     onComplete?: (ctx: {
@@ -258,6 +264,7 @@ export async function* agentLoop(
 
     // === runTurn：单回合 LLM 调用 + 流式事件 ===
     let turnResult: ChatResponse | undefined;
+    let modelIdentity: ModelIdentity | undefined;
     let streamingExecutionResults: Array<{
       toolCall: FunctionToolCall;
       result: ToolResult;
@@ -289,6 +296,7 @@ export async function* agentLoop(
         },
       });
       turnResult = turnOutcome.chatResponse;
+      modelIdentity = turnOutcome.modelIdentity;
       streamingExecutionResults = turnOutcome.streamingExecutionResults;
       modelAttemptId = turnOutcome.modelAttemptId;
     } catch (llmError) {
@@ -376,8 +384,8 @@ export async function* agentLoop(
       throw llmError;
     }
 
-    if (!turnResult) {
-      throw new Error('Agent loop completed without a chat response');
+    if (!turnResult || !modelIdentity) {
+      throw new Error('Agent loop completed without a chat response and model identity');
     }
 
     if (recovery.phase !== 'idle') {
@@ -485,10 +493,12 @@ export async function* agentLoop(
           role: 'assistant',
           content,
           reasoningContent: turnResult.reasoningContent,
+          ...modelIdentity,
         });
         await messageHooks?.onAssistant?.({
           content,
           reasoningContent: turnResult.reasoningContent,
+          modelIdentity,
           turn: turnsCount,
         });
       }
@@ -651,12 +661,14 @@ export async function* agentLoop(
       content: turnResult.content || '',
       reasoningContent: turnResult.reasoningContent,
       tool_calls: turnResult.toolCalls,
+      ...modelIdentity,
     });
 
     await messageHooks?.onAssistant?.({
       content: turnResult.content || '',
       reasoningContent: turnResult.reasoningContent,
       toolCalls: turnResult.toolCalls,
+      modelIdentity,
       turn: turnsCount,
     });
 

--- a/src/agent/AgentLoop.ts
+++ b/src/agent/AgentLoop.ts
@@ -493,7 +493,7 @@ export async function* agentLoop(
           role: 'assistant',
           content,
           reasoningContent: turnResult.reasoningContent,
-          ...modelIdentity,
+          modelIdentity,
         });
         await messageHooks?.onAssistant?.({
           content,
@@ -661,7 +661,7 @@ export async function* agentLoop(
       content: turnResult.content || '',
       reasoningContent: turnResult.reasoningContent,
       tool_calls: turnResult.toolCalls,
-      ...modelIdentity,
+      modelIdentity,
     });
 
     await messageHooks?.onAssistant?.({

--- a/src/agent/LoopHookBuilder.ts
+++ b/src/agent/LoopHookBuilder.ts
@@ -393,6 +393,9 @@ export function buildLoopConfig(deps: LoopHookBuilderDeps): AgentLoopConfig {
                 ctx.content,
                 getLastUuid(),
                 {
+                  model: ctx.modelIdentity.model,
+                  provider: ctx.modelIdentity.provider,
+                  api: ctx.modelIdentity.api,
                   reasoningContent: ctx.reasoningContent,
                   toolCalls: ctx.toolCalls,
                 },

--- a/src/agent/LoopHookBuilder.ts
+++ b/src/agent/LoopHookBuilder.ts
@@ -393,9 +393,7 @@ export function buildLoopConfig(deps: LoopHookBuilderDeps): AgentLoopConfig {
                 ctx.content,
                 getLastUuid(),
                 {
-                  model: ctx.modelIdentity.model,
-                  provider: ctx.modelIdentity.provider,
-                  api: ctx.modelIdentity.api,
+                  modelIdentity: ctx.modelIdentity,
                   reasoningContent: ctx.reasoningContent,
                   toolCalls: ctx.toolCalls,
                 },

--- a/src/agent/ModelExecutionLifecycle.ts
+++ b/src/agent/ModelExecutionLifecycle.ts
@@ -1,6 +1,8 @@
-import type { ChatResponse } from '../services/ChatServiceInterface.js';
+import type {
+  ChatResponse,
+  ModelIdentity,
+} from '../services/ChatServiceInterface.js';
 import type { ModelAttemptId } from '../types/branded.js';
-import type { ProviderType } from '../types/common.js';
 
 export type ModelRequestAbortReason = 'request_interrupted' | 'steering';
 
@@ -15,8 +17,7 @@ export interface ModelExecutionLifecycle {
   onModelRequestStarting(input: {
     readonly turn: number;
     readonly model: string;
-    readonly provider?: string;
-    readonly api?: ProviderType;
+    readonly modelIdentity?: ModelIdentity;
     readonly streaming: boolean;
   }): Promise<ModelRequestLifecycle>;
 }

--- a/src/agent/ModelExecutionLifecycle.ts
+++ b/src/agent/ModelExecutionLifecycle.ts
@@ -1,5 +1,6 @@
 import type { ChatResponse } from '../services/ChatServiceInterface.js';
 import type { ModelAttemptId } from '../types/branded.js';
+import type { ProviderType } from '../types/common.js';
 
 export type ModelRequestAbortReason = 'request_interrupted' | 'steering';
 
@@ -14,6 +15,8 @@ export interface ModelExecutionLifecycle {
   onModelRequestStarting(input: {
     readonly turn: number;
     readonly model: string;
+    readonly provider?: string;
+    readonly api?: ProviderType;
     readonly streaming: boolean;
   }): Promise<ModelRequestLifecycle>;
 }

--- a/src/agent/ModelManager.ts
+++ b/src/agent/ModelManager.ts
@@ -86,6 +86,7 @@ export class ModelManager {
 
     const chatService = await createChatServiceAsync({
       provider: modelConfig.provider,
+      providerId: modelConfig.providerId?.trim() || modelConfig.provider,
       apiKey: modelConfig.apiKey || '',
       model: modelConfig.model,
       baseUrl: modelConfig.baseUrl || '',

--- a/src/agent/__tests__/AgentLoop.test.ts
+++ b/src/agent/__tests__/AgentLoop.test.ts
@@ -77,6 +77,10 @@ function createMockChatService(responses: Array<{
       return await chatFn(...args);
     }),
     getConfig: () => ({
+      provider: 'openai',
+      providerId: 'openai-primary',
+      apiKey: 'test-key',
+      baseUrl: 'https://api.openai.com/v1',
       model: 'test-model',
       maxContextTokens: 128000,
     }),
@@ -256,6 +260,8 @@ describe('agentLoop', () => {
 
       expect(onModelRequestStarting).toHaveBeenCalledWith({
         turn: 1,
+        provider: 'openai-primary',
+        api: 'openai',
         model: 'test-model',
         streaming: false,
       });
@@ -1243,9 +1249,31 @@ describe('agentLoop', () => {
       await collectEvents(agentLoop(config));
 
       expect(onAssistantMessage).toHaveBeenCalled();
-      const firstCall = (onAssistantMessage.mock.calls as unknown as [{ content: string; turn: number }][])[0][0];
+      const firstCall = (onAssistantMessage.mock.calls as unknown as [{
+        content: string;
+        modelIdentity: {
+          provider: string;
+          api: string;
+          model: string;
+        };
+        turn: number;
+      }][])[0][0];
       expect(firstCall.content).toBe('Using tool');
+      expect(firstCall.modelIdentity).toEqual({
+        provider: 'openai-primary',
+        api: 'openai',
+        model: 'test-model',
+      });
       expect(firstCall.turn).toBe(1);
+      expect(
+        config.conversationState
+          .toArray()
+          .find((message) => message.role === 'assistant'),
+      ).toMatchObject({
+        provider: 'openai-primary',
+        api: 'openai',
+        model: 'test-model',
+      });
     });
 
     it('should call onBeforeToolExec and onAfterToolExec hooks', async () => {

--- a/src/agent/__tests__/AgentLoop.test.ts
+++ b/src/agent/__tests__/AgentLoop.test.ts
@@ -260,9 +260,12 @@ describe('agentLoop', () => {
 
       expect(onModelRequestStarting).toHaveBeenCalledWith({
         turn: 1,
-        provider: 'openai-primary',
-        api: 'openai',
         model: 'test-model',
+        modelIdentity: {
+          provider: 'openai-primary',
+          api: 'openai',
+          model: 'test-model',
+        },
         streaming: false,
       });
       expect(onCompleted).toHaveBeenCalledWith(
@@ -1270,9 +1273,11 @@ describe('agentLoop', () => {
           .toArray()
           .find((message) => message.role === 'assistant'),
       ).toMatchObject({
-        provider: 'openai-primary',
-        api: 'openai',
-        model: 'test-model',
+        modelIdentity: {
+          provider: 'openai-primary',
+          api: 'openai',
+          model: 'test-model',
+        },
       });
     });
 

--- a/src/agent/__tests__/LoopRunner.test.ts
+++ b/src/agent/__tests__/LoopRunner.test.ts
@@ -397,6 +397,10 @@ describe('LoopRunner', () => {
           chat: vi.fn(),
           streamChat,
           getConfig: () => ({
+            provider: 'openai-compatible' as const,
+            providerId: 'test-provider',
+            apiKey: 'test-key',
+            baseUrl: 'https://provider.example.test/v1',
             model: 'test-model',
             maxContextTokens: 128000,
           }),

--- a/src/agent/__tests__/ModelManager.setModel.test.ts
+++ b/src/agent/__tests__/ModelManager.setModel.test.ts
@@ -33,6 +33,7 @@ describe('ModelManager.setModel', () => {
     const config: BladeConfig = {
       models: [
         createModelConfig({
+          providerId: 'gateway-primary',
           maxOutputTokens: 4096,
           requestTimeoutMs: 120_000,
           streamIdleTimeoutMs: 30_000,
@@ -51,6 +52,7 @@ describe('ModelManager.setModel', () => {
 
     expect(mockCreateChatServiceAsync).toHaveBeenLastCalledWith(
       expect.objectContaining({
+        providerId: 'gateway-primary',
         maxOutputTokens: 4096,
         requestTimeoutMs: 120_000,
         streamIdleTimeoutMs: 30_000,

--- a/src/agent/loop/runTurn.ts
+++ b/src/agent/loop/runTurn.ts
@@ -98,7 +98,8 @@ export async function* runTurn(
   const modelIdentity = resolveModelIdentity(turnChatService.getConfig());
   const requestLifecycle = await input.modelExecutionLifecycle?.onModelRequestStarting({
     turn: turnState.turn,
-    ...modelIdentity,
+    model: modelIdentity.model,
+    modelIdentity,
     streaming: streaming === true,
   });
   await turnState.executionContext.assertExecutionLease?.();

--- a/src/agent/loop/runTurn.ts
+++ b/src/agent/loop/runTurn.ts
@@ -12,10 +12,8 @@
 
 import type { JSONSchema7 } from 'json-schema';
 import type { InternalLogger } from '../../logging/Logger.js';
-import type {
-  ChatResponse,
-  Message,
-} from '../../services/ChatServiceInterface.js';
+import type { ChatResponse, Message } from '../../services/ChatServiceInterface.js';
+import { type ModelIdentity, resolveModelIdentity } from '../../services/ModelIdentity.js';
 import type { ExecutionPipeline } from '../../tools/execution/ExecutionPipeline.js';
 import type { ToolEffect, ToolResult } from '../../tools/types/index.js';
 import type { PermissionMode } from '../../types/common.js';
@@ -76,10 +74,13 @@ export type StreamingExecutionResult = ToolExecutionOutcome;
 
 export interface TurnOutcome {
   chatResponse: ChatResponse;
+  modelIdentity: ModelIdentity;
   modelAttemptId?: ModelAttemptId;
   /** 若走了 streaming+tools 分支，工具已顺带执行完；非流式路径为 undefined */
   streamingExecutionResults?: StreamingExecutionResult[];
 }
+
+type TurnExecutionOutcome = Omit<TurnOutcome, 'modelIdentity'>;
 
 /**
  * 单回合执行。所有副作用通过 hooks 注入，事件通过 yield 输出。
@@ -94,9 +95,10 @@ export async function* runTurn(
     parameters: JSONSchema7;
   }>;
   const turnChatService = turnState.chatService;
+  const modelIdentity = resolveModelIdentity(turnChatService.getConfig());
   const requestLifecycle = await input.modelExecutionLifecycle?.onModelRequestStarting({
     turn: turnState.turn,
-    model: turnChatService.getConfig().model,
+    ...modelIdentity,
     streaming: streaming === true,
   });
   await turnState.executionContext.assertExecutionLease?.();
@@ -110,7 +112,7 @@ export async function* runTurn(
     await requestLifecycle.onCompleted(response);
   };
   try {
-    let outcome: TurnOutcome;
+    let outcome: TurnExecutionOutcome;
     try {
       // 分支 1：streaming + 有工具 — 流式边解析边执行
       if (streaming && tools.length > 0) {
@@ -223,6 +225,7 @@ export async function* runTurn(
     }
     return {
       ...outcome,
+      modelIdentity,
       ...(requestLifecycle?.modelAttemptId
         ? { modelAttemptId: requestLifecycle.modelAttemptId }
         : {}),
@@ -241,7 +244,7 @@ async function* runStreamingWithTools(
   tools: Array<{ name: string; description: string; parameters: JSONSchema7 }>,
   modelAttemptId: ModelAttemptId | undefined,
   onModelResponse: (response: ChatResponse) => Promise<void>,
-): AsyncGenerator<AgentEvent, TurnOutcome> {
+): AsyncGenerator<AgentEvent, TurnExecutionOutcome> {
   const {
     turnState, messages, executionPipeline,
     signal, requestSignal, steeringSignal, epoch,

--- a/src/context/ContextManager.ts
+++ b/src/context/ContextManager.ts
@@ -1,6 +1,10 @@
 import * as crypto from 'node:crypto';
 import { nanoid } from 'nanoid';
-import type { Message, ToolCall as ChatToolCall } from '../services/ChatServiceInterface.js';
+import type {
+  Message,
+  ModelIdentity,
+  ToolCall as ChatToolCall,
+} from '../services/ChatServiceInterface.js';
 import {
   JsonlSessionStore,
   NoopSessionStore,
@@ -14,7 +18,7 @@ import {
   type RequestId,
   SessionId,
 } from '../types/branded.js';
-import type { JsonObject, JsonValue, ProviderType } from '../types/common.js';
+import type { JsonObject, JsonValue } from '../types/common.js';
 import { ContextCompressor } from './processors/ContextCompressor.js';
 import { ContextFilter } from './processors/ContextFilter.js';
 import { CacheStore } from './storage/CacheStore.js';
@@ -322,8 +326,7 @@ export class ContextManager {
     parentUuid: string | null = null,
     metadata?: {
       model?: string;
-      provider?: string;
-      api?: ProviderType;
+      modelIdentity?: ModelIdentity;
       usage?: { input_tokens: number; output_tokens: number };
       customMetadata?: JsonObject;
       reasoningContent?: string;

--- a/src/context/ContextManager.ts
+++ b/src/context/ContextManager.ts
@@ -14,7 +14,7 @@ import {
   type RequestId,
   SessionId,
 } from '../types/branded.js';
-import type { JsonObject, JsonValue } from '../types/common.js';
+import type { JsonObject, JsonValue, ProviderType } from '../types/common.js';
 import { ContextCompressor } from './processors/ContextCompressor.js';
 import { ContextFilter } from './processors/ContextFilter.js';
 import { CacheStore } from './storage/CacheStore.js';
@@ -322,6 +322,8 @@ export class ContextManager {
     parentUuid: string | null = null,
     metadata?: {
       model?: string;
+      provider?: string;
+      api?: ProviderType;
       usage?: { input_tokens: number; output_tokens: number };
       customMetadata?: JsonObject;
       reasoningContent?: string;

--- a/src/context/storage/PersistentStore.ts
+++ b/src/context/storage/PersistentStore.ts
@@ -9,7 +9,12 @@ import {
   type RequestId,
   SessionId,
 } from '../../types/branded.js';
-import type { JsonObject, JsonValue, MessageRole } from '../../types/common.js';
+import type {
+  JsonObject,
+  JsonValue,
+  MessageRole,
+  ProviderType,
+} from '../../types/common.js';
 import type {
   ContextData,
   ConversationContext,
@@ -191,6 +196,8 @@ export class PersistentStore {
     parentUuid: string | null = null,
     metadata?: {
       model?: string;
+      provider?: string;
+      api?: ProviderType;
       usage?: { input_tokens: number; output_tokens: number };
       customMetadata?: JsonObject;
       reasoningContent?: string;
@@ -214,6 +221,8 @@ export class PersistentStore {
         parentMessageId: parentUuid ?? undefined,
         createdAt: now,
         model: metadata?.model,
+        provider: metadata?.provider,
+        api: metadata?.api,
         usage: metadata?.usage,
         customMetadata: metadata?.customMetadata,
       };
@@ -825,6 +834,8 @@ export class NoopPersistentStore {
     _parentUuid: string | null = null,
     _metadata?: {
       model?: string;
+      provider?: string;
+      api?: ProviderType;
       usage?: { input_tokens: number; output_tokens: number };
       customMetadata?: JsonObject;
     },

--- a/src/context/storage/PersistentStore.ts
+++ b/src/context/storage/PersistentStore.ts
@@ -1,7 +1,11 @@
 import { nanoid } from 'nanoid';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
-import type { ContentPart, ToolCall } from '../../services/ChatServiceInterface.js';
+import type {
+  ContentPart,
+  ModelIdentity,
+  ToolCall,
+} from '../../services/ChatServiceInterface.js';
 import { JsonlSessionStore } from '../../session/SessionStore.js';
 import {
   type InputId,
@@ -13,7 +17,6 @@ import type {
   JsonObject,
   JsonValue,
   MessageRole,
-  ProviderType,
 } from '../../types/common.js';
 import type {
   ContextData,
@@ -196,8 +199,7 @@ export class PersistentStore {
     parentUuid: string | null = null,
     metadata?: {
       model?: string;
-      provider?: string;
-      api?: ProviderType;
+      modelIdentity?: ModelIdentity;
       usage?: { input_tokens: number; output_tokens: number };
       customMetadata?: JsonObject;
       reasoningContent?: string;
@@ -220,9 +222,8 @@ export class PersistentStore {
         role: messageRole,
         parentMessageId: parentUuid ?? undefined,
         createdAt: now,
-        model: metadata?.model,
-        provider: metadata?.provider,
-        api: metadata?.api,
+        model: metadata?.modelIdentity?.model ?? metadata?.model,
+        modelIdentity: metadata?.modelIdentity,
         usage: metadata?.usage,
         customMetadata: metadata?.customMetadata,
       };
@@ -834,8 +835,7 @@ export class NoopPersistentStore {
     _parentUuid: string | null = null,
     _metadata?: {
       model?: string;
-      provider?: string;
-      api?: ProviderType;
+      modelIdentity?: ModelIdentity;
       usage?: { input_tokens: number; output_tokens: number };
       customMetadata?: JsonObject;
     },

--- a/src/context/storage/sessionEventSchema.ts
+++ b/src/context/storage/sessionEventSchema.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { JsonValue } from '../../types/common.js';
+import { type JsonValue, PROVIDER_TYPES } from '../../types/common.js';
 import type { SessionEvent } from '../types.js';
 
 const JsonValueSchema: z.ZodType<JsonValue> = z.lazy(() =>
@@ -84,6 +84,8 @@ const SessionEventSchema = z.discriminatedUnion('type', [
       parentMessageId: z.string().optional(),
       createdAt: TimestampSchema,
       model: z.string().optional(),
+      provider: z.string().optional(),
+      api: z.enum(PROVIDER_TYPES).optional(),
       usage: z.object({
         input_tokens: z.number().finite().nonnegative(),
         output_tokens: z.number().finite().nonnegative(),

--- a/src/context/storage/sessionEventSchema.ts
+++ b/src/context/storage/sessionEventSchema.ts
@@ -84,8 +84,11 @@ const SessionEventSchema = z.discriminatedUnion('type', [
       parentMessageId: z.string().optional(),
       createdAt: TimestampSchema,
       model: z.string().optional(),
-      provider: z.string().optional(),
-      api: z.enum(PROVIDER_TYPES).optional(),
+      modelIdentity: z.object({
+        provider: NonEmptyStringSchema,
+        api: z.enum(PROVIDER_TYPES),
+        model: NonEmptyStringSchema,
+      }).strict().optional(),
       usage: z.object({
         input_tokens: z.number().finite().nonnegative(),
         output_tokens: z.number().finite().nonnegative(),

--- a/src/context/types.ts
+++ b/src/context/types.ts
@@ -8,7 +8,12 @@ import type {
   RequestId,
   SessionId,
 } from '../types/branded.js';
-import type { JsonObject, JsonValue, MessageRole } from '../types/common.js';
+import type {
+  JsonObject,
+  JsonValue,
+  MessageRole,
+  ProviderType,
+} from '../types/common.js';
 
 export interface ContextMessage {
   id: string;
@@ -163,6 +168,8 @@ export interface MessageInfo {
   parentMessageId?: string;
   createdAt: string;
   model?: string;
+  provider?: string;
+  api?: ProviderType;
   usage?: {
     input_tokens: number;
     output_tokens: number;

--- a/src/context/types.ts
+++ b/src/context/types.ts
@@ -8,12 +8,8 @@ import type {
   RequestId,
   SessionId,
 } from '../types/branded.js';
-import type {
-  JsonObject,
-  JsonValue,
-  MessageRole,
-  ProviderType,
-} from '../types/common.js';
+import type { ModelIdentity } from '../services/ModelIdentity.js';
+import type { JsonObject, JsonValue, MessageRole } from '../types/common.js';
 
 export interface ContextMessage {
   id: string;
@@ -168,8 +164,7 @@ export interface MessageInfo {
   parentMessageId?: string;
   createdAt: string;
   model?: string;
-  provider?: string;
-  api?: ProviderType;
+  modelIdentity?: ModelIdentity;
   usage?: {
     input_tokens: number;
     output_tokens: number;

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -29,6 +29,7 @@ export type {
   ChatResponse,
   IChatService,
   Message,
+  ModelIdentity,
   SideQueryOptions,
   StreamChunk,
 } from '../services/ChatServiceInterface.js';

--- a/src/services/ChatServiceInterface.ts
+++ b/src/services/ChatServiceInterface.ts
@@ -6,6 +6,7 @@
 import type { JSONSchema7 } from 'json-schema';
 import { type InternalLogger, LogCategory, NOOP_LOGGER } from '../logging/Logger.js';
 import type { JsonValue, MessageRole, OutputFormat, ProviderType } from '../types/common.js';
+import type { ModelIdentity } from './ModelIdentity.js';
 import type { QuerySource, RetryConfig, RetryEvent } from './RetryPolicy.js';
 import { VercelAIChatService } from './VercelAIChatService.js';
 
@@ -107,9 +108,7 @@ export type Message = {
   name?: string;
   tool_calls?: ToolCall[];
   metadata?: JsonValue;
-  provider?: string;
-  api?: ProviderType;
-  model?: string;
+  modelIdentity?: ModelIdentity;
 };
 
 /**
@@ -134,7 +133,7 @@ export interface ChatConfig {
   supportsThinking?: boolean; // 是否支持 thinking 模式（DeepSeek Reasoner 等）
   providerOptions?: ProviderOptions;
   customHeaders?: Record<string, string>; // Provider 特定的自定义 HTTP Headers
-  /** Logical provider ID when it differs from the wire-protocol adapter. */
+  /** Logical provider ID. Adapter selection depends only on `provider`. */
   providerId?: string;
   outputFormat?: OutputFormat; // 结构化输出格式（JSON Schema）
   retry?: Partial<RetryConfig>;

--- a/src/services/ChatServiceInterface.ts
+++ b/src/services/ChatServiceInterface.ts
@@ -9,6 +9,8 @@ import type { JsonValue, MessageRole, OutputFormat, ProviderType } from '../type
 import type { QuerySource, RetryConfig, RetryEvent } from './RetryPolicy.js';
 import { VercelAIChatService } from './VercelAIChatService.js';
 
+export type { ModelIdentity } from './ModelIdentity.js';
+
 /**
  * 工具调用（完整版，LLM 返回的最终结果）
  * 替代 openai 的 ChatCompletionMessageToolCall
@@ -105,6 +107,9 @@ export type Message = {
   name?: string;
   tool_calls?: ToolCall[];
   metadata?: JsonValue;
+  provider?: string;
+  api?: ProviderType;
+  model?: string;
 };
 
 /**
@@ -129,7 +134,8 @@ export interface ChatConfig {
   supportsThinking?: boolean; // 是否支持 thinking 模式（DeepSeek Reasoner 等）
   providerOptions?: ProviderOptions;
   customHeaders?: Record<string, string>; // Provider 特定的自定义 HTTP Headers
-  providerId?: string; // models.dev 中的 Provider ID（用于获取特定配置）
+  /** Logical provider ID when it differs from the wire-protocol adapter. */
+  providerId?: string;
   outputFormat?: OutputFormat; // 结构化输出格式（JSON Schema）
   retry?: Partial<RetryConfig>;
 }

--- a/src/services/ModelIdentity.ts
+++ b/src/services/ModelIdentity.ts
@@ -1,0 +1,19 @@
+import type { ProviderType } from '../types/common.js';
+
+export interface ModelIdentity {
+  readonly provider: string;
+  readonly api: ProviderType;
+  readonly model: string;
+}
+
+export function resolveModelIdentity(config: {
+  provider: ProviderType;
+  providerId?: string;
+  model: string;
+}): ModelIdentity {
+  return {
+    provider: config.providerId?.trim() || config.provider,
+    api: config.provider,
+    model: config.model,
+  };
+}

--- a/src/services/VercelAIChatService.ts
+++ b/src/services/VercelAIChatService.ts
@@ -337,22 +337,6 @@ export class VercelAIChatService implements IChatService {
       }
 
       default: {
-        if (providerId === 'deepseek') {
-          const deepseek = createDeepSeek({
-            apiKey,
-            baseURL: resolveDeepSeekBaseUrl(
-              baseUrl,
-              shouldUseDeepSeekBetaBaseUrl({
-                provider,
-                providerId,
-                deepseek: config.providerOptions?.deepseek,
-              }),
-            ),
-            headers: customHeaders,
-          });
-          return deepseek(normalizeDeepSeekModel(model));
-        }
-
         const compatible = createOpenAICompatible({
           name: providerId || 'custom',
           apiKey,
@@ -432,9 +416,9 @@ export class VercelAIChatService implements IChatService {
         }
       } else if (msg.role === 'assistant') {
         const isSameModel =
-          msg.provider === targetModel.provider
-          && msg.api === targetModel.api
-          && msg.model === targetModel.model;
+          msg.modelIdentity?.provider === targetModel.provider
+          && msg.modelIdentity.api === targetModel.api
+          && msg.modelIdentity.model === targetModel.model;
         if (msg.tool_calls && msg.tool_calls.length > 0) {
           const content: Array<
             { type: 'reasoning'; text: string }
@@ -590,7 +574,7 @@ export class VercelAIChatService implements IChatService {
     }
   ): UsageInfo | undefined {
     if (!usage) return undefined;
-    if (providerMetadata?.deepseek || this.config.provider === 'deepseek' || this.config.providerId === 'deepseek') {
+    if (providerMetadata?.deepseek || this.config.provider === 'deepseek') {
       return mergeDeepSeekUsage(usage, providerMetadata);
     }
 
@@ -631,7 +615,7 @@ export class VercelAIChatService implements IChatService {
   }
 
   private isDeepSeekProvider(): boolean {
-    return this.config.provider === 'deepseek' || this.config.providerId === 'deepseek';
+    return this.config.provider === 'deepseek';
   }
 
   private shouldOmitSamplingOptions(): boolean {

--- a/src/services/VercelAIChatService.ts
+++ b/src/services/VercelAIChatService.ts
@@ -19,6 +19,7 @@ import type {
   ToolCall,
   UsageInfo,
 } from './ChatServiceInterface.js';
+import { resolveModelIdentity } from './ModelIdentity.js';
 import {
   DEFAULT_RETRY_CONFIG,
   type RetryConfig,
@@ -385,6 +386,7 @@ export class VercelAIChatService implements IChatService {
   private convertMessages(messages: readonly Message[]): AIMessage[] {
     const result: AIMessage[] = [];
     const isDeepSeek = this.isDeepSeekProvider();
+    const targetModel = resolveModelIdentity(this.config);
 
     for (const msg of messages) {
       if (msg.role === 'system') {
@@ -429,6 +431,10 @@ export class VercelAIChatService implements IChatService {
           result.push({ role: 'user', content: msg.content });
         }
       } else if (msg.role === 'assistant') {
+        const isSameModel =
+          msg.provider === targetModel.provider
+          && msg.api === targetModel.api
+          && msg.model === targetModel.model;
         if (msg.tool_calls && msg.tool_calls.length > 0) {
           const content: Array<
             { type: 'reasoning'; text: string }
@@ -436,7 +442,11 @@ export class VercelAIChatService implements IChatService {
             | { type: 'tool-call'; toolCallId: string; toolName: string; input: unknown }
           > = [];
           if (msg.reasoningContent) {
-            content.push({ type: 'reasoning', text: msg.reasoningContent });
+            content.push(
+              isSameModel
+                ? { type: 'reasoning', text: msg.reasoningContent }
+                : { type: 'text', text: msg.reasoningContent },
+            );
           }
           const toolCalls = msg.tool_calls.map((tc) => {
             const fn = (tc as { function?: { name: string; arguments?: string } }).function;
@@ -455,11 +465,19 @@ export class VercelAIChatService implements IChatService {
           result.push({ role: 'assistant', content });
         } else {
           const text = getTextContent(msg.content);
-          if (msg.reasoningContent && !isDeepSeek) {
+          if (msg.reasoningContent && isSameModel && !isDeepSeek) {
             result.push({
               role: 'assistant',
               content: [
                 { type: 'reasoning', text: msg.reasoningContent },
+                ...(text ? [{ type: 'text' as const, text }] : []),
+              ],
+            });
+          } else if (msg.reasoningContent && !isSameModel) {
+            result.push({
+              role: 'assistant',
+              content: [
+                { type: 'text', text: msg.reasoningContent },
                 ...(text ? [{ type: 'text' as const, text }] : []),
               ],
             });

--- a/src/services/__tests__/VercelAIChatService.test.ts
+++ b/src/services/__tests__/VercelAIChatService.test.ts
@@ -94,6 +94,30 @@ describe('VercelAIChatService', () => {
     expect(mockCreateOpenAICompatible).not.toHaveBeenCalled();
   });
 
+  it('does not let a logical provider ID change the configured API adapter', async () => {
+    const service = new VercelAIChatService(
+      {
+        provider: 'openai-compatible',
+        providerId: 'deepseek',
+        apiKey: 'test-key',
+        baseUrl: 'https://gateway.example.test/v1',
+        model: 'deepseek-chat',
+      },
+      NOOP_LOGGER,
+    );
+
+    await service.ready();
+
+    expect(mockCreateOpenAICompatible).toHaveBeenCalledWith({
+      name: 'deepseek',
+      apiKey: 'test-key',
+      baseURL: 'https://gateway.example.test/v1',
+      headers: undefined,
+    });
+    expect(mockCompatibleModelFactory).toHaveBeenCalledWith('deepseek-chat');
+    expect(mockCreateDeepSeek).not.toHaveBeenCalled();
+  });
+
   it('uses DeepSeek beta endpoint and strict sanitized tools when strictTools is enabled', async () => {
     mockGenerateText.mockResolvedValue({
       text: '',
@@ -201,9 +225,11 @@ describe('VercelAIChatService', () => {
         role: 'assistant',
         content: '',
         reasoningContent: 'need a tool',
-        provider: 'deepseek',
-        api: 'deepseek',
-        model: 'deepseek-v4-pro',
+        modelIdentity: {
+          provider: 'deepseek',
+          api: 'deepseek',
+          model: 'deepseek-v4-pro',
+        },
         tool_calls: [
           {
             id: 'call_keep',
@@ -233,9 +259,11 @@ describe('VercelAIChatService', () => {
         role: 'assistant',
         content: 'intermediate answer',
         reasoningContent: 'ignored reasoning',
-        provider: 'deepseek',
-        api: 'deepseek',
-        model: 'deepseek-v4-pro',
+        modelIdentity: {
+          provider: 'deepseek',
+          api: 'deepseek',
+          model: 'deepseek-v4-pro',
+        },
       },
       { role: 'user', content: 'continue' },
     ]);
@@ -294,9 +322,11 @@ describe('VercelAIChatService', () => {
         role: 'assistant',
         content: 'foreign answer',
         reasoningContent: 'foreign reasoning',
-        provider: 'anthropic',
-        api: 'anthropic',
-        model: 'claude-sonnet',
+        modelIdentity: {
+          provider: 'anthropic',
+          api: 'anthropic',
+          model: 'claude-sonnet',
+        },
         tool_calls: [
           {
             id: 'call_search',
@@ -315,9 +345,11 @@ describe('VercelAIChatService', () => {
         role: 'assistant',
         content: 'same answer',
         reasoningContent: 'same reasoning',
-        provider: 'openai-primary',
-        api: 'openai',
-        model: 'gpt-5',
+        modelIdentity: {
+          provider: 'openai-primary',
+          api: 'openai',
+          model: 'gpt-5',
+        },
       },
       {
         role: 'assistant',
@@ -419,7 +451,7 @@ describe('VercelAIChatService', () => {
         role: 'assistant',
         content: 'answer',
         reasoningContent: 'reasoning',
-        ...source,
+        modelIdentity: source,
       },
       { role: 'user', content: 'continue' },
     ]);

--- a/src/services/__tests__/VercelAIChatService.test.ts
+++ b/src/services/__tests__/VercelAIChatService.test.ts
@@ -201,6 +201,9 @@ describe('VercelAIChatService', () => {
         role: 'assistant',
         content: '',
         reasoningContent: 'need a tool',
+        provider: 'deepseek',
+        api: 'deepseek',
+        model: 'deepseek-v4-pro',
         tool_calls: [
           {
             id: 'call_keep',
@@ -230,6 +233,9 @@ describe('VercelAIChatService', () => {
         role: 'assistant',
         content: 'intermediate answer',
         reasoningContent: 'ignored reasoning',
+        provider: 'deepseek',
+        api: 'deepseek',
+        model: 'deepseek-v4-pro',
       },
       { role: 'user', content: 'continue' },
     ]);
@@ -263,6 +269,169 @@ describe('VercelAIChatService', () => {
       { role: 'assistant', content: 'intermediate answer' },
       { role: 'user', content: 'continue' },
     ]);
+  });
+
+  it('downgrades foreign and legacy reasoning while preserving same-model reasoning', async () => {
+    mockGenerateText.mockResolvedValue({
+      text: 'done',
+    });
+
+    const service = new VercelAIChatService(
+      {
+        provider: 'openai',
+        providerId: 'openai-primary',
+        apiKey: 'test-key',
+        baseUrl: 'https://api.openai.com/v1',
+        model: 'gpt-5',
+      },
+      NOOP_LOGGER,
+    );
+
+    await service.ready();
+    await service.chat([
+      { role: 'user', content: 'start' },
+      {
+        role: 'assistant',
+        content: 'foreign answer',
+        reasoningContent: 'foreign reasoning',
+        provider: 'anthropic',
+        api: 'anthropic',
+        model: 'claude-sonnet',
+        tool_calls: [
+          {
+            id: 'call_search',
+            type: 'function',
+            function: { name: 'Search', arguments: '{"q":"needle"}' },
+          },
+        ],
+      },
+      {
+        role: 'tool',
+        tool_call_id: 'call_search',
+        name: 'Search',
+        content: 'found',
+      },
+      {
+        role: 'assistant',
+        content: 'same answer',
+        reasoningContent: 'same reasoning',
+        provider: 'openai-primary',
+        api: 'openai',
+        model: 'gpt-5',
+      },
+      {
+        role: 'assistant',
+        content: 'legacy answer',
+        reasoningContent: 'legacy reasoning',
+      },
+      { role: 'user', content: 'continue' },
+    ]);
+
+    const request = mockGenerateText.mock.calls[0]?.[0] as { messages: unknown[] };
+    expect(request.messages).toEqual([
+      { role: 'user', content: 'start' },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'foreign reasoning' },
+          { type: 'text', text: 'foreign answer' },
+          {
+            type: 'tool-call',
+            toolCallId: 'call_search',
+            toolName: 'Search',
+            input: { q: 'needle' },
+          },
+        ],
+      },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'call_search',
+            toolName: 'Search',
+            output: { type: 'text', value: 'found' },
+          },
+        ],
+      },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'reasoning', text: 'same reasoning' },
+          { type: 'text', text: 'same answer' },
+        ],
+      },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'legacy reasoning' },
+          { type: 'text', text: 'legacy answer' },
+        ],
+      },
+      { role: 'user', content: 'continue' },
+    ]);
+  });
+
+  it.each([
+    [
+      'provider',
+      {
+        provider: 'openai-secondary',
+        api: 'openai' as const,
+        model: 'gpt-5',
+      },
+    ],
+    [
+      'API adapter',
+      {
+        provider: 'openai-primary',
+        api: 'openai-compatible' as const,
+        model: 'gpt-5',
+      },
+    ],
+    [
+      'model',
+      {
+        provider: 'openai-primary',
+        api: 'openai' as const,
+        model: 'gpt-4.1',
+      },
+    ],
+  ])('downgrades reasoning when only the source %s differs', async (_field, source) => {
+    mockGenerateText.mockResolvedValue({
+      text: 'done',
+    });
+    const service = new VercelAIChatService(
+      {
+        provider: 'openai',
+        providerId: 'openai-primary',
+        apiKey: 'test-key',
+        baseUrl: 'https://api.openai.com/v1',
+        model: 'gpt-5',
+      },
+      NOOP_LOGGER,
+    );
+
+    await service.ready();
+    await service.chat([
+      { role: 'user', content: 'start' },
+      {
+        role: 'assistant',
+        content: 'answer',
+        reasoningContent: 'reasoning',
+        ...source,
+      },
+      { role: 'user', content: 'continue' },
+    ]);
+
+    const request = mockGenerateText.mock.calls[0]?.[0] as { messages: unknown[] };
+    expect(request.messages[1]).toEqual({
+      role: 'assistant',
+      content: [
+        { type: 'text', text: 'reasoning' },
+        { type: 'text', text: 'answer' },
+      ],
+    });
   });
 
   it('normalizes DeepSeek raw and snake_case tool call responses', async () => {

--- a/src/session/Session.ts
+++ b/src/session/Session.ts
@@ -457,6 +457,7 @@ class Session implements ISession {
       id: 'default',
       name: this.options.model,
       provider: this.mapProviderType(provider.type),
+      providerId: provider.id?.trim() || provider.type,
       model: this.options.model,
       apiKey: provider.apiKey || '',
       baseUrl: provider.baseUrl || this.getDefaultBaseUrl(provider.type),
@@ -2008,7 +2009,7 @@ class Session implements ISession {
       {
         id: 'default',
         name: this.options.model,
-        provider: this.options.provider.type,
+        provider: this.options.provider.id?.trim() || this.options.provider.type,
       },
     ];
   }
@@ -2337,7 +2338,7 @@ class Session implements ISession {
     }
     const recorder = new TraceRecorder(this.sessionId, observability, {
       model: this.options.model,
-      provider: this.options.provider.type,
+      provider: this.options.provider.id?.trim() || this.options.provider.type,
       permissionMode: this.permissionMode,
     });
     recorder.addEvent('user_prompt', {

--- a/src/session/SessionStore.ts
+++ b/src/session/SessionStore.ts
@@ -369,6 +369,9 @@ export class JsonlSessionStore implements SessionStore {
         record.parentMessageId = data.parentMessageId;
         record.message.role = data.role;
         record.message.id = data.messageId;
+        record.message.model = data.model;
+        record.message.provider = data.provider;
+        record.message.api = data.api;
 
         if (data.model || data.usage || data.customMetadata) {
           record.message.metadata = {

--- a/src/session/SessionStore.ts
+++ b/src/session/SessionStore.ts
@@ -369,9 +369,9 @@ export class JsonlSessionStore implements SessionStore {
         record.parentMessageId = data.parentMessageId;
         record.message.role = data.role;
         record.message.id = data.messageId;
-        record.message.model = data.model;
-        record.message.provider = data.provider;
-        record.message.api = data.api;
+        record.message.modelIdentity = data.modelIdentity
+          ? { ...data.modelIdentity }
+          : undefined;
 
         if (data.model || data.usage || data.customMetadata) {
           record.message.metadata = {

--- a/src/session/__tests__/SessionModelConfig.test.ts
+++ b/src/session/__tests__/SessionModelConfig.test.ts
@@ -21,6 +21,7 @@ describe('Session model config', () => {
     };
     const session = await createSession({
       provider: {
+        id: 'openai-primary',
         type: 'openai',
         apiKey: 'test-key',
         requestTimeoutMs: 120_000,
@@ -42,6 +43,8 @@ describe('Session model config', () => {
       toolTimeoutMs: 45_000,
       models: [
         expect.objectContaining({
+          provider: 'openai',
+          providerId: 'openai-primary',
           temperature: 0.2,
           maxOutputTokens: 4096,
           maxContextTokens: 32000,
@@ -53,6 +56,13 @@ describe('Session model config', () => {
         }),
       ],
     });
+    await expect(session.supportedModels()).resolves.toEqual([
+      {
+        id: 'default',
+        name: 'gpt-5',
+        provider: 'openai-primary',
+      },
+    ]);
 
     await session.close();
   });

--- a/src/session/__tests__/SessionStore.test.ts
+++ b/src/session/__tests__/SessionStore.test.ts
@@ -461,9 +461,11 @@ describe('JsonlSessionStore', () => {
       '',
       userMessageId,
       {
-        provider: 'anthropic',
-        api: 'anthropic',
-        model: 'claude-sonnet-4-5',
+        modelIdentity: {
+          provider: 'anthropic',
+          api: 'anthropic',
+          model: 'claude-sonnet-4-5',
+        },
         reasoningContent: 'Need to inspect first.',
         toolCalls: [
           {
@@ -494,9 +496,11 @@ describe('JsonlSessionStore', () => {
       id: assistantMessageId,
       role: 'assistant',
       content: '',
-      provider: 'anthropic',
-      api: 'anthropic',
-      model: 'claude-sonnet-4-5',
+      modelIdentity: {
+        provider: 'anthropic',
+        api: 'anthropic',
+        model: 'claude-sonnet-4-5',
+      },
       reasoningContent: 'Need to inspect first.',
       tool_calls: [
         {

--- a/src/session/__tests__/SessionStore.test.ts
+++ b/src/session/__tests__/SessionStore.test.ts
@@ -461,6 +461,9 @@ describe('JsonlSessionStore', () => {
       '',
       userMessageId,
       {
+        provider: 'anthropic',
+        api: 'anthropic',
+        model: 'claude-sonnet-4-5',
         reasoningContent: 'Need to inspect first.',
         toolCalls: [
           {
@@ -491,6 +494,9 @@ describe('JsonlSessionStore', () => {
       id: assistantMessageId,
       role: 'assistant',
       content: '',
+      provider: 'anthropic',
+      api: 'anthropic',
+      model: 'claude-sonnet-4-5',
       reasoningContent: 'Need to inspect first.',
       tool_calls: [
         {

--- a/src/session/events/DurableSessionProjector.ts
+++ b/src/session/events/DurableSessionProjector.ts
@@ -13,7 +13,7 @@ import {
   type ToolUseId,
   type TurnId,
 } from '../../types/branded.js';
-import type { JsonObject, JsonValue } from '../../types/common.js';
+import type { JsonObject, JsonValue, ProviderType } from '../../types/common.js';
 import { canonicalJson } from './canonicalJson.js';
 import { parseDurableEventDraft, parseDurableEventEnvelope } from './schemas.js';
 import {
@@ -91,6 +91,8 @@ export interface DurableToolAttemptProjection {
 export interface DurableModelAttemptProjection {
   readonly modelAttemptId: ModelAttemptId;
   readonly model: string;
+  readonly provider?: string;
+  readonly api?: ProviderType;
   readonly streaming: boolean;
   readonly status: DurableModelAttemptStatus;
   readonly response?: DurableModelResponse;
@@ -198,6 +200,8 @@ interface MutableToolAttemptProjection {
 interface MutableModelAttemptProjection {
   modelAttemptId: ModelAttemptId;
   model: string;
+  provider?: string;
+  api?: ProviderType;
   streaming: boolean;
   status: DurableModelAttemptStatus;
   response?: DurableModelResponse;
@@ -951,6 +955,8 @@ function applyEvent(state: ProjectionAccumulator, event: DurableEventEnvelope): 
       const attempt: MutableModelAttemptProjection = {
         modelAttemptId: event.modelAttemptId,
         model: event.data.model,
+        ...(event.data.provider ? { provider: event.data.provider } : {}),
+        ...(event.data.api ? { api: event.data.api } : {}),
         streaming: event.data.streaming,
         status: 'started',
       };

--- a/src/session/events/DurableSessionProjector.ts
+++ b/src/session/events/DurableSessionProjector.ts
@@ -1,4 +1,5 @@
 import { SdkError } from '../../errors/SdkError.js';
+import type { ModelIdentity } from '../../services/ModelIdentity.js';
 import type { ToolSideEffect } from '../../tools/types/ToolKind.js';
 import {
   type CommandId,
@@ -13,7 +14,7 @@ import {
   type ToolUseId,
   type TurnId,
 } from '../../types/branded.js';
-import type { JsonObject, JsonValue, ProviderType } from '../../types/common.js';
+import type { JsonObject, JsonValue } from '../../types/common.js';
 import { canonicalJson } from './canonicalJson.js';
 import { parseDurableEventDraft, parseDurableEventEnvelope } from './schemas.js';
 import {
@@ -91,8 +92,7 @@ export interface DurableToolAttemptProjection {
 export interface DurableModelAttemptProjection {
   readonly modelAttemptId: ModelAttemptId;
   readonly model: string;
-  readonly provider?: string;
-  readonly api?: ProviderType;
+  readonly modelIdentity?: ModelIdentity;
   readonly streaming: boolean;
   readonly status: DurableModelAttemptStatus;
   readonly response?: DurableModelResponse;
@@ -200,8 +200,7 @@ interface MutableToolAttemptProjection {
 interface MutableModelAttemptProjection {
   modelAttemptId: ModelAttemptId;
   model: string;
-  provider?: string;
-  api?: ProviderType;
+  modelIdentity?: ModelIdentity;
   streaming: boolean;
   status: DurableModelAttemptStatus;
   response?: DurableModelResponse;
@@ -400,7 +399,7 @@ function assertToolMatchesModelAttempt(
   modelInput: JsonValue | undefined,
 ): void {
   if (!modelAttemptId) {
-    if (event.schemaVersion >= DURABLE_EVENT_SCHEMA_VERSION) {
+    if (event.schemaVersion >= 3) {
       invalid(event, `Tool call ${toolCallId} has no model attempt identity`);
     }
     return;
@@ -606,6 +605,9 @@ function cloneModelAttempt(
 ): DurableModelAttemptProjection {
   return {
     ...attempt,
+    ...(attempt.modelIdentity
+      ? { modelIdentity: { ...attempt.modelIdentity } }
+      : {}),
   };
 }
 
@@ -955,8 +957,9 @@ function applyEvent(state: ProjectionAccumulator, event: DurableEventEnvelope): 
       const attempt: MutableModelAttemptProjection = {
         modelAttemptId: event.modelAttemptId,
         model: event.data.model,
-        ...(event.data.provider ? { provider: event.data.provider } : {}),
-        ...(event.data.api ? { api: event.data.api } : {}),
+        ...(event.data.modelIdentity
+          ? { modelIdentity: { ...event.data.modelIdentity } }
+          : {}),
         streaming: event.data.streaming,
         status: 'started',
       };

--- a/src/session/events/DurableSessionRecoveryCoordinator.ts
+++ b/src/session/events/DurableSessionRecoveryCoordinator.ts
@@ -537,8 +537,9 @@ function buildTurnRecoveryContinuation(
             modelAttempts: retainedModelAttempts.map((attempt) => ({
               modelAttemptId: attempt.modelAttemptId,
               model: attempt.model,
-              ...(attempt.provider ? { provider: attempt.provider } : {}),
-              ...(attempt.api ? { api: attempt.api } : {}),
+              ...(attempt.modelIdentity
+                ? { modelIdentity: attempt.modelIdentity }
+                : {}),
               streaming: attempt.streaming,
               status: attempt.status,
               ...(attempt.response

--- a/src/session/events/DurableSessionRecoveryCoordinator.ts
+++ b/src/session/events/DurableSessionRecoveryCoordinator.ts
@@ -537,6 +537,8 @@ function buildTurnRecoveryContinuation(
             modelAttempts: retainedModelAttempts.map((attempt) => ({
               modelAttemptId: attempt.modelAttemptId,
               model: attempt.model,
+              ...(attempt.provider ? { provider: attempt.provider } : {}),
+              ...(attempt.api ? { api: attempt.api } : {}),
               streaming: attempt.streaming,
               status: attempt.status,
               ...(attempt.response

--- a/src/session/events/SessionDurableRecorder.ts
+++ b/src/session/events/SessionDurableRecorder.ts
@@ -11,6 +11,7 @@ import type {
   UserMessageContent,
 } from '../../agent/types.js';
 import { SdkError } from '../../errors/SdkError.js';
+import type { ModelIdentity } from '../../services/ModelIdentity.js';
 import type {
   ToolExecutionLifecycle,
   ToolExecutionStartedLifecycle,
@@ -31,7 +32,7 @@ import {
   ToolUseId,
   TurnId,
 } from '../../types/branded.js';
-import type { JsonObject, JsonValue, ProviderType } from '../../types/common.js';
+import type { JsonObject, JsonValue } from '../../types/common.js';
 import { toJsonValue } from '../../utils/jsonValue.js';
 import type {
   DurableCommandCommitOptions,
@@ -404,8 +405,7 @@ export class SessionDurableRecorder implements
   async onModelRequestStarting(input: {
     readonly turn: number;
     readonly model: string;
-    readonly provider?: string;
-    readonly api?: ProviderType;
+    readonly modelIdentity?: ModelIdentity;
     readonly streaming: boolean;
   }): Promise<ModelRequestLifecycle> {
     this.assertNewWorkAllowed();
@@ -429,8 +429,7 @@ export class SessionDurableRecorder implements
           modelAttemptId: attempt.modelAttemptId,
           data: {
             model: input.model,
-            ...(input.provider ? { provider: input.provider } : {}),
-            ...(input.api ? { api: input.api } : {}),
+            ...(input.modelIdentity ? { modelIdentity: input.modelIdentity } : {}),
             streaming: input.streaming,
           },
         },

--- a/src/session/events/SessionDurableRecorder.ts
+++ b/src/session/events/SessionDurableRecorder.ts
@@ -31,7 +31,7 @@ import {
   ToolUseId,
   TurnId,
 } from '../../types/branded.js';
-import type { JsonObject, JsonValue } from '../../types/common.js';
+import type { JsonObject, JsonValue, ProviderType } from '../../types/common.js';
 import { toJsonValue } from '../../utils/jsonValue.js';
 import type {
   DurableCommandCommitOptions,
@@ -404,6 +404,8 @@ export class SessionDurableRecorder implements
   async onModelRequestStarting(input: {
     readonly turn: number;
     readonly model: string;
+    readonly provider?: string;
+    readonly api?: ProviderType;
     readonly streaming: boolean;
   }): Promise<ModelRequestLifecycle> {
     this.assertNewWorkAllowed();
@@ -427,6 +429,8 @@ export class SessionDurableRecorder implements
           modelAttemptId: attempt.modelAttemptId,
           data: {
             model: input.model,
+            ...(input.provider ? { provider: input.provider } : {}),
+            ...(input.api ? { api: input.api } : {}),
             streaming: input.streaming,
           },
         },

--- a/src/session/events/__tests__/DurableSessionProjector.test.ts
+++ b/src/session/events/__tests__/DurableSessionProjector.test.ts
@@ -361,7 +361,7 @@ describe('DurableSessionProjector', () => {
     });
     const projector = new DurableSessionProjector().apply([legacy, upgraded]);
     expect(projector.snapshot()).toMatchObject({
-      schemaVersion: 3,
+      schemaVersion: DURABLE_EVENT_SCHEMA_VERSION,
       activeRequest: { requestId },
     });
 
@@ -379,7 +379,7 @@ describe('DurableSessionProjector', () => {
           occurredAt: timestamp,
         }),
       ]),
-    ).toThrow(/schema regressed from v3 to v2/);
+    ).toThrow(/schema regressed from v4 to v2/);
   });
 
   it('continues to project schema-v2 tool events without model attempt metadata', () => {
@@ -542,8 +542,11 @@ describe('DurableSessionProjector', () => {
         modelAttemptId,
         data: {
           model: 'claude-sonnet',
-          provider: 'anthropic-primary',
-          api: 'anthropic',
+          modelIdentity: {
+            provider: 'anthropic-primary',
+            api: 'anthropic',
+            model: 'claude-sonnet',
+          },
           streaming: true,
         },
       },
@@ -552,8 +555,11 @@ describe('DurableSessionProjector', () => {
     expect(started.activeRequest?.activeTurn?.activeModelAttempt).toMatchObject({
       modelAttemptId,
       model: 'claude-sonnet',
-      provider: 'anthropic-primary',
-      api: 'anthropic',
+      modelIdentity: {
+        provider: 'anthropic-primary',
+        api: 'anthropic',
+        model: 'claude-sonnet',
+      },
       streaming: true,
       status: 'started',
     });

--- a/src/session/events/__tests__/DurableSessionProjector.test.ts
+++ b/src/session/events/__tests__/DurableSessionProjector.test.ts
@@ -542,6 +542,8 @@ describe('DurableSessionProjector', () => {
         modelAttemptId,
         data: {
           model: 'claude-sonnet',
+          provider: 'anthropic-primary',
+          api: 'anthropic',
           streaming: true,
         },
       },
@@ -550,6 +552,8 @@ describe('DurableSessionProjector', () => {
     expect(started.activeRequest?.activeTurn?.activeModelAttempt).toMatchObject({
       modelAttemptId,
       model: 'claude-sonnet',
+      provider: 'anthropic-primary',
+      api: 'anthropic',
       streaming: true,
       status: 'started',
     });

--- a/src/session/events/__tests__/DurableSessionRecoveryCoordinator.test.ts
+++ b/src/session/events/__tests__/DurableSessionRecoveryCoordinator.test.ts
@@ -1010,8 +1010,11 @@ describe('DurableSessionRecoveryCoordinator', () => {
           modelAttemptId,
           data: {
             model: 'accepted-model',
-            provider: 'provider-primary',
-            api: 'openai-compatible',
+            modelIdentity: {
+              provider: 'provider-primary',
+              api: 'openai-compatible',
+              model: 'accepted-model',
+            },
             streaming: true,
           },
         },
@@ -1064,8 +1067,11 @@ describe('DurableSessionRecoveryCoordinator', () => {
     ).toEqual([
       expect.objectContaining({
         modelAttemptId,
-        provider: 'provider-primary',
-        api: 'openai-compatible',
+        modelIdentity: {
+          provider: 'provider-primary',
+          api: 'openai-compatible',
+          model: 'accepted-model',
+        },
         status: 'completed',
         response: expect.objectContaining({
           content: 'Use the inspected state',
@@ -1081,6 +1087,7 @@ describe('DurableSessionRecoveryCoordinator', () => {
       recoveryInputId: rolloverInputId,
     });
     expect(rollover.continuation).toContain('"modelAttempts"');
+    expect(rollover.continuation).toContain('"modelIdentity"');
     expect(rollover.continuation).toContain('"provider": "provider-primary"');
     expect(rollover.continuation).toContain('"api": "openai-compatible"');
     expect(rollover.continuation).toContain('Use the inspected state');

--- a/src/session/events/__tests__/DurableSessionRecoveryCoordinator.test.ts
+++ b/src/session/events/__tests__/DurableSessionRecoveryCoordinator.test.ts
@@ -1010,6 +1010,8 @@ describe('DurableSessionRecoveryCoordinator', () => {
           modelAttemptId,
           data: {
             model: 'accepted-model',
+            provider: 'provider-primary',
+            api: 'openai-compatible',
             streaming: true,
           },
         },
@@ -1062,6 +1064,8 @@ describe('DurableSessionRecoveryCoordinator', () => {
     ).toEqual([
       expect.objectContaining({
         modelAttemptId,
+        provider: 'provider-primary',
+        api: 'openai-compatible',
         status: 'completed',
         response: expect.objectContaining({
           content: 'Use the inspected state',
@@ -1077,6 +1081,8 @@ describe('DurableSessionRecoveryCoordinator', () => {
       recoveryInputId: rolloverInputId,
     });
     expect(rollover.continuation).toContain('"modelAttempts"');
+    expect(rollover.continuation).toContain('"provider": "provider-primary"');
+    expect(rollover.continuation).toContain('"api": "openai-compatible"');
     expect(rollover.continuation).toContain('Use the inspected state');
     expect(rollover.continuation).toContain(
       'Treat completed model responses as authoritative prior output',

--- a/src/session/events/__tests__/JsonlDurableEventStore.test.ts
+++ b/src/session/events/__tests__/JsonlDurableEventStore.test.ts
@@ -396,7 +396,7 @@ describe('JsonlDurableEventStore', () => {
     ]);
   });
 
-  it('reads schema-v2 batches and appends new schema-v3 events', async () => {
+  it('reads schema-v2 batches and appends new schema-v4 events', async () => {
     const sessionId = SessionId('session-schema-upgrade');
     const filePath = store.getFilePath(sessionId);
     const timestamp = '2026-08-22T12:00:00.000Z';
@@ -431,10 +431,10 @@ describe('JsonlDurableEventStore', () => {
       [
         {
           type: DurableEventType.REQUEST_ACCEPTED,
-          requestId: RequestId('schema-v3-request'),
-          commandId: CommandId('schema-v3-command'),
+          requestId: RequestId('schema-v4-request'),
+          commandId: CommandId('schema-v4-command'),
           data: {
-            inputId: InputId('schema-v3-input'),
+            inputId: InputId('schema-v4-input'),
             input: 'continue',
             priority: 'next',
           },
@@ -443,9 +443,9 @@ describe('JsonlDurableEventStore', () => {
       { expectedLastSequence: EventSequence(1) },
     );
 
-    expect(appended.events[0]?.schemaVersion).toBe(3);
+    expect(appended.events[0]?.schemaVersion).toBe(4);
     expect((await store.read(sessionId)).events.map((event) => event.schemaVersion)).toEqual([
-      2, 3,
+      2, 4,
     ]);
 
     await appendFile(
@@ -463,7 +463,7 @@ describe('JsonlDurableEventStore', () => {
             sequence: 3,
             sessionId,
             type: DurableEventType.REQUEST_STARTED,
-            requestId: RequestId('schema-v3-request'),
+            requestId: RequestId('schema-v4-request'),
             data: {},
             recordedAt: timestamp,
             occurredAt: timestamp,

--- a/src/session/events/__tests__/SessionDurableRecorder.test.ts
+++ b/src/session/events/__tests__/SessionDurableRecorder.test.ts
@@ -59,6 +59,8 @@ describe('SessionDurableRecorder', () => {
     const modelRequest = await recorder.onModelRequestStarting({
       turn: 1,
       model: 'test-model',
+      provider: 'provider-primary',
+      api: 'openai-compatible',
       streaming: false,
     });
     await modelRequest.onCompleted({
@@ -101,6 +103,8 @@ describe('SessionDurableRecorder', () => {
     const modelRequest = await recorder.onModelRequestStarting({
       turn: 1,
       model: 'test-model',
+      provider: 'provider-primary',
+      api: 'openai-compatible',
       streaming: false,
     });
     await modelRequest.onCompleted({
@@ -206,6 +210,14 @@ describe('SessionDurableRecorder', () => {
         id: 'request-context',
         environment: { REGION: 'test' },
       },
+    });
+    expect(events.find(
+      (event) => event.type === DurableEventType.MODEL_REQUEST_STARTED,
+    )?.data).toEqual({
+      model: 'test-model',
+      provider: 'provider-primary',
+      api: 'openai-compatible',
+      streaming: false,
     });
     expect(events.find(
       (event) => event.type === DurableEventType.TOOL_SCHEDULED,

--- a/src/session/events/__tests__/SessionDurableRecorder.test.ts
+++ b/src/session/events/__tests__/SessionDurableRecorder.test.ts
@@ -59,8 +59,11 @@ describe('SessionDurableRecorder', () => {
     const modelRequest = await recorder.onModelRequestStarting({
       turn: 1,
       model: 'test-model',
-      provider: 'provider-primary',
-      api: 'openai-compatible',
+      modelIdentity: {
+        provider: 'provider-primary',
+        api: 'openai-compatible',
+        model: 'test-model',
+      },
       streaming: false,
     });
     await modelRequest.onCompleted({
@@ -103,8 +106,11 @@ describe('SessionDurableRecorder', () => {
     const modelRequest = await recorder.onModelRequestStarting({
       turn: 1,
       model: 'test-model',
-      provider: 'provider-primary',
-      api: 'openai-compatible',
+      modelIdentity: {
+        provider: 'provider-primary',
+        api: 'openai-compatible',
+        model: 'test-model',
+      },
       streaming: false,
     });
     await modelRequest.onCompleted({
@@ -215,8 +221,11 @@ describe('SessionDurableRecorder', () => {
       (event) => event.type === DurableEventType.MODEL_REQUEST_STARTED,
     )?.data).toEqual({
       model: 'test-model',
-      provider: 'provider-primary',
-      api: 'openai-compatible',
+      modelIdentity: {
+        provider: 'provider-primary',
+        api: 'openai-compatible',
+        model: 'test-model',
+      },
       streaming: false,
     });
     expect(events.find(

--- a/src/session/events/__tests__/schemas.test.ts
+++ b/src/session/events/__tests__/schemas.test.ts
@@ -113,8 +113,11 @@ const validDrafts: readonly DurableEventDraft[] = [
     modelAttemptId,
     data: {
       model: 'claude-sonnet',
-      provider: 'anthropic-primary',
-      api: 'anthropic',
+      modelIdentity: {
+        provider: 'anthropic-primary',
+        api: 'anthropic',
+        model: 'claude-sonnet',
+      },
       streaming: true,
     },
   },
@@ -484,7 +487,35 @@ describe('durable event schemas', () => {
     ).toThrow(/requires durable event schema v3/);
   });
 
-  it('requires model-attempt identity and original input for schema-v3 tool schedules only', () => {
+  it('reads schema-v3 model attempts but reserves provider identity for schema v4', () => {
+    const modelStarted = validDrafts.find(
+      (draft) => draft.type === DurableEventType.MODEL_REQUEST_STARTED,
+    );
+    if (!modelStarted || modelStarted.type !== DurableEventType.MODEL_REQUEST_STARTED) {
+      throw new Error('Expected model_request_started fixture');
+    }
+    const { modelIdentity: _modelIdentity, ...legacyData } = modelStarted.data;
+    const envelope = {
+      ...modelStarted,
+      data: legacyData,
+      schemaVersion: 3,
+      eventId: EventId('schema-v3-model-event'),
+      sequence: 1,
+      sessionId: 'schema-v3-session',
+      recordedAt: '2026-08-22T12:00:00.000Z',
+      occurredAt: '2026-08-22T12:00:00.000Z',
+    } as const;
+
+    expect(parseDurableEventEnvelope(envelope).schemaVersion).toBe(3);
+    expect(() =>
+      parseDurableEventEnvelope({
+        ...envelope,
+        data: modelStarted.data,
+      }),
+    ).toThrow(/provider identity requires durable event schema v4/);
+  });
+
+  it('requires model-attempt identity and original input for schema-v3 and later tools', () => {
     const toolScheduled = validDrafts.find(
       (draft) => draft.type === DurableEventType.TOOL_SCHEDULED,
     );

--- a/src/session/events/__tests__/schemas.test.ts
+++ b/src/session/events/__tests__/schemas.test.ts
@@ -113,6 +113,8 @@ const validDrafts: readonly DurableEventDraft[] = [
     modelAttemptId,
     data: {
       model: 'claude-sonnet',
+      provider: 'anthropic-primary',
+      api: 'anthropic',
       streaming: true,
     },
   },

--- a/src/session/events/schemas.ts
+++ b/src/session/events/schemas.ts
@@ -9,7 +9,11 @@ import {
   ToolAttemptId,
   TurnId,
 } from '../../types/branded.js';
-import type { JsonObject, JsonValue } from '../../types/common.js';
+import {
+  type JsonObject,
+  type JsonValue,
+  PROVIDER_TYPES,
+} from '../../types/common.js';
 import {
   DURABLE_EVENT_SCHEMA_VERSION,
   type DurableEventDataMap,
@@ -160,6 +164,8 @@ const DurableEventDataSchemas = {
   [DurableEventTypeValue.MODEL_REQUEST_STARTED]: z
     .object({
       model: NonEmptyStringSchema,
+      provider: NonEmptyStringSchema.optional(),
+      api: z.enum(PROVIDER_TYPES).optional(),
       streaming: z.boolean(),
     })
     .strict(),

--- a/src/session/events/schemas.ts
+++ b/src/session/events/schemas.ts
@@ -164,8 +164,11 @@ const DurableEventDataSchemas = {
   [DurableEventTypeValue.MODEL_REQUEST_STARTED]: z
     .object({
       model: NonEmptyStringSchema,
-      provider: NonEmptyStringSchema.optional(),
-      api: z.enum(PROVIDER_TYPES).optional(),
+      modelIdentity: z.object({
+        provider: NonEmptyStringSchema,
+        api: z.enum(PROVIDER_TYPES),
+        model: NonEmptyStringSchema,
+      }).strict().optional(),
       streaming: z.boolean(),
     })
     .strict(),
@@ -270,6 +273,7 @@ const DurableEventDraftBaseSchema = z
 
 const DurableEventSchemaVersionSchema = z.union([
   z.literal(2),
+  z.literal(3),
   z.literal(DURABLE_EVENT_SCHEMA_VERSION),
 ]);
 
@@ -309,7 +313,7 @@ const DurableEventEnvelopeSchema = z
       });
     }
     if (
-      value.schemaVersion === DURABLE_EVENT_SCHEMA_VERSION
+      value.schemaVersion >= 3
       && value.type === DurableEventTypeValue.TOOL_SCHEDULED
     ) {
       if (value.modelAttemptId === undefined) {
@@ -326,6 +330,17 @@ const DurableEventEnvelopeSchema = z
           message: `${value.type} requires modelInput in durable event schema v3`,
         });
       }
+    }
+    if (
+      value.schemaVersion < DURABLE_EVENT_SCHEMA_VERSION
+      && value.type === DurableEventTypeValue.MODEL_REQUEST_STARTED
+      && value.data.modelIdentity !== undefined
+    ) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['data'],
+        message: `${value.type} provider identity requires durable event schema v4`,
+      });
     }
     if (
       value.schemaVersion === 2

--- a/src/session/events/types.ts
+++ b/src/session/events/types.ts
@@ -1,4 +1,5 @@
 import type { ToolSideEffect } from '../../tools/types/ToolKind.js';
+import type { ModelIdentity } from '../../services/ModelIdentity.js';
 import type {
   CommandId,
   EventId,
@@ -12,11 +13,11 @@ import type {
   ToolUseId,
   TurnId,
 } from '../../types/branded.js';
-import type { JsonObject, JsonValue, ProviderType } from '../../types/common.js';
+import type { JsonObject, JsonValue } from '../../types/common.js';
 import type { DurableExecutionFence } from './DurableExecutionLeaseStore.js';
 
-export const DURABLE_EVENT_SCHEMA_VERSION = 3 as const;
-export type DurableEventSchemaVersion = 2 | typeof DURABLE_EVENT_SCHEMA_VERSION;
+export const DURABLE_EVENT_SCHEMA_VERSION = 4 as const;
+export type DurableEventSchemaVersion = 2 | 3 | typeof DURABLE_EVENT_SCHEMA_VERSION;
 
 export const DurableEventType = {
   SESSION_CREATED: 'session_created',
@@ -154,8 +155,7 @@ export interface DurableEventDataMap {
   };
   [DurableEventType.MODEL_REQUEST_STARTED]: {
     model: string;
-    provider?: string;
-    api?: ProviderType;
+    modelIdentity?: ModelIdentity;
     streaming: boolean;
   };
   [DurableEventType.MODEL_REQUEST_COMPLETED]: {

--- a/src/session/events/types.ts
+++ b/src/session/events/types.ts
@@ -12,7 +12,7 @@ import type {
   ToolUseId,
   TurnId,
 } from '../../types/branded.js';
-import type { JsonObject, JsonValue } from '../../types/common.js';
+import type { JsonObject, JsonValue, ProviderType } from '../../types/common.js';
 import type { DurableExecutionFence } from './DurableExecutionLeaseStore.js';
 
 export const DURABLE_EVENT_SCHEMA_VERSION = 3 as const;
@@ -154,6 +154,8 @@ export interface DurableEventDataMap {
   };
   [DurableEventType.MODEL_REQUEST_STARTED]: {
     model: string;
+    provider?: string;
+    api?: ProviderType;
     streaming: boolean;
   };
   [DurableEventType.MODEL_REQUEST_COMPLETED]: {

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -94,6 +94,8 @@ export interface PendingSessionInput {
 }
 
 export interface ProviderConfig {
+  /** Logical provider ID. Defaults to `type`. */
+  id?: string;
   type: ProviderType;
   apiKey?: string;
   baseUrl?: string;

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -15,18 +15,23 @@ export interface TokenUsage {
   maxContextTokens: number;
 }
 
-export type ProviderType =
-  | 'anthropic'
-  | 'openai'
-  | 'azure-openai'
-  | 'gemini'
-  | 'deepseek'
-  | 'openai-compatible';
+export const PROVIDER_TYPES = [
+  'anthropic',
+  'openai',
+  'azure-openai',
+  'gemini',
+  'deepseek',
+  'openai-compatible',
+] as const;
+
+export type ProviderType = (typeof PROVIDER_TYPES)[number];
 
 export interface ModelConfig {
   id: string;
   name: string;
   provider: ProviderType;
+  /** Logical provider ID when multiple providers share the same API adapter. */
+  providerId?: string;
   model: string;
   apiKey?: string;
   baseUrl?: string;

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -30,7 +30,7 @@ export interface ModelConfig {
   id: string;
   name: string;
   provider: ProviderType;
-  /** Logical provider ID when multiple providers share the same API adapter. */
+  /** Logical provider ID. Adapter selection depends only on `provider`. */
   providerId?: string;
   model: string;
   apiKey?: string;


### PR DESCRIPTION
## Summary

- preserve the logical provider, API adapter, and model identity for every assistant turn
- persist model provenance through in-memory history, JSONL transcripts, durable model attempts, and recovery continuations
- replay native reasoning only for the exact same provider/adapter/model and downgrade foreign or legacy reasoning to ordinary assistant text
- keep logical provider IDs independent from adapter selection, including the `deepseek` collision case
- advance durable events to schema v4 while retaining explicit v2/v3 read compatibility

## Design

This slice follows the provider/history boundary used by `pi-ai` at
`earendil-works/pi@dcd461925db2edf69a43c8135db1180d418afd54`:

- provider identity and wire API are separate concepts
- assistant history records its model provenance
- cross-provider reasoning is normalized before replay

The package is not added as a dependency because its current runtime requires
Node 22.19+, while this SDK still targets Node 18.

## Compatibility

- `ProviderConfig.id` is optional and defaults to `type`
- `id` never changes adapter selection; only `type` selects the adapter
- old transcript records without `modelIdentity` remain readable
- durable schema v2 and v3 remain readable; new writes use schema v4

## Verification

- `pnpm test`: 1704 passed, 63 environment-gated tests skipped
- `pnpm type-check`
- `pnpm lint`
- `pnpm verify:entrypoints`
- `pnpm docs:build`
- `pnpm changelog:check`
- `pnpm audit:prod`
- independent standards/spec review: no remaining P0-P2 findings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional logical provider IDs for distinguishing compatible gateways and configurations.
  * Assistant history now records provider, API adapter, and model identity.
  * Reasoning content is preserved only when replayed with the same model identity; otherwise it safely falls back to plain text while retaining tool associations.

* **Documentation**
  * Updated provider, session, API, and durable-event documentation.
  * Documented durable-event schema v4 and compatibility with earlier history formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->