### PR TITLE
fix(examples): add one-command production stack

### DIFF
--- a/.changes/production-stack-example.json
+++ b/.changes/production-stack-example.json
@@ -1,0 +1,5 @@
+{
+  "type": "fix",
+  "en": "Add a one-command Web-to-Docker production stack example with an automated end-to-end smoke check.",
+  "zh-CN": "新增单命令 Web 到 Docker 生产闭环示例及自动化端到端 smoke 验证。"
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,9 @@ jobs:
           node scripts/verify-entrypoints.mjs
           node scripts/verify-minimal-install.mjs
 
+      - name: Verify production Golden Path
+        run: pnpm run verify:production-example
+
       - name: Build documentation
         run: pnpm run docs:build
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,6 +81,9 @@ jobs:
           node scripts/verify-entrypoints.mjs
           node scripts/verify-minimal-install.mjs
 
+      - name: Verify production Golden Path
+        run: pnpm run verify:production-example
+
       - name: Build documentation
         run: pnpm run docs:build
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,15 @@ import type { ModelMessage, ModelService } from '@blade-ai/agent-sdk/model';
 
 Importing a server-only entry in a browser resolves to a stub that throws a clear runtime error.
 
+Run the complete browser-to-worker production topology locally with one command:
+
+```bash
+pnpm example:production
+```
+
+This starts PostgreSQL, `AgentServer`, `AgentWorker`, and an isolated Docker
+execution host. See [Runnable golden paths](./examples/README.md).
+
 PostgreSQL, OpenTelemetry, non-bundled provider adapters, and native Node enhancements
 are opt-in peers:
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -154,6 +154,15 @@ import type { ModelMessage, ModelService } from '@blade-ai/agent-sdk/model';
 
 浏览器误导入仅服务端入口时，会解析到带清晰错误信息的 stub。
 
+使用一条命令在本地运行完整的浏览器到 Worker 生产拓扑：
+
+```bash
+pnpm example:production
+```
+
+该命令会启动 PostgreSQL、`AgentServer`、`AgentWorker` 和隔离的 Docker
+执行环境。详见[可运行 Golden Paths](./examples/README.md)。
+
 PostgreSQL、OpenTelemetry、非内置 Provider adapter 和本机原生增强是按需 peer：
 
 ```bash

--- a/docs/en/golden-paths.md
+++ b/docs/en/golden-paths.md
@@ -1,7 +1,7 @@
 # Golden Paths
 
 The repository provides four runnable paths. Every example imports only public
-only public package entrypoints.
+package entrypoints.
 
 ## Single-command production loop
 

--- a/docs/en/golden-paths.md
+++ b/docs/en/golden-paths.md
@@ -1,7 +1,38 @@
 # Golden Paths
 
-The repository includes three directly runnable paths. Every example imports
+The repository provides four runnable paths. Every example imports only public
 only public package entrypoints.
+
+## Single-command production loop
+
+```bash
+pnpm example:production
+```
+
+Open the local URL printed by the command. It starts PostgreSQL and cleans up
+PostgreSQL, worker-created Docker containers, volumes, and temporary files on
+exit. Each request traverses the complete path:
+
+```text
+Browser AgentClient
+→ AgentServer
+→ PostgreSQL route queue
+→ AgentWorker
+→ DockerExecutionHost
+→ PostgreSQL event log
+→ SSE
+```
+
+Run the non-interactive acceptance check with:
+
+```bash
+pnpm run build
+pnpm verify:production-example
+```
+
+The reported `firstResultMs` starts before infrastructure orchestration. The
+smoke command succeeds only after receiving the exact Docker worker output
+within five minutes.
 
 ## Local CLI Agent
 

--- a/docs/golden-paths.md
+++ b/docs/golden-paths.md
@@ -1,6 +1,35 @@
 # Golden Paths
 
-仓库提供三条可直接运行的完整路径，所有示例只导入公开 package entrypoint。
+仓库提供四条可直接运行的完整路径，所有示例只导入公开 package entrypoint。
+
+## 单命令生产闭环
+
+```bash
+pnpm example:production
+```
+
+打开命令输出的本地 URL。该命令自动启动并在退出时清理 PostgreSQL、Worker
+使用的 Docker 容器、volume 和临时目录。请求会完整经过：
+
+```text
+Browser AgentClient
+→ AgentServer
+→ PostgreSQL route queue
+→ AgentWorker
+→ DockerExecutionHost
+→ PostgreSQL event log
+→ SSE
+```
+
+无需浏览器的自动验收命令：
+
+```bash
+pnpm run build
+pnpm verify:production-example
+```
+
+输出中的 `firstResultMs` 从基础设施编排开始计时；smoke 只有在五分钟内收到
+Docker worker 生成的精确结果后才成功。
 
 ## 本地 CLI Agent
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,6 +2,34 @@
 
 These examples exercise the public package entrypoints after `pnpm run build`.
 
+## Complete production stack
+
+```bash
+pnpm example:production
+```
+
+Open the printed local URL. One command starts PostgreSQL and a Node control
+plane, then connects the browser through this complete path:
+
+```text
+AgentClient -> AgentServer -> PostgreSQL -> AgentWorker -> DockerExecutionHost
+```
+
+The control plane only persists and queues requests. `AgentWorker` claims each
+route, executes the prompt in a network-disabled Docker container, and publishes
+the result through the durable SSE event log. `Ctrl+C` removes the PostgreSQL
+container, execution containers, volumes, and temporary files.
+
+For a non-interactive end-to-end check:
+
+```bash
+pnpm run build
+pnpm verify:production-example
+```
+
+The smoke command prints `firstResultMs` and fails unless the browser protocol
+receives the exact output produced by the Docker worker within five minutes.
+
 ## Local CLI Agent
 
 ```bash

--- a/examples/production-stack/DockerPromptRunner.mjs
+++ b/examples/production-stack/DockerPromptRunner.mjs
@@ -1,0 +1,158 @@
+import { requireQueuedRequest } from './QueuedSessionExecutor.mjs';
+
+function withoutQueuedRequest(metadata) {
+  const { bladeQueuedRequest: _queuedRequest, ...rest } = metadata;
+  return rest;
+}
+
+export class DockerPromptRunner {
+  constructor(options) {
+    this.image = options.image;
+    this.publish = options.publish;
+  }
+
+  async run(context) {
+    const host = context.executionHost;
+    if (!host) {
+      throw new TypeError('DockerPromptRunner requires an ExecutionHost');
+    }
+    const queued = requireQueuedRequest(context.claim.route.metadata);
+    const metadata = withoutQueuedRequest(context.claim.route.metadata);
+    await context.transition('running', context.claim.route.metadata);
+    const execution = await host.provision({
+      image: this.image,
+      workspace: { kind: 'empty' },
+      resources: {
+        cpus: 0.25,
+        memoryBytes: 32 * 1024 * 1024,
+        diskBytes: 8 * 1024 * 1024,
+        pids: 32,
+        runtimeMs: 30_000,
+        maxOutputBytes: 16 * 1024,
+      },
+      network: { mode: 'none' },
+      signal: context.signal,
+    });
+
+    try {
+      await this.publish(
+        context.claim.route.tenantId,
+        context.claim.route.sessionId,
+        'session.stream',
+        {
+          type: 'input_applied',
+          inputId: queued.inputId,
+          requestId: queued.requestId,
+          priority: 'next',
+          turn: 1,
+          sessionId: context.claim.route.sessionId,
+        },
+        queued.requestId,
+      );
+      await this.publish(
+        context.claim.route.tenantId,
+        context.claim.route.sessionId,
+        'session.stream',
+        {
+          type: 'turn_start',
+          turn: 1,
+          sessionId: context.claim.route.sessionId,
+        },
+        queued.requestId,
+      );
+      const result = await host.exec(execution.executionId, {
+        command: '/bin/sh',
+        args: ['-c', 'printf "Docker worker received: "; cat'],
+        stdin: queued.input,
+        signal: context.signal,
+      });
+      const output = result.stdout.trim();
+      if (result.exitCode !== 0) {
+        await this.publishFailure(context, queued.requestId, result.stderr.trim());
+        return {
+          status: 'idle',
+          metadata: {
+            ...metadata,
+            lastExecution: {
+              requestId: queued.requestId,
+              exitCode: result.exitCode,
+              completedAt: result.completedAt,
+            },
+          },
+        };
+      }
+      await this.publish(
+        context.claim.route.tenantId,
+        context.claim.route.sessionId,
+        'session.stream',
+        {
+          type: 'content',
+          delta: output,
+          sessionId: context.claim.route.sessionId,
+        },
+        queued.requestId,
+      );
+      await this.publish(
+        context.claim.route.tenantId,
+        context.claim.route.sessionId,
+        'session.stream',
+        {
+          type: 'result',
+          subtype: 'success',
+          content: output,
+          sessionId: context.claim.route.sessionId,
+        },
+        queued.requestId,
+      );
+      return {
+        status: 'idle',
+        metadata: {
+          ...metadata,
+          lastExecution: {
+            requestId: queued.requestId,
+            exitCode: result.exitCode,
+            completedAt: result.completedAt,
+          },
+        },
+      };
+    } catch (error) {
+      if (!context.signal.aborted) {
+        await this.publishFailure(
+          context,
+          queued.requestId,
+          error instanceof Error ? error.message : String(error),
+        );
+      }
+      throw error;
+    } finally {
+      await host.terminate(execution.executionId).catch(() => undefined);
+    }
+  }
+
+  async publishFailure(context, requestId, message) {
+    const error = message || 'Docker execution failed';
+    await this.publish(
+      context.claim.route.tenantId,
+      context.claim.route.sessionId,
+      'session.stream',
+      {
+        type: 'error',
+        message: error,
+        sessionId: context.claim.route.sessionId,
+      },
+      requestId,
+    );
+    await this.publish(
+      context.claim.route.tenantId,
+      context.claim.route.sessionId,
+      'session.stream',
+      {
+        type: 'result',
+        subtype: 'error',
+        error,
+        sessionId: context.claim.route.sessionId,
+      },
+      requestId,
+    );
+  }
+}

--- a/examples/production-stack/QueuedSessionExecutor.mjs
+++ b/examples/production-stack/QueuedSessionExecutor.mjs
@@ -1,0 +1,218 @@
+import { randomUUID } from 'node:crypto';
+import {
+  InputId,
+  RequestId,
+  SessionId,
+} from '@blade-ai/agent-sdk/core';
+import { AgentProtocolError } from '@blade-ai/agent-sdk/protocol';
+
+export const QUEUED_REQUEST_METADATA_KEY = 'bladeQueuedRequest';
+
+function sessionId() {
+  return SessionId(`session-${randomUUID()}`);
+}
+
+function requireQueuedRequest(metadata) {
+  const value = metadata[QUEUED_REQUEST_METADATA_KEY];
+  if (
+    typeof value !== 'object'
+    || value === null
+    || Array.isArray(value)
+    || typeof value.input !== 'string'
+    || typeof value.inputId !== 'string'
+    || typeof value.requestId !== 'string'
+  ) {
+    throw new Error('Session route does not contain a valid queued request');
+  }
+  return value;
+}
+
+export class QueuedSessionExecutor {
+  constructor(store, publish) {
+    this.store = store;
+    this.publish = publish;
+  }
+
+  async create(context, data) {
+    const now = new Date().toISOString();
+    const record = {
+      tenantId: context.principal.tenantId,
+      createdBy: context.principal.subject,
+      sessionId: sessionId(),
+      status: 'active',
+      createdAt: now,
+      updatedAt: now,
+      ...(data.metadata ? { metadata: data.metadata } : {}),
+    };
+    await this.store.putSession(record);
+    return record;
+  }
+
+  async read(context, data) {
+    const session = await this.requireSession(
+      context.principal.tenantId,
+      data.sessionId,
+    );
+    const route = await this.store.getSessionRoute(
+      context.principal.tenantId,
+      data.sessionId,
+    );
+    const queuedRequest = route ? this.readQueuedRequest(route.metadata) : null;
+    return {
+      session,
+      messages: [],
+      pendingInputs:
+        route?.state === 'queued' && queuedRequest
+          ? [{
+              inputId: InputId(queuedRequest.inputId),
+              content: queuedRequest.input,
+              priority: 'later',
+              targetRequestId: RequestId(queuedRequest.requestId),
+              acceptedAt: queuedRequest.acceptedAt,
+            }]
+          : [],
+    };
+  }
+
+  async resume(context, data) {
+    return this.requireSession(context.principal.tenantId, data.sessionId);
+  }
+
+  async fork(context, data) {
+    const source = await this.requireSession(
+      context.principal.tenantId,
+      data.sessionId,
+    );
+    return this.create(context, {
+      metadata: {
+        ...(source.metadata ?? {}),
+        ...(data.metadata ?? {}),
+        forkedFrom: source.sessionId,
+      },
+    });
+  }
+
+  async submit(context, data) {
+    const tenantId = context.principal.tenantId;
+    const session = await this.requireSession(tenantId, data.sessionId);
+    if (session.status === 'closed') {
+      throw new AgentProtocolError('SESSION_CONFLICT', 'Session is closed', 409);
+    }
+    if (typeof data.input !== 'string') {
+      throw new AgentProtocolError(
+        'INVALID_COMMAND',
+        'The production stack example accepts text input only',
+        400,
+      );
+    }
+    const current = await this.store.getSessionRoute(tenantId, data.sessionId);
+    if (current && current.state !== 'idle') {
+      throw new AgentProtocolError(
+        'SESSION_CONFLICT',
+        `Session ${data.sessionId} is ${current.state}`,
+        409,
+        true,
+        250,
+      );
+    }
+
+    const inputId = InputId(`input-${randomUUID()}`);
+    const requestId = RequestId(`request-${randomUUID()}`);
+    await this.store.enqueueSession(tenantId, data.sessionId, {
+      metadata: {
+        ...(session.metadata ?? {}),
+        [QUEUED_REQUEST_METADATA_KEY]: {
+          version: 1,
+          inputId,
+          requestId,
+          input: data.input,
+          acceptedAt: Date.now(),
+        },
+      },
+    });
+    return {
+      sessionId: data.sessionId,
+      inputId,
+      requestId,
+      status: 'started',
+    };
+  }
+
+  async abort(context, data) {
+    const route = await this.store.getSessionRoute(
+      context.principal.tenantId,
+      data.sessionId,
+    );
+    if (route && route.state !== 'idle') {
+      throw new AgentProtocolError(
+        'SESSION_CONFLICT',
+        'This example can abort only after the active Docker execution settles',
+        409,
+        true,
+        250,
+      );
+    }
+  }
+
+  async closeSession(context, data) {
+    const tenantId = context.principal.tenantId;
+    const record = await this.requireSession(tenantId, data.sessionId);
+    const route = await this.store.getSessionRoute(tenantId, data.sessionId);
+    if (
+      route
+      && route.state !== 'idle'
+      && route.state !== 'completed'
+      && route.state !== 'failed'
+    ) {
+      throw new AgentProtocolError(
+        'SESSION_CONFLICT',
+        `Session ${data.sessionId} cannot close while ${route.state}`,
+        409,
+        true,
+        250,
+      );
+    }
+    const closed = {
+      ...record,
+      status: 'closed',
+      updatedAt: new Date().toISOString(),
+    };
+    await this.store.putSession(closed);
+    await this.publish(tenantId, data.sessionId, 'session.closed', {
+      reason: 'user',
+    });
+    return closed;
+  }
+
+  async resolvePermission() {
+    throw new AgentProtocolError(
+      'PERMISSION_NOT_FOUND',
+      'This example does not request permissions',
+      404,
+    );
+  }
+
+  async shutdown() {}
+
+  async requireSession(tenantId, id) {
+    const record = await this.store.getSession(tenantId, id);
+    if (!record) {
+      throw new AgentProtocolError(
+        'SESSION_NOT_FOUND',
+        `Session ${id} was not found`,
+        404,
+      );
+    }
+    return record;
+  }
+
+  readQueuedRequest(metadata) {
+    try {
+      return requireQueuedRequest(metadata);
+    } catch {
+      return null;
+    }
+  }
+}
+
+export { requireQueuedRequest };

--- a/examples/production-stack/compose.yaml
+++ b/examples/production-stack/compose.yaml
@@ -1,0 +1,14 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: blade_agent_stack
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER: postgres
+    ports:
+      - "127.0.0.1::5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d blade_agent_stack"]
+      interval: 1s
+      timeout: 3s
+      retries: 30

--- a/examples/production-stack/run.mjs
+++ b/examples/production-stack/run.mjs
@@ -124,6 +124,7 @@ async function runSmoke(baseUrl) {
   );
   let resolveResult;
   let rejectResult;
+  let resultSettled = false;
   const resultReceived = new Promise((resolve, reject) => {
     resolveResult = resolve;
     rejectResult = reject;
@@ -138,18 +139,24 @@ async function runSmoke(baseUrl) {
           output += event.data.delta;
         }
         if (event.type === 'session.stream' && event.data.type === 'result') {
+          resultSettled = true;
           resolveResult({
             output,
             result: event.data,
           });
         }
         if (event.type === 'session.closed') {
+          if (!resultSettled) {
+            rejectResult(new Error('Session closed before producing a result'));
+          }
           return;
         }
       }
       throw new Error('Session event stream ended before session.closed');
     } catch (error) {
-      rejectResult(error);
+      if (!resultSettled) {
+        rejectResult(error);
+      }
       throw error;
     }
   })();
@@ -295,6 +302,12 @@ try {
     conditions: ['browser'],
   });
   httpServer = createServer(async (request, response) => {
+    const requestController = new AbortController();
+    const abortUpstream = () => {
+      requestController.abort(new Error('Client disconnected'));
+    };
+    request.once('aborted', abortUpstream);
+    response.once('close', abortUpstream);
     try {
       const url = new URL(request.url || '/', 'http://127.0.0.1');
       if (request.method === 'GET' && url.pathname === '/') {
@@ -315,6 +328,7 @@ try {
         new Request(`http://127.0.0.1${request.url || '/'}`, {
           method: request.method,
           headers: request.headers,
+          signal: requestController.signal,
           ...(body ? { body } : {}),
         }),
       );
@@ -323,8 +337,19 @@ try {
         response.end();
         return;
       }
-      Readable.fromWeb(upstream.body).pipe(response);
+      const bodyStream = Readable.fromWeb(upstream.body);
+      response.once('close', () => bodyStream.destroy());
+      bodyStream.on('error', (error) => {
+        requestController.abort(error);
+        if (!response.destroyed) {
+          response.destroy(error);
+        }
+      });
+      bodyStream.pipe(response);
     } catch (error) {
+      if (response.destroyed) {
+        return;
+      }
       response.writeHead(500, { 'content-type': 'application/json' });
       response.end(JSON.stringify({
         error: error instanceof Error ? error.message : String(error),

--- a/examples/production-stack/run.mjs
+++ b/examples/production-stack/run.mjs
@@ -1,0 +1,353 @@
+import { execFile } from 'node:child_process';
+import { createServer } from 'node:http';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { Readable } from 'node:stream';
+import { promisify } from 'node:util';
+import { fileURLToPath } from 'node:url';
+import { build } from 'esbuild';
+import { AgentClient } from '@blade-ai/agent-sdk/browser';
+import { WorkerId } from '@blade-ai/agent-sdk/core';
+import {
+  AgentServer,
+  AgentWorker,
+} from '@blade-ai/agent-sdk/server';
+import { PostgresRuntimeStore } from '@blade-ai/agent-sdk/server/postgres';
+import { DockerExecutionHost } from '@blade-ai/agent-sdk/node';
+import { DockerPromptRunner } from './DockerPromptRunner.mjs';
+import { QueuedSessionExecutor } from './QueuedSessionExecutor.mjs';
+
+const execFileAsync = promisify(execFile);
+const root = dirname(fileURLToPath(import.meta.url));
+const webRoot = join(root, '../web-agent-server');
+const composeFile = join(root, 'compose.yaml');
+const composeProject = `blade-production-stack-${process.pid}`;
+const schema = `blade_production_stack_${process.pid}`;
+const tablePrefix = 'runtime';
+const tenantId = 'production-demo';
+const smoke = process.argv.includes('--smoke');
+const launchedAt = performance.now();
+const FIRST_RESULT_BUDGET_MS = 5 * 60 * 1_000;
+const temporaryRoot = await mkdtemp(join(tmpdir(), 'blade-production-stack-'));
+const generated = join(temporaryRoot, 'web');
+let store;
+let worker;
+let agent;
+let httpServer;
+let composeStarted = false;
+let cleanupStarted = false;
+
+async function dockerCompose(...args) {
+  return execFileAsync('docker', [
+    'compose',
+    '--project-name',
+    composeProject,
+    '--file',
+    composeFile,
+    ...args,
+  ]);
+}
+
+async function resolveImage() {
+  if (process.env.TEST_DOCKER_IMAGE) {
+    return process.env.TEST_DOCKER_IMAGE;
+  }
+  await execFileAsync('docker', ['pull', 'alpine:3.22']);
+  const { stdout } = await execFileAsync(
+    'docker',
+    ['image', 'inspect', '--format', '{{index .RepoDigests 0}}', 'alpine:3.22'],
+  );
+  return stdout.trim();
+}
+
+async function requestBody(request) {
+  const chunks = [];
+  for await (const chunk of request) {
+    chunks.push(chunk);
+  }
+  return chunks.length === 0 ? undefined : Buffer.concat(chunks);
+}
+
+async function waitUntil(predicate, timeoutMs = 30_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await predicate()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(`Production stack did not settle within ${timeoutMs}ms`);
+}
+
+function listen(server, port) {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(port, '127.0.0.1', () => {
+      server.removeListener('error', reject);
+      resolve();
+    });
+  });
+}
+
+function closeServer(server) {
+  return new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    });
+    server.closeAllConnections();
+  });
+}
+
+async function runSmoke(baseUrl) {
+  const client = new AgentClient({
+    baseUrl: `${baseUrl}/v1/agent`,
+    client: {
+      name: 'blade-production-stack-smoke',
+      version: '1.0.0',
+    },
+    headers: {
+      authorization: 'Bearer local-demo',
+    },
+  });
+  const session = await client.createSession({
+    source: 'production-stack-smoke',
+  });
+  const eventController = new AbortController();
+  const deadline = setTimeout(
+    () => eventController.abort(new Error('Five-minute first-result budget exceeded')),
+    Math.max(1, FIRST_RESULT_BUDGET_MS - (performance.now() - launchedAt)),
+  );
+  let resolveResult;
+  let rejectResult;
+  const resultReceived = new Promise((resolve, reject) => {
+    resolveResult = resolve;
+    rejectResult = reject;
+  });
+  const events = (async () => {
+    let output = '';
+    try {
+      for await (const event of session.events({
+        signal: eventController.signal,
+      })) {
+        if (event.type === 'session.stream' && event.data.type === 'content') {
+          output += event.data.delta;
+        }
+        if (event.type === 'session.stream' && event.data.type === 'result') {
+          resolveResult({
+            output,
+            result: event.data,
+          });
+        }
+        if (event.type === 'session.closed') {
+          return;
+        }
+      }
+      throw new Error('Session event stream ended before session.closed');
+    } catch (error) {
+      rejectResult(error);
+      throw error;
+    }
+  })();
+  try {
+    await session.send('single-command production path');
+    const completed = await resultReceived;
+    const firstResultMs = Math.round((performance.now() - launchedAt) * 100) / 100;
+    const expected = 'Docker worker received: single-command production path';
+    if (
+      completed.output !== expected
+      || completed.result.subtype !== 'success'
+    ) {
+      throw new Error(`Unexpected production stack result: ${JSON.stringify(completed)}`);
+    }
+    if (firstResultMs > FIRST_RESULT_BUDGET_MS) {
+      throw new Error(`First result exceeded ${FIRST_RESULT_BUDGET_MS}ms`);
+    }
+    await waitUntil(
+      async () =>
+        (await store.getSessionRoute(tenantId, session.sessionId))?.state === 'idle',
+    );
+    await session.close();
+    await events;
+    return {
+      sessionId: session.sessionId,
+      firstResultMs,
+      output: completed.output,
+      worker: worker.getSnapshot(),
+    };
+  } finally {
+    clearTimeout(deadline);
+    eventController.abort();
+    await events.catch(() => undefined);
+  }
+}
+
+async function cleanup() {
+  if (cleanupStarted) {
+    return;
+  }
+  cleanupStarted = true;
+  if (httpServer?.listening) {
+    await closeServer(httpServer).catch(() => undefined);
+  }
+  await agent?.close().catch(() => undefined);
+  await worker?.shutdown().catch(() => undefined);
+  await store?.close().catch(() => undefined);
+  if (composeStarted) {
+    await dockerCompose('down', '--volumes', '--remove-orphans')
+      .catch(() => undefined);
+  }
+  await rm(temporaryRoot, { recursive: true, force: true });
+}
+
+for (const signal of ['SIGINT', 'SIGTERM']) {
+  process.once(signal, () => {
+    void cleanup().then(
+      () => process.exit(0),
+      (error) => {
+        process.stderr.write(
+          `${error instanceof Error ? error.stack : String(error)}\n`,
+        );
+        process.exit(1);
+      },
+    );
+  });
+}
+
+try {
+  await dockerCompose('up', '--detach', '--wait');
+  composeStarted = true;
+  const { stdout: portOutput } = await dockerCompose('port', 'postgres', '5432');
+  const databasePort = portOutput.trim().split(':').at(-1);
+  if (!databasePort) {
+    throw new Error(`Could not resolve PostgreSQL port from "${portOutput.trim()}"`);
+  }
+  const connectionString =
+    `postgresql://postgres:postgres@127.0.0.1:${databasePort}/blade_agent_stack`;
+  const image = await resolveImage();
+
+  store = new PostgresRuntimeStore({
+    connectionString,
+    schema,
+    tablePrefix,
+  });
+  await store.initialize();
+
+  const publish = (
+    eventTenantId,
+    sessionId,
+    type,
+    data,
+    requestId,
+  ) =>
+    store.appendEvent(eventTenantId, sessionId, {
+      protocolVersion: 1,
+      sessionId,
+      ...(requestId ? { requestId } : {}),
+      occurredAt: new Date().toISOString(),
+      type,
+      data,
+    });
+  const executor = new QueuedSessionExecutor(store, publish);
+  agent = new AgentServer({
+    runtimeStore: store,
+    sessionExecutor: executor,
+    authenticate(request) {
+      if (request.headers.get('authorization') !== 'Bearer local-demo') {
+        return null;
+      }
+      return {
+        tenantId,
+        subject: 'browser-user',
+        scopes: ['session:admin'],
+      };
+    },
+  });
+  const host = new DockerExecutionHost({
+    rootDirectory: join(temporaryRoot, 'executions'),
+    checkpointDirectory: join(temporaryRoot, 'checkpoints'),
+  });
+  worker = new AgentWorker({
+    store,
+    workerId: WorkerId(`production-worker-${process.pid}`),
+    tenantId,
+    capacity: 2,
+    executionHost: host,
+    sessionRunner: new DockerPromptRunner({ image, publish }),
+    workerTtlMs: 5_000,
+    sessionLeaseTtlMs: 5_000,
+    heartbeatIntervalMs: 500,
+    pollIntervalMs: 25,
+    recoveryIntervalMs: 250,
+  });
+  await worker.start();
+
+  await build({
+    entryPoints: [join(webRoot, 'client.js')],
+    outfile: join(generated, 'client.js'),
+    bundle: true,
+    format: 'esm',
+    platform: 'browser',
+    conditions: ['browser'],
+  });
+  httpServer = createServer(async (request, response) => {
+    try {
+      const url = new URL(request.url || '/', 'http://127.0.0.1');
+      if (request.method === 'GET' && url.pathname === '/') {
+        response.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+        response.end(await readFile(join(webRoot, 'index.html')));
+        return;
+      }
+      if (request.method === 'GET' && url.pathname === '/client.js') {
+        response.writeHead(200, {
+          'content-type': 'text/javascript; charset=utf-8',
+          'cache-control': 'no-store',
+        });
+        response.end(await readFile(join(generated, 'client.js')));
+        return;
+      }
+      const body = await requestBody(request);
+      const upstream = await agent.handle(
+        new Request(`http://127.0.0.1${request.url || '/'}`, {
+          method: request.method,
+          headers: request.headers,
+          ...(body ? { body } : {}),
+        }),
+      );
+      response.writeHead(upstream.status, Object.fromEntries(upstream.headers));
+      if (!upstream.body) {
+        response.end();
+        return;
+      }
+      Readable.fromWeb(upstream.body).pipe(response);
+    } catch (error) {
+      response.writeHead(500, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({
+        error: error instanceof Error ? error.message : String(error),
+      }));
+    }
+  });
+  await listen(httpServer, smoke ? 0 : Number(process.env.PORT || 8787));
+  const address = httpServer.address();
+  if (!address || typeof address === 'string') {
+    throw new Error('Could not determine production stack HTTP address');
+  }
+  const baseUrl = `http://127.0.0.1:${address.port}`;
+
+  if (smoke) {
+    const result = await runSmoke(baseUrl);
+    process.stdout.write(`${JSON.stringify({
+      baseUrl,
+      ...result,
+    }, null, 2)}\n`);
+  } else {
+    process.stdout.write(`Production Agent stack: ${baseUrl}\n`);
+    await new Promise(() => undefined);
+  }
+} finally {
+  await cleanup();
+}

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "audit:prod": "pnpm audit --prod --audit-level low",
     "verify:entrypoints": "pnpm run build && node scripts/verify-entrypoints.mjs",
     "verify:install": "pnpm run build && node scripts/verify-minimal-install.mjs",
+    "verify:production-example": "node examples/production-stack/run.mjs --smoke",
     "changelog:check": "node scripts/semantic-release-bilingual-changelog.cjs --check",
     "release": "semantic-release",
     "release:dry": "semantic-release --dry-run --no-ci",
@@ -102,6 +103,7 @@
     "docs:preview": "vitepress preview docs",
     "benchmark:runtime": "pnpm run build && node benchmarks/runtime.mjs",
     "example:local": "pnpm run build && node examples/local-cli-agent/index.mjs",
+    "example:production": "pnpm run build && node examples/production-stack/run.mjs",
     "example:web": "pnpm run build && node examples/web-agent-server/server.mjs",
     "example:worker-recovery": "pnpm run build && node examples/postgres-worker-recovery/run.mjs"
   },

--- a/scripts/__tests__/golden-paths.test.ts
+++ b/scripts/__tests__/golden-paths.test.ts
@@ -10,10 +10,14 @@ const goldenPaths = [
   'examples/postgres-worker-recovery/compose.yaml',
   'examples/postgres-worker-recovery/run.mjs',
   'examples/postgres-worker-recovery/worker.mjs',
+  'examples/production-stack/compose.yaml',
+  'examples/production-stack/DockerPromptRunner.mjs',
+  'examples/production-stack/QueuedSessionExecutor.mjs',
+  'examples/production-stack/run.mjs',
 ] as const;
 
 describe('golden paths', () => {
-  it('keeps all three runnable entrypoints wired to package scripts', () => {
+  it('keeps every runnable entrypoint wired to package scripts', () => {
     const packageJson = JSON.parse(readFileSync(resolve('package.json'), 'utf8')) as {
       scripts: Record<string, string>;
     };
@@ -21,6 +25,8 @@ describe('golden paths', () => {
     expect(packageJson.scripts).toMatchObject({
       'example:local':
         'pnpm run build && node examples/local-cli-agent/index.mjs',
+      'example:production':
+        'pnpm run build && node examples/production-stack/run.mjs',
       'example:web':
         'pnpm run build && node examples/web-agent-server/server.mjs',
       'example:worker-recovery':
@@ -55,6 +61,20 @@ describe('golden paths', () => {
     expect(worker).toContain('AgentWorker');
     expect(worker).toContain('ExecutionHostSessionRunner');
     expect(worker).toContain('DockerExecutionHost');
+
+    const production = readFileSync(
+      resolve('examples/production-stack/run.mjs'),
+      'utf8',
+    );
+    for (const boundary of [
+      'AgentClient',
+      'AgentServer',
+      'PostgresRuntimeStore',
+      'AgentWorker',
+      'DockerExecutionHost',
+    ]) {
+      expect(production).toContain(boundary);
+    }
   });
 
   it('keeps the Web example in standards mode without external assets', () => {

--- a/scripts/__tests__/semantic-release-config.test.ts
+++ b/scripts/__tests__/semantic-release-config.test.ts
@@ -110,6 +110,7 @@ describe('release workflow', () => {
         'node scripts/verify-minimal-install.mjs',
         '',
       ].join('\n'),
+      'pnpm run verify:production-example',
       'pnpm run docs:build',
       'pnpm run test',
       'pnpm exec semantic-release',
@@ -158,6 +159,7 @@ describe('pull request workflow', () => {
         '',
       ].join('\n'),
     );
+    expect(commands).toContain('pnpm run verify:production-example');
     expect(commands).toContain('pnpm run docs:build');
   });
 });


### PR DESCRIPTION
## Summary

- add a one-command Browser → AgentServer → PostgreSQL → AgentWorker → DockerExecutionHost example
- persist requests in the PostgreSQL route queue and return worker output through the SSE event log
- add an automated smoke command with a five-minute first-result budget
- run the production Golden Path in PR and release CI

## Verification

- production smoke completed in 3.57s and returned the exact Docker output
- browser UI submitted a request and received the Docker worker response over SSE
- TypeScript build, lint, documentation, changelog, and workflow tests pass
- interactive SIGTERM cleanup leaves no containers or volumes

Release intent: patch within the locked 6.0.x line.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a complete local production-stack example connecting the browser, server, PostgreSQL, worker, and isolated Docker execution.
  - Added one-command launch and verification scripts with streamed-result smoke validation.
  - Added automatic cleanup for containers, volumes, temporary files, and interrupted runs.

- **Documentation**
  - Added English and Chinese setup instructions, architecture diagrams, runnable golden paths, timing expectations, and verification guidance.

- **Tests**
  - Extended automated checks to validate the production example and its CI/release verification steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->