### PR TITLE
refactor(server): add PostgreSQL runtime store

### DIFF
--- a/.changes/postgres-runtime-store.json
+++ b/.changes/postgres-runtime-store.json
@@ -1,0 +1,5 @@
+{
+  "type": "refactor",
+  "en": "Add a PostgreSQL Runtime Store with atomic command, event, effect, and projection commits plus a public conformance suite.",
+  "zh-CN": "新增 PostgreSQL Runtime Store，原子提交 command、event、effect 与 projection，并提供公开 conformance suite。"
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,22 @@ jobs:
     name: Verify (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    env:
+      TEST_POSTGRES_URL: postgresql://postgres:postgres@127.0.0.1:5432/blade_agent_test
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_DB: blade_agent_test
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_USER: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d blade_agent_test"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
     strategy:
       matrix:
         node-version: ['22']

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
       - 'codex/**'
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   verify:
     name: Verify (Node ${{ matrix.node-version }})

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,22 @@ jobs:
     name: Publish package
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    env:
+      TEST_POSTGRES_URL: postgresql://postgres:postgres@127.0.0.1:5432/blade_agent_test
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_DB: blade_agent_test
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_USER: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d blade_agent_test"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
 
     steps:
       - name: Checkout repository

--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ import { composeMiddleware } from '@blade-ai/agent-sdk/middleware';
 ```
 
 - Root and `/server`: server-side agents; expose `AgentServer` with an injectable `SessionExecutor` and load only explicitly supplied capabilities
+- `/server/postgres`: shared PostgreSQL Runtime Store for commands, events, effects, projections, transcripts, and durable journals
+- `/server/testing`: framework-independent Runtime Store conformance suite
 - `/node`: Node.js runtimes with local host access; enables file, search, shell, and task tools plus local agent/Skill discovery, and exports Node host adapters
 - `/browser`: browser-safe `AgentClient`, protocol view, and explicit server-only execution stubs
 - `/protocol`: browser-safe versioned command/event contracts and strict parsers
@@ -148,8 +150,9 @@ Importing a server-only entry in a browser resolves to a stub that throws a clea
 
 ## Persistence and Workspace
 
-Sessions are ephemeral unless a `SessionRepository` is configured. The `/node`
-entry converts `storagePath` into a local JSONL repository:
+Sessions are ephemeral unless a read-side `SessionRepository` and write-side
+`SessionEventStore` are configured. The `/node` entry converts `storagePath`
+into one local JSONL `SessionPersistence` implementation:
 
 ```ts
 import { createSession } from '@blade-ai/agent-sdk/node';
@@ -170,9 +173,11 @@ const session = await createSession({
 ```
 
 The root and `/server` entries never interpret `storagePath` as local access.
-Server applications must inject `sessionRepository` explicitly. See
+Server applications must inject `sessionRepository` plus `sessionEventStore`,
+or configure one shared `runtimeStore`. See
 [Server Runtime](./docs/en/server-runtime.md) for the HTTP/SSE server,
 browser client, multi-tenant storage, idempotency, approvals, and telemetry.
+For multi-instance storage, see [Runtime Store](./docs/en/runtime-store.md).
 
 The workspace is optional. Sessions and explicitly configured agents work without one, but local filesystem tools and project-level discovery require a filesystem-capable workspace.
 
@@ -181,6 +186,7 @@ The workspace is optional. Sessions and explicitly configured agents work withou
 - [English documentation](./docs/en/index.md)
 - [Middleware and plugins](./docs/en/middleware.md)
 - [Server Runtime](./docs/en/server-runtime.md)
+- [Runtime Store](./docs/en/runtime-store.md)
 - [Durable Event Store](./docs/en/durable-events.md)
 - [中文文档](./docs/index.md)
 - [English changelog](./CHANGELOG.md)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -136,6 +136,8 @@ import { composeMiddleware } from '@blade-ai/agent-sdk/middleware';
 ```
 
 - 根入口与 `/server`：服务端 Agent；提供可注入 `SessionExecutor` 的 `AgentServer`，只加载显式传入的能力
+- `/server/postgres`：共享 PostgreSQL Runtime Store，统一承载 command、event、effect、projection、transcript 和 durable journal
+- `/server/testing`：不依赖测试框架的 Runtime Store conformance suite
 - `/node`：具备本机访问能力的 Node.js 运行时；默认加载文件、搜索、Shell、任务工具和本地 Agent/Skill 发现，并导出 Node 宿主适配器
 - `/browser`：browser-safe `AgentClient`、协议视图和明确的 server-only stub
 - `/protocol`：browser-safe 版本化 command/event 契约与 strict parser
@@ -148,8 +150,9 @@ import { composeMiddleware } from '@blade-ai/agent-sdk/middleware';
 
 ## 持久化与 Workspace
 
-未配置 `SessionRepository` 时，Session 只保存在内存中。`/node` 入口会把
-`storagePath` 转换成本地 JSONL repository：
+未同时配置只读 `SessionRepository` 与只写 `SessionEventStore` 时，Session
+只保存在内存中。`/node` 入口会把 `storagePath` 转换为同时实现两者的本地
+JSONL `SessionPersistence`：
 
 ```ts
 import { createSession } from '@blade-ai/agent-sdk/node';
@@ -170,8 +173,10 @@ const session = await createSession({
 ```
 
 根入口和 `/server` 不会把 `storagePath` 解释成本机访问权限；服务端应用必须显式
-注入 `sessionRepository`。HTTP/SSE 服务端、浏览器客户端、多租户存储、幂等、
+注入 `sessionRepository` 和 `sessionEventStore`，或配置共享 `runtimeStore`。
+HTTP/SSE 服务端、浏览器客户端、多租户存储、幂等、
 审批和遥测见 [Server Runtime](./docs/server-runtime.md)。
+多实例持久化见 [Runtime Store](./docs/runtime-store.md)。
 
 workspace 是可选的。没有 workspace 时，Session 和显式配置的 Agent 仍可工作，但本地文件工具和项目级发现需要具备文件系统能力的 workspace。
 
@@ -180,6 +185,7 @@ workspace 是可选的。没有 workspace 时，Session 和显式配置的 Agent
 - [中文文档](./docs/index.md)
 - [Middleware 与插件](./docs/middleware.md)
 - [Server Runtime](./docs/server-runtime.md)
+- [Runtime Store](./docs/runtime-store.md)
 - [Durable Event Store](./docs/durable-events.md)
 - [English documentation](./docs/en/index.md)
 - [中文更新日志](./CHANGELOG.zh-CN.md)

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -16,6 +16,7 @@ const zhSidebar = [
     items: [
       { text: 'Session 会话', link: '/session' },
       { text: 'Server Runtime', link: '/server-runtime' },
+      { text: 'Runtime Store', link: '/runtime-store' },
       { text: 'Durable Event Store', link: '/durable-events' },
       { text: '工具系统', link: '/tools' },
       { text: '权限控制', link: '/permissions' },
@@ -54,6 +55,7 @@ const enSidebar = [
     items: [
       { text: 'Session', link: '/en/session' },
       { text: 'Server Runtime', link: '/en/server-runtime' },
+      { text: 'Runtime Store', link: '/en/runtime-store' },
       { text: 'Durable Event Store', link: '/en/durable-events' },
       { text: 'Tools', link: '/en/tools' },
       { text: 'Permissions', link: '/en/permissions' },

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -10,6 +10,8 @@
 |------|---------|------|
 | `@blade-ai/agent-sdk` | Node.js server | 默认服务端入口；仅加载显式配置的工具、Agent、middleware 和 MCP |
 | `@blade-ai/agent-sdk/server` | Node.js server | 无隐式本机访问的服务端入口，行为等价于 root |
+| `@blade-ai/agent-sdk/server/postgres` | Node.js server | PostgreSQL Runtime Store adapter |
+| `@blade-ai/agent-sdk/server/testing` | Node.js test | Runtime Store conformance suite |
 | `@blade-ai/agent-sdk/node` | Node.js local process | 具备本机访问能力的入口；默认启用本地工具和工作区发现，并导出 Node 宿主适配器 |
 | `@blade-ai/agent-sdk/session` | Node.js server | 底层 Session API 子入口，采用 server profile |
 | `@blade-ai/agent-sdk/core` | Browser-safe / Node | 类型、协议、事件、常量，不导入 Node-only runtime |
@@ -73,6 +75,8 @@ Node-local 能力外，这些函数都从根入口导出；实际 subpath 以“
 | `InProcessSessionExecutor` | server | `SessionExecutor` 的进程内参考实现，负责 Session 生命周期与 stream pump |
 | `AgentClient` / `RemoteAgentSession` | browser | 带 command 重试和 SSE cursor 重连的远程客户端 |
 | `InMemoryAgentServerStore` | server | 单进程控制面参考 Store；不用于多实例生产部署 |
+| `PostgresRuntimeStore` | server/postgres | 共享 command、event、outbox、projection 和 Session persistence |
+| `RuntimeStoreError` | server | Runtime transaction 的稳定错误类型 |
 | `TenantAdmissionController` | server | 每 tenant 并发、队列和固定窗口限流 |
 | `OpenTelemetryAgentServerTelemetry` | server | 默认不采集 payload 的 metric、trace 与 audit adapter |
 | `JsonlSessionRepository` | node | Node.js transcript repository |
@@ -100,7 +104,9 @@ Node-local 能力外，这些函数都从根入口导出；实际 subpath 以“
 |------|------|
 | `ISession` | Session 实例接口 |
 | `SessionOptions` | Session 创建选项 |
-| `SessionRepository` | transcript append 与 read projection 的统一持久化端口 |
+| `SessionRepository` | transcript 的只读 projection 端口 |
+| `SessionEventStore` | transcript domain event append 端口 |
+| `SessionPersistence` | 组合 read projection 与 event append 的兼容端口 |
 | `SessionRepositoryMessageMetadata` / `SessionRepositoryCompactionMetadata` | repository 消息与 compaction append 元数据 |
 | `SessionRepositorySubagentInfo` / `SessionRepositorySubagentRef` | 子 Agent transcript 归属与结果引用 |
 | `SessionRepositoryHealth` / `SessionRepositoryStorageStats` | repository 健康与容量统计 |
@@ -141,8 +147,15 @@ Node-local 能力外，这些函数都从根入口导出；实际 subpath 以“
 | `AGENT_PROTOCOL_VERSION` / `AgentCommandType` | 协议版本与 command 常量 |
 | `parseAgentCommand` / `parseAgentCommandResult` | strict command envelope parser |
 | `parseAgentEventCursor` / `parseAgentServerEvent` | strict event/cursor parser |
+| `RuntimeStore` / `RuntimeTenantStore` | 共享 authority 与 tenant-scoped Session/durable adapter |
+| `RuntimeCommandCommit` / `RuntimeCommitResult` | 原子 command、event、effect、projection transaction |
+| `RuntimeDomainEvent` / `RuntimeDomainEventDraft` / `RuntimeDomainEventPage` | Runtime domain event stream |
+| `RuntimeEffectIntent` / `RuntimeEffectRecord` / `RuntimeEffectStatus` | Transactional outbox 类型 |
+| `RuntimeProjectionCheckpoint` / `RuntimeProjectionRecord` | Projection CAS 与 checkpoint |
+| `assertRuntimeStoreConformance` | 不依赖测试框架的公开 Store conformance suite |
 
-完整部署约束见 [Server Runtime](./server-runtime)。
+完整部署约束见 [Server Runtime](./server-runtime) 和
+[Runtime Store](./runtime-store)。
 
 ### Durable Events
 

--- a/docs/en/api-reference.md
+++ b/docs/en/api-reference.md
@@ -12,6 +12,8 @@ split npm dependencies into separate packages.
 |-------|---------|----------|
 | `@blade-ai/agent-sdk` | Node.js server | Server-first Session API; only explicit tools, agents, middleware, and MCP servers are loaded |
 | `@blade-ai/agent-sdk/server` | Node.js server | Server entry without implicit local host access, equivalent to root |
+| `@blade-ai/agent-sdk/server/postgres` | Node.js server | PostgreSQL Runtime Store adapter |
+| `@blade-ai/agent-sdk/server/testing` | Node.js test | Runtime Store conformance suite |
 | `@blade-ai/agent-sdk/node` | Local Node.js process | Entry with local tools, workspace discovery, and Node host adapters enabled |
 | `@blade-ai/agent-sdk/session` | Node.js server | Lower-level Session functions and types using the server profile |
 | `@blade-ai/agent-sdk/core` | Browser and Node.js | Browser-safe contracts, constants, and types |
@@ -42,7 +44,8 @@ Types:
 `PendingSessionInput`, `PromptResult`, `ProviderAdapter`, `ProviderConfig`,
 `ProviderRegistryErrorCode`, `ProviderType`,
 `ResumeOptions`, `SendOptions`, `SessionHandoffErrorCode`,
-`SessionHandoffResult`, `SessionOptions`, `SessionRepository`, `SessionTool`, `StreamMessage`,
+`SessionHandoffResult`, `SessionOptions`, `SessionRepository`,
+`SessionEventStore`, `SessionPersistence`, `SessionTool`, `StreamMessage`,
 `StreamOptions`, `SubagentInfo`, `TokenUsage`, `ToolCallRecord`,
 `ToolDefinition`, and `ToolResult`.
 
@@ -87,6 +90,8 @@ Runtime:
 - `AgentClient`
 - `RemoteAgentSession`
 - `InMemoryAgentServerStore`
+- `PostgresRuntimeStore`
+- `RuntimeStoreError`
 - `TenantAdmissionController`
 - `OpenTelemetryAgentServerTelemetry`
 - `JsonlSessionRepository` (`/node` only)
@@ -108,6 +113,18 @@ Types:
 - `SessionExecutorReadResult`
 - `InProcessSessionExecutorOptions`
 - `AgentServerStore`
+- `RuntimeStore`
+- `RuntimeTenantStore`
+- `RuntimeCommandCommit`
+- `RuntimeCommitResult`
+- `RuntimeDomainEvent`
+- `RuntimeDomainEventDraft`
+- `RuntimeDomainEventPage`
+- `RuntimeEffectIntent`
+- `RuntimeEffectRecord`
+- `RuntimeEffectStatus`
+- `RuntimeProjectionCheckpoint`
+- `RuntimeProjectionRecord`
 - `AgentCommandClaim`
 - `AgentServerSessionRecord`
 - `AgentServerTelemetry`
@@ -125,8 +142,10 @@ Types:
 - `AgentProtocolCapabilities`
 - `AgentClientCapabilities`
 - `AgentProtocolErrorCode`
+- `assertRuntimeStoreConformance` (`/server/testing`)
 
-See [Server Runtime](./server-runtime) for deployment and failure semantics.
+See [Server Runtime](./server-runtime) and [Runtime Store](./runtime-store) for
+deployment and failure semantics.
 
 ## Durable Events
 

--- a/docs/en/runtime-store.md
+++ b/docs/en/runtime-store.md
@@ -1,0 +1,185 @@
+# Runtime Store
+
+`RuntimeStore` is the shared persistence boundary for server-hosted agents. It
+commits command receipts, domain events, effect intents, and projection
+checkpoints in one transaction while exposing adapters for `AgentServer`,
+Session transcripts, and the durable execution journal.
+
+## Install and import
+
+```bash
+pnpm add @blade-ai/agent-sdk
+```
+
+```ts
+import { AgentServer } from '@blade-ai/agent-sdk/server';
+import { PostgresRuntimeStore } from '@blade-ai/agent-sdk/server/postgres';
+
+const runtimeStore = new PostgresRuntimeStore({
+  connectionString: process.env.DATABASE_URL!,
+});
+
+const server = new AgentServer({
+  runtimeStore,
+  authenticate,
+  resolveSessionOptions: () => ({
+    provider,
+    model,
+  }),
+  requirePersistentSessions: true,
+});
+```
+
+When `runtimeStore` is present, the default `InProcessSessionExecutor` scopes
+it with the authenticated `tenantId` and uses that same Store as:
+
+- `SessionRepository`, the read-only transcript projection.
+- `SessionEventStore`, the transcript event append port.
+- `DurableEventStore`, the Request, Turn, model, tool, and approval journal.
+- `AgentServerStore`, the command receipt, remote event, and Session record store.
+
+Once `runtimeStore` is configured, Session-level repository, event Store, or
+durable Store overrides are rejected with `SESSION_CONFLICT`. This prevents
+multiple persistence authorities from reintroducing dual writes.
+
+## Transaction model
+
+```ts
+const claim = await runtimeStore.claimCommand(
+  tenantId,
+  commandId,
+  commandFingerprint,
+  30_000,
+);
+
+if (claim.status !== 'claimed') {
+  throw new Error(`Unexpected claim: ${claim.status}`);
+}
+
+await runtimeStore.sealCommand(tenantId, commandId, claim.leaseId);
+
+await runtimeStore.commitRuntimeTransaction({
+  tenantId,
+  sessionId,
+  command: {
+    commandId,
+    fingerprint: commandFingerprint,
+    leaseId: claim.leaseId,
+    result: {
+      protocolVersion: 1,
+      commandId,
+      ok: true,
+      data: { accepted: true },
+    },
+  },
+  expectedLastSequence: null,
+  events: [{
+    type: 'request.accepted',
+    data: { requestId: 'request-1' },
+  }],
+  effects: [{
+    effectId: 'effect-1',
+    type: 'tool.execute',
+    payload: { toolName: 'Search' },
+    idempotencyKey: 'request-1:tool-1',
+  }],
+  projection: {
+    name: 'request',
+    expectedOffset: null,
+    offset: 1,
+    state: { status: 'accepted' },
+  },
+});
+```
+
+One PostgreSQL transaction:
+
+1. Validates the command fingerprint and optional lease.
+2. Compare-and-appends domain events.
+3. Inserts effect intents with unique idempotency keys.
+4. CAS-updates projection state and offset.
+5. Marks the command receipt completed with its deterministic result.
+
+Any failure rolls back every write. Retrying a completed command returns
+`status: 'replayed'` without duplicating events or effects. Reusing a command ID
+for a different payload throws `RUNTIME_STORE_COMMAND_CONFLICT`.
+
+## PostgreSQL schema
+
+`PostgresRuntimeStore.initialize()` idempotently creates seven tables:
+
+| Table | Purpose |
+|-------|---------|
+| `*_metadata` | Runtime Store schema version |
+| `*_commands` | Command fingerprint, lease, state, and deterministic result |
+| `*_sessions` | Tenant-scoped Session records |
+| `*_stream_heads` | Monotonic sequence per Session and stream |
+| `*_events` | `agent`, `domain`, `durable`, and `transcript` events |
+| `*_outbox` | Effect intents waiting for execution |
+| `*_projections` | Projection state and consumed offset |
+
+`schema` and `tablePrefix` accept PostgreSQL identifiers only. Data values use
+parameterized queries. Concurrent command and stream writes use
+transaction-scoped advisory locks. PostgreSQL is authoritative; Redis is not in
+the correctness path.
+
+`InMemoryAgentServerStore` remains a test and single-process implementation. Do
+not combine it with PostgreSQL transcript storage in production.
+
+## Session projection
+
+`SessionRepository` now describes only the read/projection API.
+`SessionEventStore` describes transcript appends, while `SessionPersistence`
+combines both for compatibility. The existing `JsonlSessionRepository`
+continues to implement the combined interface, so local Node.js usage is
+unchanged.
+
+```ts
+interface SessionRepository extends SessionStore {
+  initialize(): Promise<void>;
+  deleteSession(sessionId: SessionId): Promise<void>;
+  cleanupOldSessions(): Promise<void>;
+  getStorageStats(): Promise<SessionRepositoryStorageStats>;
+  checkStorageHealth(): Promise<SessionRepositoryHealth>;
+}
+
+interface SessionEventStore {
+  createSession(...): Promise<void>;
+  saveMessage(...): Promise<string>;
+  saveToolUse(...): Promise<PersistedToolUse>;
+  saveToolResult(...): Promise<string>;
+  // Input, compaction, and context append methods.
+}
+```
+
+Each PostgreSQL transcript append writes a `transcript` event and updates the
+`session` projection in the same transaction. Reads, resume, and fork use only
+that projection.
+
+## Conformance
+
+Third-party Stores can run the public framework-independent conformance suite:
+
+```ts
+import {
+  assertRuntimeStoreConformance,
+} from '@blade-ai/agent-sdk/server/testing';
+
+await assertRuntimeStoreConformance(runtimeStore, {
+  tenantId: 'conformance-a',
+  otherTenantId: 'conformance-b',
+});
+```
+
+The suite verifies health, Session projection, tenant isolation, command
+receipts, agent and durable events, atomic commits, transaction rollback, and
+projection checkpoints. Run it against a dedicated schema or test database.
+
+## Operational boundaries
+
+- Schema initialization requires DDL privileges; production deployments may call `initialize()` during deployment.
+- `close()` closes an internally created Pool; an injected Pool remains caller-owned.
+- `maxAgentEventsPerSession` limits replayable SSE events, not durable or domain events.
+- `maxSessionsPerTenant` applies only to transcript projection cleanup.
+- This release writes and queries the outbox. Effect claim, heartbeat, and recovery belong to the next Worker lease milestone.
+- Redis may provide notifications, wake-ups, and short-lived quotas only. Losing Redis data must not affect command, event, effect, or projection correctness.

--- a/docs/en/server-runtime.md
+++ b/docs/en/server-runtime.md
@@ -14,8 +14,9 @@ model providers, tool executors, or local host capabilities.
 | `@blade-ai/agent-sdk/node` | Local JSONL repository and Node adapters such as files, shell, and sandbox |
 
 `/server` never interprets `storagePath` as permission to access local files.
-A resumable Session requires an explicitly supplied `sessionRepository`.
-Set `requirePersistentSessions: true` to fail closed when the port is missing.
+A resumable Session requires an explicitly supplied `sessionRepository` and
+`sessionEventStore`, or one `runtimeStore`. Set
+`requirePersistentSessions: true` to fail closed on incomplete configuration.
 
 ## Create a server
 
@@ -54,6 +55,7 @@ const server = new AgentServer({
       },
       model: 'gpt-4o-mini',
       sessionRepository: repository,
+      sessionEventStore: repository,
       defaultContext: {
         metadata: { tenantId: principal.tenantId },
       },
@@ -73,6 +75,8 @@ The JSONL adapter is suitable for a single Node.js host. A multi-instance
 service must use a shared `SessionRepository` and a shared `AgentServerStore`.
 The repository should also partition data by the authenticated `tenantId`.
 There is no trusted client-supplied tenant field.
+
+See [Runtime Store](./runtime-store) for the PostgreSQL single-authority setup.
 
 ## SessionExecutor
 
@@ -246,7 +250,8 @@ window, `STALE_CURSOR` tells the client to reload Session state.
 
 | Port | Source of truth |
 |------|-----------------|
-| `SessionRepository` | Transcript appends, Session state/message projection, fork, and list |
+| `SessionRepository` | Read-only transcript state/message projection, fork, and list |
+| `SessionEventStore` | Transcript domain event appends |
 | `AgentServerStore` | Tenant Session records, command idempotency, and remote event replay |
 | `DurableEventStore` | Request, Turn, model, and tool lifecycle journal and recovery |
 

--- a/docs/en/server-runtime.md
+++ b/docs/en/server-runtime.md
@@ -72,9 +72,9 @@ export function handleAgentRequest(request: Request): Promise<Response> {
 ```
 
 The JSONL adapter is suitable for a single Node.js host. A multi-instance
-service must use a shared `SessionRepository` and a shared `AgentServerStore`.
-The repository should also partition data by the authenticated `tenantId`.
-There is no trusted client-supplied tenant field.
+service must use one shared `runtimeStore`, or a shared `SessionRepository`,
+`SessionEventStore`, and `AgentServerStore`. Every Store must partition data by
+the authenticated `tenantId`. There is no trusted client-supplied tenant field.
 
 See [Runtime Store](./runtime-store) for the PostgreSQL single-authority setup.
 
@@ -117,6 +117,11 @@ const server = new AgentServer({
   authenticate,
 });
 ```
+
+When a custom executor and `runtimeStore` are both configured, every command
+receives the authenticated tenant's `RuntimeTenantStore` through
+`SessionExecutorCommandContext.runtimeStore`. Custom executors must use that
+Store as their persistence authority.
 
 A custom executor must:
 

--- a/docs/runtime-store.md
+++ b/docs/runtime-store.md
@@ -1,0 +1,181 @@
+# Runtime Store
+
+`RuntimeStore` 是服务端 Agent 的共享持久化边界。它把 command receipt、domain
+event、effect outbox 和 projection checkpoint 放进同一个事务，同时向现有
+`AgentServer`、Session transcript 和 durable journal 暴露兼容端口。
+
+## 安装与导入
+
+```bash
+pnpm add @blade-ai/agent-sdk
+```
+
+```ts
+import { AgentServer } from '@blade-ai/agent-sdk/server';
+import { PostgresRuntimeStore } from '@blade-ai/agent-sdk/server/postgres';
+
+const runtimeStore = new PostgresRuntimeStore({
+  connectionString: process.env.DATABASE_URL!,
+});
+
+const server = new AgentServer({
+  runtimeStore,
+  authenticate,
+  resolveSessionOptions: () => ({
+    provider,
+    model,
+  }),
+  requirePersistentSessions: true,
+});
+```
+
+传入 `runtimeStore` 后，默认 `InProcessSessionExecutor` 会按认证得到的
+`tenantId` 调用 `forTenant()`，并把同一个 scoped Store 同时用作：
+
+- `SessionRepository`：只读 transcript projection。
+- `SessionEventStore`：追加 transcript domain event。
+- `DurableEventStore`：Request、Turn、模型、工具与审批 journal。
+- `AgentServerStore`：command receipt、远程 event 和 Session record。
+
+配置 `runtimeStore` 后不允许再覆盖 Session 级 repository、event Store 或
+durable Store；混用会返回 `SESSION_CONFLICT`，防止重新产生双写事实源。
+
+## 事务模型
+
+```ts
+const claim = await runtimeStore.claimCommand(
+  tenantId,
+  commandId,
+  commandFingerprint,
+  30_000,
+);
+
+if (claim.status !== 'claimed') {
+  throw new Error(`Unexpected claim: ${claim.status}`);
+}
+
+await runtimeStore.sealCommand(tenantId, commandId, claim.leaseId);
+
+await runtimeStore.commitRuntimeTransaction({
+  tenantId,
+  sessionId,
+  command: {
+    commandId,
+    fingerprint: commandFingerprint,
+    leaseId: claim.leaseId,
+    result: {
+      protocolVersion: 1,
+      commandId,
+      ok: true,
+      data: { accepted: true },
+    },
+  },
+  expectedLastSequence: null,
+  events: [{
+    type: 'request.accepted',
+    data: { requestId: 'request-1' },
+  }],
+  effects: [{
+    effectId: 'effect-1',
+    type: 'tool.execute',
+    payload: { toolName: 'Search' },
+    idempotencyKey: 'request-1:tool-1',
+  }],
+  projection: {
+    name: 'request',
+    expectedOffset: null,
+    offset: 1,
+    state: { status: 'accepted' },
+  },
+});
+```
+
+一次 commit 在单个 PostgreSQL transaction 中完成：
+
+1. 校验 command fingerprint 与可选 lease。
+2. compare-and-append domain events。
+3. 写入具有唯一 idempotency key 的 effect intents。
+4. CAS 更新 projection 和 offset。
+5. 将 command receipt 标记为 completed 并保存结果。
+
+任何一步失败都会回滚全部写入。重复提交已完成的 command 返回
+`status: 'replayed'`，不会重复 event 或 effect。不同 payload 复用同一 command
+ID 会抛出 `RUNTIME_STORE_COMMAND_CONFLICT`。
+
+## PostgreSQL schema
+
+`PostgresRuntimeStore.initialize()` 幂等创建七类表：
+
+| 表 | 作用 |
+|----|------|
+| `*_metadata` | Runtime Store schema version |
+| `*_commands` | command fingerprint、lease、状态和确定性结果 |
+| `*_sessions` | tenant-scoped Session record |
+| `*_stream_heads` | 每 Session、每 stream 的单调 sequence |
+| `*_events` | `agent`、`domain`、`durable`、`transcript` 事件 |
+| `*_outbox` | 待执行 effect intent |
+| `*_projections` | projection state 与已消费 offset |
+
+`schema` 与 `tablePrefix` 只接受 PostgreSQL identifier。所有数据值使用参数化
+查询。并发 command 和 stream append 使用 transaction-scoped advisory lock；
+PostgreSQL 是事实源，Redis 不参与 correctness path。
+
+`InMemoryAgentServerStore` 仍只适合测试和单进程。生产环境不得把它与
+PostgreSQL transcript 混用。
+
+## Session projection
+
+`SessionRepository` 从本版本开始只描述 read/projection API。
+`SessionEventStore` 描述 append API，`SessionPersistence` 是兼容两者的组合。
+现有 `JsonlSessionRepository` 继续实现组合接口，因此 Node 本地用法不变。
+
+```ts
+interface SessionRepository extends SessionStore {
+  initialize(): Promise<void>;
+  deleteSession(sessionId: SessionId): Promise<void>;
+  cleanupOldSessions(): Promise<void>;
+  getStorageStats(): Promise<SessionRepositoryStorageStats>;
+  checkStorageHealth(): Promise<SessionRepositoryHealth>;
+}
+
+interface SessionEventStore {
+  createSession(...): Promise<void>;
+  saveMessage(...): Promise<string>;
+  saveToolUse(...): Promise<PersistedToolUse>;
+  saveToolResult(...): Promise<string>;
+  // input、compaction 与 context append 方法
+}
+```
+
+PostgreSQL transcript append 会在同一个 transaction 中追加 `transcript`
+event 并更新 `session` projection。读取、恢复和 fork 只访问 projection。
+
+## Conformance
+
+第三方 Store 可以直接运行公开的无测试框架 conformance：
+
+```ts
+import {
+  assertRuntimeStoreConformance,
+} from '@blade-ai/agent-sdk/server/testing';
+
+await assertRuntimeStoreConformance(runtimeStore, {
+  tenantId: 'conformance-a',
+  otherTenantId: 'conformance-b',
+});
+```
+
+该套件验证 health、Session projection、tenant isolation、command receipt、
+agent/durable event、原子 commit、事务回滚和 projection checkpoint。应在专用
+schema 或测试数据库中运行。
+
+## 运维边界
+
+- schema 初始化需要 DDL 权限；生产环境可在部署阶段提前调用 `initialize()`。
+- `PostgresRuntimeStore` 自建 Pool 时 `close()` 会关闭 Pool；注入的 Pool 由调用方管理。
+- `maxAgentEventsPerSession` 只限制可重放的远程 SSE 事件，不裁剪 durable/domain event。
+- `maxSessionsPerTenant` 只用于 transcript projection 清理。
+- outbox 在本版本只提供原子写入和查询；claim、heartbeat 与执行恢复由下一阶段
+  Worker lease 协议负责。
+- Redis只能用于通知、wake-up 和短期配额；丢失 Redis 数据不得影响 command、
+  event、effect 或 projection 的正确性。

--- a/docs/runtime-store.md
+++ b/docs/runtime-store.md
@@ -116,8 +116,8 @@ ID 会抛出 `RUNTIME_STORE_COMMAND_CONFLICT`。
 | `*_outbox` | 待执行 effect intent |
 | `*_projections` | projection state 与已消费 offset |
 
-`schema` 与 `tablePrefix` 只接受 PostgreSQL identifier。所有数据值使用参数化
-查询。并发 command 和 stream append 使用 transaction-scoped advisory lock；
+`schema` 与 `tablePrefix` 只接受 PostgreSQL identifier。所有数据值使用
+参数化查询。并发 command 和 stream append 使用 transaction-scoped advisory lock；
 PostgreSQL 是事实源，Redis 不参与 correctness path。
 
 `InMemoryAgentServerStore` 仍只适合测试和单进程。生产环境不得把它与

--- a/docs/server-runtime.md
+++ b/docs/server-runtime.md
@@ -70,9 +70,10 @@ export function handleAgentRequest(request: Request): Promise<Response> {
 }
 ```
 
-JSONL adapter 适合单机 Node.js 部署。多实例服务必须使用共享
-`SessionRepository` 和共享 `AgentServerStore`；repository 还应按认证得到的
-`tenantId` 分区。客户端 body 中不存在可信 tenant 字段。
+JSONL adapter 适合单机 Node.js 部署。多实例服务必须使用一个共享
+`runtimeStore`，或共享的 `SessionRepository`、`SessionEventStore` 和
+`AgentServerStore`；所有 Store 都必须按认证得到的 `tenantId` 分区。客户端
+body 中不存在可信 tenant 字段。
 
 PostgreSQL 单一事实源配置见 [Runtime Store](./runtime-store)。
 
@@ -114,6 +115,10 @@ const server = new AgentServer({
   authenticate,
 });
 ```
+
+同时配置自定义 executor 和 `runtimeStore` 时，每个 command 都会通过
+`SessionExecutorCommandContext.runtimeStore` 得到认证 tenant 对应的
+`RuntimeTenantStore`。自定义 executor 必须将它作为持久化 authority。
 
 自定义 executor 必须：
 

--- a/docs/server-runtime.md
+++ b/docs/server-runtime.md
@@ -14,8 +14,8 @@ SSE event stream。浏览器通过 `AgentClient` 调用，不直接加载模型 
 | `@blade-ai/agent-sdk/node` | 本机 JSONL repository、文件、Shell、Sandbox 等 Node adapter |
 
 `/server` 不会根据 `storagePath` 隐式访问本机文件。需要恢复 Session 时，宿主必须
-显式传入 `sessionRepository`；`requirePersistentSessions: true` 可使缺少该端口
-的配置 fail-closed。
+显式传入 `sessionRepository` 和 `sessionEventStore`，或提供一个
+`runtimeStore`；`requirePersistentSessions: true` 会使不完整配置 fail-closed。
 
 ## 创建服务端
 
@@ -54,6 +54,7 @@ const server = new AgentServer({
       },
       model: 'gpt-4o-mini',
       sessionRepository: repository,
+      sessionEventStore: repository,
       defaultContext: {
         metadata: { tenantId: principal.tenantId },
       },
@@ -72,6 +73,8 @@ export function handleAgentRequest(request: Request): Promise<Response> {
 JSONL adapter 适合单机 Node.js 部署。多实例服务必须使用共享
 `SessionRepository` 和共享 `AgentServerStore`；repository 还应按认证得到的
 `tenantId` 分区。客户端 body 中不存在可信 tenant 字段。
+
+PostgreSQL 单一事实源配置见 [Runtime Store](./runtime-store)。
 
 ## SessionExecutor
 
@@ -235,7 +238,8 @@ SSE 使用 pull-based `ReadableStream`，每次 pull 最多写一个 frame，
 
 | Port | 事实范围 |
 |------|---------|
-| `SessionRepository` | transcript append、Session state/messages projection、fork 与 list |
+| `SessionRepository` | transcript state/messages 的只读 projection、fork 与 list |
+| `SessionEventStore` | transcript domain event append |
 | `AgentServerStore` | tenant Session records、command 幂等、远程 event replay |
 | `DurableEventStore` | Request/Turn/model/tool 生命周期 journal 与恢复 |
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,15 @@
       "browser": "./dist/browser/server-only-stub.js",
       "import": "./dist/server/index.js"
     },
+    "./server/postgres": {
+      "types": "./dist/server/postgres.d.ts",
+      "browser": "./dist/browser/server-only-stub.js",
+      "import": "./dist/server/postgres.js"
+    },
+    "./server/testing": {
+      "types": "./dist/server/testing/index.d.ts",
+      "import": "./dist/server/testing/index.js"
+    },
     "./session": {
       "types": "./dist/session/index.d.ts",
       "browser": "./dist/browser/server-only-stub.js",
@@ -124,6 +133,7 @@
     "lru-cache": "^11.3.5",
     "nanoid": "^5.1.16",
     "open": "^11.0.0",
+    "pg": "8.23.0",
     "picomatch": "^4.0.4",
     "semver": "^7.7.4",
     "undici": "^7.29.0",
@@ -140,6 +150,7 @@
     "@types/json-schema": "^7.0.15",
     "@types/lodash-es": "^4.17.12",
     "@types/node": "^22.15.0",
+    "@types/pg": "8.23.1",
     "@types/picomatch": "^4.0.2",
     "@types/semver": "^7.7.1",
     "@types/write-file-atomic": "^4.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       open:
         specifier: ^11.0.0
         version: 11.0.0
+      pg:
+        specifier: 8.23.0
+        version: 8.23.0
       picomatch:
         specifier: ^4.0.4
         version: 4.0.4
@@ -105,6 +108,9 @@ importers:
       '@types/node':
         specifier: ^22.15.0
         version: 22.19.15
+      '@types/pg':
+        specifier: 8.23.1
+        version: 8.23.1
       '@types/picomatch':
         specifier: ^4.0.2
         version: 4.0.2
@@ -1139,6 +1145,9 @@ packages:
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
+
+  '@types/pg@8.23.1':
+    resolution: {integrity: sha512-fKVHpikPdg4GKks3JuLEhvwSyvwzF23hnabPy6DD8ljVbC7+6J5dQzdv4arV6jqq57djnMgs1HKBxX4P8aBI3A==}
 
   '@types/picomatch@4.0.2':
     resolution: {integrity: sha512-qHHxQ+P9PysNEGbALT8f8YOSHW0KJu6l2xU8DYY0fu/EmGxXdVnuTLvFUvBgPJMSqXq29SYHveejeAha+4AYgA==}
@@ -2683,6 +2692,40 @@ packages:
   perfect-debounce@1.0.0:
     resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
 
+  pg-cloudflare@1.4.0:
+    resolution: {integrity: sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==}
+
+  pg-connection-string@2.14.0:
+    resolution: {integrity: sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==}
+
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-pool@3.14.0:
+    resolution: {integrity: sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==}
+    peerDependencies:
+      pg: '>=8.0'
+
+  pg-protocol@1.16.0:
+    resolution: {integrity: sha512-sILXutLVjCLjcDuOmvhX5e2Z4cS5qG/6Bu3VkpFwdf/633ElGLpEh9bgmuI5I4sqKqkifQiGyiCcx1HdtrK7tg==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
+  pg@8.23.0:
+    resolution: {integrity: sha512-Ip2EQCngowJLGOfCwkFhPXU7/ljlhn6Rxlmy4XYfL2Y+vyRM59+8uR2xqRWKdYmbXmxCFOAmKxBuSUCdF34qLg==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -2734,6 +2777,22 @@ packages:
   postcss@8.5.8:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
+
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-bytea@1.0.1:
+    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
 
   powershell-utils@0.1.0:
     resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
@@ -2992,6 +3051,10 @@ packages:
 
   split2@1.0.0:
     resolution: {integrity: sha512-NKywug4u4pX/AZBB1FCPzZ6/7O+Xhz1qMVbzTvvKvikjO99oPN87SkK08mEY9P63/5lWjK+wgOOgApnTg5r6qg==}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
@@ -4372,6 +4435,12 @@ snapshots:
       undici-types: 6.21.0
 
   '@types/normalize-package-data@2.4.4': {}
+
+  '@types/pg@8.23.1':
+    dependencies:
+      '@types/node': 22.19.15
+      pg-protocol: 1.16.0
+      pg-types: 2.2.0
 
   '@types/picomatch@4.0.2': {}
 
@@ -5892,6 +5961,41 @@ snapshots:
 
   perfect-debounce@1.0.0: {}
 
+  pg-cloudflare@1.4.0:
+    optional: true
+
+  pg-connection-string@2.14.0: {}
+
+  pg-int8@1.0.1: {}
+
+  pg-pool@3.14.0(pg@8.23.0):
+    dependencies:
+      pg: 8.23.0
+
+  pg-protocol@1.16.0: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.1
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
+  pg@8.23.0:
+    dependencies:
+      pg-connection-string: 2.14.0
+      pg-pool: 3.14.0(pg@8.23.0)
+      pg-protocol: 1.16.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.4.0
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.2: {}
@@ -5927,6 +6031,16 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  postgres-array@2.0.0: {}
+
+  postgres-bytea@1.0.1: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
 
   powershell-utils@0.1.0: {}
 
@@ -6264,6 +6378,8 @@ snapshots:
   split2@1.0.0:
     dependencies:
       through2: 2.0.5
+
+  split2@4.2.0: {}
 
   sprintf-js@1.0.3: {}
 

--- a/scripts/__tests__/documentation-parity.test.ts
+++ b/scripts/__tests__/documentation-parity.test.ts
@@ -10,6 +10,7 @@ const publicDocuments = [
   'providers.md',
   'session.md',
   'server-runtime.md',
+  'runtime-store.md',
   'durable-events.md',
   'tools.md',
   'permissions.md',

--- a/scripts/verify-entrypoints.mjs
+++ b/scripts/verify-entrypoints.mjs
@@ -111,12 +111,18 @@ const browserServerOutput = run(process.execPath, [
   [
     "const m = await import('@blade-ai/agent-sdk/server');",
     'try { new m.InProcessSessionExecutor({}); } catch (error) { console.log(error.message); }',
+    'try { new m.PostgresRuntimeStore({}); } catch (error) { console.log(error.message); }',
   ].join(' '),
 ]);
 assertIncludes(
   browserServerOutput,
   'server-only for InProcessSessionExecutor',
   'browser in-process Session executor stub',
+);
+assertIncludes(
+  browserServerOutput,
+  'server-only for PostgresRuntimeStore',
+  'browser PostgreSQL runtime Store stub',
 );
 
 const subpathOutput = run(process.execPath, [
@@ -125,16 +131,18 @@ const subpathOutput = run(process.execPath, [
     "const core = await import('@blade-ai/agent-sdk/core');",
     "const browser = await import('@blade-ai/agent-sdk/browser');",
     "const server = await import('@blade-ai/agent-sdk/server');",
+    "const postgres = await import('@blade-ai/agent-sdk/server/postgres');",
+    "const testing = await import('@blade-ai/agent-sdk/server/testing');",
     "const tools = await import('@blade-ai/agent-sdk/tools');",
     "const node = await import('@blade-ai/agent-sdk/node');",
     "const protocol = await import('@blade-ai/agent-sdk/protocol');",
     "const middleware = await import('@blade-ai/agent-sdk/middleware');",
-    "console.log(core.PermissionMode.DEFAULT, core.DurableEventType.REQUEST_ACCEPTED, core.projectDurableSession([]).status, typeof core.DurableSessionJournal.open, typeof core.DurableSessionRecoveryCoordinator.open, typeof core.DurableEventSubscription.open, browser.PermissionMode.DEFAULT, typeof browser.AgentClient, typeof server.createSession, typeof server.AgentServer, typeof server.InProcessSessionExecutor, typeof tools.defineTool, typeof node.createSession, typeof node.getBuiltinTools, typeof node.JsonlDurableEventStore, typeof node.JsonlSessionRepository, protocol.AGENT_PROTOCOL_VERSION, typeof middleware.composeMiddleware);",
+    "console.log(core.PermissionMode.DEFAULT, core.DurableEventType.REQUEST_ACCEPTED, core.projectDurableSession([]).status, typeof core.DurableSessionJournal.open, typeof core.DurableSessionRecoveryCoordinator.open, typeof core.DurableEventSubscription.open, browser.PermissionMode.DEFAULT, typeof browser.AgentClient, typeof server.createSession, typeof server.AgentServer, typeof server.InProcessSessionExecutor, typeof postgres.PostgresRuntimeStore, typeof testing.assertRuntimeStoreConformance, typeof tools.defineTool, typeof node.createSession, typeof node.getBuiltinTools, typeof node.JsonlDurableEventStore, typeof node.JsonlSessionRepository, protocol.AGENT_PROTOCOL_VERSION, typeof middleware.composeMiddleware);",
   ].join(' '),
 ]);
 assertIncludes(
   subpathOutput,
-  'default request_accepted empty function function function default function function function function function function function function function 1 function',
+  'default request_accepted empty function function function default function function function function function function function function function function function 1 function',
   'subpath imports',
 );
 
@@ -154,6 +162,7 @@ verifyBrowserSafeDist('dist/browser/server-only-stub.js');
 verifyBrowserSafeDist('dist/core/index.js');
 verifyBrowserSafeDist('dist/middleware/index.js');
 verifyBrowserSafeDist('dist/protocol/index.js');
+verifyBrowserSafeDist('dist/server/testing/index.js');
 verifyBrowserSafeDist('dist/tools/index.js');
 
 const tempDir = mkdtempSync(join(repoRoot, '.tmp-entrypoints-'));

--- a/src/__tests__/packageEntrypoints.test.ts
+++ b/src/__tests__/packageEntrypoints.test.ts
@@ -32,6 +32,15 @@ describe('package entrypoints', () => {
         browser: './dist/browser/server-only-stub.js',
         import: './dist/server/index.js',
       },
+      './server/postgres': {
+        types: './dist/server/postgres.d.ts',
+        browser: './dist/browser/server-only-stub.js',
+        import: './dist/server/postgres.js',
+      },
+      './server/testing': {
+        types: './dist/server/testing/index.d.ts',
+        import: './dist/server/testing/index.js',
+      },
       './session': {
         types: './dist/session/index.d.ts',
         browser: './dist/browser/server-only-stub.js',
@@ -60,6 +69,8 @@ describe('package entrypoints', () => {
       'src/browser/server-only-stub.ts',
       'src/protocol/index.ts',
       'src/server/index.ts',
+      'src/server/postgres.ts',
+      'src/server/testing/index.ts',
       'src/tools/index.ts',
       'src/node/index.ts',
       'src/middleware/index.ts',
@@ -96,6 +107,9 @@ describe('package entrypoints', () => {
       /server-only.*JsonlDurableEventStore/,
     );
     expect(() => new serverOnly.AgentServer()).toThrow(/server-only.*AgentServer/);
+    expect(() => new serverOnly.PostgresRuntimeStore()).toThrow(
+      /server-only.*PostgresRuntimeStore/,
+    );
     expect(() => new serverOnly.InProcessSessionExecutor()).toThrow(
       /server-only.*InProcessSessionExecutor/,
     );
@@ -110,6 +124,7 @@ describe('package entrypoints', () => {
     expect(node.createSession).not.toBe(server.createSession);
     expect(server.AgentServer).toBeTypeOf('function');
     expect(server.InProcessSessionExecutor).toBeTypeOf('function');
+    expect(server.PostgresRuntimeStore).toBeTypeOf('function');
     expect(node.JsonlSessionRepository).toBeTypeOf('function');
     expect('getBuiltinTools' in root).toBe(false);
     expect(node.getBuiltinTools).toBeTypeOf('function');

--- a/src/__tests__/rootExports.test.ts
+++ b/src/__tests__/rootExports.test.ts
@@ -48,6 +48,8 @@ import type {
   SessionHandoffErrorCode,
   SessionHandoffResult,
   SessionOptions,
+  SessionEventStore,
+  SessionPersistence,
   SessionRepository,
   SessionTool,
   ToolCatalogEntry,
@@ -366,6 +368,13 @@ describe('root exports', () => {
     expectTypeOf<SessionOptions['durableEventStore']>().toEqualTypeOf<
       DurableEventStore | undefined
     >();
+    expectTypeOf<SessionOptions['sessionRepository']>().toEqualTypeOf<
+      SessionRepository | undefined
+    >();
+    expectTypeOf<SessionOptions['sessionEventStore']>().toEqualTypeOf<
+      SessionEventStore | undefined
+    >();
+    expectTypeOf<SessionPersistence>().toMatchTypeOf<SessionRepository>();
     expectTypeOf<SessionOptions['executionLease']>().toEqualTypeOf<
       DurableExecutionLeaseOptions | undefined
     >();

--- a/src/browser/server-only-stub.ts
+++ b/src/browser/server-only-stub.ts
@@ -82,6 +82,12 @@ export class InMemoryAgentServerStore {
   }
 }
 
+export class PostgresRuntimeStore {
+  constructor(..._args: unknown[]) {
+    serverOnly('PostgresRuntimeStore');
+  }
+}
+
 export class TenantAdmissionController {
   constructor(..._args: unknown[]) {
     serverOnly('TenantAdmissionController');

--- a/src/context/ContextManager.ts
+++ b/src/context/ContextManager.ts
@@ -5,6 +5,7 @@ import type {
   ModelIdentity,
   ToolCall as ChatToolCall,
 } from '../services/ChatServiceInterface.js';
+import { ConfigError } from '../errors/ConfigError.js';
 import type { SessionState, SessionSummary } from '../session/SessionStore.js';
 import {
   isSessionEventStore,
@@ -69,12 +70,22 @@ export class ContextManager {
 
   constructor(
     options: Partial<ContextManagerOptions> = {},
-    repository: SessionRepository = new NoopSessionRepository(),
-    eventStore: SessionEventStore = isSessionEventStore(repository)
-      ? repository
-      : new NoopSessionRepository(),
+    repository?: SessionRepository,
+    eventStore?: SessionEventStore,
   ) {
     const persistenceEnabled = options.storage?.persistenceEnabled ?? true;
+    const compatibleEventStore = eventStore
+      ?? (isSessionEventStore(repository) ? repository : undefined);
+    if (
+      persistenceEnabled
+      && ((repository && !compatibleEventStore)
+        || (!repository && compatibleEventStore))
+    ) {
+      throw new ConfigError(
+        'Persistent context requires both SessionRepository and SessionEventStore.',
+      );
+    }
+    const noopRepository = new NoopSessionRepository();
     // 持久化路径必须由调用方显式提供；未提供时禁用持久化
     const defaultPersistentPath =
       persistenceEnabled ? options.storage?.persistentPath : undefined;
@@ -102,8 +113,12 @@ export class ContextManager {
 
     // Session selects explicit read projection and event append ports.
     this.memory = new MemoryStore(this.options.storage.maxMemorySize);
-    this.repository = repository;
-    this.eventStore = eventStore;
+    this.repository = persistenceEnabled && repository
+      ? repository
+      : noopRepository;
+    this.eventStore = persistenceEnabled && compatibleEventStore
+      ? compatibleEventStore
+      : noopRepository;
     this.cache = new CacheStore(
       this.options.storage.cacheSize,
       5 * 60 * 1000 // 5分钟默认TTL

--- a/src/context/ContextManager.ts
+++ b/src/context/ContextManager.ts
@@ -7,8 +7,10 @@ import type {
 } from '../services/ChatServiceInterface.js';
 import type { SessionState, SessionSummary } from '../session/SessionStore.js';
 import {
+  isSessionEventStore,
   NoopSessionRepository,
   type PersistedToolUse,
+  type SessionEventStore,
   type SessionRepository,
 } from '../session/SessionRepository.js';
 import type { ContentPart } from '../services/ChatServiceInterface.js';
@@ -54,6 +56,7 @@ function isUsageMetadata(
 export class ContextManager {
   private readonly memory: MemoryStore;
   private readonly repository: SessionRepository;
+  private readonly eventStore: SessionEventStore;
   private readonly cache: CacheStore;
   private readonly compressor: ContextCompressor;
   private readonly filter: ContextFilter;
@@ -67,6 +70,9 @@ export class ContextManager {
   constructor(
     options: Partial<ContextManagerOptions> = {},
     repository: SessionRepository = new NoopSessionRepository(),
+    eventStore: SessionEventStore = isSessionEventStore(repository)
+      ? repository
+      : new NoopSessionRepository(),
   ) {
     const persistenceEnabled = options.storage?.persistenceEnabled ?? true;
     // 持久化路径必须由调用方显式提供；未提供时禁用持久化
@@ -94,9 +100,10 @@ export class ContextManager {
     };
     this.projectPath = this.options.projectPath;
 
-    // Session owns repository selection so reads and writes always share one backend.
+    // Session selects explicit read projection and event append ports.
     this.memory = new MemoryStore(this.options.storage.maxMemorySize);
     this.repository = repository;
+    this.eventStore = eventStore;
     this.cache = new CacheStore(
       this.options.storage.cacheSize,
       5 * 60 * 1000 // 5分钟默认TTL
@@ -180,7 +187,7 @@ export class ContextManager {
 
     // 初始化内存并写入首个 session_created 事件
     this.memory.setContext(contextData);
-    await this.repository.createSession(sessionId);
+    await this.eventStore.createSession(sessionId);
 
     this.currentSessionId = sessionId;
 
@@ -222,7 +229,7 @@ export class ContextManager {
       throw new Error('没有活动会话');
     }
 
-    const messageId = await this.repository.saveMessage(
+    const messageId = await this.eventStore.saveMessage(
       this.currentSessionId,
       role,
       content,
@@ -263,7 +270,7 @@ export class ContextManager {
 
     const pendingToolUseKey = `${this.currentSessionId}\0${toolCall.id}`;
     if (toolCall.status === 'pending') {
-      const persisted = await this.repository.saveToolUse(
+      const persisted = await this.eventStore.saveToolUse(
         this.currentSessionId,
         toolCall.name,
         toolCall.input,
@@ -282,7 +289,7 @@ export class ContextManager {
       } else {
         this.pendingToolUses.delete(pendingToolUseKey);
       }
-      await this.repository.saveToolResult(
+      await this.eventStore.saveToolResult(
         this.currentSessionId,
         toolCall.id,
         toolCall.name,
@@ -320,7 +327,7 @@ export class ContextManager {
       isSidechain: boolean;
     }
   ): Promise<string> {
-    return this.repository.saveMessage(
+    return this.eventStore.saveMessage(
       sessionId,
       role,
       content,
@@ -334,7 +341,7 @@ export class ContextManager {
     sessionId: SessionId,
     input: PendingInputInfo,
   ): Promise<void> {
-    return this.repository.saveInputEnqueued(sessionId, input);
+    return this.eventStore.saveInputEnqueued(sessionId, input);
   }
 
   async saveAppliedInputMessage(
@@ -349,7 +356,7 @@ export class ContextManager {
       isSidechain: boolean;
     },
   ): Promise<string> {
-    return this.repository.saveAppliedInputMessage(
+    return this.eventStore.saveAppliedInputMessage(
       sessionId,
       inputId,
       requestId,
@@ -364,7 +371,7 @@ export class ContextManager {
     inputId: InputId,
     reason: string,
   ): Promise<void> {
-    return this.repository.saveInputCancelled(sessionId, inputId, reason);
+    return this.eventStore.saveInputCancelled(sessionId, inputId, reason);
   }
 
   /** 保存工具调用到 repository。 */
@@ -380,7 +387,7 @@ export class ContextManager {
     },
     requestedToolCallId?: string,
   ): Promise<PersistedToolUse> {
-    return this.repository.saveToolUse(
+    return this.eventStore.saveToolUse(
       sessionId,
       toolName,
       toolInput,
@@ -410,7 +417,7 @@ export class ContextManager {
       subagentSummary?: string;
     }
   ): Promise<string> {
-    return this.repository.saveToolResult(
+    return this.eventStore.saveToolResult(
       sessionId,
       toolId,
       toolName,
@@ -434,7 +441,7 @@ export class ContextManager {
     },
     parentUuid: string | null = null
   ): Promise<string> {
-    return this.repository.saveCompaction(sessionId, summary, metadata, parentUuid);
+    return this.eventStore.saveCompaction(sessionId, summary, metadata, parentUuid);
   }
 
   /**

--- a/src/context/__tests__/ContextManager.test.ts
+++ b/src/context/__tests__/ContextManager.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import type { SessionRepository } from '../../session/SessionRepository.js';
 import { JsonlSessionStore } from '../../session/SessionStore.js';
 import { PersistentStore } from '../storage/PersistentStore.js';
 import { ContextManager } from '../ContextManager.js';
@@ -13,6 +14,39 @@ function createWorkspaceRoot(): string {
 }
 
 describe('ContextManager', () => {
+  it('rejects a read-only repository when persistence is enabled', () => {
+    const readOnlyRepository: SessionRepository = {
+      async initialize() {},
+      async loadState() {
+        return null;
+      },
+      async loadMessages() {
+        return [];
+      },
+      async forkState() {
+        return null;
+      },
+      async listSessions() {
+        return [];
+      },
+      async getSessionSummary() {
+        return null;
+      },
+      async deleteSession() {},
+      async cleanupOldSessions() {},
+      async getStorageStats() {
+        return { totalSessions: 0, totalSize: 0 };
+      },
+      async checkStorageHealth() {
+        return { isAvailable: true, canWrite: false };
+      },
+    };
+
+    expect(() => new ContextManager({}, readOnlyRepository)).toThrow(
+      /both SessionRepository and SessionEventStore/,
+    );
+  });
+
   it('should hydrate conversation history from the unified session store', async () => {
     const workspaceRoot = createWorkspaceRoot();
     const persistentStore = new PersistentStore(workspaceRoot);

--- a/src/context/storage/PersistentStore.ts
+++ b/src/context/storage/PersistentStore.ts
@@ -10,7 +10,7 @@ import { JsonlSessionStore } from '../../session/SessionStore.js';
 import {
   NoopSessionRepository,
   type PersistedToolUse,
-  type SessionRepository,
+  type SessionPersistence,
 } from '../../session/SessionRepository.js';
 import {
   type InputId,
@@ -81,7 +81,7 @@ function parseToolCallArguments(value: string): JsonValue {
  * 持久化存储实现 - JSONL 格式
  * 存储路径: {storageRoot}/projects/{escaped-path}/{sessionId}.jsonl
  */
-export class PersistentStore implements SessionRepository {
+export class PersistentStore implements SessionPersistence {
   private readonly storageRoot: string;
   private readonly projectPath?: string;
   private readonly maxSessions: number;

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -37,6 +37,8 @@ export type {
 } from '../session/types.js';
 export type {
   PersistedToolUse,
+  SessionEventStore,
+  SessionPersistence,
   SessionRepository,
   SessionRepositoryCompactionMetadata,
   SessionRepositoryHealth,

--- a/src/index.ts
+++ b/src/index.ts
@@ -162,6 +162,8 @@ export type {
   SendOptions,
   SessionHandoffResult,
   SessionOptions,
+  SessionEventStore,
+  SessionPersistence,
   SessionRepository,
   SessionRepositoryCompactionMetadata,
   SessionRepositoryHealth,

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -19,21 +19,24 @@ export * from '../index.js';
 
 function withNodeRepository(options: SessionOptions): SessionOptions {
   if (
-    options.sessionRepository ||
-    options.persistSession === false ||
-    !options.storagePath
+    options.sessionRepository
+    || options.sessionEventStore
+    || options.persistSession === false
+    || !options.storagePath
   ) {
     return options;
   }
 
+  const persistence = new PersistentStore(
+    options.storagePath,
+    100,
+    '0.0.10',
+    getContextCwd(options.defaultContext),
+  );
   return {
     ...options,
-    sessionRepository: new PersistentStore(
-      options.storagePath,
-      100,
-      '0.0.10',
-      getContextCwd(options.defaultContext),
-    ),
+    sessionRepository: persistence,
+    sessionEventStore: persistence,
   };
 }
 

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -467,6 +467,13 @@ export class AgentServer {
       principal,
       commandId: command.commandId,
       ...(signal ? { signal } : {}),
+      ...(this.options.runtimeStore
+        ? {
+            runtimeStore: this.options.runtimeStore.forTenant(
+              principal.tenantId,
+            ),
+          }
+        : {}),
     };
     switch (command.type) {
       case AgentCommandType.INITIALIZE:

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -37,6 +37,7 @@ import {
   type SessionExecutor,
   type SessionExecutorCommandContext,
 } from './SessionExecutor.js';
+import type { RuntimeStore } from './RuntimeStore.js';
 import {
   TenantAdmissionController,
   type TenantAdmissionLimits,
@@ -52,6 +53,7 @@ export interface AgentServerOptions {
     context: AgentServerSessionContext,
   ) => SessionOptions | Promise<SessionOptions>;
   readonly sessionExecutor?: SessionExecutor;
+  readonly runtimeStore?: RuntimeStore;
   readonly authenticate?: (
     request: Request,
   ) => AgentPrincipal | null | Promise<AgentPrincipal | null>;
@@ -160,7 +162,17 @@ export class AgentServer {
   private readonly basePath: string;
 
   constructor(private readonly options: AgentServerOptions) {
-    this.store = options.store ?? new InMemoryAgentServerStore();
+    if (
+      options.runtimeStore
+      && options.store
+      && options.runtimeStore !== options.store
+    ) {
+      throw new TypeError(
+        'AgentServer store and runtimeStore must reference the same backend',
+      );
+    }
+    this.store =
+      options.runtimeStore ?? options.store ?? new InMemoryAgentServerStore();
     this.telemetry = options.telemetry ?? NOOP_AGENT_SERVER_TELEMETRY;
     this.admission = new TenantAdmissionController(options.admission);
     this.commandLeaseTtlMs =
@@ -190,9 +202,37 @@ export class AgentServer {
     this.sessionExecutor = options.sessionExecutor
       ?? new InProcessSessionExecutor({
         store: this.store,
-        resolveSessionOptions: resolveSessionOptions as NonNullable<
-          AgentServerOptions['resolveSessionOptions']
-        >,
+        resolveSessionOptions: async (context) => {
+          const sessionOptions = await (
+            resolveSessionOptions as NonNullable<
+              AgentServerOptions['resolveSessionOptions']
+            >
+          )(context);
+          if (!options.runtimeStore) {
+            return sessionOptions;
+          }
+          if (
+            sessionOptions.sessionRepository
+            || sessionOptions.sessionEventStore
+            || sessionOptions.durableEventStore
+          ) {
+            throw new AgentProtocolError(
+              'SESSION_CONFLICT',
+              'runtimeStore is authoritative; Session-level persistence '
+                + 'overrides are not allowed',
+              409,
+            );
+          }
+          const tenantStore = options.runtimeStore.forTenant(
+            context.principal.tenantId,
+          );
+          return {
+            ...sessionOptions,
+            sessionRepository: tenantStore,
+            sessionEventStore: tenantStore,
+            durableEventStore: tenantStore,
+          };
+        },
         publish: (tenantId, sessionId, type, data, requestId) =>
           this.publish(tenantId, sessionId, type, data, requestId),
         maxActiveSessionsPerTenant:

--- a/src/server/PostgresRuntimeStore.ts
+++ b/src/server/PostgresRuntimeStore.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { nanoid } from 'nanoid';
 import {
   Pool,
@@ -165,6 +166,20 @@ function asJsonObject(value: unknown): JsonObject {
 
 function asSessionState(value: unknown): SessionState {
   return structuredClone(value) as SessionState;
+}
+
+function advisoryLockKey(key: string): readonly [number, number] {
+  const digest = createHash('sha256').update(key).digest();
+  return [digest.readInt32BE(0), digest.readInt32BE(4)];
+}
+
+function isPostgresUniqueViolation(error: unknown): boolean {
+  return (
+    typeof error === 'object'
+    && error !== null
+    && 'code' in error
+    && error.code === '23505'
+  );
 }
 
 function assertStrictJsonValue(
@@ -700,90 +715,101 @@ export class PostgresRuntimeStore implements RuntimeStore {
         'Projection offset must reference a committed event',
       );
     }
-    return this.transaction(async (client) => {
-      await this.lock(
-        client,
-        `command:${commit.tenantId}:${commit.command.commandId}`,
-      );
-      const commandResult = await client.query<CommandRow>(
-        `SELECT command_fingerprint, lease_id, status, expires_at, result
-           FROM ${this.table('commands')}
-          WHERE tenant_id = $1 AND command_id = $2
-          FOR UPDATE`,
-        [commit.tenantId, commit.command.commandId],
-      );
-      const existing = commandResult.rows[0];
-      if (
-        existing
-        && existing.command_fingerprint !== commit.command.fingerprint
-      ) {
-        throw new RuntimeStoreError(
-          'RUNTIME_STORE_COMMAND_CONFLICT',
-          `Command ${commit.command.commandId} has a different fingerprint`,
+    try {
+      return await this.transaction(async (client) => {
+        await this.lock(
+          client,
+          `command:${commit.tenantId}:${commit.command.commandId}`,
         );
-      }
-      if (existing?.result !== null && existing?.result !== undefined) {
-        return this.loadCommittedRuntimeResult(client, commit);
-      }
-      if (commit.command.leaseId) {
-        if (!existing || existing.lease_id !== commit.command.leaseId) {
+        const commandResult = await client.query<CommandRow>(
+          `SELECT command_fingerprint, lease_id, status, expires_at, result
+             FROM ${this.table('commands')}
+            WHERE tenant_id = $1 AND command_id = $2
+            FOR UPDATE`,
+          [commit.tenantId, commit.command.commandId],
+        );
+        const existing = commandResult.rows[0];
+        if (
+          existing
+          && existing.command_fingerprint !== commit.command.fingerprint
+        ) {
           throw new RuntimeStoreError(
-            'RUNTIME_STORE_LEASE_LOST',
-            `Command lease ${commit.command.commandId}/${commit.command.leaseId} is not active`,
+            'RUNTIME_STORE_COMMAND_CONFLICT',
+            `Command ${commit.command.commandId} has a different fingerprint`,
           );
         }
-      } else if (existing) {
-        throw new RuntimeStoreError(
-          'RUNTIME_STORE_LEASE_LOST',
-          `Command ${commit.command.commandId} already has an active receipt`,
-        );
-      } else {
-        await client.query(
-          `INSERT INTO ${this.table('commands')} (
-             tenant_id, command_id, command_fingerprint, lease_id,
-             status, expires_at, created_at, updated_at
-           ) VALUES ($1, $2, $3, $4, 'sealed', 'infinity', NOW(), NOW())`,
+        if (existing?.result !== null && existing?.result !== undefined) {
+          return this.loadCommittedRuntimeResult(client, commit);
+        }
+        if (commit.command.leaseId) {
+          if (!existing || existing.lease_id !== commit.command.leaseId) {
+            throw new RuntimeStoreError(
+              'RUNTIME_STORE_LEASE_LOST',
+              `Command lease ${commit.command.commandId}/${commit.command.leaseId} is not active`,
+            );
+          }
+        } else if (existing) {
+          throw new RuntimeStoreError(
+            'RUNTIME_STORE_LEASE_LOST',
+            `Command ${commit.command.commandId} already has an active receipt`,
+          );
+        } else {
+          await client.query(
+            `INSERT INTO ${this.table('commands')} (
+               tenant_id, command_id, command_fingerprint, lease_id,
+               status, expires_at, created_at, updated_at
+             ) VALUES ($1, $2, $3, $4, 'sealed', 'infinity', NOW(), NOW())`,
+            [
+              commit.tenantId,
+              commit.command.commandId,
+              commit.command.fingerprint,
+              `atomic:${commit.command.commandId}`,
+            ],
+          );
+        }
+
+        const storedEvents = await this.appendDomainEvents(client, commit);
+        const effects = await this.insertEffects(client, commit);
+        const projection = commit.projection
+          ? await this.writeProjection(client, commit)
+          : undefined;
+
+        const completed = await client.query(
+          `UPDATE ${this.table('commands')}
+              SET status = 'completed', expires_at = 'infinity',
+                  result = $4::jsonb, updated_at = NOW()
+            WHERE tenant_id = $1 AND command_id = $2
+              AND command_fingerprint = $3`,
           [
             commit.tenantId,
             commit.command.commandId,
             commit.command.fingerprint,
-            `atomic:${commit.command.commandId}`,
+            JSON.stringify(commit.command.result),
           ],
         );
-      }
-
-      const storedEvents = await this.appendDomainEvents(client, commit);
-      const effects = await this.insertEffects(client, commit);
-      const projection = commit.projection
-        ? await this.writeProjection(client, commit)
-        : undefined;
-
-      const completed = await client.query(
-        `UPDATE ${this.table('commands')}
-            SET status = 'completed', expires_at = 'infinity',
-                result = $4::jsonb, updated_at = NOW()
-          WHERE tenant_id = $1 AND command_id = $2
-            AND command_fingerprint = $3`,
-        [
-          commit.tenantId,
-          commit.command.commandId,
-          commit.command.fingerprint,
-          JSON.stringify(commit.command.result),
-        ],
-      );
-      if (completed.rowCount !== 1) {
+        if (completed.rowCount !== 1) {
+          throw new RuntimeStoreError(
+            'RUNTIME_STORE_LEASE_LOST',
+            `Command ${commit.command.commandId} could not be completed`,
+          );
+        }
+        return {
+          status: 'committed',
+          events: storedEvents,
+          effects,
+          ...(projection ? { projection } : {}),
+        };
+      });
+    } catch (error) {
+      if (isPostgresUniqueViolation(error)) {
         throw new RuntimeStoreError(
-          'RUNTIME_STORE_LEASE_LOST',
-          `Command ${commit.command.commandId} could not be completed`,
+          'RUNTIME_STORE_COMMAND_CONFLICT',
+          `Runtime transaction ${commit.command.commandId} reuses an event or effect identity`,
+          { cause: error },
         );
       }
-      return {
-        status: 'committed',
-        events: storedEvents,
-        effects,
-        ...(projection ? { projection } : {}),
-      };
-    });
+      throw error;
+    }
   }
 
   async readDomainEvents(
@@ -1013,9 +1039,37 @@ export class PostgresRuntimeStore implements RuntimeStore {
     mutate: (state: SessionState, now: number) => T,
     subagentInfo?: SessionRepositorySubagentInfo,
   ): Promise<T> {
+    return this.mutateSessionStateBatch(
+      tenantId,
+      sessionId,
+      [{ type: eventType, data: eventData }],
+      mutate,
+      subagentInfo,
+    );
+  }
+
+  async mutateSessionStateBatch<T>(
+    tenantId: string,
+    sessionId: SessionId,
+    events: readonly {
+      readonly type: string;
+      readonly data: JsonObject;
+    }[],
+    mutate: (state: SessionState, now: number) => T,
+    subagentInfo?: SessionRepositorySubagentInfo,
+  ): Promise<T> {
+    if (events.length === 0) {
+      throw new RuntimeStoreError(
+        'RUNTIME_STORE_INVALID_TRANSACTION',
+        'A Session projection mutation requires at least one event',
+      );
+    }
     await this.initialize();
     return this.transaction(async (client) => {
-      await this.lock(client, `projection:${tenantId}:${sessionId}`);
+      await this.lock(
+        client,
+        `projection:${tenantId}:${sessionId}:${SESSION_PROJECTION}`,
+      );
       const projectionResult = await client.query<ProjectionRow>(
         `SELECT projection_offset, state, updated_at
            FROM ${this.table('projections')}
@@ -1029,26 +1083,32 @@ export class PostgresRuntimeStore implements RuntimeStore {
         ? asSessionState(projectionResult.rows[0].state)
         : initialSessionState(sessionId, now, subagentInfo);
       const result = mutate(state, now);
-      const [stored] = await this.appendStream(
+      const stored = await this.appendStream(
         client,
         tenantId,
         sessionId,
         'transcript',
         undefined,
-        [({ sequence, eventId, recordedAt }) => ({
+        events.map((event) => ({ sequence, eventId, recordedAt }) => ({
           schemaVersion: RUNTIME_STORE_SCHEMA_VERSION,
           eventId,
           sequence,
           tenantId,
           sessionId,
           commandId: `transcript:${eventId}`,
-          type: eventType,
-          data: eventData,
+          type: event.type,
+          data: event.data,
           occurredAt: recordedAt,
           recordedAt,
-        })],
+        })),
       );
-      const offset = stored.sequence;
+      const offset = stored.at(-1)?.sequence;
+      if (offset === undefined) {
+        throw new RuntimeStoreError(
+          'RUNTIME_STORE_INVALID_TRANSACTION',
+          'A Session projection mutation produced no events',
+        );
+      }
       await client.query(
         `INSERT INTO ${this.table('projections')} (
            tenant_id, session_id, projection_name, projection_offset, state, updated_at
@@ -1075,6 +1135,14 @@ export class PostgresRuntimeStore implements RuntimeStore {
   ): Promise<void> {
     await this.initialize();
     await this.transaction(async (client) => {
+      await this.lock(
+        client,
+        `projection:${tenantId}:${sessionId}:${SESSION_PROJECTION}`,
+      );
+      await this.lock(
+        client,
+        `stream:${tenantId}:${sessionId}:transcript`,
+      );
       await client.query(
         `DELETE FROM ${this.table('events')}
           WHERE tenant_id = $1 AND session_id = $2 AND stream_name = 'transcript'`,
@@ -1112,7 +1180,7 @@ export class PostgresRuntimeStore implements RuntimeStore {
       `SELECT session_id
          FROM ${this.table('projections')}
         WHERE tenant_id = $1 AND projection_name = $2
-        ORDER BY (state->>'lastActivity')::bigint DESC
+        ORDER BY (state->>'lastActivity')::bigint DESC, session_id ASC
         OFFSET $3`,
       [tenantId, SESSION_PROJECTION, this.maxSessionsPerTenant],
     );
@@ -1272,8 +1340,19 @@ export class PostgresRuntimeStore implements RuntimeStore {
   }
 
   private async createSchema(): Promise<void> {
-    await this.pool.query(`CREATE SCHEMA IF NOT EXISTS ${this.schema}`);
-    await this.pool.query(`
+    const client = await this.pool.connect();
+    const lockKey = advisoryLockKey(
+      `runtime-store-schema:${this.schema}:${this.prefix}`,
+    );
+    let lockAcquired = false;
+    try {
+      await client.query(
+        'SELECT pg_advisory_lock($1, $2)',
+        [lockKey[0], lockKey[1]],
+      );
+      lockAcquired = true;
+      await client.query(`CREATE SCHEMA IF NOT EXISTS ${this.schema}`);
+      await client.query(`
       CREATE TABLE IF NOT EXISTS ${this.table('metadata')} (
         key TEXT PRIMARY KEY,
         value TEXT NOT NULL
@@ -1302,6 +1381,11 @@ export class PostgresRuntimeStore implements RuntimeStore {
         metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
         PRIMARY KEY (tenant_id, session_id)
       );
+
+      CREATE INDEX IF NOT EXISTS ${this.prefix}_sessions_listing_idx
+        ON ${this.table('sessions')} (
+          tenant_id, updated_at DESC, session_id ASC
+        );
 
       CREATE TABLE IF NOT EXISTS ${this.table('stream_heads')} (
         tenant_id TEXT NOT NULL,
@@ -1363,26 +1447,35 @@ export class PostgresRuntimeStore implements RuntimeStore {
         PRIMARY KEY (tenant_id, session_id, projection_name)
       );
     `);
-    await this.pool.query(
-      `INSERT INTO ${this.table('metadata')} (key, value)
-       VALUES ('schema_version', $1)
-       ON CONFLICT (key) DO NOTHING`,
-      [String(RUNTIME_STORE_SCHEMA_VERSION)],
-    );
-    const version = await this.pool.query(
-      `SELECT value
-         FROM ${this.table('metadata')}
-        WHERE key = 'schema_version'`,
-    );
-    if (
-      Number(version.rows[0]?.value) !== RUNTIME_STORE_SCHEMA_VERSION
-    ) {
-      throw new RuntimeStoreError(
-        'RUNTIME_STORE_INVALID_TRANSACTION',
-        `Unsupported Runtime Store schema version: ${String(
-          version.rows[0]?.value,
-        )}`,
+      await client.query(
+        `INSERT INTO ${this.table('metadata')} (key, value)
+         VALUES ('schema_version', $1)
+         ON CONFLICT (key) DO NOTHING`,
+        [String(RUNTIME_STORE_SCHEMA_VERSION)],
       );
+      const version = await client.query(
+        `SELECT value
+           FROM ${this.table('metadata')}
+          WHERE key = 'schema_version'`,
+      );
+      if (
+        Number(version.rows[0]?.value) !== RUNTIME_STORE_SCHEMA_VERSION
+      ) {
+        throw new RuntimeStoreError(
+          'RUNTIME_STORE_INVALID_TRANSACTION',
+          `Unsupported Runtime Store schema version: ${String(
+            version.rows[0]?.value,
+          )}`,
+        );
+      }
+    } finally {
+      if (lockAcquired) {
+        await client.query(
+          'SELECT pg_advisory_unlock($1, $2)',
+          [lockKey[0], lockKey[1]],
+        ).catch(() => undefined);
+      }
+      client.release();
     }
   }
 
@@ -1408,9 +1501,10 @@ export class PostgresRuntimeStore implements RuntimeStore {
   }
 
   private async lock(client: PoolClient, key: string): Promise<void> {
+    const lockKey = advisoryLockKey(key);
     await client.query(
-      'SELECT pg_advisory_xact_lock(hashtextextended($1, 0))',
-      [key],
+      'SELECT pg_advisory_xact_lock($1, $2)',
+      [lockKey[0], lockKey[1]],
     );
   }
 
@@ -1465,26 +1559,43 @@ export class PostgresRuntimeStore implements RuntimeStore {
     if (payloads.length === 0) {
       return [];
     }
-    for (const [index, payload] of payloads.entries()) {
-      await client.query(
-        `INSERT INTO ${this.table('events')} (
-           tenant_id, session_id, stream_name, sequence, event_id,
-           command_id, event_type, payload, occurred_at, recorded_at
-         ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9, $10)`,
-        [
-          tenantId,
-          sessionId,
-          streamName,
-          firstSequence + index,
-          String(payload.eventId),
-          typeof payload.commandId === 'string' ? payload.commandId : null,
-          String(payload.type),
-          JSON.stringify(payload),
-          String(payload.occurredAt ?? recordedAt),
-          recordedAt,
-        ],
-      );
-    }
+    const rows = payloads.map((payload, index) => ({
+      tenant_id: tenantId,
+      session_id: sessionId,
+      stream_name: streamName,
+      sequence: firstSequence + index,
+      event_id: String(payload.eventId),
+      command_id: typeof payload.commandId === 'string'
+        ? payload.commandId
+        : null,
+      event_type: String(payload.type),
+      payload,
+      occurred_at: String(payload.occurredAt ?? recordedAt),
+      recorded_at: recordedAt,
+    }));
+    await client.query(
+      `INSERT INTO ${this.table('events')} (
+         tenant_id, session_id, stream_name, sequence, event_id,
+         command_id, event_type, payload, occurred_at, recorded_at
+       )
+       SELECT entry.tenant_id, entry.session_id, entry.stream_name,
+              entry.sequence, entry.event_id, entry.command_id,
+              entry.event_type, entry.payload, entry.occurred_at,
+              entry.recorded_at
+         FROM jsonb_to_recordset($1::jsonb) AS entry(
+           tenant_id TEXT,
+           session_id TEXT,
+           stream_name TEXT,
+           sequence BIGINT,
+           event_id TEXT,
+           command_id TEXT,
+           event_type TEXT,
+           payload JSONB,
+           occurred_at TIMESTAMPTZ,
+           recorded_at TIMESTAMPTZ
+         )`,
+      [JSON.stringify(rows)],
+    );
     const nextSequence = firstSequence + payloads.length;
     const retainedFirst = retention
       ? Math.max(1, nextSequence - retention)
@@ -1527,42 +1638,48 @@ export class PostgresRuntimeStore implements RuntimeStore {
     if (!Number.isSafeInteger(limit) || limit < 1 || limit > 1000) {
       throw new RangeError('Event page limit must be between 1 and 1000');
     }
-    const headResult = await this.pool.query<StreamHeadRow>(
-      `SELECT first_sequence, next_sequence
-         FROM ${this.table('stream_heads')}
-        WHERE tenant_id = $1 AND session_id = $2 AND stream_name = $3`,
-      [tenantId, sessionId, streamName],
-    );
-    const head = headResult.rows[0];
-    if (!head) {
-      if (after > 0) {
+    return this.transaction(async (client) => {
+      await this.lock(
+        client,
+        `stream:${tenantId}:${sessionId}:${streamName}`,
+      );
+      const headResult = await client.query<StreamHeadRow>(
+        `SELECT first_sequence, next_sequence
+           FROM ${this.table('stream_heads')}
+          WHERE tenant_id = $1 AND session_id = $2 AND stream_name = $3`,
+        [tenantId, sessionId, streamName],
+      );
+      const head = headResult.rows[0];
+      if (!head) {
+        if (after > 0) {
+          throw new RangeError('Event cursor is ahead of the session head');
+        }
+        return { payloads: [], headSequence: null, hasMore: false };
+      }
+      const firstSequence = asNumber(head.first_sequence);
+      const nextSequence = asNumber(head.next_sequence);
+      if (after < firstSequence - 1) {
+        throw new RangeError('Event cursor is stale');
+      }
+      if (after >= nextSequence) {
         throw new RangeError('Event cursor is ahead of the session head');
       }
-      return { payloads: [], headSequence: null, hasMore: false };
-    }
-    const firstSequence = asNumber(head.first_sequence);
-    const nextSequence = asNumber(head.next_sequence);
-    if (after < firstSequence - 1) {
-      throw new RangeError('Event cursor is stale');
-    }
-    if (after >= nextSequence) {
-      throw new RangeError('Event cursor is ahead of the session head');
-    }
-    const result = await this.pool.query<PayloadRow>(
-      `SELECT payload
-         FROM ${this.table('events')}
-        WHERE tenant_id = $1 AND session_id = $2 AND stream_name = $3
-          AND sequence > $4
-        ORDER BY sequence ASC
-        LIMIT $5`,
-      [tenantId, sessionId, streamName, after, limit + 1],
-    );
-    return {
-      payloads: result.rows.slice(0, limit).map((row) =>
-        asJsonObject(row.payload)),
-      headSequence: nextSequence - 1,
-      hasMore: result.rows.length > limit,
-    };
+      const result = await client.query<PayloadRow>(
+        `SELECT payload
+           FROM ${this.table('events')}
+          WHERE tenant_id = $1 AND session_id = $2 AND stream_name = $3
+            AND sequence > $4
+          ORDER BY sequence ASC
+          LIMIT $5`,
+        [tenantId, sessionId, streamName, after, limit + 1],
+      );
+      return {
+        payloads: result.rows.slice(0, limit).map((row) =>
+          asJsonObject(row.payload)),
+        headSequence: nextSequence - 1,
+        hasMore: result.rows.length > limit,
+      };
+    });
   }
 
   private async appendDomainEvents(
@@ -2105,9 +2222,36 @@ class PostgresTenantRuntimeStore implements RuntimeTenantStore {
     sessionId: SessionId,
     contextData: ContextData,
   ): Promise<void> {
-    for (const message of contextData.layers.conversation.messages) {
-      await this.saveMessage(sessionId, message.role, message.content);
+    const messages = contextData.layers.conversation.messages.map((message) => ({
+      messageId: MessageId(nanoid()),
+      role: message.role,
+      content: structuredClone(message.content),
+    }));
+    if (messages.length === 0) {
+      return;
     }
+    await this.runtime.mutateSessionStateBatch(
+      this.tenantId,
+      sessionId,
+      messages.map(({ messageId, role }) => ({
+        type: 'transcript.message_saved',
+        data: { messageId, role },
+      })),
+      (state, now) => {
+        for (const message of messages) {
+          appendMessage(
+            state,
+            message.messageId,
+            {
+              id: message.messageId,
+              role: message.role,
+              content: message.content,
+            },
+            now,
+          );
+        }
+      },
+    );
   }
 
   loadState(sessionId: SessionId): Promise<SessionState | null> {

--- a/src/server/PostgresRuntimeStore.ts
+++ b/src/server/PostgresRuntimeStore.ts
@@ -1,0 +1,2226 @@
+import { nanoid } from 'nanoid';
+import {
+  Pool,
+  type PoolClient,
+  type PoolConfig,
+  type QueryResultRow,
+} from 'pg';
+import {
+  AGENT_PROTOCOL_VERSION,
+  parseAgentCommandResult,
+  parseAgentServerEvent,
+  type AgentCommandResult,
+  type AgentEventPage,
+  type AgentServerEvent,
+} from '../protocol/index.js';
+import type { ContentPart, Message } from '../services/ChatServiceInterface.js';
+import {
+  DurableEventSequenceConflictError,
+  DurableEventStoreError,
+} from '../session/events/DurableEventStore.js';
+import {
+  parseDurableEventDraft,
+  parseDurableEventEnvelope,
+} from '../session/events/schemas.js';
+import {
+  DURABLE_EVENT_SCHEMA_VERSION,
+  type DurableEventAppendOptions,
+  type DurableEventAppendResult,
+  type DurableEventDraft,
+  type DurableEventPage,
+  type DurableEventReadOptions,
+} from '../session/events/types.js';
+import type {
+  PersistedToolUse,
+  SessionRepositoryCompactionMetadata,
+  SessionRepositoryHealth,
+  SessionRepositoryMessageMetadata,
+  SessionRepositoryStorageStats,
+  SessionRepositorySubagentInfo,
+  SessionRepositorySubagentRef,
+} from '../session/SessionRepository.js';
+import type {
+  SessionSnapshot,
+  SessionState,
+  SessionSummary,
+} from '../session/SessionStore.js';
+import type {
+  ContextData,
+  PendingInputInfo,
+  SessionInfo,
+} from '../context/types.js';
+import {
+  EventSequence,
+  MessageId,
+  type InputId,
+  type RequestId,
+  type SessionId,
+} from '../types/branded.js';
+import type {
+  JsonObject,
+  JsonValue,
+  MessageRole,
+} from '../types/common.js';
+import {
+  cloneJsonValue,
+  cloneMessage,
+} from '../services/messageUtils.js';
+import { toJsonValue } from '../utils/jsonValue.js';
+import type {
+  AgentCommandClaim,
+  AgentServerSessionRecord,
+} from './AgentServerStore.js';
+import {
+  RUNTIME_STORE_SCHEMA_VERSION,
+  RuntimeStoreError,
+  type RuntimeCommandCommit,
+  type RuntimeCommitResult,
+  type RuntimeDomainEvent,
+  type RuntimeDomainEventPage,
+  type RuntimeEffectRecord,
+  type RuntimeEffectStatus,
+  type RuntimeProjectionRecord,
+  type RuntimeStore,
+  type RuntimeTenantStore,
+} from './RuntimeStore.js';
+
+const DEFAULT_MAX_EVENTS_PER_SESSION = 10_000;
+const DEFAULT_MAX_SESSIONS_PER_TENANT = 10_000;
+const SESSION_PROJECTION = 'session';
+
+export interface PostgresRuntimeStoreOptions {
+  readonly connectionString?: string;
+  readonly pool?: Pool;
+  readonly poolConfig?: PoolConfig;
+  readonly schema?: string;
+  readonly tablePrefix?: string;
+  readonly maxAgentEventsPerSession?: number;
+  readonly maxSessionsPerTenant?: number;
+}
+
+interface StreamHeadRow extends QueryResultRow {
+  first_sequence: string | number;
+  next_sequence: string | number;
+}
+
+interface PayloadRow extends QueryResultRow {
+  payload: unknown;
+}
+
+interface CommandRow extends QueryResultRow {
+  command_fingerprint: string;
+  lease_id: string;
+  status: 'claimed' | 'sealed' | 'completed';
+  expires_at: Date | string;
+  result: unknown | null;
+}
+
+interface ProjectionRow extends QueryResultRow {
+  projection_offset: string | number;
+  state: unknown;
+  updated_at: Date | string;
+}
+
+interface EffectRow extends QueryResultRow {
+  tenant_id: string;
+  session_id: string;
+  command_id: string;
+  effect_id: string;
+  effect_type: string;
+  payload: unknown;
+  idempotency_key: string;
+  status: RuntimeEffectStatus;
+  attempts: number;
+  available_at: Date | string;
+  created_at: Date | string;
+  result: unknown | null;
+  error: unknown | null;
+}
+
+function quoteIdentifier(value: string, label: string): string {
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(value)) {
+    throw new RangeError(`${label} must be a PostgreSQL identifier`);
+  }
+  return `"${value}"`;
+}
+
+function asNumber(value: string | number): number {
+  const parsed = typeof value === 'number' ? value : Number(value);
+  if (!Number.isSafeInteger(parsed)) {
+    throw new RuntimeStoreError(
+      'RUNTIME_STORE_INVALID_TRANSACTION',
+      `PostgreSQL returned an unsafe integer: ${String(value)}`,
+    );
+  }
+  return parsed;
+}
+
+function asIso(value: Date | string): string {
+  return value instanceof Date ? value.toISOString() : new Date(value).toISOString();
+}
+
+function asJsonObject(value: unknown): JsonObject {
+  return structuredClone(value) as JsonObject;
+}
+
+function asSessionState(value: unknown): SessionState {
+  return structuredClone(value) as SessionState;
+}
+
+function assertStrictJsonValue(
+  value: unknown,
+  label: string,
+  seen = new WeakSet<object>(),
+): void {
+  if (
+    value === null
+    || typeof value === 'string'
+    || typeof value === 'boolean'
+  ) {
+    return;
+  }
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      throw new RuntimeStoreError(
+        'RUNTIME_STORE_INVALID_TRANSACTION',
+        `${label} contains a non-finite number`,
+      );
+    }
+    return;
+  }
+  if (typeof value !== 'object') {
+    throw new RuntimeStoreError(
+      'RUNTIME_STORE_INVALID_TRANSACTION',
+      `${label} contains a non-JSON value`,
+    );
+  }
+  if (seen.has(value)) {
+    throw new RuntimeStoreError(
+      'RUNTIME_STORE_INVALID_TRANSACTION',
+      `${label} contains a circular reference`,
+    );
+  }
+  seen.add(value);
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => {
+      assertStrictJsonValue(item, `${label}[${index}]`, seen);
+    });
+    seen.delete(value);
+    return;
+  }
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw new RuntimeStoreError(
+      'RUNTIME_STORE_INVALID_TRANSACTION',
+      `${label} contains a non-plain object`,
+    );
+  }
+  for (const [key, item] of Object.entries(value)) {
+    assertStrictJsonValue(item, `${label}.${key}`, seen);
+  }
+  seen.delete(value);
+}
+
+function assertJsonObject(value: unknown, label: string): void {
+  assertStrictJsonValue(value, label);
+  let converted: JsonValue;
+  try {
+    converted = toJsonValue(value);
+  } catch (error) {
+    throw new RuntimeStoreError(
+      'RUNTIME_STORE_INVALID_TRANSACTION',
+      `${label} is not JSON serializable`,
+      { cause: error },
+    );
+  }
+  if (
+    converted === null
+    || Array.isArray(converted)
+    || typeof converted !== 'object'
+  ) {
+    throw new RuntimeStoreError(
+      'RUNTIME_STORE_INVALID_TRANSACTION',
+      `${label} must be a JSON object`,
+    );
+  }
+}
+
+function initialSessionState(
+  sessionId: SessionId,
+  now: number,
+  subagentInfo?: SessionRepositorySubagentInfo,
+): SessionState {
+  const timestamp = new Date(now).toISOString();
+  const sessionInfo: Partial<SessionInfo> = {
+    sessionId,
+    rootId: subagentInfo?.parentSessionId ?? sessionId,
+    parentId: subagentInfo?.parentSessionId,
+    relationType: subagentInfo ? 'subagent' : undefined,
+    status: 'running',
+    agentType: subagentInfo?.subagentType,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  };
+  return {
+    sessionId,
+    createdAt: now,
+    lastActivity: now,
+    sessionInfo,
+    timeline: [],
+    messages: [],
+    messageIds: [],
+    summaryMessageIds: [],
+    toolCalls: [],
+    subagentRefs: [],
+    pendingInputs: [],
+  };
+}
+
+function appendMessage(
+  state: SessionState,
+  messageId: string,
+  message: Message,
+  createdAt: number,
+  parentMessageId?: string,
+): void {
+  state.timeline.push({
+    id: messageId,
+    parentMessageId,
+    createdAt,
+    message: cloneMessage(message),
+  });
+  state.messages.push(cloneMessage(message));
+  state.messageIds.push(messageId);
+  state.lastActivity = createdAt;
+}
+
+function messageMetadata(
+  metadata?: SessionRepositoryMessageMetadata,
+): JsonValue | undefined {
+  if (!metadata) {
+    return undefined;
+  }
+  const result: JsonObject = {
+    ...(metadata.model ? { model: metadata.model } : {}),
+    ...(metadata.usage ? { usage: metadata.usage } : {}),
+    ...(metadata.customMetadata ?? {}),
+  };
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+export class PostgresRuntimeStore implements RuntimeStore {
+  private readonly pool: Pool;
+  private readonly ownsPool: boolean;
+  private readonly schema: string;
+  private readonly prefix: string;
+  private readonly maxAgentEventsPerSession: number;
+  private readonly maxSessionsPerTenant: number;
+  private initialization?: Promise<void>;
+
+  constructor(options: PostgresRuntimeStoreOptions = {}) {
+    if (!options.pool && !options.connectionString && !options.poolConfig) {
+      throw new TypeError(
+        'PostgresRuntimeStore requires pool, connectionString, or poolConfig',
+      );
+    }
+    this.pool = options.pool ?? new Pool({
+      ...options.poolConfig,
+      connectionString:
+        options.connectionString ?? options.poolConfig?.connectionString,
+    });
+    this.ownsPool = !options.pool;
+    this.schema = quoteIdentifier(options.schema ?? 'public', 'schema');
+    this.prefix = quoteIdentifier(
+      options.tablePrefix ?? 'blade_runtime',
+      'tablePrefix',
+    ).slice(1, -1);
+    this.maxAgentEventsPerSession =
+      options.maxAgentEventsPerSession ?? DEFAULT_MAX_EVENTS_PER_SESSION;
+    this.maxSessionsPerTenant =
+      options.maxSessionsPerTenant ?? DEFAULT_MAX_SESSIONS_PER_TENANT;
+    for (const [name, value] of [
+      ['maxAgentEventsPerSession', this.maxAgentEventsPerSession],
+      ['maxSessionsPerTenant', this.maxSessionsPerTenant],
+    ] as const) {
+      if (!Number.isSafeInteger(value) || value < 1) {
+        throw new RangeError(`${name} must be a positive safe integer`);
+      }
+    }
+  }
+
+  initialize(): Promise<void> {
+    if (!this.initialization) {
+      const initializing = this.createSchema();
+      this.initialization = initializing;
+      void initializing.catch(() => {
+        if (this.initialization === initializing) {
+          this.initialization = undefined;
+        }
+      });
+    }
+    return this.initialization;
+  }
+
+  forTenant(tenantId: string): RuntimeTenantStore {
+    if (!tenantId.trim()) {
+      throw new TypeError('tenantId must not be empty');
+    }
+    return new PostgresTenantRuntimeStore(this, tenantId);
+  }
+
+  async healthCheck(): Promise<{
+    readonly ready: boolean;
+    readonly details?: JsonObject;
+  }> {
+    try {
+      await this.initialize();
+      await this.pool.query('SELECT 1');
+      return {
+        ready: true,
+        details: {
+          backend: 'postgresql',
+          schemaVersion: RUNTIME_STORE_SCHEMA_VERSION,
+        },
+      };
+    } catch (error) {
+      return {
+        ready: false,
+        details: {
+          backend: 'postgresql',
+          error: error instanceof Error ? error.message : String(error),
+        },
+      };
+    }
+  }
+
+  async claimCommand(
+    tenantId: string,
+    commandId: string,
+    commandFingerprint: string,
+    ttlMs: number,
+  ): Promise<AgentCommandClaim> {
+    if (
+      !tenantId.trim()
+      || !commandId.trim()
+      || !commandFingerprint.trim()
+      || !Number.isSafeInteger(ttlMs)
+      || ttlMs < 1
+    ) {
+      throw new RangeError('Command claim parameters are invalid');
+    }
+    await this.initialize();
+    return this.transaction(async (client) => {
+      await this.lock(client, `command:${tenantId}:${commandId}`);
+      const existing = await client.query<CommandRow>(
+        `SELECT command_fingerprint, lease_id, status, expires_at, result
+           FROM ${this.table('commands')}
+          WHERE tenant_id = $1 AND command_id = $2
+          FOR UPDATE`,
+        [tenantId, commandId],
+      );
+      const row = existing.rows[0];
+      if (row && row.command_fingerprint !== commandFingerprint) {
+        return { status: 'conflict' };
+      }
+      if (row?.result !== null && row?.result !== undefined) {
+        return {
+          status: 'completed',
+          result: parseAgentCommandResult(row.result),
+        };
+      }
+      const now = Date.now();
+      if (
+        row
+        && (
+          row.status === 'sealed'
+          || new Date(row.expires_at).getTime() > now
+        )
+      ) {
+        return {
+          status: 'in_progress',
+          retryAfterMs: row.status === 'sealed'
+            ? 1000
+            : Math.max(1, new Date(row.expires_at).getTime() - now),
+        };
+      }
+      const leaseId = nanoid();
+      const expiresAt = new Date(now + ttlMs);
+      await client.query(
+        `INSERT INTO ${this.table('commands')} (
+           tenant_id, command_id, command_fingerprint, lease_id,
+           status, expires_at, created_at, updated_at
+         ) VALUES ($1, $2, $3, $4, 'claimed', $5, NOW(), NOW())
+         ON CONFLICT (tenant_id, command_id) DO UPDATE SET
+           command_fingerprint = EXCLUDED.command_fingerprint,
+           lease_id = EXCLUDED.lease_id,
+           status = 'claimed',
+           expires_at = EXCLUDED.expires_at,
+           result = NULL,
+           updated_at = NOW()`,
+        [tenantId, commandId, commandFingerprint, leaseId, expiresAt],
+      );
+      return { status: 'claimed', leaseId };
+    });
+  }
+
+  async sealCommand(
+    tenantId: string,
+    commandId: string,
+    leaseId: string,
+  ): Promise<void> {
+    await this.initialize();
+    const result = await this.pool.query(
+      `UPDATE ${this.table('commands')}
+          SET status = 'sealed', expires_at = 'infinity', updated_at = NOW()
+        WHERE tenant_id = $1 AND command_id = $2 AND lease_id = $3
+          AND status = 'claimed' AND result IS NULL`,
+      [tenantId, commandId, leaseId],
+    );
+    if (result.rowCount !== 1) {
+      throw new Error(`Command lease ${commandId}/${leaseId} is no longer active`);
+    }
+  }
+
+  async completeCommand(
+    tenantId: string,
+    commandId: string,
+    leaseId: string,
+    result: AgentCommandResult,
+  ): Promise<void> {
+    await this.initialize();
+    const updated = await this.pool.query(
+      `UPDATE ${this.table('commands')}
+          SET status = 'completed', expires_at = 'infinity',
+              result = $4::jsonb, updated_at = NOW()
+        WHERE tenant_id = $1 AND command_id = $2 AND lease_id = $3
+          AND status IN ('claimed', 'sealed')`,
+      [tenantId, commandId, leaseId, JSON.stringify(result)],
+    );
+    if (updated.rowCount !== 1) {
+      throw new Error(`Command lease ${commandId}/${leaseId} is no longer active`);
+    }
+  }
+
+  async releaseCommand(
+    tenantId: string,
+    commandId: string,
+    leaseId: string,
+  ): Promise<void> {
+    await this.initialize();
+    await this.pool.query(
+      `DELETE FROM ${this.table('commands')}
+        WHERE tenant_id = $1 AND command_id = $2 AND lease_id = $3
+          AND status = 'claimed'`,
+      [tenantId, commandId, leaseId],
+    );
+  }
+
+  async putSession(record: AgentServerSessionRecord): Promise<void> {
+    await this.initialize();
+    await this.pool.query(
+      `INSERT INTO ${this.table('sessions')} (
+         tenant_id, session_id, created_by, status,
+         created_at, updated_at, metadata
+       ) VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb)
+       ON CONFLICT (tenant_id, session_id) DO UPDATE SET
+         status = EXCLUDED.status,
+         updated_at = EXCLUDED.updated_at,
+         metadata = EXCLUDED.metadata`,
+      [
+        record.tenantId,
+        record.sessionId,
+        record.createdBy,
+        record.status,
+        record.createdAt,
+        record.updatedAt,
+        JSON.stringify(record.metadata ?? {}),
+      ],
+    );
+  }
+
+  async getSession(
+    tenantId: string,
+    sessionId: SessionId,
+  ): Promise<AgentServerSessionRecord | null> {
+    await this.initialize();
+    const result = await this.pool.query(
+      `SELECT tenant_id, session_id, created_by, status,
+              created_at, updated_at, metadata
+         FROM ${this.table('sessions')}
+        WHERE tenant_id = $1 AND session_id = $2`,
+      [tenantId, sessionId],
+    );
+    const row = result.rows[0] as
+      | {
+          tenant_id: string;
+          session_id: string;
+          created_by: string;
+          status: 'active' | 'closed';
+          created_at: Date | string;
+          updated_at: Date | string;
+          metadata: JsonObject;
+        }
+      | undefined;
+    return row
+      ? {
+          tenantId: row.tenant_id,
+          createdBy: row.created_by,
+          sessionId: row.session_id as SessionId,
+          status: row.status,
+          createdAt: asIso(row.created_at),
+          updatedAt: asIso(row.updated_at),
+          ...(Object.keys(row.metadata ?? {}).length > 0
+            ? { metadata: asJsonObject(row.metadata) }
+            : {}),
+        }
+      : null;
+  }
+
+  async listSessions(
+    tenantId: string,
+    options: { cursor?: string; limit?: number } = {},
+  ): Promise<{ sessions: AgentServerSessionRecord[]; nextCursor?: string }> {
+    await this.initialize();
+    const limit = options.limit ?? 50;
+    const offset = options.cursor ? Number(options.cursor) : 0;
+    if (
+      !Number.isSafeInteger(offset)
+      || offset < 0
+      || !Number.isSafeInteger(limit)
+      || limit < 1
+      || limit > 100
+    ) {
+      throw new RangeError('Session list pagination is invalid');
+    }
+    const result = await this.pool.query(
+      `SELECT tenant_id, session_id, created_by, status,
+              created_at, updated_at, metadata
+         FROM ${this.table('sessions')}
+        WHERE tenant_id = $1
+        ORDER BY updated_at DESC, session_id ASC
+        OFFSET $2 LIMIT $3`,
+      [tenantId, offset, limit + 1],
+    );
+    const hasMore = result.rows.length > limit;
+    const rows = result.rows.slice(0, limit) as Array<{
+      tenant_id: string;
+      session_id: string;
+      created_by: string;
+      status: 'active' | 'closed';
+      created_at: Date | string;
+      updated_at: Date | string;
+      metadata: JsonObject;
+    }>;
+    return {
+      sessions: rows.map((row) => ({
+        tenantId: row.tenant_id,
+        createdBy: row.created_by,
+        sessionId: row.session_id as SessionId,
+        status: row.status,
+        createdAt: asIso(row.created_at),
+        updatedAt: asIso(row.updated_at),
+        ...(Object.keys(row.metadata ?? {}).length > 0
+          ? { metadata: asJsonObject(row.metadata) }
+          : {}),
+      })),
+      ...(hasMore ? { nextCursor: String(offset + limit) } : {}),
+    };
+  }
+
+  async appendEvent(
+    tenantId: string,
+    sessionId: SessionId,
+    event: Omit<AgentServerEvent, 'eventId' | 'sequence'>,
+  ): Promise<AgentServerEvent> {
+    if (event.sessionId !== sessionId) {
+      throw new RangeError('Event Session does not match the target event log');
+    }
+    await this.initialize();
+    return this.transaction(async (client) => {
+      const [stored] = await this.appendStream(
+        client,
+        tenantId,
+        sessionId,
+        'agent',
+        undefined,
+        [({ sequence, eventId, recordedAt }) => ({
+          ...event,
+          protocolVersion: AGENT_PROTOCOL_VERSION,
+          eventId,
+          sequence,
+          occurredAt: event.occurredAt ?? recordedAt,
+        })],
+        this.maxAgentEventsPerSession,
+      );
+      return parseAgentServerEvent(stored);
+    });
+  }
+
+  async readEvents(
+    tenantId: string,
+    sessionId: SessionId,
+    options: { after?: number; limit?: number } = {},
+  ): Promise<AgentEventPage> {
+    const page = await this.readStream(
+      tenantId,
+      sessionId,
+      'agent',
+      options.after,
+      options.limit,
+    );
+    const events = page.payloads.map((payload) =>
+      parseAgentServerEvent(payload));
+    const last = events.at(-1);
+    return {
+      events,
+      nextCursor: last
+        ? {
+            protocolVersion: AGENT_PROTOCOL_VERSION,
+            sessionId,
+            sequence: last.sequence,
+            eventId: last.eventId,
+          }
+        : null,
+      hasMore: page.hasMore,
+    };
+  }
+
+  async commitRuntimeTransaction(
+    commit: RuntimeCommandCommit,
+  ): Promise<RuntimeCommitResult> {
+    await this.initialize();
+    this.validateRuntimeCommit(commit);
+    if (
+      commit.projection
+      && commit.events?.length
+      && commit.projection.offset < 1
+    ) {
+      throw new RuntimeStoreError(
+        'RUNTIME_STORE_INVALID_TRANSACTION',
+        'Projection offset must reference a committed event',
+      );
+    }
+    return this.transaction(async (client) => {
+      await this.lock(
+        client,
+        `command:${commit.tenantId}:${commit.command.commandId}`,
+      );
+      const commandResult = await client.query<CommandRow>(
+        `SELECT command_fingerprint, lease_id, status, expires_at, result
+           FROM ${this.table('commands')}
+          WHERE tenant_id = $1 AND command_id = $2
+          FOR UPDATE`,
+        [commit.tenantId, commit.command.commandId],
+      );
+      const existing = commandResult.rows[0];
+      if (
+        existing
+        && existing.command_fingerprint !== commit.command.fingerprint
+      ) {
+        throw new RuntimeStoreError(
+          'RUNTIME_STORE_COMMAND_CONFLICT',
+          `Command ${commit.command.commandId} has a different fingerprint`,
+        );
+      }
+      if (existing?.result !== null && existing?.result !== undefined) {
+        return this.loadCommittedRuntimeResult(client, commit);
+      }
+      if (commit.command.leaseId) {
+        if (!existing || existing.lease_id !== commit.command.leaseId) {
+          throw new RuntimeStoreError(
+            'RUNTIME_STORE_LEASE_LOST',
+            `Command lease ${commit.command.commandId}/${commit.command.leaseId} is not active`,
+          );
+        }
+      } else if (existing) {
+        throw new RuntimeStoreError(
+          'RUNTIME_STORE_LEASE_LOST',
+          `Command ${commit.command.commandId} already has an active receipt`,
+        );
+      } else {
+        await client.query(
+          `INSERT INTO ${this.table('commands')} (
+             tenant_id, command_id, command_fingerprint, lease_id,
+             status, expires_at, created_at, updated_at
+           ) VALUES ($1, $2, $3, $4, 'sealed', 'infinity', NOW(), NOW())`,
+          [
+            commit.tenantId,
+            commit.command.commandId,
+            commit.command.fingerprint,
+            `atomic:${commit.command.commandId}`,
+          ],
+        );
+      }
+
+      const storedEvents = await this.appendDomainEvents(client, commit);
+      const effects = await this.insertEffects(client, commit);
+      const projection = commit.projection
+        ? await this.writeProjection(client, commit)
+        : undefined;
+
+      const completed = await client.query(
+        `UPDATE ${this.table('commands')}
+            SET status = 'completed', expires_at = 'infinity',
+                result = $4::jsonb, updated_at = NOW()
+          WHERE tenant_id = $1 AND command_id = $2
+            AND command_fingerprint = $3`,
+        [
+          commit.tenantId,
+          commit.command.commandId,
+          commit.command.fingerprint,
+          JSON.stringify(commit.command.result),
+        ],
+      );
+      if (completed.rowCount !== 1) {
+        throw new RuntimeStoreError(
+          'RUNTIME_STORE_LEASE_LOST',
+          `Command ${commit.command.commandId} could not be completed`,
+        );
+      }
+      return {
+        status: 'committed',
+        events: storedEvents,
+        effects,
+        ...(projection ? { projection } : {}),
+      };
+    });
+  }
+
+  async readDomainEvents(
+    tenantId: string,
+    sessionId: SessionId,
+    options: { readonly after?: number; readonly limit?: number } = {},
+  ): Promise<RuntimeDomainEventPage> {
+    const page = await this.readStream(
+      tenantId,
+      sessionId,
+      'domain',
+      options.after,
+      options.limit,
+    );
+    return {
+      events: page.payloads.map((payload) =>
+        structuredClone(payload) as unknown as RuntimeDomainEvent),
+      headSequence: page.headSequence,
+      hasMore: page.hasMore,
+    };
+  }
+
+  async listEffects(
+    tenantId: string,
+    options: {
+      readonly sessionId?: SessionId;
+      readonly status?: RuntimeEffectStatus;
+      readonly limit?: number;
+    } = {},
+  ): Promise<readonly RuntimeEffectRecord[]> {
+    await this.initialize();
+    const limit = options.limit ?? 100;
+    if (!Number.isSafeInteger(limit) || limit < 1 || limit > 1000) {
+      throw new RangeError('Effect list limit must be between 1 and 1000');
+    }
+    const values: unknown[] = [tenantId];
+    const predicates = ['tenant_id = $1'];
+    if (options.sessionId) {
+      values.push(options.sessionId);
+      predicates.push(`session_id = $${values.length}`);
+    }
+    if (options.status) {
+      values.push(options.status);
+      predicates.push(`status = $${values.length}`);
+    }
+    values.push(limit);
+    const result = await this.pool.query<EffectRow>(
+      `SELECT tenant_id, session_id, command_id, effect_id, effect_type,
+              payload, idempotency_key, status, attempts, available_at,
+              created_at, result, error
+         FROM ${this.table('outbox')}
+        WHERE ${predicates.join(' AND ')}
+        ORDER BY created_at ASC, effect_id ASC
+        LIMIT $${values.length}`,
+      values,
+    );
+    return result.rows.map((row) => this.effectRecord(row));
+  }
+
+  async getProjection(
+    tenantId: string,
+    sessionId: SessionId,
+    name: string,
+  ): Promise<RuntimeProjectionRecord | null> {
+    await this.initialize();
+    const result = await this.pool.query<ProjectionRow>(
+      `SELECT projection_offset, state, updated_at
+         FROM ${this.table('projections')}
+        WHERE tenant_id = $1 AND session_id = $2 AND projection_name = $3`,
+      [tenantId, sessionId, name],
+    );
+    const row = result.rows[0];
+    return row
+      ? {
+          tenantId,
+          sessionId,
+          name,
+          offset: asNumber(row.projection_offset),
+          state: asJsonObject(row.state),
+          updatedAt: asIso(row.updated_at),
+        }
+      : null;
+  }
+
+  async close(): Promise<void> {
+    if (this.ownsPool) {
+      await this.pool.end();
+    }
+  }
+
+  async appendDurableEvents(
+    tenantId: string,
+    sessionId: SessionId,
+    drafts: readonly DurableEventDraft[],
+    options: DurableEventAppendOptions = {},
+  ): Promise<DurableEventAppendResult> {
+    await this.initialize();
+    if (drafts.length === 0) {
+      throw new DurableEventStoreError(
+        'DURABLE_EVENT_INVALID_APPEND',
+        'A durable event append requires at least one event',
+      );
+    }
+    const parsed = drafts.map((draft, index) => {
+      try {
+        return parseDurableEventDraft(draft);
+      } catch (error) {
+        throw new DurableEventStoreError(
+          'DURABLE_EVENT_INVALID_APPEND',
+          `Invalid durable event draft at index ${index}`,
+          { cause: error },
+        );
+      }
+    });
+    options.signal?.throwIfAborted();
+    return this.transaction(async (client) => {
+      const previousSequence = await this.currentHead(
+        client,
+        tenantId,
+        sessionId,
+        'durable',
+      );
+      if (
+        options.expectedLastSequence !== undefined
+        && options.expectedLastSequence !== previousSequence
+      ) {
+        throw new DurableEventSequenceConflictError(
+          options.expectedLastSequence,
+          previousSequence === null
+            ? null
+            : EventSequence(previousSequence),
+        );
+      }
+      const events = await this.appendStream(
+        client,
+        tenantId,
+        sessionId,
+        'durable',
+        previousSequence,
+        parsed.map((draft) => ({ sequence, eventId, recordedAt }) => ({
+          ...draft,
+          schemaVersion: DURABLE_EVENT_SCHEMA_VERSION,
+          eventId,
+          sequence: EventSequence(sequence),
+          sessionId,
+          recordedAt,
+          occurredAt: draft.occurredAt ?? recordedAt,
+        })),
+      );
+      const durableEvents = events.map((value) =>
+        parseDurableEventEnvelope(value));
+      const last = durableEvents.at(-1);
+      if (!last) {
+        throw new DurableEventStoreError(
+          'DURABLE_EVENT_INVALID_APPEND',
+          'A durable event append produced no events',
+        );
+      }
+      return {
+        events: durableEvents,
+        previousSequence: previousSequence === null
+          ? null
+          : EventSequence(previousSequence),
+        lastSequence: last.sequence,
+      };
+    });
+  }
+
+  async readDurableEvents(
+    tenantId: string,
+    sessionId: SessionId,
+    options: DurableEventReadOptions = {},
+  ): Promise<DurableEventPage> {
+    options.signal?.throwIfAborted();
+    const page = await this.readStream(
+      tenantId,
+      sessionId,
+      'durable',
+      options.after === undefined ? undefined : Number(options.after),
+      options.limit,
+    );
+    const events = page.payloads.map((value) =>
+      parseDurableEventEnvelope(value));
+    const last = events.at(-1);
+    return {
+      events,
+      headSequence: page.headSequence === null
+        ? null
+        : EventSequence(page.headSequence),
+      nextCursor: last?.sequence ?? null,
+      hasMore: page.hasMore,
+    };
+  }
+
+  async getDurableHead(
+    tenantId: string,
+    sessionId: SessionId,
+  ): Promise<EventSequence | null> {
+    await this.initialize();
+    const result = await this.pool.query<StreamHeadRow>(
+      `SELECT first_sequence, next_sequence
+         FROM ${this.table('stream_heads')}
+        WHERE tenant_id = $1 AND session_id = $2 AND stream_name = 'durable'`,
+      [tenantId, sessionId],
+    );
+    const row = result.rows[0];
+    return row ? EventSequence(asNumber(row.next_sequence) - 1) : null;
+  }
+
+  async loadSessionState(
+    tenantId: string,
+    sessionId: SessionId,
+  ): Promise<SessionState | null> {
+    const projection = await this.getProjection(
+      tenantId,
+      sessionId,
+      SESSION_PROJECTION,
+    );
+    return projection ? asSessionState(projection.state) : null;
+  }
+
+  async mutateSessionState<T>(
+    tenantId: string,
+    sessionId: SessionId,
+    eventType: string,
+    eventData: JsonObject,
+    mutate: (state: SessionState, now: number) => T,
+    subagentInfo?: SessionRepositorySubagentInfo,
+  ): Promise<T> {
+    await this.initialize();
+    return this.transaction(async (client) => {
+      await this.lock(client, `projection:${tenantId}:${sessionId}`);
+      const projectionResult = await client.query<ProjectionRow>(
+        `SELECT projection_offset, state, updated_at
+           FROM ${this.table('projections')}
+          WHERE tenant_id = $1 AND session_id = $2
+            AND projection_name = $3
+          FOR UPDATE`,
+        [tenantId, sessionId, SESSION_PROJECTION],
+      );
+      const now = Date.now();
+      const state = projectionResult.rows[0]
+        ? asSessionState(projectionResult.rows[0].state)
+        : initialSessionState(sessionId, now, subagentInfo);
+      const result = mutate(state, now);
+      const [stored] = await this.appendStream(
+        client,
+        tenantId,
+        sessionId,
+        'transcript',
+        undefined,
+        [({ sequence, eventId, recordedAt }) => ({
+          schemaVersion: RUNTIME_STORE_SCHEMA_VERSION,
+          eventId,
+          sequence,
+          tenantId,
+          sessionId,
+          commandId: `transcript:${eventId}`,
+          type: eventType,
+          data: eventData,
+          occurredAt: recordedAt,
+          recordedAt,
+        })],
+      );
+      const offset = stored.sequence;
+      await client.query(
+        `INSERT INTO ${this.table('projections')} (
+           tenant_id, session_id, projection_name, projection_offset, state, updated_at
+         ) VALUES ($1, $2, $3, $4, $5::jsonb, NOW())
+         ON CONFLICT (tenant_id, session_id, projection_name) DO UPDATE SET
+           projection_offset = EXCLUDED.projection_offset,
+           state = EXCLUDED.state,
+           updated_at = NOW()`,
+        [
+          tenantId,
+          sessionId,
+          SESSION_PROJECTION,
+          offset,
+          JSON.stringify(state),
+        ],
+      );
+      return result;
+    });
+  }
+
+  async deleteSessionProjection(
+    tenantId: string,
+    sessionId: SessionId,
+  ): Promise<void> {
+    await this.initialize();
+    await this.transaction(async (client) => {
+      await client.query(
+        `DELETE FROM ${this.table('events')}
+          WHERE tenant_id = $1 AND session_id = $2 AND stream_name = 'transcript'`,
+        [tenantId, sessionId],
+      );
+      await client.query(
+        `DELETE FROM ${this.table('stream_heads')}
+          WHERE tenant_id = $1 AND session_id = $2 AND stream_name = 'transcript'`,
+        [tenantId, sessionId],
+      );
+      await client.query(
+        `DELETE FROM ${this.table('projections')}
+          WHERE tenant_id = $1 AND session_id = $2
+            AND projection_name = $3`,
+        [tenantId, sessionId, SESSION_PROJECTION],
+      );
+    });
+  }
+
+  async listSessionProjectionIds(tenantId: string): Promise<string[]> {
+    await this.initialize();
+    const result = await this.pool.query(
+      `SELECT session_id
+         FROM ${this.table('projections')}
+        WHERE tenant_id = $1 AND projection_name = $2
+        ORDER BY session_id ASC`,
+      [tenantId, SESSION_PROJECTION],
+    );
+    return result.rows.map((row) => String(row.session_id));
+  }
+
+  async cleanupSessionProjections(tenantId: string): Promise<void> {
+    await this.initialize();
+    const result = await this.pool.query(
+      `SELECT session_id
+         FROM ${this.table('projections')}
+        WHERE tenant_id = $1 AND projection_name = $2
+        ORDER BY (state->>'lastActivity')::bigint DESC
+        OFFSET $3`,
+      [tenantId, SESSION_PROJECTION, this.maxSessionsPerTenant],
+    );
+    for (const row of result.rows) {
+      await this.deleteSessionProjection(
+        tenantId,
+        String(row.session_id) as SessionId,
+      );
+    }
+  }
+
+  async sessionStorageStats(
+    tenantId: string,
+  ): Promise<SessionRepositoryStorageStats> {
+    await this.initialize();
+    const result = await this.pool.query(
+      `SELECT COUNT(*)::int AS total_sessions,
+              COALESCE(SUM(octet_length(state::text)), 0)::bigint AS total_size
+         FROM ${this.table('projections')}
+        WHERE tenant_id = $1 AND projection_name = $2`,
+      [tenantId, SESSION_PROJECTION],
+    );
+    return {
+      totalSessions: Number(result.rows[0]?.total_sessions ?? 0),
+      totalSize: Number(result.rows[0]?.total_size ?? 0),
+    };
+  }
+
+  private validateRuntimeCommit(commit: RuntimeCommandCommit): void {
+    for (const [label, value] of [
+      ['tenantId', commit.tenantId],
+      ['sessionId', commit.sessionId],
+      ['commandId', commit.command.commandId],
+      ['command fingerprint', commit.command.fingerprint],
+    ] as const) {
+      if (!String(value).trim()) {
+        throw new RuntimeStoreError(
+          'RUNTIME_STORE_INVALID_TRANSACTION',
+          `${label} must not be empty`,
+        );
+      }
+    }
+    try {
+      parseAgentCommandResult(commit.command.result);
+    } catch (error) {
+      throw new RuntimeStoreError(
+        'RUNTIME_STORE_INVALID_TRANSACTION',
+        'Command result is not a valid protocol result',
+        { cause: error },
+      );
+    }
+    if (
+      commit.expectedLastSequence !== undefined
+      && commit.expectedLastSequence !== null
+      && (
+        !Number.isSafeInteger(commit.expectedLastSequence)
+        || commit.expectedLastSequence < 1
+      )
+    ) {
+      throw new RuntimeStoreError(
+        'RUNTIME_STORE_INVALID_TRANSACTION',
+        'expectedLastSequence must be null or a positive safe integer',
+      );
+    }
+
+    const eventIds = new Set<string>();
+    for (const [index, event] of (commit.events ?? []).entries()) {
+      if (!event.type.trim()) {
+        throw new RuntimeStoreError(
+          'RUNTIME_STORE_INVALID_TRANSACTION',
+          `Event type at index ${index} must not be empty`,
+        );
+      }
+      assertJsonObject(event.data, `Event data at index ${index}`);
+      if (event.eventId) {
+        if (eventIds.has(event.eventId)) {
+          throw new RuntimeStoreError(
+            'RUNTIME_STORE_INVALID_TRANSACTION',
+            `Duplicate eventId in transaction: ${event.eventId}`,
+          );
+        }
+        eventIds.add(event.eventId);
+      }
+      if (
+        event.occurredAt
+        && !Number.isFinite(Date.parse(event.occurredAt))
+      ) {
+        throw new RuntimeStoreError(
+          'RUNTIME_STORE_INVALID_TRANSACTION',
+          `Event occurredAt at index ${index} is invalid`,
+        );
+      }
+    }
+
+    const effectIds = new Set<string>();
+    const idempotencyKeys = new Set<string>();
+    for (const [index, effect] of (commit.effects ?? []).entries()) {
+      if (
+        !effect.effectId.trim()
+        || !effect.type.trim()
+        || !effect.idempotencyKey.trim()
+      ) {
+        throw new RuntimeStoreError(
+          'RUNTIME_STORE_INVALID_TRANSACTION',
+          `Effect identifiers at index ${index} must not be empty`,
+        );
+      }
+      if (
+        effectIds.has(effect.effectId)
+        || idempotencyKeys.has(effect.idempotencyKey)
+      ) {
+        throw new RuntimeStoreError(
+          'RUNTIME_STORE_INVALID_TRANSACTION',
+          `Duplicate effect identity at index ${index}`,
+        );
+      }
+      effectIds.add(effect.effectId);
+      idempotencyKeys.add(effect.idempotencyKey);
+      assertJsonObject(effect.payload, `Effect payload at index ${index}`);
+      if (
+        effect.availableAt
+        && !Number.isFinite(Date.parse(effect.availableAt))
+      ) {
+        throw new RuntimeStoreError(
+          'RUNTIME_STORE_INVALID_TRANSACTION',
+          `Effect availableAt at index ${index} is invalid`,
+        );
+      }
+    }
+
+    if (commit.projection) {
+      if (
+        !commit.projection.name.trim()
+        || !Number.isSafeInteger(commit.projection.offset)
+        || commit.projection.offset < 0
+      ) {
+        throw new RuntimeStoreError(
+          'RUNTIME_STORE_INVALID_TRANSACTION',
+          'Projection name and offset are invalid',
+        );
+      }
+      if (
+        commit.projection.expectedOffset !== undefined
+        && commit.projection.expectedOffset !== null
+        && (
+          !Number.isSafeInteger(commit.projection.expectedOffset)
+          || commit.projection.expectedOffset < 0
+        )
+      ) {
+        throw new RuntimeStoreError(
+          'RUNTIME_STORE_INVALID_TRANSACTION',
+          'Projection expectedOffset is invalid',
+        );
+      }
+      assertJsonObject(commit.projection.state, 'Projection state');
+    }
+  }
+
+  private async createSchema(): Promise<void> {
+    await this.pool.query(`CREATE SCHEMA IF NOT EXISTS ${this.schema}`);
+    await this.pool.query(`
+      CREATE TABLE IF NOT EXISTS ${this.table('metadata')} (
+        key TEXT PRIMARY KEY,
+        value TEXT NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS ${this.table('commands')} (
+        tenant_id TEXT NOT NULL,
+        command_id TEXT NOT NULL,
+        command_fingerprint TEXT NOT NULL,
+        lease_id TEXT NOT NULL,
+        status TEXT NOT NULL CHECK (status IN ('claimed', 'sealed', 'completed')),
+        expires_at TIMESTAMPTZ NOT NULL,
+        result JSONB,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        PRIMARY KEY (tenant_id, command_id)
+      );
+
+      CREATE TABLE IF NOT EXISTS ${this.table('sessions')} (
+        tenant_id TEXT NOT NULL,
+        session_id TEXT NOT NULL,
+        created_by TEXT NOT NULL,
+        status TEXT NOT NULL CHECK (status IN ('active', 'closed')),
+        created_at TIMESTAMPTZ NOT NULL,
+        updated_at TIMESTAMPTZ NOT NULL,
+        metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+        PRIMARY KEY (tenant_id, session_id)
+      );
+
+      CREATE TABLE IF NOT EXISTS ${this.table('stream_heads')} (
+        tenant_id TEXT NOT NULL,
+        session_id TEXT NOT NULL,
+        stream_name TEXT NOT NULL,
+        first_sequence BIGINT NOT NULL DEFAULT 1,
+        next_sequence BIGINT NOT NULL DEFAULT 1,
+        PRIMARY KEY (tenant_id, session_id, stream_name)
+      );
+
+      CREATE TABLE IF NOT EXISTS ${this.table('events')} (
+        tenant_id TEXT NOT NULL,
+        session_id TEXT NOT NULL,
+        stream_name TEXT NOT NULL,
+        sequence BIGINT NOT NULL,
+        event_id TEXT NOT NULL,
+        command_id TEXT,
+        event_type TEXT NOT NULL,
+        payload JSONB NOT NULL,
+        occurred_at TIMESTAMPTZ NOT NULL,
+        recorded_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        PRIMARY KEY (tenant_id, session_id, stream_name, sequence),
+        UNIQUE (tenant_id, event_id)
+      );
+
+      CREATE INDEX IF NOT EXISTS ${this.prefix}_events_command_idx
+        ON ${this.table('events')} (tenant_id, command_id)
+        WHERE command_id IS NOT NULL;
+
+      CREATE TABLE IF NOT EXISTS ${this.table('outbox')} (
+        tenant_id TEXT NOT NULL,
+        effect_id TEXT NOT NULL,
+        session_id TEXT NOT NULL,
+        command_id TEXT NOT NULL,
+        effect_type TEXT NOT NULL,
+        payload JSONB NOT NULL,
+        idempotency_key TEXT NOT NULL,
+        status TEXT NOT NULL DEFAULT 'pending'
+          CHECK (status IN ('pending', 'completed', 'failed')),
+        attempts INTEGER NOT NULL DEFAULT 0,
+        available_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        result JSONB,
+        error JSONB,
+        PRIMARY KEY (tenant_id, effect_id),
+        UNIQUE (tenant_id, idempotency_key)
+      );
+
+      CREATE INDEX IF NOT EXISTS ${this.prefix}_outbox_pending_idx
+        ON ${this.table('outbox')} (tenant_id, status, available_at);
+
+      CREATE TABLE IF NOT EXISTS ${this.table('projections')} (
+        tenant_id TEXT NOT NULL,
+        session_id TEXT NOT NULL,
+        projection_name TEXT NOT NULL,
+        projection_offset BIGINT NOT NULL,
+        state JSONB NOT NULL,
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        PRIMARY KEY (tenant_id, session_id, projection_name)
+      );
+    `);
+    await this.pool.query(
+      `INSERT INTO ${this.table('metadata')} (key, value)
+       VALUES ('schema_version', $1)
+       ON CONFLICT (key) DO NOTHING`,
+      [String(RUNTIME_STORE_SCHEMA_VERSION)],
+    );
+    const version = await this.pool.query(
+      `SELECT value
+         FROM ${this.table('metadata')}
+        WHERE key = 'schema_version'`,
+    );
+    if (
+      Number(version.rows[0]?.value) !== RUNTIME_STORE_SCHEMA_VERSION
+    ) {
+      throw new RuntimeStoreError(
+        'RUNTIME_STORE_INVALID_TRANSACTION',
+        `Unsupported Runtime Store schema version: ${String(
+          version.rows[0]?.value,
+        )}`,
+      );
+    }
+  }
+
+  private table(suffix: string): string {
+    return `${this.schema}.${quoteIdentifier(`${this.prefix}_${suffix}`, 'table')}`;
+  }
+
+  private async transaction<T>(
+    operation: (client: PoolClient) => Promise<T>,
+  ): Promise<T> {
+    const client = await this.pool.connect();
+    try {
+      await client.query('BEGIN');
+      const result = await operation(client);
+      await client.query('COMMIT');
+      return result;
+    } catch (error) {
+      await client.query('ROLLBACK').catch(() => undefined);
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+
+  private async lock(client: PoolClient, key: string): Promise<void> {
+    await client.query(
+      'SELECT pg_advisory_xact_lock(hashtextextended($1, 0))',
+      [key],
+    );
+  }
+
+  private async currentHead(
+    client: PoolClient,
+    tenantId: string,
+    sessionId: SessionId,
+    streamName: string,
+  ): Promise<number | null> {
+    await this.lock(client, `stream:${tenantId}:${sessionId}:${streamName}`);
+    const result = await client.query<StreamHeadRow>(
+      `SELECT first_sequence, next_sequence
+         FROM ${this.table('stream_heads')}
+        WHERE tenant_id = $1 AND session_id = $2 AND stream_name = $3
+        FOR UPDATE`,
+      [tenantId, sessionId, streamName],
+    );
+    return result.rows[0]
+      ? asNumber(result.rows[0].next_sequence) - 1
+      : null;
+  }
+
+  private async appendStream<TPayload extends {
+    readonly eventId: string;
+    readonly type: string;
+    readonly occurredAt: string;
+    readonly commandId?: string;
+  }>(
+    client: PoolClient,
+    tenantId: string,
+    sessionId: SessionId,
+    streamName: string,
+    knownHead: number | null | undefined,
+    factories: readonly ((fields: {
+      sequence: number;
+      eventId: string;
+      recordedAt: string;
+    }) => TPayload)[],
+    retention?: number,
+  ): Promise<TPayload[]> {
+    const current = knownHead === undefined
+      ? await this.currentHead(client, tenantId, sessionId, streamName)
+      : knownHead;
+    const firstSequence = (current ?? 0) + 1;
+    const recordedAt = new Date().toISOString();
+    const payloads = factories.map((factory, index) =>
+      factory({
+        sequence: firstSequence + index,
+        eventId: nanoid(),
+        recordedAt,
+      }));
+    if (payloads.length === 0) {
+      return [];
+    }
+    for (const [index, payload] of payloads.entries()) {
+      await client.query(
+        `INSERT INTO ${this.table('events')} (
+           tenant_id, session_id, stream_name, sequence, event_id,
+           command_id, event_type, payload, occurred_at, recorded_at
+         ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9, $10)`,
+        [
+          tenantId,
+          sessionId,
+          streamName,
+          firstSequence + index,
+          String(payload.eventId),
+          typeof payload.commandId === 'string' ? payload.commandId : null,
+          String(payload.type),
+          JSON.stringify(payload),
+          String(payload.occurredAt ?? recordedAt),
+          recordedAt,
+        ],
+      );
+    }
+    const nextSequence = firstSequence + payloads.length;
+    const retainedFirst = retention
+      ? Math.max(1, nextSequence - retention)
+      : 1;
+    await client.query(
+      `INSERT INTO ${this.table('stream_heads')} (
+         tenant_id, session_id, stream_name, first_sequence, next_sequence
+       ) VALUES ($1, $2, $3, $4, $5)
+       ON CONFLICT (tenant_id, session_id, stream_name) DO UPDATE SET
+         first_sequence = EXCLUDED.first_sequence,
+         next_sequence = EXCLUDED.next_sequence`,
+      [tenantId, sessionId, streamName, retainedFirst, nextSequence],
+    );
+    if (retention) {
+      await client.query(
+        `DELETE FROM ${this.table('events')}
+          WHERE tenant_id = $1 AND session_id = $2 AND stream_name = $3
+            AND sequence < $4`,
+        [tenantId, sessionId, streamName, retainedFirst],
+      );
+    }
+    return payloads;
+  }
+
+  private async readStream(
+    tenantId: string,
+    sessionId: SessionId,
+    streamName: string,
+    after = 0,
+    limit = 100,
+  ): Promise<{
+    payloads: JsonObject[];
+    headSequence: number | null;
+    hasMore: boolean;
+  }> {
+    await this.initialize();
+    if (!Number.isSafeInteger(after) || after < 0) {
+      throw new RangeError('Event cursor is invalid');
+    }
+    if (!Number.isSafeInteger(limit) || limit < 1 || limit > 1000) {
+      throw new RangeError('Event page limit must be between 1 and 1000');
+    }
+    const headResult = await this.pool.query<StreamHeadRow>(
+      `SELECT first_sequence, next_sequence
+         FROM ${this.table('stream_heads')}
+        WHERE tenant_id = $1 AND session_id = $2 AND stream_name = $3`,
+      [tenantId, sessionId, streamName],
+    );
+    const head = headResult.rows[0];
+    if (!head) {
+      if (after > 0) {
+        throw new RangeError('Event cursor is ahead of the session head');
+      }
+      return { payloads: [], headSequence: null, hasMore: false };
+    }
+    const firstSequence = asNumber(head.first_sequence);
+    const nextSequence = asNumber(head.next_sequence);
+    if (after < firstSequence - 1) {
+      throw new RangeError('Event cursor is stale');
+    }
+    if (after >= nextSequence) {
+      throw new RangeError('Event cursor is ahead of the session head');
+    }
+    const result = await this.pool.query<PayloadRow>(
+      `SELECT payload
+         FROM ${this.table('events')}
+        WHERE tenant_id = $1 AND session_id = $2 AND stream_name = $3
+          AND sequence > $4
+        ORDER BY sequence ASC
+        LIMIT $5`,
+      [tenantId, sessionId, streamName, after, limit + 1],
+    );
+    return {
+      payloads: result.rows.slice(0, limit).map((row) =>
+        asJsonObject(row.payload)),
+      headSequence: nextSequence - 1,
+      hasMore: result.rows.length > limit,
+    };
+  }
+
+  private async appendDomainEvents(
+    client: PoolClient,
+    commit: RuntimeCommandCommit,
+  ): Promise<RuntimeDomainEvent[]> {
+    const current = await this.currentHead(
+      client,
+      commit.tenantId,
+      commit.sessionId,
+      'domain',
+    );
+    if (
+      commit.expectedLastSequence !== undefined
+      && commit.expectedLastSequence !== current
+    ) {
+      throw new RuntimeStoreError(
+        'RUNTIME_STORE_SEQUENCE_CONFLICT',
+        `Expected runtime event sequence ${String(commit.expectedLastSequence)}, `
+          + `but current sequence is ${String(current)}`,
+      );
+    }
+    const payloads = await this.appendStream(
+      client,
+      commit.tenantId,
+      commit.sessionId,
+      'domain',
+      current,
+      (commit.events ?? []).map((draft) => ({ sequence, eventId, recordedAt }) => ({
+        schemaVersion: RUNTIME_STORE_SCHEMA_VERSION,
+        eventId: draft.eventId ?? eventId,
+        tenantId: commit.tenantId,
+        sessionId: commit.sessionId,
+        commandId: commit.command.commandId,
+        sequence,
+        type: draft.type,
+        data: draft.data,
+        occurredAt: draft.occurredAt ?? recordedAt,
+        recordedAt,
+      })),
+    );
+    return payloads;
+  }
+
+  private async insertEffects(
+    client: PoolClient,
+    commit: RuntimeCommandCommit,
+  ): Promise<RuntimeEffectRecord[]> {
+    const effects: RuntimeEffectRecord[] = [];
+    for (const effect of commit.effects ?? []) {
+      const result = await client.query<EffectRow>(
+        `INSERT INTO ${this.table('outbox')} (
+           tenant_id, effect_id, session_id, command_id, effect_type,
+           payload, idempotency_key, available_at
+         ) VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7, $8)
+         RETURNING tenant_id, session_id, command_id, effect_id, effect_type,
+                   payload, idempotency_key, status, attempts, available_at,
+                   created_at, result, error`,
+        [
+          commit.tenantId,
+          effect.effectId,
+          commit.sessionId,
+          commit.command.commandId,
+          effect.type,
+          JSON.stringify(effect.payload),
+          effect.idempotencyKey,
+          effect.availableAt ?? new Date().toISOString(),
+        ],
+      );
+      const row = result.rows[0];
+      if (row) {
+        effects.push(this.effectRecord(row));
+      }
+    }
+    return effects;
+  }
+
+  private async writeProjection(
+    client: PoolClient,
+    commit: RuntimeCommandCommit,
+  ): Promise<RuntimeProjectionRecord> {
+    const projection = commit.projection;
+    if (!projection) {
+      throw new RuntimeStoreError(
+        'RUNTIME_STORE_INVALID_TRANSACTION',
+        'Projection is required',
+      );
+    }
+    const domainHead = await this.currentHead(
+      client,
+      commit.tenantId,
+      commit.sessionId,
+      'domain',
+    );
+    if (projection.offset !== (domainHead ?? 0)) {
+      throw new RuntimeStoreError(
+        'RUNTIME_STORE_INVALID_TRANSACTION',
+        `Projection ${projection.name} offset ${projection.offset} `
+          + `does not match domain head ${String(domainHead)}`,
+      );
+    }
+    await this.lock(
+      client,
+      `projection:${commit.tenantId}:${commit.sessionId}:${projection.name}`,
+    );
+    const current = await client.query<ProjectionRow>(
+      `SELECT projection_offset, state, updated_at
+         FROM ${this.table('projections')}
+        WHERE tenant_id = $1 AND session_id = $2 AND projection_name = $3
+        FOR UPDATE`,
+      [commit.tenantId, commit.sessionId, projection.name],
+    );
+    const currentOffset = current.rows[0]
+      ? asNumber(current.rows[0].projection_offset)
+      : null;
+    if (
+      projection.expectedOffset !== undefined
+      && projection.expectedOffset !== currentOffset
+    ) {
+      throw new RuntimeStoreError(
+        'RUNTIME_STORE_PROJECTION_CONFLICT',
+        `Expected ${projection.name} offset ${String(projection.expectedOffset)}, `
+          + `but current offset is ${String(currentOffset)}`,
+      );
+    }
+    await client.query(
+      `INSERT INTO ${this.table('projections')} (
+         tenant_id, session_id, projection_name, projection_offset, state, updated_at
+       ) VALUES ($1, $2, $3, $4, $5::jsonb, NOW())
+       ON CONFLICT (tenant_id, session_id, projection_name) DO UPDATE SET
+         projection_offset = EXCLUDED.projection_offset,
+         state = EXCLUDED.state,
+         updated_at = NOW()`,
+      [
+        commit.tenantId,
+        commit.sessionId,
+        projection.name,
+        projection.offset,
+        JSON.stringify(projection.state),
+      ],
+    );
+    const stored = await this.getProjectionWithClient(
+      client,
+      commit.tenantId,
+      commit.sessionId,
+      projection.name,
+    );
+    if (!stored) {
+      throw new RuntimeStoreError(
+        'RUNTIME_STORE_INVALID_TRANSACTION',
+        'Projection commit did not produce a record',
+      );
+    }
+    return stored;
+  }
+
+  private async loadCommittedRuntimeResult(
+    client: PoolClient,
+    commit: RuntimeCommandCommit,
+  ): Promise<RuntimeCommitResult> {
+    const events = await client.query<PayloadRow>(
+      `SELECT payload
+         FROM ${this.table('events')}
+        WHERE tenant_id = $1 AND session_id = $2
+          AND stream_name = 'domain' AND command_id = $3
+        ORDER BY sequence ASC`,
+      [commit.tenantId, commit.sessionId, commit.command.commandId],
+    );
+    const effects = await client.query<EffectRow>(
+      `SELECT tenant_id, session_id, command_id, effect_id, effect_type,
+              payload, idempotency_key, status, attempts, available_at,
+              created_at, result, error
+         FROM ${this.table('outbox')}
+        WHERE tenant_id = $1 AND session_id = $2 AND command_id = $3
+        ORDER BY created_at ASC, effect_id ASC`,
+      [commit.tenantId, commit.sessionId, commit.command.commandId],
+    );
+    const projection = commit.projection
+      ? await this.getProjectionWithClient(
+          client,
+          commit.tenantId,
+          commit.sessionId,
+          commit.projection.name,
+        )
+      : null;
+    return {
+      status: 'replayed',
+      events: events.rows.map((row) =>
+        structuredClone(row.payload) as RuntimeDomainEvent),
+      effects: effects.rows.map((row) => this.effectRecord(row)),
+      ...(projection ? { projection } : {}),
+    };
+  }
+
+  private async getProjectionWithClient(
+    client: PoolClient,
+    tenantId: string,
+    sessionId: SessionId,
+    name: string,
+  ): Promise<RuntimeProjectionRecord | null> {
+    const result = await client.query<ProjectionRow>(
+      `SELECT projection_offset, state, updated_at
+         FROM ${this.table('projections')}
+        WHERE tenant_id = $1 AND session_id = $2 AND projection_name = $3`,
+      [tenantId, sessionId, name],
+    );
+    const row = result.rows[0];
+    return row
+      ? {
+          tenantId,
+          sessionId,
+          name,
+          offset: asNumber(row.projection_offset),
+          state: asJsonObject(row.state),
+          updatedAt: asIso(row.updated_at),
+        }
+      : null;
+  }
+
+  private effectRecord(row: EffectRow): RuntimeEffectRecord {
+    return {
+      tenantId: row.tenant_id,
+      sessionId: row.session_id as SessionId,
+      commandId: row.command_id,
+      effectId: row.effect_id,
+      type: row.effect_type,
+      payload: asJsonObject(row.payload),
+      idempotencyKey: row.idempotency_key,
+      status: row.status,
+      attempts: row.attempts,
+      availableAt: asIso(row.available_at),
+      createdAt: asIso(row.created_at),
+      ...(row.result ? { result: asJsonObject(row.result) } : {}),
+      ...(row.error ? { error: asJsonObject(row.error) } : {}),
+    };
+  }
+}
+
+class PostgresTenantRuntimeStore implements RuntimeTenantStore {
+  constructor(
+    private readonly runtime: PostgresRuntimeStore,
+    private readonly tenantId: string,
+  ) {}
+
+  initialize(): Promise<void> {
+    return this.runtime.initialize();
+  }
+
+  async createSession(
+    sessionId: SessionId,
+    subagentInfo?: SessionRepositorySubagentInfo,
+  ): Promise<void> {
+    const existing = await this.runtime.loadSessionState(this.tenantId, sessionId);
+    if (existing) {
+      return;
+    }
+    await this.runtime.mutateSessionState(
+      this.tenantId,
+      sessionId,
+      'transcript.session_created',
+      {
+        ...(subagentInfo
+          ? {
+              parentSessionId: subagentInfo.parentSessionId,
+              subagentType: subagentInfo.subagentType,
+              isSidechain: subagentInfo.isSidechain,
+            }
+          : {}),
+      },
+      () => initialSessionState(sessionId, Date.now(), subagentInfo),
+      subagentInfo,
+    );
+  }
+
+  async saveMessage(
+    sessionId: SessionId,
+    messageRole: MessageRole,
+    content: string | ContentPart[],
+    parentUuid: string | null = null,
+    metadata?: SessionRepositoryMessageMetadata,
+    subagentInfo?: SessionRepositorySubagentInfo,
+  ): Promise<string> {
+    const messageId = MessageId(nanoid());
+    return this.runtime.mutateSessionState(
+      this.tenantId,
+      sessionId,
+      'transcript.message_saved',
+      { messageId, role: messageRole },
+      (state, now) => {
+        appendMessage(
+          state,
+          messageId,
+          {
+            id: messageId,
+            role: messageRole,
+            content: structuredClone(content),
+            reasoningContent: metadata?.reasoningContent,
+            tool_calls: metadata?.toolCalls
+              ? structuredClone(metadata.toolCalls)
+              : undefined,
+            metadata: messageMetadata(metadata),
+            modelIdentity: metadata?.modelIdentity
+              ? structuredClone(metadata.modelIdentity)
+              : undefined,
+          },
+          now,
+          parentUuid ?? undefined,
+        );
+        return messageId;
+      },
+      subagentInfo,
+    );
+  }
+
+  async saveInputEnqueued(
+    sessionId: SessionId,
+    input: PendingInputInfo,
+  ): Promise<void> {
+    await this.runtime.mutateSessionState(
+      this.tenantId,
+      sessionId,
+      'transcript.input_enqueued',
+      { inputId: input.inputId },
+      (state, now) => {
+        state.pendingInputs = [
+          ...state.pendingInputs.filter((item) => item.inputId !== input.inputId),
+          {
+            ...input,
+            content: cloneJsonValue(input.content),
+          },
+        ];
+        state.lastActivity = now;
+      },
+    );
+  }
+
+  async saveAppliedInputMessage(
+    sessionId: SessionId,
+    inputId: InputId,
+    requestId: RequestId,
+    content: string | ContentPart[],
+    parentUuid: string | null = null,
+    subagentInfo?: SessionRepositorySubagentInfo,
+  ): Promise<string> {
+    const messageId = MessageId(nanoid());
+    return this.runtime.mutateSessionState(
+      this.tenantId,
+      sessionId,
+      'transcript.input_applied',
+      { inputId, requestId, messageId },
+      (state, now) => {
+        state.pendingInputs = state.pendingInputs.filter(
+          (input) => input.inputId !== inputId,
+        );
+        appendMessage(
+          state,
+          messageId,
+          {
+            id: messageId,
+            role: 'user',
+            content: structuredClone(content),
+            metadata: { inputId, requestId },
+          },
+          now,
+          parentUuid ?? undefined,
+        );
+        return messageId;
+      },
+      subagentInfo,
+    );
+  }
+
+  async saveInputCancelled(
+    sessionId: SessionId,
+    inputId: InputId,
+    reason: string,
+  ): Promise<void> {
+    await this.runtime.mutateSessionState(
+      this.tenantId,
+      sessionId,
+      'transcript.input_cancelled',
+      { inputId, reason },
+      (state, now) => {
+        state.pendingInputs = state.pendingInputs.filter(
+          (input) => input.inputId !== inputId,
+        );
+        state.lastActivity = now;
+      },
+    );
+  }
+
+  async saveToolUse(
+    sessionId: SessionId,
+    toolName: string,
+    toolInput: JsonValue,
+    parentUuid: string | null = null,
+    subagentInfo?: SessionRepositorySubagentInfo,
+    requestedToolCallId?: string,
+  ): Promise<PersistedToolUse> {
+    const messageId = MessageId(nanoid());
+    const toolCallId = requestedToolCallId ?? nanoid();
+    return this.runtime.mutateSessionState(
+      this.tenantId,
+      sessionId,
+      'transcript.tool_use_saved',
+      { messageId, toolCallId, toolName },
+      (state, now) => {
+        appendMessage(
+          state,
+          messageId,
+          {
+            id: messageId,
+            role: 'assistant',
+            content: '',
+            tool_calls: [{
+              id: toolCallId,
+              type: 'function',
+              function: {
+                name: toolName,
+                arguments: typeof toolInput === 'string'
+                  ? toolInput
+                  : JSON.stringify(toolInput),
+              },
+            }],
+          },
+          now,
+          parentUuid ?? undefined,
+        );
+        state.toolCalls.push({
+          id: toolCallId,
+          name: toolName,
+          input: cloneJsonValue(toolInput),
+          messageId,
+          timestamp: now,
+          status: 'pending',
+        });
+        return { messageId, toolCallId };
+      },
+      subagentInfo,
+    );
+  }
+
+  async saveToolResult(
+    sessionId: SessionId,
+    toolId: string,
+    toolName: string,
+    toolOutput: JsonValue,
+    parentUuid: string | null = null,
+    error?: string,
+    subagentInfo?: SessionRepositorySubagentInfo,
+    subagentRef?: SessionRepositorySubagentRef,
+  ): Promise<string> {
+    const messageId = MessageId(nanoid());
+    return this.runtime.mutateSessionState(
+      this.tenantId,
+      sessionId,
+      'transcript.tool_result_saved',
+      { messageId, toolId, toolName },
+      (state, now) => {
+        appendMessage(
+          state,
+          messageId,
+          {
+            id: messageId,
+            role: 'tool',
+            content: error
+              ? `Error: ${error}`
+              : typeof toolOutput === 'string'
+                ? toolOutput
+                : JSON.stringify(toolOutput),
+            tool_call_id: toolId,
+            name: toolName,
+          },
+          now,
+          parentUuid ?? undefined,
+        );
+        const call = [...state.toolCalls]
+          .reverse()
+          .find((item) => item.id === toolId && item.status === 'pending');
+        if (call) {
+          call.output = cloneJsonValue(toolOutput);
+          call.error = error;
+          call.status = error ? 'error' : 'success';
+        }
+        if (subagentRef) {
+          state.subagentRefs.push({
+            messageId,
+            childSessionId: subagentRef.subagentSessionId,
+            agentType: subagentRef.subagentType,
+            status: subagentRef.subagentStatus,
+            summary: subagentRef.subagentSummary,
+            startedAt: new Date(now).toISOString(),
+            finishedAt: subagentRef.subagentStatus === 'running'
+              ? null
+              : new Date(now).toISOString(),
+          });
+        }
+        return messageId;
+      },
+      subagentInfo,
+    );
+  }
+
+  async saveCompaction(
+    sessionId: SessionId,
+    summary: string,
+    metadata: SessionRepositoryCompactionMetadata,
+    parentUuid: string | null = null,
+  ): Promise<string> {
+    const messageId = MessageId(nanoid());
+    return this.runtime.mutateSessionState(
+      this.tenantId,
+      sessionId,
+      'transcript.compaction_saved',
+      { messageId, trigger: metadata.trigger },
+      (state, now) => {
+        appendMessage(
+          state,
+          messageId,
+          {
+            id: messageId,
+            role: 'system',
+            content: summary,
+            metadata: {
+              ...metadata,
+              _systemSource: 'compaction_summary',
+            },
+          },
+          now,
+          parentUuid ?? undefined,
+        );
+        state.summary = summary;
+        state.summaryMessageIds.push(messageId);
+        return messageId;
+      },
+    );
+  }
+
+  async saveContext(
+    sessionId: SessionId,
+    contextData: ContextData,
+  ): Promise<void> {
+    for (const message of contextData.layers.conversation.messages) {
+      await this.saveMessage(sessionId, message.role, message.content);
+    }
+  }
+
+  loadState(sessionId: SessionId): Promise<SessionState | null> {
+    return this.runtime.loadSessionState(this.tenantId, sessionId);
+  }
+
+  async loadMessages(sessionId: SessionId): Promise<Message[]> {
+    const state = await this.loadState(sessionId);
+    return state?.messages.map((message) => cloneMessage(message)) ?? [];
+  }
+
+  async forkState(
+    sessionId: SessionId,
+    options?: { messageId?: string },
+  ): Promise<SessionSnapshot | null> {
+    const state = await this.loadState(sessionId);
+    if (!state) {
+      return null;
+    }
+    let endIndex = state.timeline.length;
+    if (options?.messageId) {
+      const index = state.messageIds.indexOf(options.messageId);
+      if (index === -1) {
+        throw new Error(
+          `Message with ID "${options.messageId}" not found in session history`,
+        );
+      }
+      endIndex = index + 1;
+    }
+    const timeline = state.timeline.slice(0, endIndex);
+    const messageIds = timeline.map((entry) => entry.id);
+    return {
+      sessionId,
+      messages: timeline.map((entry) => cloneMessage(entry.message)),
+      messageIds,
+      lastActivity: timeline.at(-1)?.createdAt ?? state.createdAt,
+      summary: [...timeline]
+        .reverse()
+        .find((entry) => state.summaryMessageIds.includes(entry.id))
+        ?.message.content as string | undefined,
+    };
+  }
+
+  listSessions(): Promise<string[]> {
+    return this.runtime.listSessionProjectionIds(this.tenantId);
+  }
+
+  async getSessionSummary(
+    sessionId: SessionId,
+  ): Promise<SessionSummary | null> {
+    const state = await this.loadState(sessionId);
+    return state
+      ? {
+          sessionId,
+          lastActivity: state.lastActivity,
+          messageCount: state.messages.filter(
+            (message) =>
+              message.role === 'user' || message.role === 'assistant',
+          ).length,
+          topics: [],
+          summaryText: state.summary,
+        }
+      : null;
+  }
+
+  deleteSession(sessionId: SessionId): Promise<void> {
+    return this.runtime.deleteSessionProjection(this.tenantId, sessionId);
+  }
+
+  cleanupOldSessions(): Promise<void> {
+    return this.runtime.cleanupSessionProjections(this.tenantId);
+  }
+
+  getStorageStats(): Promise<SessionRepositoryStorageStats> {
+    return this.runtime.sessionStorageStats(this.tenantId);
+  }
+
+  async checkStorageHealth(): Promise<SessionRepositoryHealth> {
+    const health = await this.runtime.healthCheck();
+    return {
+      isAvailable: health.ready,
+      canWrite: health.ready,
+      ...(!health.ready && health.details?.error
+        ? { error: String(health.details.error) }
+        : {}),
+    };
+  }
+
+  append(
+    sessionId: SessionId,
+    events: readonly DurableEventDraft[],
+    options?: DurableEventAppendOptions,
+  ): Promise<DurableEventAppendResult> {
+    return this.runtime.appendDurableEvents(
+      this.tenantId,
+      sessionId,
+      events,
+      options,
+    );
+  }
+
+  read(
+    sessionId: SessionId,
+    options?: DurableEventReadOptions,
+  ): Promise<DurableEventPage> {
+    return this.runtime.readDurableEvents(
+      this.tenantId,
+      sessionId,
+      options,
+    );
+  }
+
+  getHeadSequence(sessionId: SessionId): Promise<EventSequence | null> {
+    return this.runtime.getDurableHead(this.tenantId, sessionId);
+  }
+}

--- a/src/server/RuntimeStore.ts
+++ b/src/server/RuntimeStore.ts
@@ -1,0 +1,142 @@
+import { SdkError } from '../errors/SdkError.js';
+import type {
+  AgentCommandResult,
+} from '../protocol/index.js';
+import type { DurableEventStore } from '../session/events/DurableEventStore.js';
+import type { SessionPersistence } from '../session/SessionRepository.js';
+import type { SessionId } from '../types/branded.js';
+import type { JsonObject } from '../types/common.js';
+import type { AgentServerStore } from './AgentServerStore.js';
+
+export const RUNTIME_STORE_SCHEMA_VERSION = 1 as const;
+
+export interface RuntimeDomainEventDraft {
+  readonly eventId?: string;
+  readonly type: string;
+  readonly data: JsonObject;
+  readonly occurredAt?: string;
+}
+
+export interface RuntimeDomainEvent extends RuntimeDomainEventDraft {
+  readonly schemaVersion: typeof RUNTIME_STORE_SCHEMA_VERSION;
+  readonly eventId: string;
+  readonly tenantId: string;
+  readonly sessionId: SessionId;
+  readonly commandId: string;
+  readonly sequence: number;
+  readonly occurredAt: string;
+  readonly recordedAt: string;
+}
+
+export interface RuntimeEffectIntent {
+  readonly effectId: string;
+  readonly type: string;
+  readonly payload: JsonObject;
+  readonly idempotencyKey: string;
+  readonly availableAt?: string;
+}
+
+export type RuntimeEffectStatus = 'pending' | 'completed' | 'failed';
+
+export interface RuntimeEffectRecord extends RuntimeEffectIntent {
+  readonly tenantId: string;
+  readonly sessionId: SessionId;
+  readonly commandId: string;
+  readonly status: RuntimeEffectStatus;
+  readonly attempts: number;
+  readonly createdAt: string;
+  readonly result?: JsonObject;
+  readonly error?: JsonObject;
+}
+
+export interface RuntimeProjectionCheckpoint {
+  readonly name: string;
+  readonly offset: number;
+  readonly expectedOffset?: number | null;
+  readonly state: JsonObject;
+}
+
+export interface RuntimeProjectionRecord {
+  readonly tenantId: string;
+  readonly sessionId: SessionId;
+  readonly name: string;
+  readonly offset: number;
+  readonly state: JsonObject;
+  readonly updatedAt: string;
+}
+
+export interface RuntimeCommandCommit {
+  readonly tenantId: string;
+  readonly sessionId: SessionId;
+  readonly command: {
+    readonly commandId: string;
+    readonly fingerprint: string;
+    readonly leaseId?: string;
+    readonly result: AgentCommandResult;
+  };
+  readonly expectedLastSequence?: number | null;
+  readonly events?: readonly RuntimeDomainEventDraft[];
+  readonly effects?: readonly RuntimeEffectIntent[];
+  readonly projection?: RuntimeProjectionCheckpoint;
+}
+
+export interface RuntimeCommitResult {
+  readonly status: 'committed' | 'replayed';
+  readonly events: readonly RuntimeDomainEvent[];
+  readonly effects: readonly RuntimeEffectRecord[];
+  readonly projection?: RuntimeProjectionRecord;
+}
+
+export interface RuntimeDomainEventPage {
+  readonly events: readonly RuntimeDomainEvent[];
+  readonly headSequence: number | null;
+  readonly hasMore: boolean;
+}
+
+export interface RuntimeStore extends AgentServerStore {
+  initialize(): Promise<void>;
+  forTenant(tenantId: string): RuntimeTenantStore;
+  commitRuntimeTransaction(
+    commit: RuntimeCommandCommit,
+  ): Promise<RuntimeCommitResult>;
+  readDomainEvents(
+    tenantId: string,
+    sessionId: SessionId,
+    options?: { readonly after?: number; readonly limit?: number },
+  ): Promise<RuntimeDomainEventPage>;
+  listEffects(
+    tenantId: string,
+    options?: {
+      readonly sessionId?: SessionId;
+      readonly status?: RuntimeEffectStatus;
+      readonly limit?: number;
+    },
+  ): Promise<readonly RuntimeEffectRecord[]>;
+  getProjection(
+    tenantId: string,
+    sessionId: SessionId,
+    name: string,
+  ): Promise<RuntimeProjectionRecord | null>;
+  close(): Promise<void>;
+}
+
+export interface RuntimeTenantStore
+  extends SessionPersistence, DurableEventStore {}
+
+export type RuntimeStoreErrorCode =
+  | 'RUNTIME_STORE_COMMAND_CONFLICT'
+  | 'RUNTIME_STORE_LEASE_LOST'
+  | 'RUNTIME_STORE_SEQUENCE_CONFLICT'
+  | 'RUNTIME_STORE_PROJECTION_CONFLICT'
+  | 'RUNTIME_STORE_INVALID_TRANSACTION';
+
+export class RuntimeStoreError extends SdkError {
+  // biome-ignore lint/complexity/noUselessConstructor: narrows the public error-code contract
+  constructor(
+    code: RuntimeStoreErrorCode,
+    message: string,
+    options?: { cause?: unknown },
+  ) {
+    super(code, message, options);
+  }
+}

--- a/src/server/SessionExecutor.ts
+++ b/src/server/SessionExecutor.ts
@@ -39,6 +39,7 @@ import type {
   AgentServerStore,
 } from './AgentServerStore.js';
 import { RemoteApprovalBroker } from './RemoteApprovalBroker.js';
+import type { RuntimeTenantStore } from './RuntimeStore.js';
 
 export interface AgentServerSessionContext {
   readonly principal: AgentPrincipal;
@@ -51,6 +52,8 @@ export interface SessionExecutorCommandContext {
   readonly principal: AgentPrincipal;
   readonly commandId: string;
   readonly signal?: AbortSignal;
+  /** Tenant-scoped persistence authority supplied by AgentServer. */
+  readonly runtimeStore?: RuntimeTenantStore;
 }
 
 export interface SessionExecutorReadResult {

--- a/src/server/SessionExecutor.ts
+++ b/src/server/SessionExecutor.ts
@@ -18,6 +18,7 @@ import {
   forkSession,
   resumeSession,
 } from '../session/Session.js';
+import { isSessionEventStore } from '../session/SessionRepository.js';
 import type {
   ISession,
   PendingSessionInput,
@@ -498,10 +499,15 @@ export class InProcessSessionExecutor implements SessionExecutor {
     context: AgentServerSessionContext,
   ): Promise<SessionOptions> {
     const options = await this.options.resolveSessionOptions(context);
-    if (this.options.requirePersistentSessions && !options.sessionRepository) {
+    const hasEventStore = options.sessionEventStore
+      || isSessionEventStore(options.sessionRepository);
+    if (
+      this.options.requirePersistentSessions
+      && (!options.sessionRepository || !hasEventStore)
+    ) {
       throw new AgentProtocolError(
         'SESSION_CONFLICT',
-        'This executor requires a persistent sessionRepository',
+        'This executor requires sessionRepository and sessionEventStore',
         409,
       );
     }

--- a/src/server/__tests__/PostgresRuntimeStore.integration.test.ts
+++ b/src/server/__tests__/PostgresRuntimeStore.integration.test.ts
@@ -119,6 +119,114 @@ describePostgres('PostgresRuntimeStore', () => {
     )).resolves.toMatchObject({ status: 'claimed' });
   });
 
+  it('maps duplicate event and effect identities to stable conflicts with rollback', async () => {
+    const suffix = `${process.pid}-${Date.now()}`;
+    const tenantId = `tenant-conflict-${suffix}`;
+    const seedSessionId = `session-seed-${suffix}` as SessionId;
+    const duplicateEventId = `event-${suffix}`;
+    const duplicateEffectKey = `effect-key-${suffix}`;
+    await store.commitRuntimeTransaction({
+      tenantId,
+      sessionId: seedSessionId,
+      command: {
+        commandId: `seed-${suffix}`,
+        fingerprint: `seed-fingerprint-${suffix}`,
+        result: {
+          protocolVersion: 1,
+          commandId: `seed-${suffix}`,
+          ok: true,
+          data: {},
+        },
+      },
+      expectedLastSequence: null,
+      events: [{
+        eventId: duplicateEventId,
+        type: 'seeded',
+        data: {},
+      }],
+      effects: [{
+        effectId: `seed-effect-${suffix}`,
+        type: 'seeded',
+        payload: {},
+        idempotencyKey: duplicateEffectKey,
+      }],
+    });
+
+    for (const duplicate of ['event', 'effect'] as const) {
+      const commandId = `duplicate-${duplicate}-${suffix}`;
+      const sessionId = `session-${duplicate}-${suffix}` as SessionId;
+      await expect(store.commitRuntimeTransaction({
+        tenantId,
+        sessionId,
+        command: {
+          commandId,
+          fingerprint: `fingerprint-${commandId}`,
+          result: {
+            protocolVersion: 1,
+            commandId,
+            ok: true,
+            data: {},
+          },
+        },
+        expectedLastSequence: null,
+        events: [{
+          eventId: duplicate === 'event'
+            ? duplicateEventId
+            : `unique-event-${suffix}`,
+          type: 'duplicate',
+          data: { duplicate },
+        }],
+        effects: duplicate === 'effect'
+          ? [{
+              effectId: `effect-${suffix}`,
+              type: 'duplicate',
+              payload: {},
+              idempotencyKey: duplicateEffectKey,
+            }]
+          : [],
+      })).rejects.toMatchObject({
+        code: 'RUNTIME_STORE_COMMAND_CONFLICT',
+      });
+      await expect(
+        store.readDomainEvents(tenantId, sessionId),
+      ).resolves.toMatchObject({ events: [] });
+      await expect(store.claimCommand(
+        tenantId,
+        commandId,
+        `fingerprint-${commandId}`,
+        1000,
+      )).resolves.toMatchObject({ status: 'claimed' });
+    }
+  });
+
+  it('serializes concurrent schema initialization', async () => {
+    if (!connectionString || !pool) {
+      throw new Error('TEST_POSTGRES_URL is required');
+    }
+    const concurrentSchema = `${schema}_init`;
+    const firstPool = new Pool({ connectionString });
+    const secondPool = new Pool({ connectionString });
+    const first = new PostgresRuntimeStore({
+      pool: firstPool,
+      schema: concurrentSchema,
+      tablePrefix: 'runtime',
+    });
+    const second = new PostgresRuntimeStore({
+      pool: secondPool,
+      schema: concurrentSchema,
+      tablePrefix: 'runtime',
+    });
+    try {
+      await expect(Promise.all([
+        first.initialize(),
+        second.initialize(),
+      ])).resolves.toEqual([undefined, undefined]);
+    } finally {
+      await pool.query(`DROP SCHEMA IF EXISTS "${concurrentSchema}" CASCADE`);
+      await Promise.all([firstPool.end(), secondPool.end()]);
+    }
+  });
+
   it('runs AgentServer with one tenant-scoped PostgreSQL authority', async () => {
     const server = new AgentServer({
       runtimeStore: store,

--- a/src/server/__tests__/PostgresRuntimeStore.integration.test.ts
+++ b/src/server/__tests__/PostgresRuntimeStore.integration.test.ts
@@ -1,0 +1,284 @@
+import { Pool } from 'pg';
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import { AgentCommandType, type AgentPrincipal } from '../../protocol/index.js';
+import type { SessionId } from '../../types/branded.js';
+import { AgentServer } from '../AgentServer.js';
+import { PostgresRuntimeStore } from '../PostgresRuntimeStore.js';
+import { assertRuntimeStoreConformance } from '../testing/RuntimeStoreConformance.js';
+
+const connectionString = process.env.TEST_POSTGRES_URL;
+const describePostgres = connectionString ? describe : describe.skip;
+const schema = `blade_test_${process.pid}_${Date.now()}`;
+const pool = connectionString ? new Pool({ connectionString }) : null;
+
+const { createAgent } = vi.hoisted(() => ({
+  createAgent: vi.fn(async () => ({
+    async *streamChat() {
+      yield { type: 'content_delta', delta: 'postgres-ok' };
+      return {
+        success: true,
+        finalMessage: 'done',
+        metadata: {
+          turnsCount: 1,
+          toolCallsCount: 0,
+          duration: 0,
+        },
+      };
+    },
+    async setModel() {},
+  })),
+}));
+
+vi.mock('../../agent/Agent.js', () => ({
+  Agent: { create: createAgent },
+}));
+
+const principal: AgentPrincipal = {
+  tenantId: 'tenant-agent-server',
+  subject: 'user-a',
+  scopes: ['session:admin'],
+};
+
+describePostgres('PostgresRuntimeStore', () => {
+  let store: PostgresRuntimeStore;
+
+  beforeAll(async () => {
+    if (!pool) {
+      throw new Error('TEST_POSTGRES_URL is required');
+    }
+    store = new PostgresRuntimeStore({
+      pool,
+      schema,
+      tablePrefix: 'runtime',
+      maxAgentEventsPerSession: 100,
+    });
+    await store.initialize();
+  });
+
+  afterAll(async () => {
+    if (!pool) {
+      return;
+    }
+    await pool.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`);
+    await pool.end();
+  });
+
+  it('passes the public RuntimeStore conformance suite', async () => {
+    const result = await assertRuntimeStoreConformance(store, {
+      idPrefix: `postgres-${process.pid}`,
+    });
+    expect(result.checks).toEqual([
+      'health',
+      'session-projection',
+      'tenant-isolation',
+      'command-receipts',
+      'agent-events',
+      'durable-events',
+      'atomic-runtime-commit',
+      'transaction-rollback',
+      'projection-checkpoint',
+    ]);
+  });
+
+  it('rejects invalid transaction payloads before writing a receipt', async () => {
+    const commandId = `invalid-${Date.now()}`;
+    await expect(store.commitRuntimeTransaction({
+      tenantId: 'tenant-invalid',
+      sessionId: `session-${commandId}` as SessionId,
+      command: {
+        commandId,
+        fingerprint: `fingerprint-${commandId}`,
+        result: {
+          protocolVersion: 1,
+          commandId,
+          ok: true,
+          data: {},
+        },
+      },
+      effects: [{
+        effectId: `effect-${commandId}`,
+        type: 'invalid',
+        payload: { value: Number.NaN },
+        idempotencyKey: `key-${commandId}`,
+      }],
+    })).rejects.toMatchObject({
+      code: 'RUNTIME_STORE_INVALID_TRANSACTION',
+    });
+    await expect(store.claimCommand(
+      'tenant-invalid',
+      commandId,
+      `fingerprint-${commandId}`,
+      1000,
+    )).resolves.toMatchObject({ status: 'claimed' });
+  });
+
+  it('runs AgentServer with one tenant-scoped PostgreSQL authority', async () => {
+    const server = new AgentServer({
+      runtimeStore: store,
+      resolveSessionOptions: () => ({
+        provider: {
+          type: 'openai-compatible',
+          apiKey: 'test-key',
+        },
+        model: 'test-model',
+      }),
+      requirePersistentSessions: true,
+      eventPollIntervalMs: 5,
+    });
+    const created = await server.execute({
+      protocolVersion: 1,
+      commandId: 'postgres-create',
+      type: AgentCommandType.SESSION_CREATE,
+      data: {},
+    }, principal);
+    expect(created.ok).toBe(true);
+    if (!created.ok) {
+      throw new Error(created.error.message);
+    }
+    const sessionId = (
+      created.data as { session: { sessionId: SessionId } }
+    ).session.sessionId;
+    const submitted = await server.execute({
+      protocolVersion: 1,
+      commandId: 'postgres-submit',
+      type: AgentCommandType.INPUT_SUBMIT,
+      data: { sessionId, input: 'hello' },
+    }, principal);
+    expect(submitted.ok).toBe(true);
+
+    const events = [];
+    for await (const event of server.events(principal, sessionId)) {
+      events.push(event);
+      if (event.type === 'session.stream' && event.data.type === 'result') {
+        break;
+      }
+    }
+    expect(events).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        type: 'session.stream',
+        data: expect.objectContaining({
+          type: 'content',
+          delta: 'postgres-ok',
+        }),
+      }),
+    ]));
+    expect(
+      await store.forTenant(principal.tenantId).loadState(sessionId),
+    ).toMatchObject({
+      sessionId,
+      messages: expect.any(Array),
+    });
+    await server.close();
+  });
+
+  it('rejects Session-level persistence overrides when runtimeStore is set', async () => {
+    const server = new AgentServer({
+      runtimeStore: store,
+      resolveSessionOptions: () => ({
+        provider: {
+          type: 'openai-compatible',
+          apiKey: 'test-key',
+        },
+        model: 'test-model',
+        sessionRepository: store.forTenant(principal.tenantId),
+      }),
+    });
+
+    await expect(server.execute({
+      protocolVersion: 1,
+      commandId: `conflicting-store-${Date.now()}`,
+      type: AgentCommandType.SESSION_CREATE,
+      data: {},
+    }, principal)).resolves.toMatchObject({
+      ok: false,
+      error: { code: 'SESSION_CONFLICT' },
+    });
+    await server.close();
+  });
+
+  it('coordinates command claims and compare-and-append across Store instances', async () => {
+    if (!connectionString) {
+      throw new Error('TEST_POSTGRES_URL is required');
+    }
+    const secondPool = new Pool({ connectionString });
+    const second = new PostgresRuntimeStore({
+      pool: secondPool,
+      schema,
+      tablePrefix: 'runtime',
+    });
+    try {
+      await second.initialize();
+      const commandId = `shared-command-${Date.now()}`;
+      const claims = await Promise.all([
+        store.claimCommand(
+          'tenant-shared',
+          commandId,
+          'fingerprint-shared',
+          10_000,
+        ),
+        second.claimCommand(
+          'tenant-shared',
+          commandId,
+          'fingerprint-shared',
+          10_000,
+        ),
+      ]);
+      expect(claims.map(({ status }) => status).sort()).toEqual([
+        'claimed',
+        'in_progress',
+      ]);
+
+      const sessionId = `shared-session-${Date.now()}` as SessionId;
+      const makeCommit = (suffix: string) => ({
+        tenantId: 'tenant-shared',
+        sessionId,
+        command: {
+          commandId: `transaction-${suffix}`,
+          fingerprint: `fingerprint-${suffix}`,
+          result: {
+            protocolVersion: 1 as const,
+            commandId: `transaction-${suffix}`,
+            ok: true as const,
+            data: { committed: suffix },
+          },
+        },
+        expectedLastSequence: null,
+        events: [{ type: 'request.accepted', data: { source: suffix } }],
+        effects: [{
+          effectId: `effect-${suffix}`,
+          type: 'tool.execute',
+          payload: { source: suffix },
+          idempotencyKey: `effect-${suffix}`,
+        }],
+        projection: {
+          name: 'shared',
+          expectedOffset: null,
+          offset: 1,
+          state: { source: suffix },
+        },
+      });
+      const outcomes = await Promise.allSettled([
+        store.commitRuntimeTransaction(makeCommit('a')),
+        second.commitRuntimeTransaction(makeCommit('b')),
+      ]);
+
+      expect(outcomes.filter(({ status }) => status === 'fulfilled')).toHaveLength(1);
+      expect(outcomes.filter(({ status }) => status === 'rejected')).toHaveLength(1);
+      expect(
+        (await store.readDomainEvents('tenant-shared', sessionId)).events,
+      ).toHaveLength(1);
+      expect(
+        await store.listEffects('tenant-shared', { sessionId }),
+      ).toHaveLength(1);
+    } finally {
+      await secondPool.end();
+    }
+  });
+});

--- a/src/server/__tests__/SessionExecutorBoundary.test.ts
+++ b/src/server/__tests__/SessionExecutorBoundary.test.ts
@@ -13,6 +13,11 @@ import {
   SessionId,
 } from '../../types/branded.js';
 import { AgentServer } from '../AgentServer.js';
+import { InMemoryAgentServerStore } from '../AgentServerStore.js';
+import type {
+  RuntimeStore,
+  RuntimeTenantStore,
+} from '../RuntimeStore.js';
 import type {
   SessionExecutor,
   SessionExecutorCommandContext,
@@ -182,6 +187,23 @@ describe('SessionExecutor boundary', () => {
 
     expect(source).not.toContain("../session/Session.js");
     expect(source).not.toContain('activeSessions');
+  });
+
+  it('passes the tenant-scoped runtime authority to a custom executor', async () => {
+    const { executor, calls } = createExecutor();
+    const tenantStore = {} as RuntimeTenantStore;
+    const runtimeStore = Object.assign(new InMemoryAgentServerStore(), {
+      forTenant: () => tenantStore,
+    }) as unknown as RuntimeStore;
+    const server = new AgentServer({ runtimeStore, sessionExecutor: executor });
+
+    await expect(server.execute(
+      command(AgentCommandType.SESSION_CREATE, 'create-runtime-store', {}),
+      principal,
+    )).resolves.toMatchObject({ ok: true });
+
+    expect(calls[0]?.context?.runtimeStore).toBe(tenantStore);
+    await server.close();
   });
 
   it('requires either an executor or a Session options resolver', () => {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -23,6 +23,27 @@ export {
   type OpenTelemetryAgentServerOptions,
 } from './OpenTelemetryAgentServerTelemetry.js';
 export {
+  PostgresRuntimeStore,
+  type PostgresRuntimeStoreOptions,
+} from './PostgresRuntimeStore.js';
+export {
+  RUNTIME_STORE_SCHEMA_VERSION,
+  RuntimeStoreError,
+  type RuntimeCommandCommit,
+  type RuntimeCommitResult,
+  type RuntimeDomainEvent,
+  type RuntimeDomainEventDraft,
+  type RuntimeDomainEventPage,
+  type RuntimeEffectIntent,
+  type RuntimeEffectRecord,
+  type RuntimeEffectStatus,
+  type RuntimeProjectionCheckpoint,
+  type RuntimeProjectionRecord,
+  type RuntimeStore,
+  type RuntimeStoreErrorCode,
+  type RuntimeTenantStore,
+} from './RuntimeStore.js';
+export {
   type AgentServerSessionContext,
   InProcessSessionExecutor,
   type InProcessSessionExecutorOptions,

--- a/src/server/postgres.ts
+++ b/src/server/postgres.ts
@@ -1,0 +1,21 @@
+export {
+  PostgresRuntimeStore,
+  type PostgresRuntimeStoreOptions,
+} from './PostgresRuntimeStore.js';
+export {
+  RUNTIME_STORE_SCHEMA_VERSION,
+  RuntimeStoreError,
+  type RuntimeCommandCommit,
+  type RuntimeCommitResult,
+  type RuntimeDomainEvent,
+  type RuntimeDomainEventDraft,
+  type RuntimeDomainEventPage,
+  type RuntimeEffectIntent,
+  type RuntimeEffectRecord,
+  type RuntimeEffectStatus,
+  type RuntimeProjectionCheckpoint,
+  type RuntimeProjectionRecord,
+  type RuntimeStore,
+  type RuntimeStoreErrorCode,
+  type RuntimeTenantStore,
+} from './RuntimeStore.js';

--- a/src/server/testing/RuntimeStoreConformance.ts
+++ b/src/server/testing/RuntimeStoreConformance.ts
@@ -1,0 +1,336 @@
+import {
+  AGENT_PROTOCOL_VERSION,
+  AgentCommandType,
+} from '../../protocol/index.js';
+import {
+  InputId,
+  RequestId,
+  SessionId,
+} from '../../types/branded.js';
+import type { RuntimeStore } from '../RuntimeStore.js';
+
+export interface RuntimeStoreConformanceOptions {
+  readonly tenantId?: string;
+  readonly otherTenantId?: string;
+  readonly idPrefix?: string;
+}
+
+export interface RuntimeStoreConformanceResult {
+  readonly checks: readonly string[];
+}
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) {
+    throw new Error(`RuntimeStore conformance failed: ${message}`);
+  }
+}
+
+/**
+ * Executes the public RuntimeStore contract without depending on a test
+ * framework. Run it against a dedicated database/schema because it writes data.
+ */
+export async function assertRuntimeStoreConformance(
+  store: RuntimeStore,
+  options: RuntimeStoreConformanceOptions = {},
+): Promise<RuntimeStoreConformanceResult> {
+  const suffix = options.idPrefix ?? `${Date.now()}-${Math.random()}`;
+  const tenantId = options.tenantId ?? `tenant-${suffix}`;
+  const otherTenantId = options.otherTenantId ?? `other-${suffix}`;
+  const sessionId = SessionId(`session-${suffix}`);
+  const checks: string[] = [];
+
+  await store.initialize();
+  const health = await store.healthCheck();
+  assert(health.ready, 'healthCheck must report ready after initialize');
+  checks.push('health');
+
+  const sessions = store.forTenant(tenantId);
+  await sessions.createSession(sessionId);
+  await sessions.saveMessage(sessionId, 'user', 'hello');
+  const tool = await sessions.saveToolUse(
+    sessionId,
+    'Search',
+    { query: 'blade' },
+  );
+  await sessions.saveToolResult(
+    sessionId,
+    tool.toolCallId,
+    'Search',
+    { matches: 1 },
+    tool.messageId,
+  );
+  await sessions.saveCompaction(
+    sessionId,
+    'summary',
+    { trigger: 'manual', preTokens: 100, postTokens: 20 },
+  );
+  await sessions.saveInputEnqueued(sessionId, {
+    inputId: InputId(`input-${suffix}`),
+    content: 'queued',
+    priority: 'later',
+    acceptedAt: 1,
+  });
+  const state = await sessions.loadState(sessionId);
+  assert(state?.summary === 'summary', 'Session projection must include summary');
+  assert(state.messages.length === 4, 'Session projection must include all messages');
+  assert(state.pendingInputs.length === 1, 'Session projection must include pending input');
+  const pendingInputId = state.pendingInputs[0]?.inputId;
+  assert(pendingInputId !== undefined, 'Pending input must expose its ID');
+  await sessions.saveAppliedInputMessage(
+    sessionId,
+    pendingInputId,
+    RequestId(`request-applied-${suffix}`),
+    'queued',
+  );
+  await sessions.saveInputEnqueued(sessionId, {
+    inputId: InputId(`cancel-${suffix}`),
+    content: 'cancel',
+    priority: 'later',
+    acceptedAt: 2,
+  });
+  await sessions.saveInputCancelled(
+    sessionId,
+    InputId(`cancel-${suffix}`),
+    'conformance',
+  );
+  const updatedState = await sessions.loadState(sessionId);
+  assert(
+    updatedState?.pendingInputs.length === 0,
+    'Applied and cancelled inputs must leave no pending projection',
+  );
+  assert(
+    (await sessions.loadMessages(sessionId)).length === 5,
+    'Message projection must include the applied input',
+  );
+  assert(
+    (await sessions.forkState(sessionId))?.messageIds.length === 5,
+    'Fork projection must preserve the message timeline',
+  );
+  assert(
+    (await sessions.getSessionSummary(sessionId))?.messageCount === 3,
+    'Session summary must count user and assistant messages',
+  );
+  assert(
+    (await sessions.listSessions()).includes(sessionId),
+    'Session list must include the projected Session',
+  );
+  assert(
+    (await sessions.getStorageStats()).totalSessions >= 1,
+    'Session storage stats must include projected Sessions',
+  );
+  assert(
+    await store.forTenant(otherTenantId).loadState(sessionId) === null,
+    'Session projections must be tenant isolated',
+  );
+  const deleteSessionId = SessionId(`delete-${suffix}`);
+  await sessions.createSession(deleteSessionId);
+  await sessions.deleteSession(deleteSessionId);
+  assert(
+    await sessions.loadState(deleteSessionId) === null,
+    'Deleted Session projection must not remain readable',
+  );
+  checks.push('session-projection');
+
+  const serverRecord = {
+    tenantId,
+    createdBy: 'conformance',
+    sessionId,
+    status: 'active' as const,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+  await store.putSession(serverRecord);
+  assert(
+    (await store.getSession(tenantId, sessionId))?.sessionId === sessionId,
+    'Server Session record must round-trip',
+  );
+  assert(
+    await store.getSession(otherTenantId, sessionId) === null,
+    'Server Session records must be tenant isolated',
+  );
+  checks.push('tenant-isolation');
+
+  const commandId = `command-${suffix}`;
+  const fingerprint = `fingerprint-${suffix}`;
+  const claim = await store.claimCommand(tenantId, commandId, fingerprint, 1000);
+  assert(claim.status === 'claimed', 'First command claim must succeed');
+  if (claim.status !== 'claimed') {
+    throw new Error('unreachable');
+  }
+  await store.sealCommand(tenantId, commandId, claim.leaseId);
+  const commandResult = {
+    protocolVersion: AGENT_PROTOCOL_VERSION,
+    commandId,
+    ok: true as const,
+    data: { accepted: true },
+  };
+  await store.completeCommand(
+    tenantId,
+    commandId,
+    claim.leaseId,
+    commandResult,
+  );
+  const replay = await store.claimCommand(
+    tenantId,
+    commandId,
+    fingerprint,
+    1000,
+  );
+  assert(
+    replay.status === 'completed'
+    && JSON.stringify(replay.result) === JSON.stringify(commandResult),
+    'Completed command must replay its deterministic result',
+  );
+  assert(
+    (await store.claimCommand(
+      tenantId,
+      commandId,
+      `${fingerprint}-different`,
+      1000,
+    )).status === 'conflict',
+    'A reused command ID with a different fingerprint must conflict',
+  );
+  checks.push('command-receipts');
+
+  await store.appendEvent(tenantId, sessionId, {
+    protocolVersion: AGENT_PROTOCOL_VERSION,
+    sessionId,
+    occurredAt: new Date().toISOString(),
+    type: 'session.closed',
+    data: { reason: 'conformance' },
+  });
+  const agentEvents = await store.readEvents(tenantId, sessionId);
+  assert(
+    agentEvents.events.length === 1
+    && agentEvents.events[0]?.sequence === 1,
+    'Agent event stream must be sequenced',
+  );
+  checks.push('agent-events');
+
+  const durable = await sessions.append(
+    sessionId,
+    [{
+      type: 'session_created',
+      data: { source: 'create' },
+    }],
+    { expectedLastSequence: null },
+  );
+  assert(
+    durable.lastSequence === 1
+    && (await sessions.read(sessionId)).events.length === 1,
+    'Durable event stream must support compare-and-append',
+  );
+  checks.push('durable-events');
+
+  const transactionCommandId = `transaction-${suffix}`;
+  const transaction = {
+    tenantId,
+    sessionId,
+    command: {
+      commandId: transactionCommandId,
+      fingerprint: `fingerprint-${transactionCommandId}`,
+      result: {
+        protocolVersion: AGENT_PROTOCOL_VERSION,
+        commandId: transactionCommandId,
+        ok: true as const,
+        data: { committed: true },
+      },
+    },
+    expectedLastSequence: null,
+    events: [{
+      type: 'request.accepted',
+      data: { requestId: RequestId(`request-${suffix}`) },
+    }],
+    effects: [{
+      effectId: `effect-${suffix}`,
+      type: 'tool.execute',
+      payload: { toolName: 'Search' },
+      idempotencyKey: `effect-key-${suffix}`,
+    }],
+    projection: {
+      name: 'conformance',
+      expectedOffset: null,
+      offset: 1,
+      state: { status: 'accepted' },
+    },
+  };
+  const committed = await store.commitRuntimeTransaction(transaction);
+  assert(committed.status === 'committed', 'Runtime transaction must commit');
+  assert(committed.events.length === 1, 'Runtime transaction must append events');
+  assert(committed.effects.length === 1, 'Runtime transaction must enqueue effects');
+  assert(
+    committed.projection?.offset === 1,
+    'Runtime transaction must checkpoint its projection',
+  );
+  const replayed = await store.commitRuntimeTransaction(transaction);
+  assert(replayed.status === 'replayed', 'Runtime transaction retry must replay');
+  assert(
+    (await store.readDomainEvents(tenantId, sessionId)).events.length === 1,
+    'Runtime transaction retry must not duplicate events',
+  );
+  checks.push('atomic-runtime-commit');
+
+  const rollbackCommandId = `rollback-${suffix}`;
+  let rejected = false;
+  try {
+    await store.commitRuntimeTransaction({
+      tenantId,
+      sessionId,
+      command: {
+        commandId: rollbackCommandId,
+        fingerprint: `fingerprint-${rollbackCommandId}`,
+        result: {
+          protocolVersion: AGENT_PROTOCOL_VERSION,
+          commandId: rollbackCommandId,
+          ok: true,
+          data: {},
+        },
+      },
+      expectedLastSequence: 999,
+      events: [{ type: 'must.rollback', data: {} }],
+      effects: [{
+        effectId: `rollback-effect-${suffix}`,
+        type: 'must.rollback',
+        payload: {},
+        idempotencyKey: `rollback-key-${suffix}`,
+      }],
+    });
+  } catch {
+    rejected = true;
+  }
+  assert(rejected, 'Conflicting runtime transaction must reject');
+  assert(
+    (await store.readDomainEvents(tenantId, sessionId)).events.length === 1,
+    'Rejected transaction must not append domain events',
+  );
+  assert(
+    (await store.listEffects(tenantId)).length === 1,
+    'Rejected transaction must not enqueue effects',
+  );
+  assert(
+    (await store.claimCommand(
+      tenantId,
+      rollbackCommandId,
+      `fingerprint-${rollbackCommandId}`,
+      1000,
+    )).status === 'claimed',
+    'Rejected transaction must roll back its command receipt',
+  );
+  checks.push('transaction-rollback');
+
+  assert(
+    (await store.getProjection(
+      tenantId,
+      sessionId,
+      'conformance',
+    ))?.state.status === 'accepted',
+    'Projection state must be readable at its committed offset',
+  );
+  checks.push('projection-checkpoint');
+
+  assert(
+    Object.values(AgentCommandType).length > 0,
+    'Protocol command catalog must be available',
+  );
+  return { checks };
+}

--- a/src/server/testing/index.ts
+++ b/src/server/testing/index.ts
@@ -1,0 +1,5 @@
+export {
+  assertRuntimeStoreConformance,
+  type RuntimeStoreConformanceOptions,
+  type RuntimeStoreConformanceResult,
+} from './RuntimeStoreConformance.js';

--- a/src/session/Session.ts
+++ b/src/session/Session.ts
@@ -68,7 +68,9 @@ import {
 } from './SessionHostProfile.js';
 import { SessionInputInbox } from './SessionInputInbox.js';
 import {
+  isSessionEventStore,
   NoopSessionRepository,
+  type SessionEventStore,
   type SessionRepository,
 } from './SessionRepository.js';
 import { SessionRuntime } from './SessionRuntime.js';
@@ -99,6 +101,14 @@ import { InputPriority } from './types.js';
 
 export interface ResumeOptions extends SessionOptions {
   sessionId: SessionId;
+}
+
+function hasSessionPersistence(options: SessionOptions): boolean {
+  return options.sessionRepository !== undefined
+    && (
+      options.sessionEventStore !== undefined
+      || isSessionEventStore(options.sessionRepository)
+    );
 }
 
 interface SessionStreamExecution {
@@ -155,6 +165,7 @@ class Session implements ISession {
   private _messages: Message[] = [];
   private readonly options: SessionOptions;
   private readonly store: SessionRepository;
+  private readonly eventStore: SessionEventStore;
   private readonly persistenceEnabled: boolean;
   private readonly isResumeSession: boolean;
   private readonly rootLogger: InternalLogger;
@@ -211,7 +222,8 @@ class Session implements ISession {
       !options.sessionRepository
     ) {
       throw new ConfigError(
-        'Server sessions require sessionRepository for persistence. '
+        'Server sessions require sessionRepository and sessionEventStore '
+          + 'for persistence. '
           + 'Import from @blade-ai/agent-sdk/node to use storagePath-backed local persistence.',
       );
     }
@@ -224,12 +236,30 @@ class Session implements ISession {
     this.confirmationHandler =
       options.confirmationHandlerFactory?.(this.sessionId)
       ?? options.confirmationHandler;
-    this.persistenceEnabled =
-      options.persistSession !== false && options.sessionRepository !== undefined;
-    this.store =
-      this.persistenceEnabled && options.sessionRepository
+    const eventStore = options.sessionEventStore
+      ?? (isSessionEventStore(options.sessionRepository)
         ? options.sessionRepository
-        : new NoopSessionRepository();
+        : undefined);
+    if (
+      options.persistSession !== false
+      && ((options.sessionRepository && !eventStore)
+        || (!options.sessionRepository && eventStore))
+    ) {
+      throw new ConfigError(
+        'Persistent Sessions require both sessionRepository and sessionEventStore.',
+      );
+    }
+    this.persistenceEnabled =
+      options.persistSession !== false
+      && options.sessionRepository !== undefined
+      && eventStore !== undefined;
+    const noopRepository = new NoopSessionRepository();
+    this.store = this.persistenceEnabled && options.sessionRepository
+      ? options.sessionRepository
+      : noopRepository;
+    this.eventStore = this.persistenceEnabled && eventStore
+      ? eventStore
+      : noopRepository;
     this.isResumeSession = isResume;
     this.rootLogger = createRootLogger(options.logger, this.sessionId);
     this.logger = this.rootLogger.child(LogCategory.AGENT);
@@ -323,6 +353,7 @@ class Session implements ISession {
         this.rootLogger,
         this.hostProfile,
         this.store,
+        this.eventStore,
       );
       await this.runtime.initialize();
       if (this.isResumeSession) {
@@ -2483,9 +2514,10 @@ export async function resumeSessionWithHost(
   options: ResumeOptions,
   hostProfile: SessionHostProfile,
 ): Promise<ISession> {
-  if (options.persistSession === false || !options.sessionRepository) {
+  if (options.persistSession === false || !hasSessionPersistence(options)) {
     throw new Error(
-      'resumeSession() requires session persistence through sessionRepository.',
+      'resumeSession() requires session persistence through '
+        + 'sessionRepository and sessionEventStore.',
     );
   }
   const { sessionId, ...sessionOptions } = options;
@@ -2512,9 +2544,10 @@ export async function forkSessionWithHost(
   options: ForkOptions,
   hostProfile: SessionHostProfile,
 ): Promise<ISession> {
-  if (options.persistSession === false || !options.sessionRepository) {
+  if (options.persistSession === false || !hasSessionPersistence(options)) {
     throw new Error(
-      'forkSession() requires session persistence through sessionRepository. '
+      'forkSession() requires session persistence through '
+        + 'sessionRepository and sessionEventStore. '
         + 'Use session.fork() for an in-memory Session.',
     );
   }

--- a/src/session/SessionRepository.ts
+++ b/src/session/SessionRepository.ts
@@ -59,14 +59,17 @@ export interface SessionRepositoryHealth {
   error?: string;
 }
 
-/**
- * Complete transcript persistence port used by Session and ContextManager.
- *
- * Implementations own both append operations and read projections so a Session
- * never writes through one backend and resumes through another.
- */
+/** Read-side Session projection port. */
 export interface SessionRepository extends SessionStore {
   initialize(): Promise<void>;
+  deleteSession(sessionId: SessionId): Promise<void>;
+  cleanupOldSessions(): Promise<void>;
+  getStorageStats(): Promise<SessionRepositoryStorageStats>;
+  checkStorageHealth(): Promise<SessionRepositoryHealth>;
+}
+
+/** Append-only transcript event port used to update Session projections. */
+export interface SessionEventStore {
   createSession(
     sessionId: SessionId,
     subagentInfo?: SessionRepositorySubagentInfo,
@@ -118,17 +121,37 @@ export interface SessionRepository extends SessionStore {
     parentUuid?: string | null,
   ): Promise<string>;
   saveContext(sessionId: SessionId, contextData: ContextData): Promise<void>;
-  deleteSession(sessionId: SessionId): Promise<void>;
-  cleanupOldSessions(): Promise<void>;
-  getStorageStats(): Promise<SessionRepositoryStorageStats>;
-  checkStorageHealth(): Promise<SessionRepositoryHealth>;
+}
+
+/** Compatibility port for backends that expose reads and appends together. */
+export interface SessionPersistence
+  extends SessionRepository, SessionEventStore {}
+
+export function isSessionEventStore(
+  value: SessionRepository | SessionEventStore | undefined,
+): value is SessionEventStore {
+  if (!value) {
+    return false;
+  }
+  const candidate = value as unknown as Record<string, unknown>;
+  return [
+    'createSession',
+    'saveMessage',
+    'saveInputEnqueued',
+    'saveAppliedInputMessage',
+    'saveInputCancelled',
+    'saveToolUse',
+    'saveToolResult',
+    'saveCompaction',
+    'saveContext',
+  ].every((method) => typeof candidate[method] === 'function');
 }
 
 /**
  * Non-persistent repository used when callers intentionally run an ephemeral
  * Session without a shared store.
  */
-export class NoopSessionRepository implements SessionRepository {
+export class NoopSessionRepository implements SessionPersistence {
   async initialize(): Promise<void> {}
 
   async createSession(

--- a/src/session/SessionRuntime.ts
+++ b/src/session/SessionRuntime.ts
@@ -20,7 +20,10 @@ import { getSandboxExecutor } from '../sandbox/SandboxExecutor.js';
 import { getSandboxService } from '../sandbox/SandboxService.js';
 import type { DurableExecutionFence } from './events/DurableExecutionLeaseStore.js';
 import { NODE_SESSION_HOST, type SessionHostProfile } from './SessionHostProfile.js';
-import type { SessionRepository } from './SessionRepository.js';
+import type {
+  SessionEventStore,
+  SessionRepository,
+} from './SessionRepository.js';
 import { getBuiltinTools } from '../tools/builtin/index.js';
 import { BackgroundShellManager } from '../tools/builtin/shell/BackgroundShellManager.js';
 import { ToolCatalog } from '../tools/catalog/ToolCatalog.js';
@@ -123,6 +126,7 @@ export class SessionRuntime {
     logger: InternalLogger,
     private readonly hostProfile: SessionHostProfile = NODE_SESSION_HOST,
     sessionRepository?: SessionRepository,
+    sessionEventStore?: SessionEventStore,
   ) {
     this.rootLogger = logger;
     this.logger = logger.child(LogCategory.AGENT);
@@ -150,13 +154,16 @@ export class SessionRuntime {
           maxMemorySize: 1000,
           persistentPath: options.storagePath,
           persistenceEnabled:
-            options.persistSession !== false && sessionRepository !== undefined,
+            options.persistSession !== false
+            && sessionRepository !== undefined
+            && sessionEventStore !== undefined,
           cacheSize: 100,
           compressionEnabled: true,
         },
         projectPath: getContextCwd(defaultContext),
       },
       sessionRepository,
+      sessionEventStore,
     );
     this.hookCallbacks = this.pluginHost.mergeHooks(options.hooks);
     this.hookRuntime = new HookRuntime({

--- a/src/session/__tests__/SessionPersistence.test.ts
+++ b/src/session/__tests__/SessionPersistence.test.ts
@@ -15,6 +15,10 @@ import {
   resumeSession as resumeServerSession,
 } from '../Session.js';
 import { MessageId, SessionId } from '../../types/branded.js';
+import {
+  isSessionEventStore,
+  type SessionRepository,
+} from '../SessionRepository.js';
 
 function createWorkspaceRoot(): string {
   return mkdtempSync(join(tmpdir(), 'session-persistence-test-'));
@@ -50,6 +54,52 @@ function createOptions(workspaceRoot: string) {
 }
 
 describe('Session persistence', () => {
+  it('recognizes only complete transcript event Stores', () => {
+    expect(isSessionEventStore({
+      saveMessage: async () => 'message-1',
+    } as never)).toBe(false);
+    expect(isSessionEventStore(
+      new PersistentStore(createWorkspaceRoot()),
+    )).toBe(true);
+  });
+
+  it('requires an event writer when a read-only repository is configured', async () => {
+    const repository: SessionRepository = {
+      async initialize() {},
+      async loadState() {
+        return null;
+      },
+      async loadMessages() {
+        return [];
+      },
+      async forkState() {
+        return null;
+      },
+      async listSessions() {
+        return [];
+      },
+      async getSessionSummary() {
+        return null;
+      },
+      async deleteSession() {},
+      async cleanupOldSessions() {},
+      async getStorageStats() {
+        return { totalSessions: 0, totalSize: 0 };
+      },
+      async checkStorageHealth() {
+        return { isAvailable: true, canWrite: false };
+      },
+    };
+
+    await expect(createServerSession({
+      ...createOptions(createWorkspaceRoot()),
+      storagePath: undefined,
+      sessionRepository: repository,
+    })).rejects.toMatchObject({
+      code: 'CONFIG_ERROR',
+    });
+  });
+
   it('supports an injected repository without a local storage path', async () => {
     const repository = new PersistentStore(createWorkspaceRoot());
     const session = await createServerSession({

--- a/src/session/__tests__/SessionRepository.contract.test.ts
+++ b/src/session/__tests__/SessionRepository.contract.test.ts
@@ -4,17 +4,17 @@ import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { PersistentStore } from '../../context/storage/PersistentStore.js';
 import { InputId, RequestId, SessionId } from '../../types/branded.js';
-import type { SessionRepository } from '../SessionRepository.js';
+import type { SessionPersistence } from '../SessionRepository.js';
 
 interface RepositoryFixture {
-  readonly repository: SessionRepository;
+  readonly repository: SessionPersistence;
 }
 
-function sessionRepositoryContract(
+function sessionPersistenceContract(
   name: string,
   createFixture: () => RepositoryFixture,
 ): void {
-  describe(`${name} SessionRepository conformance`, () => {
+  describe(`${name} SessionPersistence conformance`, () => {
     it('uses one backend for append operations and read projections', async () => {
       const { repository } = createFixture();
       const sessionId = SessionId('contract-session');
@@ -99,7 +99,7 @@ function sessionRepositoryContract(
   });
 }
 
-sessionRepositoryContract('JSONL', () => ({
+sessionPersistenceContract('JSONL', () => ({
   repository: new PersistentStore(
     mkdtempSync(join(tmpdir(), 'session-repository-contract-')),
   ),

--- a/src/session/index.ts
+++ b/src/session/index.ts
@@ -9,8 +9,11 @@ export {
   type SessionHandoffErrorCode,
 } from '../errors/SessionHandoffError.js';
 export * from './events/core.js';
+export { isSessionEventStore } from './SessionRepository.js';
 export type {
   PersistedToolUse,
+  SessionEventStore,
+  SessionPersistence,
   SessionRepository,
   SessionRepositoryCompactionMetadata,
   SessionRepositoryHealth,

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -51,7 +51,10 @@ import type {
   DurableSessionProjection,
   DurableSessionRecoveryPlan,
 } from './events/DurableSessionProjector.js';
-import type { SessionRepository } from './SessionRepository.js';
+import type {
+  SessionEventStore,
+  SessionRepository,
+} from './SessionRepository.js';
 
 export type {
   AgentMiddlewareConfig,
@@ -323,6 +326,8 @@ export interface SessionOptions {
    * The /node entry creates a JSONL repository from storagePath when omitted.
    */
   sessionRepository?: SessionRepository;
+  /** Append-only transcript event port paired with sessionRepository. */
+  sessionEventStore?: SessionEventStore;
   durableEventStore?: DurableEventStore;
   /** Maximum wall-clock duration of one durable Store call. Defaults to 15000ms. */
   durableStoreTimeoutMs?: number;

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -23,6 +23,8 @@ export default defineConfig({
     'node/index': 'src/node/index.ts',
     'protocol/index': 'src/protocol/index.ts',
     'server/index': 'src/server/index.ts',
+    'server/postgres': 'src/server/postgres.ts',
+    'server/testing/index': 'src/server/testing/index.ts',
     'session/index': 'src/session/index.ts',
     'tools/index': 'src/tools/index.ts',
   },


### PR DESCRIPTION
## Summary

- split Session persistence into read-side `SessionRepository` and append-side `SessionEventStore` ports
- add a PostgreSQL `RuntimeStore` that atomically commits command receipts, domain events, effect intents, and projection checkpoints
- expose `/server/postgres` and `/server/testing` with a public conformance suite
- make `AgentServer.runtimeStore` the tenant-scoped persistence authority and reject mixed Session-level overrides
- run PostgreSQL 16 in CI and release workflows; document Redis as notification/quota only

## Verification

- `TEST_POSTGRES_URL=postgresql://postgres@127.0.0.1:55432/blade_agent_test pnpm test` (1774 passed, 63 credential-gated live tests skipped)
- `pnpm run type-check`
- `pnpm run lint`
- `pnpm run docs:build`
- `pnpm run verify:entrypoints`
- `pnpm run changelog:check`
- `pnpm run audit:prod`

## Release

Patch release: `v5.3.13`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a PostgreSQL-backed Runtime Store with transactional commits, event streams, projections, command coordination, and tenant isolation.
  * Added dedicated server/postgres and server/testing entry points.
  * Added a public Runtime Store conformance test suite.
  * Added support for separate session read and event-writing stores, or a shared runtime store.

* **Documentation**
  * Added Runtime Store setup, configuration, API, and operational guidance in English and Simplified Chinese.

* **Tests**
  * Added PostgreSQL integration coverage and CI/release database testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->