### PR TITLE
refactor(server): extract SessionExecutor boundary

### DIFF
--- a/.changes/session-executor-boundary.json
+++ b/.changes/session-executor-boundary.json
@@ -1,0 +1,5 @@
+{
+  "type": "refactor",
+  "en": "Extract Session execution behind injectable SessionExecutor and InProcessSessionExecutor contracts.",
+  "zh-CN": "将 Session 执行提取为可注入的 SessionExecutor 与 InProcessSessionExecutor 契约。"
+}

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ import { defineTool } from '@blade-ai/agent-sdk/tools';
 import { composeMiddleware } from '@blade-ai/agent-sdk/middleware';
 ```
 
-- Root and `/server`: server-side agents; load only explicitly supplied tools, agents, middleware, and MCP servers without scanning the host workspace
+- Root and `/server`: server-side agents; expose `AgentServer` with an injectable `SessionExecutor` and load only explicitly supplied capabilities
 - `/node`: Node.js runtimes with local host access; enables file, search, shell, and task tools plus local agent/Skill discovery, and exports Node host adapters
 - `/browser`: browser-safe `AgentClient`, protocol view, and explicit server-only execution stubs
 - `/protocol`: browser-safe versioned command/event contracts and strict parsers

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -135,7 +135,7 @@ import { defineTool } from '@blade-ai/agent-sdk/tools';
 import { composeMiddleware } from '@blade-ai/agent-sdk/middleware';
 ```
 
-- 根入口与 `/server`：服务端 Agent；只加载显式传入的工具、Agent、middleware 和 MCP，不扫描宿主工作区
+- 根入口与 `/server`：服务端 Agent；提供可注入 `SessionExecutor` 的 `AgentServer`，只加载显式传入的能力
 - `/node`：具备本机访问能力的 Node.js 运行时；默认加载文件、搜索、Shell、任务工具和本地 Agent/Skill 发现，并导出 Node 宿主适配器
 - `/browser`：browser-safe `AgentClient`、协议视图和明确的 server-only stub
 - `/protocol`：browser-safe 版本化 command/event 契约与 strict parser

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -70,6 +70,7 @@ Node-local 能力外，这些函数都从根入口导出；实际 subpath 以“
 | `JsonlDurableEventStore` | node | 支持同机多进程锁的 Node.js durable event JSONL adapter |
 | `DurableExecutionLeaseError` | durable events | lease 冲突、失租、缺少 fence 或状态损坏错误 |
 | `AgentServer` | server | 多租户 command 调度、Session 管理和 Fetch-compatible HTTP/SSE transport |
+| `InProcessSessionExecutor` | server | `SessionExecutor` 的进程内参考实现，负责 Session 生命周期与 stream pump |
 | `AgentClient` / `RemoteAgentSession` | browser | 带 command 重试和 SSE cursor 重连的远程客户端 |
 | `InMemoryAgentServerStore` | server | 单进程控制面参考 Store；不用于多实例生产部署 |
 | `TenantAdmissionController` | server | 每 tenant 并发、队列和固定窗口限流 |
@@ -126,6 +127,9 @@ Node-local 能力外，这些函数都从根入口导出；实际 subpath 以“
 | 导出 | 说明 |
 |------|------|
 | `AgentServerOptions` / `AgentServerSessionContext` | 认证、Session options、Store、遥测、准入和 transport 限制 |
+| `SessionExecutor` / `SessionExecutorCommandContext` | command transport 与 Session 执行面的稳定边界 |
+| `InProcessSessionExecutorOptions` | 进程内 executor 的 Store、Session resolver、event publisher 与容量配置 |
+| `SessionExecutorEventPublisher` / `SessionExecutorReadResult` | executor 的事件输出与 Session read projection |
 | `AgentServerStore` / `AgentCommandClaim` / `AgentServerSessionRecord` | command claim/seal/complete、tenant Session 和 event replay 端口 |
 | `AgentServerTelemetry` / `AgentServerAuditRecord` | payload-free metric 与审计端口 |
 | `AgentClientOptions` / `AgentClientCommandOptions` / `AgentClientEventOptions` | 浏览器 transport、重试和 cursor 选项 |

--- a/docs/en/api-reference.md
+++ b/docs/en/api-reference.md
@@ -83,6 +83,7 @@ These ID exports are branded identifiers, not arbitrary strings.
 Runtime:
 
 - `AgentServer`
+- `InProcessSessionExecutor`
 - `AgentClient`
 - `RemoteAgentSession`
 - `InMemoryAgentServerStore`
@@ -101,6 +102,11 @@ Types:
 
 - `AgentServerOptions`
 - `AgentServerSessionContext`
+- `SessionExecutor`
+- `SessionExecutorCommandContext`
+- `SessionExecutorEventPublisher`
+- `SessionExecutorReadResult`
+- `InProcessSessionExecutorOptions`
 - `AgentServerStore`
 - `AgentCommandClaim`
 - `AgentServerSessionRecord`

--- a/docs/en/server-runtime.md
+++ b/docs/en/server-runtime.md
@@ -74,6 +74,59 @@ service must use a shared `SessionRepository` and a shared `AgentServerStore`.
 The repository should also partition data by the authenticated `tenantId`.
 There is no trusted client-supplied tenant field.
 
+## SessionExecutor
+
+`AgentServer` owns authentication, authorization, command idempotency, HTTP,
+and SSE only. `SessionExecutor` owns Session creation, resume, fork, input,
+abort, close, approval correlation, mutation serialization, and stream pumps.
+
+When `sessionExecutor` is omitted, `AgentServer` creates an
+`InProcessSessionExecutor` from `resolveSessionOptions`, preserving the original
+in-process behavior:
+
+```ts
+import {
+  AgentServer,
+  InProcessSessionExecutor,
+  InMemoryAgentServerStore,
+} from '@blade-ai/agent-sdk/server';
+
+const store = new InMemoryAgentServerStore();
+const executor = new InProcessSessionExecutor({
+  store,
+  resolveSessionOptions,
+  publish: async (tenantId, sessionId, type, data, requestId) => {
+    await store.appendEvent(tenantId, sessionId, {
+      protocolVersion: 1,
+      sessionId,
+      requestId,
+      occurredAt: new Date().toISOString(),
+      type,
+      data,
+    });
+  },
+});
+
+const server = new AgentServer({
+  store,
+  sessionExecutor: executor,
+  authenticate,
+});
+```
+
+A custom executor must:
+
+- Isolate active Sessions by tenant.
+- Serialize mutations for each Session.
+- Persist Session records and append stream, approval, and close events to the
+  same Store used by `AgentServer`.
+- Stop admission and release owned runtimes in `shutdown()`.
+- Never expose provider credentials, internal failures, or non-JSON values in
+  command results.
+
+This port is the replacement boundary for remote workers, container executors,
+and schedulers. It is not a tool adapter and does not grant local host access.
+
 ## HTTP API
 
 The default base path is `/v1/agent`:

--- a/docs/server-runtime.md
+++ b/docs/server-runtime.md
@@ -73,6 +73,57 @@ JSONL adapter 适合单机 Node.js 部署。多实例服务必须使用共享
 `SessionRepository` 和共享 `AgentServerStore`；repository 还应按认证得到的
 `tenantId` 分区。客户端 body 中不存在可信 tenant 字段。
 
+## SessionExecutor
+
+`AgentServer` 只处理认证、授权、command 幂等、HTTP 和 SSE。Session 的创建、
+恢复、fork、输入、abort、关闭、审批关联、并发串行化和 stream pump 均由
+`SessionExecutor` 负责。
+
+未传 `sessionExecutor` 时，`AgentServer` 根据 `resolveSessionOptions` 创建
+`InProcessSessionExecutor`，行为与原来的进程内运行模式一致：
+
+```ts
+import {
+  AgentServer,
+  InProcessSessionExecutor,
+  InMemoryAgentServerStore,
+} from '@blade-ai/agent-sdk/server';
+
+const store = new InMemoryAgentServerStore();
+const executor = new InProcessSessionExecutor({
+  store,
+  resolveSessionOptions,
+  publish: async (tenantId, sessionId, type, data, requestId) => {
+    await store.appendEvent(tenantId, sessionId, {
+      protocolVersion: 1,
+      sessionId,
+      requestId,
+      occurredAt: new Date().toISOString(),
+      type,
+      data,
+    });
+  },
+});
+
+const server = new AgentServer({
+  store,
+  sessionExecutor: executor,
+  authenticate,
+});
+```
+
+自定义 executor 必须：
+
+- 按 tenant 隔离运行中 Session。
+- 对同一 Session 的 mutation 串行化。
+- 自行持久化 Session record，并把 stream/approval/close event 追加到与
+  `AgentServer` 相同的 Store。
+- 在 `shutdown()` 中停止接受新工作并回收所拥有的 runtime。
+- 不向 command 返回值暴露 Provider credential、内部异常或非 JSON 数据。
+
+这一端口是后续远程 worker、容器 executor 和调度器的替换边界。它不是工具
+adapter，也不授予本机能力。
+
 ## HTTP API
 
 默认 base path 是 `/v1/agent`：

--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
     "@types/picomatch": "^4.0.2",
     "@types/semver": "^7.7.1",
     "@types/write-file-atomic": "^4.0.3",
+    "esbuild": "0.27.4",
     "semantic-release": "^25.0.5",
     "tsup": "^8.5.1",
     "typescript": "^6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,9 @@ importers:
       '@types/write-file-atomic':
         specifier: ^4.0.3
         version: 4.0.3
+      esbuild:
+        specifier: 0.27.4
+        version: 0.27.4
       semantic-release:
         specifier: ^25.0.5
         version: 25.0.5(typescript@6.0.3)

--- a/scripts/verify-entrypoints.mjs
+++ b/scripts/verify-entrypoints.mjs
@@ -105,6 +105,20 @@ assertIncludes(
   'browser Node Session repository stub',
 );
 
+const browserServerOutput = run(process.execPath, [
+  '--conditions=browser',
+  '-e',
+  [
+    "const m = await import('@blade-ai/agent-sdk/server');",
+    'try { new m.InProcessSessionExecutor({}); } catch (error) { console.log(error.message); }',
+  ].join(' '),
+]);
+assertIncludes(
+  browserServerOutput,
+  'server-only for InProcessSessionExecutor',
+  'browser in-process Session executor stub',
+);
+
 const subpathOutput = run(process.execPath, [
   '-e',
   [
@@ -115,12 +129,12 @@ const subpathOutput = run(process.execPath, [
     "const node = await import('@blade-ai/agent-sdk/node');",
     "const protocol = await import('@blade-ai/agent-sdk/protocol');",
     "const middleware = await import('@blade-ai/agent-sdk/middleware');",
-    "console.log(core.PermissionMode.DEFAULT, core.DurableEventType.REQUEST_ACCEPTED, core.projectDurableSession([]).status, typeof core.DurableSessionJournal.open, typeof core.DurableSessionRecoveryCoordinator.open, typeof core.DurableEventSubscription.open, browser.PermissionMode.DEFAULT, typeof browser.AgentClient, typeof server.createSession, typeof server.AgentServer, typeof tools.defineTool, typeof node.createSession, typeof node.getBuiltinTools, typeof node.JsonlDurableEventStore, typeof node.JsonlSessionRepository, protocol.AGENT_PROTOCOL_VERSION, typeof middleware.composeMiddleware);",
+    "console.log(core.PermissionMode.DEFAULT, core.DurableEventType.REQUEST_ACCEPTED, core.projectDurableSession([]).status, typeof core.DurableSessionJournal.open, typeof core.DurableSessionRecoveryCoordinator.open, typeof core.DurableEventSubscription.open, browser.PermissionMode.DEFAULT, typeof browser.AgentClient, typeof server.createSession, typeof server.AgentServer, typeof server.InProcessSessionExecutor, typeof tools.defineTool, typeof node.createSession, typeof node.getBuiltinTools, typeof node.JsonlDurableEventStore, typeof node.JsonlSessionRepository, protocol.AGENT_PROTOCOL_VERSION, typeof middleware.composeMiddleware);",
   ].join(' '),
 ]);
 assertIncludes(
   subpathOutput,
-  'default request_accepted empty function function function default function function function function function function function function 1 function',
+  'default request_accepted empty function function function default function function function function function function function function function 1 function',
   'subpath imports',
 );
 

--- a/src/__tests__/packageEntrypoints.test.ts
+++ b/src/__tests__/packageEntrypoints.test.ts
@@ -96,6 +96,9 @@ describe('package entrypoints', () => {
       /server-only.*JsonlDurableEventStore/,
     );
     expect(() => new serverOnly.AgentServer()).toThrow(/server-only.*AgentServer/);
+    expect(() => new serverOnly.InProcessSessionExecutor()).toThrow(
+      /server-only.*InProcessSessionExecutor/,
+    );
   });
 
   it('uses distinct server and Node Session factories', async () => {
@@ -106,6 +109,7 @@ describe('package entrypoints', () => {
     expect(server.createSession).toBe(root.createSession);
     expect(node.createSession).not.toBe(server.createSession);
     expect(server.AgentServer).toBeTypeOf('function');
+    expect(server.InProcessSessionExecutor).toBeTypeOf('function');
     expect(node.JsonlSessionRepository).toBeTypeOf('function');
     expect('getBuiltinTools' in root).toBe(false);
     expect(node.getBuiltinTools).toBeTypeOf('function');

--- a/src/browser/server-only-stub.ts
+++ b/src/browser/server-only-stub.ts
@@ -70,6 +70,12 @@ export class AgentServer {
   }
 }
 
+export class InProcessSessionExecutor {
+  constructor(..._args: unknown[]) {
+    serverOnly('InProcessSessionExecutor');
+  }
+}
+
 export class InMemoryAgentServerStore {
   constructor(..._args: unknown[]) {
     serverOnly('InMemoryAgentServerStore');

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -14,27 +14,13 @@ import {
   type AgentServerEvent,
   type AgentServerScope,
 } from '../protocol/index.js';
-import {
-  createSession,
-  forkSession,
-  resumeSession,
-} from '../session/Session.js';
 import { canonicalJson } from '../session/events/canonicalJson.js';
-import type {
-  ISession,
-  SessionOptions,
-  StreamMessage,
-} from '../session/types.js';
+import type { SessionOptions } from '../session/types.js';
 import {
   SessionId,
   type RequestId,
 } from '../types/branded.js';
-import type { JsonObject } from '../types/common.js';
-import {
-  getErrorCode,
-  getErrorMessage,
-  getErrorName,
-} from '../utils/errorUtils.js';
+import { getErrorName } from '../utils/errorUtils.js';
 import { toJsonValue } from '../utils/jsonValue.js';
 import {
   InMemoryAgentServerStore,
@@ -45,7 +31,12 @@ import {
   NOOP_AGENT_SERVER_TELEMETRY,
   type AgentServerTelemetry,
 } from './AgentServerTelemetry.js';
-import { RemoteApprovalBroker } from './RemoteApprovalBroker.js';
+import {
+  type AgentServerSessionContext,
+  InProcessSessionExecutor,
+  type SessionExecutor,
+  type SessionExecutorCommandContext,
+} from './SessionExecutor.js';
 import {
   TenantAdmissionController,
   type TenantAdmissionLimits,
@@ -56,17 +47,11 @@ const DEFAULT_EVENT_POLL_INTERVAL_MS = 1_000;
 const DEFAULT_HEARTBEAT_INTERVAL_MS = 15_000;
 const DEFAULT_MAX_REQUEST_BYTES = 1024 * 1024;
 
-export interface AgentServerSessionContext {
-  readonly principal: AgentPrincipal;
-  readonly operation: 'create' | 'resume' | 'fork';
-  readonly sessionId?: SessionId;
-  readonly metadata?: JsonObject;
-}
-
 export interface AgentServerOptions {
-  readonly resolveSessionOptions: (
+  readonly resolveSessionOptions?: (
     context: AgentServerSessionContext,
   ) => SessionOptions | Promise<SessionOptions>;
+  readonly sessionExecutor?: SessionExecutor;
   readonly authenticate?: (
     request: Request,
   ) => AgentPrincipal | null | Promise<AgentPrincipal | null>;
@@ -82,18 +67,6 @@ export interface AgentServerOptions {
   readonly maxRequestBytes?: number;
   readonly basePath?: string;
   readonly requirePersistentSessions?: boolean;
-}
-
-interface ManagedSession {
-  readonly tenantId: string;
-  readonly session: ISession;
-  readonly metadata?: JsonObject;
-  pump?: Promise<void>;
-  activeRequestId?: RequestId;
-}
-
-function sessionKey(tenantId: string, sessionId: SessionId): string {
-  return `${tenantId}\0${sessionId}`;
 }
 
 function commandSessionId(command: AgentCommand): SessionId | undefined {
@@ -176,14 +149,10 @@ export class AgentServer {
     },
   };
 
-  private readonly activeSessions = new Map<string, ManagedSession>();
-  private readonly sessionReservations = new Map<string, number>();
-  private readonly sessionOperations = new Map<string, Promise<void>>();
   private readonly store: AgentServerStore;
   private readonly telemetry: AgentServerTelemetry;
   private readonly admission: TenantAdmissionController;
-  private readonly approvals: RemoteApprovalBroker;
-  private readonly maxActiveSessionsPerTenant: number;
+  private readonly sessionExecutor: SessionExecutor;
   private readonly commandLeaseTtlMs: number;
   private readonly eventPollIntervalMs: number;
   private readonly heartbeatIntervalMs: number;
@@ -194,8 +163,6 @@ export class AgentServer {
     this.store = options.store ?? new InMemoryAgentServerStore();
     this.telemetry = options.telemetry ?? NOOP_AGENT_SERVER_TELEMETRY;
     this.admission = new TenantAdmissionController(options.admission);
-    this.maxActiveSessionsPerTenant =
-      options.admission?.maxActiveSessionsPerTenant ?? 100;
     this.commandLeaseTtlMs =
       options.commandLeaseTtlMs ?? DEFAULT_COMMAND_LEASE_TTL_MS;
     this.eventPollIntervalMs =
@@ -204,7 +171,6 @@ export class AgentServer {
       options.heartbeatIntervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS;
     this.maxRequestBytes = options.maxRequestBytes ?? DEFAULT_MAX_REQUEST_BYTES;
     for (const [name, value] of [
-      ['maxActiveSessionsPerTenant', this.maxActiveSessionsPerTenant],
       ['commandLeaseTtlMs', this.commandLeaseTtlMs],
       ['eventPollIntervalMs', this.eventPollIntervalMs],
       ['heartbeatIntervalMs', this.heartbeatIntervalMs],
@@ -215,11 +181,25 @@ export class AgentServer {
       }
     }
     this.basePath = `/${(options.basePath ?? 'v1/agent').replace(/^\/+|\/+$/g, '')}`;
-    this.approvals = new RemoteApprovalBroker({
-      timeoutMs: options.approvalTimeoutMs,
-      publish: (tenantId, sessionId, request) =>
-        this.publish(tenantId, sessionId, 'permission.requested', request),
-    });
+    const resolveSessionOptions = options.resolveSessionOptions;
+    if (!options.sessionExecutor && !resolveSessionOptions) {
+      throw new TypeError(
+        'AgentServer requires sessionExecutor or resolveSessionOptions',
+      );
+    }
+    this.sessionExecutor = options.sessionExecutor
+      ?? new InProcessSessionExecutor({
+        store: this.store,
+        resolveSessionOptions: resolveSessionOptions as NonNullable<
+          AgentServerOptions['resolveSessionOptions']
+        >,
+        publish: (tenantId, sessionId, type, data, requestId) =>
+          this.publish(tenantId, sessionId, type, data, requestId),
+        maxActiveSessionsPerTenant:
+          options.admission?.maxActiveSessionsPerTenant,
+        approvalTimeoutMs: options.approvalTimeoutMs,
+        requirePersistentSessions: options.requirePersistentSessions,
+      });
   }
 
   async execute(
@@ -265,13 +245,9 @@ export class AgentServer {
         command.commandId,
         claim.leaseId,
       );
-      const sessionId = commandSessionId(command);
       let result: AgentCommandResult;
       try {
-        result = sessionId
-          ? await this.runForSession(principal, sessionId, () =>
-              this.dispatch(command, principal, signal))
-          : await this.dispatch(command, principal, signal);
+        result = await this.dispatch(command, principal, signal);
       } catch (error) {
         result = this.failure(command.commandId, error);
       }
@@ -439,116 +415,70 @@ export class AgentServer {
   }
 
   async close(): Promise<void> {
-    const sessions = Array.from(this.activeSessions.values());
-    this.activeSessions.clear();
-    await Promise.allSettled(sessions.map(async ({ tenantId, session }) => {
-      this.approvals.cancelSession(
-        tenantId,
-        session.sessionId,
-        new Error('Agent server is closing'),
-      );
-      await session.close();
-    }));
+    await this.sessionExecutor.shutdown();
   }
 
   private async dispatch(
     command: AgentCommand,
     principal: AgentPrincipal,
-    _signal?: AbortSignal,
+    signal?: AbortSignal,
   ): Promise<AgentCommandResult> {
+    const context: SessionExecutorCommandContext = {
+      principal,
+      commandId: command.commandId,
+      ...(signal ? { signal } : {}),
+    };
     switch (command.type) {
       case AgentCommandType.INITIALIZE:
         return this.success(command.commandId, {
           ...this.capabilities,
           serverTime: new Date().toISOString(),
         });
-      case AgentCommandType.SESSION_CREATE:
-        return this.create(command.commandId, principal, command.data.metadata);
+      case AgentCommandType.SESSION_CREATE: {
+        const session = await this.sessionExecutor.create(context, command.data);
+        return this.success(command.commandId, { session });
+      }
       case AgentCommandType.SESSION_READ:
-        return this.read(command.commandId, principal, command.data.sessionId);
+        return this.success(
+          command.commandId,
+          await this.sessionExecutor.read(context, command.data),
+        );
       case AgentCommandType.SESSION_LIST:
         return this.list(command.commandId, principal, command.data);
-      case AgentCommandType.SESSION_RESUME:
-        return this.resume(command.commandId, principal, command.data.sessionId);
-      case AgentCommandType.SESSION_FORK:
-        return this.fork(command.commandId, principal, command.data);
-      case AgentCommandType.SESSION_CLOSE:
-        return this.closeSession(command.commandId, principal, command.data.sessionId);
-      case AgentCommandType.INPUT_SUBMIT:
-        return this.submit(command.commandId, principal, command.data);
-      case AgentCommandType.REQUEST_ABORT:
-        return this.abort(command.commandId, principal, command.data.sessionId);
-      case AgentCommandType.PERMISSION_RESOLVE:
-        this.approvals.resolve(
-          principal.tenantId,
-          command.data.sessionId,
-          command.data.permissionRequestId,
-          {
-            approved: command.data.approved,
-            reason: command.data.reason,
-            scope: command.data.scope,
-          },
+      case AgentCommandType.SESSION_RESUME: {
+        const session = await this.sessionExecutor.resume(context, command.data);
+        return this.success(command.commandId, { session });
+      }
+      case AgentCommandType.SESSION_FORK: {
+        const session = await this.sessionExecutor.fork(context, command.data);
+        return this.success(command.commandId, { session });
+      }
+      case AgentCommandType.SESSION_CLOSE: {
+        const session = await this.sessionExecutor.closeSession(
+          context,
+          command.data,
         );
+        return this.success(command.commandId, { session });
+      }
+      case AgentCommandType.INPUT_SUBMIT:
+        return this.success(
+          command.commandId,
+          await this.sessionExecutor.submit(context, command.data),
+        );
+      case AgentCommandType.REQUEST_ABORT:
+        await this.sessionExecutor.abort(context, command.data);
+        return this.success(command.commandId, {
+          sessionId: command.data.sessionId,
+          aborted: true,
+        });
+      case AgentCommandType.PERMISSION_RESOLVE:
+        await this.sessionExecutor.resolvePermission(context, command.data);
         return this.success(command.commandId, {
           sessionId: command.data.sessionId,
           permissionRequestId: command.data.permissionRequestId,
           resolved: true,
         });
     }
-  }
-
-  private async create(
-    commandId: string,
-    principal: AgentPrincipal,
-    metadata?: JsonObject,
-  ): Promise<AgentCommandResult> {
-    const releaseCapacity = this.reserveSessionCapacity(principal.tenantId);
-    try {
-      const options = await this.resolveSessionOptions({
-        principal,
-        operation: 'create',
-        metadata,
-      });
-      const session = await createSession(options);
-      const now = new Date().toISOString();
-      const record: AgentServerSessionRecord = {
-        tenantId: principal.tenantId,
-        createdBy: principal.subject,
-        sessionId: session.sessionId,
-        status: 'active',
-        createdAt: now,
-        updatedAt: now,
-        metadata,
-      };
-      try {
-        await this.store.putSession(record);
-      } catch (error) {
-        await session.close().catch(() => undefined);
-        throw error;
-      }
-      this.activeSessions.set(sessionKey(principal.tenantId, session.sessionId), {
-        tenantId: principal.tenantId,
-        session,
-        metadata,
-      });
-      return this.success(commandId, { session: record });
-    } finally {
-      releaseCapacity();
-    }
-  }
-
-  private async read(
-    commandId: string,
-    principal: AgentPrincipal,
-    sessionId: SessionId,
-  ): Promise<AgentCommandResult> {
-    const record = await this.requireSessionRecord(principal.tenantId, sessionId);
-    const managed = this.activeSessions.get(sessionKey(principal.tenantId, sessionId));
-    return this.success(commandId, {
-      session: record,
-      messages: managed?.session.messages ?? [],
-      pendingInputs: managed?.session.getPendingInputs() ?? [],
-    });
   }
 
   private async list(
@@ -561,207 +491,6 @@ export class AgentServer {
       sessions: page.sessions,
       ...(page.nextCursor ? { nextCursor: page.nextCursor } : {}),
     });
-  }
-
-  private async resume(
-    commandId: string,
-    principal: AgentPrincipal,
-    sessionId: SessionId,
-  ): Promise<AgentCommandResult> {
-    const existing = this.activeSessions.get(sessionKey(principal.tenantId, sessionId));
-    if (existing) {
-      return this.success(commandId, {
-        session: await this.requireSessionRecord(principal.tenantId, sessionId),
-      });
-    }
-    const releaseCapacity = this.reserveSessionCapacity(principal.tenantId);
-    try {
-      const record = await this.requireSessionRecord(principal.tenantId, sessionId);
-      if (record.status === 'closed') {
-        throw new AgentProtocolError('SESSION_CONFLICT', 'Session is closed', 409);
-      }
-      const options = await this.resolveSessionOptions({
-        principal,
-        operation: 'resume',
-        sessionId,
-        metadata: record.metadata,
-      });
-      const session = await resumeSession({ ...options, sessionId });
-      this.activeSessions.set(sessionKey(principal.tenantId, sessionId), {
-        tenantId: principal.tenantId,
-        session,
-        metadata: record.metadata,
-      });
-      return this.success(commandId, { session: record });
-    } finally {
-      releaseCapacity();
-    }
-  }
-
-  private async fork(
-    commandId: string,
-    principal: AgentPrincipal,
-    data: {
-      sessionId: SessionId;
-      messageId?: string;
-      metadata?: JsonObject;
-    },
-  ): Promise<AgentCommandResult> {
-    const releaseCapacity = this.reserveSessionCapacity(principal.tenantId);
-    try {
-      const sourceRecord = await this.requireSessionRecord(
-        principal.tenantId,
-        data.sessionId,
-      );
-      const source = this.activeSessions.get(
-        sessionKey(principal.tenantId, data.sessionId),
-      );
-      let forked: ISession;
-      if (source) {
-        forked = await source.session.fork({ messageId: data.messageId });
-      } else {
-        const options = await this.resolveSessionOptions({
-          principal,
-          operation: 'fork',
-          sessionId: data.sessionId,
-          metadata: sourceRecord.metadata,
-        });
-        forked = await forkSession({
-          ...options,
-          sessionId: data.sessionId,
-          messageId: data.messageId,
-        });
-      }
-      const now = new Date().toISOString();
-      const record: AgentServerSessionRecord = {
-        tenantId: principal.tenantId,
-        createdBy: principal.subject,
-        sessionId: forked.sessionId,
-        status: 'active',
-        createdAt: now,
-        updatedAt: now,
-        metadata: data.metadata ?? sourceRecord.metadata,
-      };
-      try {
-        await this.store.putSession(record);
-      } catch (error) {
-        await forked.close().catch(() => undefined);
-        throw error;
-      }
-      this.activeSessions.set(sessionKey(principal.tenantId, forked.sessionId), {
-        tenantId: principal.tenantId,
-        session: forked,
-        metadata: record.metadata,
-      });
-      return this.success(commandId, { session: record });
-    } finally {
-      releaseCapacity();
-    }
-  }
-
-  private async submit(
-    commandId: string,
-    principal: AgentPrincipal,
-    data: Extract<AgentCommand, { type: 'input.submit' }>['data'],
-  ): Promise<AgentCommandResult> {
-    const managed = this.requireActiveSession(principal.tenantId, data.sessionId);
-    const submission = await managed.session.send(data.input, {
-      priority: data.priority,
-      expectedRequestId: data.expectedRequestId,
-      maxTurns: data.maxTurns,
-    });
-    if (submission.status === 'started') {
-      managed.activeRequestId = submission.requestId;
-      this.startPump(managed);
-    }
-    return this.success(commandId, {
-      sessionId: data.sessionId,
-      ...submission,
-    });
-  }
-
-  private async abort(
-    commandId: string,
-    principal: AgentPrincipal,
-    sessionId: SessionId,
-  ): Promise<AgentCommandResult> {
-    const managed = this.requireActiveSession(principal.tenantId, sessionId);
-    await managed.session.abort();
-    return this.success(commandId, { sessionId, aborted: true });
-  }
-
-  private async closeSession(
-    commandId: string,
-    principal: AgentPrincipal,
-    sessionId: SessionId,
-  ): Promise<AgentCommandResult> {
-    const record = await this.requireSessionRecord(principal.tenantId, sessionId);
-    const key = sessionKey(principal.tenantId, sessionId);
-    const managed = this.activeSessions.get(key);
-    this.approvals.cancelSession(
-      principal.tenantId,
-      sessionId,
-      new Error('Session closed'),
-    );
-    await managed?.session.close();
-    this.activeSessions.delete(key);
-    const updated: AgentServerSessionRecord = {
-      ...record,
-      status: 'closed',
-      updatedAt: new Date().toISOString(),
-    };
-    await this.store.putSession(updated);
-    await this.publish(principal.tenantId, sessionId, 'session.closed', {
-      reason: 'user',
-    });
-    return this.success(commandId, { session: updated });
-  }
-
-  private startPump(managed: ManagedSession): void {
-    if (managed.pump) {
-      return;
-    }
-    managed.pump = this.pump(managed)
-      .catch(async () => {
-        await managed.session.abort().catch(() => undefined);
-      })
-      .finally(() => {
-        managed.pump = undefined;
-        managed.activeRequestId = undefined;
-      });
-  }
-
-  private async pump(managed: ManagedSession): Promise<void> {
-    try {
-      do {
-        for await (const message of managed.session.stream()) {
-          await this.publish(
-            managed.tenantId,
-            managed.session.sessionId,
-            'session.stream',
-            message,
-            'requestId' in message ? message.requestId : managed.activeRequestId,
-          );
-        }
-      } while (
-        !managed.session.isClosed &&
-        managed.session.getPendingInputs().length > 0
-      );
-    } catch (error) {
-      const message: StreamMessage = {
-        type: 'error',
-        message: getErrorMessage(error),
-        code: getErrorCode(error),
-        sessionId: managed.session.sessionId,
-      };
-      await this.publish(
-        managed.tenantId,
-        managed.session.sessionId,
-        'session.stream',
-        message,
-        managed.activeRequestId,
-      );
-    }
   }
 
   private async publish(
@@ -791,44 +520,6 @@ export class AgentServer {
     }
   }
 
-  private async resolveSessionOptions(
-    context: AgentServerSessionContext,
-  ): Promise<SessionOptions> {
-    const options = await this.options.resolveSessionOptions(context);
-    if (this.options.requirePersistentSessions && !options.sessionRepository) {
-      throw new AgentProtocolError(
-        'SESSION_CONFLICT',
-        'This server requires a persistent sessionRepository',
-        409,
-      );
-    }
-    const configuredFactory = options.confirmationHandlerFactory;
-    const configuredHandler = options.confirmationHandler;
-    return {
-      ...options,
-      confirmationHandler: undefined,
-      confirmationHandlerFactory: (sessionId) =>
-        configuredFactory?.(sessionId)
-        ?? configuredHandler
-        ?? this.approvals.createHandler(context.principal.tenantId, sessionId),
-    };
-  }
-
-  private requireActiveSession(
-    tenantId: string,
-    sessionId: SessionId,
-  ): ManagedSession {
-    const session = this.activeSessions.get(sessionKey(tenantId, sessionId));
-    if (!session) {
-      throw new AgentProtocolError(
-        'SESSION_NOT_FOUND',
-        `Session ${sessionId} is not active; resume it before issuing this command`,
-        404,
-      );
-    }
-    return session;
-  }
-
   private async requireSessionRecord(
     tenantId: string,
     sessionId: SessionId,
@@ -842,35 +533,6 @@ export class AgentServer {
       );
     }
     return record;
-  }
-
-  private reserveSessionCapacity(tenantId: string): () => void {
-    const active = Array.from(this.activeSessions.values())
-      .filter((session) => session.tenantId === tenantId).length;
-    const reserved = this.sessionReservations.get(tenantId) ?? 0;
-    if (active + reserved >= this.maxActiveSessionsPerTenant) {
-      throw new AgentProtocolError(
-        'OVERLOADED',
-        'Tenant active Session limit exceeded',
-        503,
-        true,
-        1000,
-      );
-    }
-    this.sessionReservations.set(tenantId, reserved + 1);
-    let released = false;
-    return () => {
-      if (released) {
-        return;
-      }
-      released = true;
-      const remaining = (this.sessionReservations.get(tenantId) ?? 1) - 1;
-      if (remaining === 0) {
-        this.sessionReservations.delete(tenantId);
-      } else {
-        this.sessionReservations.set(tenantId, remaining);
-      }
-    };
   }
 
   private authorize(principal: AgentPrincipal, command: AgentCommand): void {
@@ -900,24 +562,6 @@ export class AgentServer {
         401,
       );
     }
-  }
-
-  private runForSession<T>(
-    principal: AgentPrincipal,
-    sessionId: SessionId,
-    operation: () => Promise<T>,
-  ): Promise<T> {
-    const key = sessionKey(principal.tenantId, sessionId);
-    const previous = this.sessionOperations.get(key) ?? Promise.resolve();
-    const current = previous.catch(() => undefined).then(operation);
-    const marker = current.then(() => undefined, () => undefined);
-    this.sessionOperations.set(key, marker);
-    void marker.finally(() => {
-      if (this.sessionOperations.get(key) === marker) {
-        this.sessionOperations.delete(key);
-      }
-    });
-    return current;
   }
 
   private async waitForEvents(

--- a/src/server/SessionExecutor.ts
+++ b/src/server/SessionExecutor.ts
@@ -1,0 +1,596 @@
+import { AgentProtocolError } from '../protocol/AgentProtocolError.js';
+import type {
+  AbortRequestCommand,
+  AgentInputSubmissionData,
+  AgentPrincipal,
+  AgentServerEvent,
+  CloseSessionCommand,
+  CreateSessionCommand,
+  ForkSessionCommand,
+  ReadSessionCommand,
+  ResolvePermissionCommand,
+  ResumeSessionCommand,
+  SubmitInputCommand,
+} from '../protocol/index.js';
+import type { Message } from '../services/ChatServiceInterface.js';
+import {
+  createSession,
+  forkSession,
+  resumeSession,
+} from '../session/Session.js';
+import type {
+  ISession,
+  PendingSessionInput,
+  SessionOptions,
+  StreamMessage,
+} from '../session/types.js';
+import type {
+  RequestId,
+  SessionId,
+} from '../types/branded.js';
+import type { JsonObject } from '../types/common.js';
+import {
+  getErrorCode,
+  getErrorMessage,
+} from '../utils/errorUtils.js';
+import type {
+  AgentServerSessionRecord,
+  AgentServerStore,
+} from './AgentServerStore.js';
+import { RemoteApprovalBroker } from './RemoteApprovalBroker.js';
+
+export interface AgentServerSessionContext {
+  readonly principal: AgentPrincipal;
+  readonly operation: 'create' | 'resume' | 'fork';
+  readonly sessionId?: SessionId;
+  readonly metadata?: JsonObject;
+}
+
+export interface SessionExecutorCommandContext {
+  readonly principal: AgentPrincipal;
+  readonly commandId: string;
+  readonly signal?: AbortSignal;
+}
+
+export interface SessionExecutorReadResult {
+  readonly session: AgentServerSessionRecord;
+  readonly messages: readonly Message[];
+  readonly pendingInputs: readonly PendingSessionInput[];
+}
+
+export type SessionExecutorEventPublisher = (
+  tenantId: string,
+  sessionId: SessionId,
+  type: AgentServerEvent['type'],
+  data: AgentServerEvent['data'],
+  requestId?: RequestId,
+) => Promise<void>;
+
+/**
+ * Runtime boundary between command transport and Session execution.
+ *
+ * Implementations own active execution state, per-Session serialization,
+ * approval correlation, and runtime shutdown. They must publish stream events
+ * through the event publisher associated with the AgentServerStore used by the
+ * transport.
+ */
+export interface SessionExecutor {
+  create(
+    context: SessionExecutorCommandContext,
+    data: CreateSessionCommand['data'],
+  ): Promise<AgentServerSessionRecord>;
+  read(
+    context: SessionExecutorCommandContext,
+    data: ReadSessionCommand['data'],
+  ): Promise<SessionExecutorReadResult>;
+  resume(
+    context: SessionExecutorCommandContext,
+    data: ResumeSessionCommand['data'],
+  ): Promise<AgentServerSessionRecord>;
+  fork(
+    context: SessionExecutorCommandContext,
+    data: ForkSessionCommand['data'],
+  ): Promise<AgentServerSessionRecord>;
+  submit(
+    context: SessionExecutorCommandContext,
+    data: SubmitInputCommand['data'],
+  ): Promise<AgentInputSubmissionData>;
+  abort(
+    context: SessionExecutorCommandContext,
+    data: AbortRequestCommand['data'],
+  ): Promise<void>;
+  closeSession(
+    context: SessionExecutorCommandContext,
+    data: CloseSessionCommand['data'],
+  ): Promise<AgentServerSessionRecord>;
+  resolvePermission(
+    context: SessionExecutorCommandContext,
+    data: ResolvePermissionCommand['data'],
+  ): Promise<void>;
+  shutdown(): Promise<void>;
+}
+
+export interface InProcessSessionExecutorOptions {
+  readonly store: AgentServerStore;
+  readonly resolveSessionOptions: (
+    context: AgentServerSessionContext,
+  ) => SessionOptions | Promise<SessionOptions>;
+  readonly publish: SessionExecutorEventPublisher;
+  readonly maxActiveSessionsPerTenant?: number;
+  readonly approvalTimeoutMs?: number;
+  readonly requirePersistentSessions?: boolean;
+}
+
+interface ManagedSession {
+  readonly tenantId: string;
+  readonly session: ISession;
+  readonly metadata?: JsonObject;
+  pump?: Promise<void>;
+  activeRequestId?: RequestId;
+}
+
+function sessionKey(tenantId: string, sessionId: SessionId): string {
+  return `${tenantId}\0${sessionId}`;
+}
+
+export class InProcessSessionExecutor implements SessionExecutor {
+  private readonly activeSessions = new Map<string, ManagedSession>();
+  private readonly sessionReservations = new Map<string, number>();
+  private readonly sessionOperations = new Map<string, Promise<void>>();
+  private readonly approvals: RemoteApprovalBroker;
+  private readonly maxActiveSessionsPerTenant: number;
+
+  constructor(private readonly options: InProcessSessionExecutorOptions) {
+    this.maxActiveSessionsPerTenant =
+      options.maxActiveSessionsPerTenant ?? 100;
+    if (
+      !Number.isSafeInteger(this.maxActiveSessionsPerTenant)
+      || this.maxActiveSessionsPerTenant < 1
+    ) {
+      throw new RangeError(
+        'maxActiveSessionsPerTenant must be a positive safe integer',
+      );
+    }
+    this.approvals = new RemoteApprovalBroker({
+      timeoutMs: options.approvalTimeoutMs,
+      publish: (tenantId, sessionId, request) =>
+        options.publish(
+          tenantId,
+          sessionId,
+          'permission.requested',
+          request,
+        ),
+    });
+  }
+
+  async create(
+    context: SessionExecutorCommandContext,
+    data: CreateSessionCommand['data'],
+  ): Promise<AgentServerSessionRecord> {
+    const releaseCapacity = this.reserveSessionCapacity(
+      context.principal.tenantId,
+    );
+    try {
+      const options = await this.resolveSessionOptions({
+        principal: context.principal,
+        operation: 'create',
+        metadata: data.metadata,
+      });
+      const session = await createSession(options);
+      const now = new Date().toISOString();
+      const record: AgentServerSessionRecord = {
+        tenantId: context.principal.tenantId,
+        createdBy: context.principal.subject,
+        sessionId: session.sessionId,
+        status: 'active',
+        createdAt: now,
+        updatedAt: now,
+        metadata: data.metadata,
+      };
+      try {
+        await this.options.store.putSession(record);
+      } catch (error) {
+        await session.close().catch(() => undefined);
+        throw error;
+      }
+      this.activeSessions.set(
+        sessionKey(context.principal.tenantId, session.sessionId),
+        {
+          tenantId: context.principal.tenantId,
+          session,
+          metadata: data.metadata,
+        },
+      );
+      return record;
+    } finally {
+      releaseCapacity();
+    }
+  }
+
+  read(
+    context: SessionExecutorCommandContext,
+    data: ReadSessionCommand['data'],
+  ): Promise<SessionExecutorReadResult> {
+    return this.runForSession(context.principal, data.sessionId, async () => {
+      const record = await this.requireSessionRecord(
+        context.principal.tenantId,
+        data.sessionId,
+      );
+      const managed = this.activeSessions.get(
+        sessionKey(context.principal.tenantId, data.sessionId),
+      );
+      return {
+        session: record,
+        messages: managed?.session.messages ?? [],
+        pendingInputs: managed?.session.getPendingInputs() ?? [],
+      };
+    });
+  }
+
+  resume(
+    context: SessionExecutorCommandContext,
+    data: ResumeSessionCommand['data'],
+  ): Promise<AgentServerSessionRecord> {
+    return this.runForSession(context.principal, data.sessionId, async () => {
+      const existing = this.activeSessions.get(
+        sessionKey(context.principal.tenantId, data.sessionId),
+      );
+      if (existing) {
+        return this.requireSessionRecord(
+          context.principal.tenantId,
+          data.sessionId,
+        );
+      }
+      const releaseCapacity = this.reserveSessionCapacity(
+        context.principal.tenantId,
+      );
+      try {
+        const record = await this.requireSessionRecord(
+          context.principal.tenantId,
+          data.sessionId,
+        );
+        if (record.status === 'closed') {
+          throw new AgentProtocolError(
+            'SESSION_CONFLICT',
+            'Session is closed',
+            409,
+          );
+        }
+        const options = await this.resolveSessionOptions({
+          principal: context.principal,
+          operation: 'resume',
+          sessionId: data.sessionId,
+          metadata: record.metadata,
+        });
+        const session = await resumeSession({
+          ...options,
+          sessionId: data.sessionId,
+        });
+        this.activeSessions.set(
+          sessionKey(context.principal.tenantId, data.sessionId),
+          {
+            tenantId: context.principal.tenantId,
+            session,
+            metadata: record.metadata,
+          },
+        );
+        return record;
+      } finally {
+        releaseCapacity();
+      }
+    });
+  }
+
+  fork(
+    context: SessionExecutorCommandContext,
+    data: ForkSessionCommand['data'],
+  ): Promise<AgentServerSessionRecord> {
+    return this.runForSession(context.principal, data.sessionId, async () => {
+      const releaseCapacity = this.reserveSessionCapacity(
+        context.principal.tenantId,
+      );
+      try {
+        const sourceRecord = await this.requireSessionRecord(
+          context.principal.tenantId,
+          data.sessionId,
+        );
+        const source = this.activeSessions.get(
+          sessionKey(context.principal.tenantId, data.sessionId),
+        );
+        let forked: ISession;
+        if (source) {
+          forked = await source.session.fork({ messageId: data.messageId });
+        } else {
+          const options = await this.resolveSessionOptions({
+            principal: context.principal,
+            operation: 'fork',
+            sessionId: data.sessionId,
+            metadata: sourceRecord.metadata,
+          });
+          forked = await forkSession({
+            ...options,
+            sessionId: data.sessionId,
+            messageId: data.messageId,
+          });
+        }
+        const now = new Date().toISOString();
+        const record: AgentServerSessionRecord = {
+          tenantId: context.principal.tenantId,
+          createdBy: context.principal.subject,
+          sessionId: forked.sessionId,
+          status: 'active',
+          createdAt: now,
+          updatedAt: now,
+          metadata: data.metadata ?? sourceRecord.metadata,
+        };
+        try {
+          await this.options.store.putSession(record);
+        } catch (error) {
+          await forked.close().catch(() => undefined);
+          throw error;
+        }
+        this.activeSessions.set(
+          sessionKey(context.principal.tenantId, forked.sessionId),
+          {
+            tenantId: context.principal.tenantId,
+            session: forked,
+            metadata: record.metadata,
+          },
+        );
+        return record;
+      } finally {
+        releaseCapacity();
+      }
+    });
+  }
+
+  submit(
+    context: SessionExecutorCommandContext,
+    data: SubmitInputCommand['data'],
+  ): Promise<AgentInputSubmissionData> {
+    return this.runForSession(context.principal, data.sessionId, async () => {
+      const managed = this.requireActiveSession(
+        context.principal.tenantId,
+        data.sessionId,
+      );
+      const submission = await managed.session.send(data.input, {
+        priority: data.priority,
+        expectedRequestId: data.expectedRequestId,
+        maxTurns: data.maxTurns,
+      });
+      if (submission.status === 'started') {
+        managed.activeRequestId = submission.requestId;
+        this.startPump(managed);
+      }
+      return {
+        sessionId: data.sessionId,
+        ...submission,
+      };
+    });
+  }
+
+  abort(
+    context: SessionExecutorCommandContext,
+    data: AbortRequestCommand['data'],
+  ): Promise<void> {
+    return this.runForSession(context.principal, data.sessionId, async () => {
+      const managed = this.requireActiveSession(
+        context.principal.tenantId,
+        data.sessionId,
+      );
+      await managed.session.abort();
+    });
+  }
+
+  closeSession(
+    context: SessionExecutorCommandContext,
+    data: CloseSessionCommand['data'],
+  ): Promise<AgentServerSessionRecord> {
+    return this.runForSession(context.principal, data.sessionId, async () => {
+      const record = await this.requireSessionRecord(
+        context.principal.tenantId,
+        data.sessionId,
+      );
+      const key = sessionKey(context.principal.tenantId, data.sessionId);
+      const managed = this.activeSessions.get(key);
+      this.approvals.cancelSession(
+        context.principal.tenantId,
+        data.sessionId,
+        new Error('Session closed'),
+      );
+      await managed?.session.close();
+      this.activeSessions.delete(key);
+      const updated: AgentServerSessionRecord = {
+        ...record,
+        status: 'closed',
+        updatedAt: new Date().toISOString(),
+      };
+      await this.options.store.putSession(updated);
+      await this.options.publish(
+        context.principal.tenantId,
+        data.sessionId,
+        'session.closed',
+        { reason: 'user' },
+      );
+      return updated;
+    });
+  }
+
+  resolvePermission(
+    context: SessionExecutorCommandContext,
+    data: ResolvePermissionCommand['data'],
+  ): Promise<void> {
+    return this.runForSession(context.principal, data.sessionId, async () => {
+      this.approvals.resolve(
+        context.principal.tenantId,
+        data.sessionId,
+        data.permissionRequestId,
+        {
+          approved: data.approved,
+          reason: data.reason,
+          scope: data.scope,
+        },
+      );
+    });
+  }
+
+  async shutdown(): Promise<void> {
+    const sessions = Array.from(this.activeSessions.values());
+    this.activeSessions.clear();
+    await Promise.allSettled(sessions.map(async ({ tenantId, session }) => {
+      this.approvals.cancelSession(
+        tenantId,
+        session.sessionId,
+        new Error('Session executor is shutting down'),
+      );
+      await session.close();
+    }));
+  }
+
+  private startPump(managed: ManagedSession): void {
+    if (managed.pump) {
+      return;
+    }
+    managed.pump = this.pump(managed)
+      .catch(async () => {
+        await managed.session.abort().catch(() => undefined);
+      })
+      .finally(() => {
+        managed.pump = undefined;
+        managed.activeRequestId = undefined;
+      });
+  }
+
+  private async pump(managed: ManagedSession): Promise<void> {
+    try {
+      do {
+        for await (const message of managed.session.stream()) {
+          await this.options.publish(
+            managed.tenantId,
+            managed.session.sessionId,
+            'session.stream',
+            message,
+            'requestId' in message ? message.requestId : managed.activeRequestId,
+          );
+        }
+      } while (
+        !managed.session.isClosed
+        && managed.session.getPendingInputs().length > 0
+      );
+    } catch (error) {
+      const message: StreamMessage = {
+        type: 'error',
+        message: getErrorMessage(error),
+        code: getErrorCode(error),
+        sessionId: managed.session.sessionId,
+      };
+      await this.options.publish(
+        managed.tenantId,
+        managed.session.sessionId,
+        'session.stream',
+        message,
+        managed.activeRequestId,
+      );
+    }
+  }
+
+  private async resolveSessionOptions(
+    context: AgentServerSessionContext,
+  ): Promise<SessionOptions> {
+    const options = await this.options.resolveSessionOptions(context);
+    if (this.options.requirePersistentSessions && !options.sessionRepository) {
+      throw new AgentProtocolError(
+        'SESSION_CONFLICT',
+        'This executor requires a persistent sessionRepository',
+        409,
+      );
+    }
+    const configuredFactory = options.confirmationHandlerFactory;
+    const configuredHandler = options.confirmationHandler;
+    return {
+      ...options,
+      confirmationHandler: undefined,
+      confirmationHandlerFactory: (sessionId) =>
+        configuredFactory?.(sessionId)
+        ?? configuredHandler
+        ?? this.approvals.createHandler(context.principal.tenantId, sessionId),
+    };
+  }
+
+  private requireActiveSession(
+    tenantId: string,
+    sessionId: SessionId,
+  ): ManagedSession {
+    const session = this.activeSessions.get(sessionKey(tenantId, sessionId));
+    if (!session) {
+      throw new AgentProtocolError(
+        'SESSION_NOT_FOUND',
+        `Session ${sessionId} is not active; resume it before issuing this command`,
+        404,
+      );
+    }
+    return session;
+  }
+
+  private async requireSessionRecord(
+    tenantId: string,
+    sessionId: SessionId,
+  ): Promise<AgentServerSessionRecord> {
+    const record = await this.options.store.getSession(tenantId, sessionId);
+    if (!record) {
+      throw new AgentProtocolError(
+        'SESSION_NOT_FOUND',
+        `Session ${sessionId} was not found`,
+        404,
+      );
+    }
+    return record;
+  }
+
+  private reserveSessionCapacity(tenantId: string): () => void {
+    const active = Array.from(this.activeSessions.values())
+      .filter((session) => session.tenantId === tenantId).length;
+    const reserved = this.sessionReservations.get(tenantId) ?? 0;
+    if (active + reserved >= this.maxActiveSessionsPerTenant) {
+      throw new AgentProtocolError(
+        'OVERLOADED',
+        'Tenant active Session limit exceeded',
+        503,
+        true,
+        1000,
+      );
+    }
+    this.sessionReservations.set(tenantId, reserved + 1);
+    let released = false;
+    return () => {
+      if (released) {
+        return;
+      }
+      released = true;
+      const remaining = (this.sessionReservations.get(tenantId) ?? 1) - 1;
+      if (remaining === 0) {
+        this.sessionReservations.delete(tenantId);
+      } else {
+        this.sessionReservations.set(tenantId, remaining);
+      }
+    };
+  }
+
+  private runForSession<T>(
+    principal: AgentPrincipal,
+    sessionId: SessionId,
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    const key = sessionKey(principal.tenantId, sessionId);
+    const previous = this.sessionOperations.get(key) ?? Promise.resolve();
+    const current = previous.catch(() => undefined).then(operation);
+    const marker = current.then(() => undefined, () => undefined);
+    this.sessionOperations.set(key, marker);
+    void marker.finally(() => {
+      if (this.sessionOperations.get(key) === marker) {
+        this.sessionOperations.delete(key);
+      }
+    });
+    return current;
+  }
+}

--- a/src/server/__tests__/SessionExecutorBoundary.test.ts
+++ b/src/server/__tests__/SessionExecutorBoundary.test.ts
@@ -1,0 +1,192 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import {
+  AGENT_PROTOCOL_VERSION,
+  AgentCommandType,
+  type AgentCommand,
+  type AgentPrincipal,
+} from '../../protocol/index.js';
+import {
+  InputId,
+  PermissionRequestId,
+  RequestId,
+  SessionId,
+} from '../../types/branded.js';
+import { AgentServer } from '../AgentServer.js';
+import type {
+  SessionExecutor,
+  SessionExecutorCommandContext,
+} from '../SessionExecutor.js';
+
+const principal: AgentPrincipal = {
+  tenantId: 'tenant-a',
+  subject: 'user-a',
+  scopes: ['session:admin'],
+};
+
+const sessionId = SessionId('session-1');
+const forkedSessionId = SessionId('session-2');
+const now = '2026-08-25T00:00:00.000Z';
+
+function command<T extends AgentCommand>(
+  type: T['type'],
+  commandId: string,
+  data: T['data'],
+): T {
+  return {
+    protocolVersion: AGENT_PROTOCOL_VERSION,
+    commandId,
+    type,
+    data,
+  } as T;
+}
+
+function createExecutor() {
+  const calls: Array<{
+    method: string;
+    context?: SessionExecutorCommandContext;
+  }> = [];
+  const executor: SessionExecutor = {
+    async create(context) {
+      calls.push({ method: 'create', context });
+      return {
+        tenantId: principal.tenantId,
+        createdBy: principal.subject,
+        sessionId,
+        status: 'active',
+        createdAt: now,
+        updatedAt: now,
+      };
+    },
+    async read(context) {
+      calls.push({ method: 'read', context });
+      return {
+        session: {
+          tenantId: principal.tenantId,
+          createdBy: principal.subject,
+          sessionId,
+          status: 'active',
+          createdAt: now,
+          updatedAt: now,
+        },
+        messages: [],
+        pendingInputs: [],
+      };
+    },
+    async resume(context) {
+      calls.push({ method: 'resume', context });
+      return {
+        tenantId: principal.tenantId,
+        createdBy: principal.subject,
+        sessionId,
+        status: 'active',
+        createdAt: now,
+        updatedAt: now,
+      };
+    },
+    async fork(context) {
+      calls.push({ method: 'fork', context });
+      return {
+        tenantId: principal.tenantId,
+        createdBy: principal.subject,
+        sessionId: forkedSessionId,
+        status: 'active',
+        createdAt: now,
+        updatedAt: now,
+      };
+    },
+    async submit(context) {
+      calls.push({ method: 'submit', context });
+      return {
+        sessionId,
+        inputId: InputId('input-1'),
+        requestId: RequestId('request-1'),
+        status: 'started',
+      };
+    },
+    async abort(context) {
+      calls.push({ method: 'abort', context });
+    },
+    async closeSession(context) {
+      calls.push({ method: 'closeSession', context });
+      return {
+        tenantId: principal.tenantId,
+        createdBy: principal.subject,
+        sessionId,
+        status: 'closed',
+        createdAt: now,
+        updatedAt: now,
+      };
+    },
+    async resolvePermission(context) {
+      calls.push({ method: 'resolvePermission', context });
+    },
+    async shutdown() {
+      calls.push({ method: 'shutdown' });
+    },
+  };
+  return { executor, calls };
+}
+
+describe('SessionExecutor boundary', () => {
+  it('routes every Session command through an injected executor', async () => {
+    const { executor, calls } = createExecutor();
+    const server = new AgentServer({ sessionExecutor: executor });
+    const commands: AgentCommand[] = [
+      command(AgentCommandType.SESSION_CREATE, 'create-1', {}),
+      command(AgentCommandType.SESSION_READ, 'read-1', { sessionId }),
+      command(AgentCommandType.SESSION_RESUME, 'resume-1', { sessionId }),
+      command(AgentCommandType.SESSION_FORK, 'fork-1', { sessionId }),
+      command(AgentCommandType.INPUT_SUBMIT, 'submit-1', {
+        sessionId,
+        input: 'hello',
+      }),
+      command(AgentCommandType.REQUEST_ABORT, 'abort-1', { sessionId }),
+      command(AgentCommandType.PERMISSION_RESOLVE, 'permission-1', {
+        sessionId,
+        permissionRequestId: PermissionRequestId('approval-1'),
+        approved: true,
+      }),
+      command(AgentCommandType.SESSION_CLOSE, 'close-1', { sessionId }),
+    ];
+
+    for (const agentCommand of commands) {
+      await expect(server.execute(agentCommand, principal)).resolves.toMatchObject({
+        ok: true,
+        commandId: agentCommand.commandId,
+      });
+    }
+    await server.close();
+
+    expect(calls.map(({ method }) => method)).toEqual([
+      'create',
+      'read',
+      'resume',
+      'fork',
+      'submit',
+      'abort',
+      'resolvePermission',
+      'closeSession',
+      'shutdown',
+    ]);
+    expect(calls.slice(0, -1).map(({ context }) => context?.commandId)).toEqual(
+      commands.map(({ commandId }) => commandId),
+    );
+  });
+
+  it('keeps AgentServer independent from Session implementation state', () => {
+    const source = readFileSync(
+      new URL('../AgentServer.ts', import.meta.url),
+      'utf8',
+    );
+
+    expect(source).not.toContain("../session/Session.js");
+    expect(source).not.toContain('activeSessions');
+  });
+
+  it('requires either an executor or a Session options resolver', () => {
+    expect(() => new AgentServer({} as never)).toThrow(
+      /sessionExecutor or resolveSessionOptions/,
+    );
+  });
+});

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -4,7 +4,6 @@ export * from '../index.js';
 export {
   AgentServer,
   type AgentServerOptions,
-  type AgentServerSessionContext,
 } from './AgentServer.js';
 export {
   type AgentCommandClaim,
@@ -23,6 +22,15 @@ export {
   OpenTelemetryAgentServerTelemetry,
   type OpenTelemetryAgentServerOptions,
 } from './OpenTelemetryAgentServerTelemetry.js';
+export {
+  type AgentServerSessionContext,
+  InProcessSessionExecutor,
+  type InProcessSessionExecutorOptions,
+  type SessionExecutor,
+  type SessionExecutorCommandContext,
+  type SessionExecutorEventPublisher,
+  type SessionExecutorReadResult,
+} from './SessionExecutor.js';
 export {
   type TenantAdmissionLimits,
   TenantAdmissionController,


### PR DESCRIPTION
## Summary
- add the injectable SessionExecutor contract and InProcessSessionExecutor reference implementation
- move Session lifecycle, active runtime state, stream pumping, approvals, and per-Session serialization out of AgentServer
- keep AgentServer focused on authentication, authorization, command handling, and HTTP/SSE
- declare esbuild directly so clean-worktree entrypoint verification is reproducible
- document the executor contract in English and Chinese

## Verification
- pnpm test (1766 passed, 63 credential-gated live tests skipped)
- pnpm run type-check
- pnpm run lint
- pnpm run verify:entrypoints
- pnpm run docs:build
- pnpm run changelog:check
- pnpm audit --prod --audit-level low