### PR TITLE
fix(server): add production runtime operations

### DIFF
--- a/.changes/runtime-operations.json
+++ b/.changes/runtime-operations.json
@@ -1,0 +1,5 @@
+{
+  "type": "fix",
+  "en": "Add authenticated runtime health, queue metrics, uncertain-effect reconciliation, and payload-free Worker OpenTelemetry.",
+  "zh-CN": "新增带鉴权的 runtime 健康检查、队列指标、uncertain effect 对账与不采集 payload 的 Worker OpenTelemetry。"
+}

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -80,6 +80,7 @@ Node-local 能力外，这些函数都从根入口导出；实际 subpath 以“
 | `SdkSessionRunner` | server | 在 worker fencing 下恢复并执行 durable SDK Session |
 | `ExecutionHostSessionRunner` | server | 在隔离 ExecutionHost 中 provision、执行、checkpoint 和恢复 workload |
 | `AgentWorker` | server | worker 注册、heartbeat、Session claim、lease 续期、恢复与 drain supervisor |
+| `AgentRuntimeOperations` | server | 受鉴权的 runtime health、queue metrics 与 uncertain effect reconciliation |
 | `EffectDispatcher` | server | 消费持久化 outbox，并执行显式重试或 uncertain 收敛 |
 | `AgentClient` / `RemoteAgentSession` | browser | 带 command 重试和 SSE cursor 重连的远程客户端 |
 | `InMemoryAgentServerStore` | server | 单进程控制面参考 Store；不用于多实例生产部署 |
@@ -87,6 +88,7 @@ Node-local 能力外，这些函数都从根入口导出；实际 subpath 以“
 | `RuntimeStoreError` | server | Runtime transaction 的稳定错误类型 |
 | `TenantAdmissionController` | server | 每 tenant 并发、队列和固定窗口限流 |
 | `OpenTelemetryAgentServerTelemetry` | server/otel | 默认不采集 payload 的 metric、trace 与 audit adapter |
+| `OpenTelemetryAgentWorkerTelemetry` | server/otel | 默认不采集 payload 的 Worker readiness、吞吐、恢复和 effect metric adapter |
 | `JsonlSessionRepository` | node | Node.js transcript repository |
 | `SessionInputError` | session | 输入队列容量、请求匹配或活动请求选项错误 |
 | `SessionHandoffError` | session | handoff 配置、生命周期或活动后台工作前置条件错误 |
@@ -166,11 +168,13 @@ Node-local 能力外，这些函数都从根入口导出；实际 subpath 以“
 | `RuntimeEffectIntent` / `RuntimeEffectRecord` / `RuntimeEffectStatus` | Transactional outbox 类型 |
 | `RuntimeProjectionCheckpoint` / `RuntimeProjectionRecord` | Projection CAS 与 checkpoint |
 | `RuntimeWorkerRecord` / `RuntimeWorkerRegistration` | worker heartbeat、容量与 drain 状态 |
+| `RuntimeQueueMetrics` / `AgentWorkerHealth` | tenant backlog、Worker capacity 与本地 readiness 快照 |
 | `RuntimeSessionRoute` / `RuntimeSessionClaim` / `RuntimeSessionState` | Session 路由、含可重入 `idle` 的八态状态机与 execution lease |
 | `RuntimeEffectClaim` / `RuntimeEffectLease` / `RuntimeEffectExecutionMode` / `RuntimeEffectReconciliation` | effect 领取、fencing、at-most-once 与人工对账语义 |
 | `RuntimeEffectHandler` / `RuntimeEffectHandlerContext` | 类型化 outbox effect handler |
 | `RetryableRuntimeEffectError` / `UncertainRuntimeEffectError` | 显式声明 effect 可重试或结果未知 |
 | `SessionRunner` / `SessionRunnerContext` / `SessionRunResult` | 单个 fenced Session 的执行边界 |
+| `AgentRuntimeOperationsOptions` / `RuntimeOperationsPrincipal` | 运维 HTTP 面、鉴权与 tenant scope 配置 |
 | `WorkerRuntimeStore` / `WorkerRuntimeError` | worker 调度与恢复端口及稳定错误 |
 | `assertRuntimeStoreConformance` | 不依赖测试框架的公开 Store conformance suite |
 

--- a/docs/en/api-reference.md
+++ b/docs/en/api-reference.md
@@ -97,6 +97,7 @@ Runtime:
 - `SdkSessionRunner`
 - `ExecutionHostSessionRunner`
 - `AgentWorker`
+- `AgentRuntimeOperations`
 - `EffectDispatcher`
 - `AgentClient`
 - `RemoteAgentSession`
@@ -144,6 +145,7 @@ Types:
 - `RuntimeEffectLease`
 - `RuntimeEffectExecutionMode`
 - `RuntimeEffectReconciliation`
+- `RuntimeQueueMetrics`
 - `RuntimeEffectHandler`
 - `RuntimeEffectHandlerContext`
 - `RetryableRuntimeEffectError`
@@ -176,7 +178,8 @@ Types:
 - `assertRuntimeStoreConformance` (`/server/testing`)
 
 `PostgresRuntimeStore` is exported by `/server/postgres`.
-`OpenTelemetryAgentServerTelemetry` is exported by `/server/otel`.
+`OpenTelemetryAgentServerTelemetry` and
+`OpenTelemetryAgentWorkerTelemetry` are exported by `/server/otel`.
 
 See [Server Runtime](./server-runtime), [Runtime Store](./runtime-store),
 [Worker Runtime](./worker-runtime), and

--- a/docs/en/golden-paths.md
+++ b/docs/en/golden-paths.md
@@ -34,6 +34,11 @@ The reported `firstResultMs` starts before infrastructure orchestration. The
 smoke command succeeds only after receiving the exact Docker worker output
 within five minutes.
 
+The same smoke verifies unauthenticated `/v1/runtime/readyz` and
+tenant-scoped `/v1/runtime/metrics` using the local operator token. Acceptance
+passes only when the Worker is ready and queue metrics reflect the completed
+Session.
+
 ## Local CLI Agent
 
 ```bash

--- a/docs/en/runtime-store.md
+++ b/docs/en/runtime-store.md
@@ -165,6 +165,26 @@ Each PostgreSQL transcript append writes a `transcript` event and updates the
 `session` projection in the same transaction. Reads, resume, and fork use only
 that projection.
 
+## Queue metrics capability
+
+The PostgreSQL adapter implements the optional
+`getQueueMetrics(tenantId?)` capability:
+
+```ts
+const metrics = await runtimeStore.getQueueMetrics?.(tenantId);
+```
+
+The result contains zero-filled counts for every Session and effect state,
+current claimable counts, oldest-backlog timestamps and ages, plus global
+active/draining/offline Worker counts, total capacity, active Sessions, and
+available capacity. Session and effect values are tenant-scoped; Worker
+capacity describes the shared scheduler.
+
+The method remains optional on `WorkerRuntimeStore`, preserving compatibility
+for existing third-party Store implementations throughout `6.0.x`.
+`AgentRuntimeOperations` returns HTTP `501` when a Store does not expose the
+capability.
+
 ## Conformance
 
 Third-party Stores can run the public framework-independent conformance suite:
@@ -183,7 +203,8 @@ await assertRuntimeStoreConformance(runtimeStore, {
 The suite verifies health, Session projection, tenant isolation, command
 receipts, agent and durable events, atomic commits, transaction rollback,
 projection checkpoints, worker routing, lease recovery, and effect delivery.
-Run it against a dedicated schema or test database.
+When the Store exposes queue metrics, the suite also verifies tenant scoping
+and capacity accounting. Run it against a dedicated schema or test database.
 
 ## Operational boundaries
 

--- a/docs/en/worker-runtime.md
+++ b/docs/en/worker-runtime.md
@@ -254,6 +254,81 @@ The operation:
 4. Requeues executing `idempotent` effects only.
 5. Marks executing `at_most_once` effects `uncertain`.
 
+## Production operations
+
+`AgentRuntimeOperations` exposes an operations surface separate from the Agent
+protocol. Every endpoint except liveness and readiness requires caller-supplied
+authorization and is scoped to the tenant returned by that callback:
+
+```ts
+import {
+  AgentRuntimeOperations,
+} from '@blade-ai/agent-sdk/server';
+
+const operations = new AgentRuntimeOperations({
+  store,
+  workers: () => [worker],
+  authorize: async (request, action) => {
+    const operator = await authenticateOperator(request, action);
+    return operator
+      ? { tenantId: operator.tenantId, subject: operator.id }
+      : null;
+  },
+});
+
+const response = await operations.handle(request);
+```
+
+Default routes:
+
+| Route | Purpose |
+|-------|---------|
+| `GET /v1/runtime/healthz` | Process and Worker liveness |
+| `GET /v1/runtime/readyz` | Store and configured-Worker readiness |
+| `GET /v1/runtime/metrics` | Tenant Session/effect backlog and global Worker capacity |
+| `GET /v1/runtime/effects/uncertain` | Redacted uncertain-effect list |
+| `POST /v1/runtime/effects/:id/reconcile` | Resolve an effect to `completed` or `failed` |
+
+A reconciliation body is either:
+
+```json
+{ "status": "completed", "result": { "receiptId": "provider-123" } }
+```
+
+or:
+
+```json
+{ "status": "failed", "error": { "reason": "provider_rejected" } }
+```
+
+The HTTP list omits effect payloads and idempotency keys. The underlying
+`reconcileEffect()` operation still accepts only `uncertain` effects.
+Unauthenticated health/readiness responses expose aggregate counts only, not
+Worker IDs, Session IDs, Store details, or failure payloads. When no local
+Workers are configured, readiness depends on the Store alone.
+
+`worker.getHealth()` is a local, I/O-free snapshot. Readiness requires a
+`running` worker and a successful heartbeat newer than the worker TTL.
+`draining` and `stopped` workers remain live but are not ready.
+
+## Worker OpenTelemetry
+
+```ts
+import {
+  OpenTelemetryAgentWorkerTelemetry,
+} from '@blade-ai/agent-sdk/server/otel';
+
+const worker = new AgentWorker({
+  // ...
+  telemetry: new OpenTelemetryAgentWorkerTelemetry(),
+});
+```
+
+The adapter exports readiness, active Session, claim, success/failure,
+recovery-duration, and uncertain-effect instruments. It omits prompts, effect
+payloads, Session IDs, credentials, and Worker IDs by default. Set
+`includeWorkerIdAttribute: true` to opt into Worker ID attributes.
+
 ## Failure boundaries
 
 - Session and effect leases use monotonic fencing tokens.

--- a/docs/golden-paths.md
+++ b/docs/golden-paths.md
@@ -31,6 +31,10 @@ pnpm verify:production-example
 输出中的 `firstResultMs` 从基础设施编排开始计时；smoke 只有在五分钟内收到
 Docker worker 生成的精确结果后才成功。
 
+同一 smoke 还会验证无需鉴权的 `/v1/runtime/readyz`，以及使用本地 operator
+令牌访问的、按租户隔离的 `/v1/runtime/metrics`。只有 Worker ready 且队列指标
+反映已完成的 Session 时，验收才会通过。
+
 ## 本地 CLI Agent
 
 ```bash

--- a/docs/runtime-store.md
+++ b/docs/runtime-store.md
@@ -158,6 +158,23 @@ interface SessionEventStore {
 PostgreSQL transcript append 会在同一个 transaction 中追加 `transcript`
 event 并更新 `session` projection。读取、恢复和 fork 只访问 projection。
 
+## Queue metrics capability
+
+PostgreSQL adapter 实现可选的 `getQueueMetrics(tenantId?)` capability：
+
+```ts
+const metrics = await runtimeStore.getQueueMetrics?.(tenantId);
+```
+
+结果包含所有 Session/effect 状态的零填充计数、当前可领取数量、最老 backlog
+时间与年龄，以及全局 active/draining/offline Worker、总容量、活动 Session
+和可用容量。Session/effect 数据按 tenant 过滤；Worker capacity 是共享调度层的
+全局视图。
+
+该方法在 `WorkerRuntimeStore` 上保持可选，以确保现有第三方 Store 在 `6.0.x`
+中继续兼容。`AgentRuntimeOperations` 遇到不支持该 capability 的 Store 时返回
+HTTP `501`。
+
 ## Conformance
 
 第三方 Store 可以直接运行公开的无测试框架 conformance：
@@ -175,7 +192,8 @@ await assertRuntimeStoreConformance(runtimeStore, {
 
 该套件验证 health、Session projection、tenant isolation、command receipt、
 agent/durable event、原子 commit、事务回滚、projection checkpoint、worker
-路由、lease 恢复与 effect delivery。应在专用 schema 或测试数据库中运行。
+路由、lease 恢复与 effect delivery。Store 提供 queue metrics capability 时也会
+验证其 tenant 隔离与容量统计。应在专用 schema 或测试数据库中运行。
 
 ## 运维边界
 

--- a/docs/worker-runtime.md
+++ b/docs/worker-runtime.md
@@ -240,6 +240,79 @@ const recovered = await store.recoverExpiredWork();
 4. 只重排 `idempotent` 的执行中 effect。
 5. 将 `at_most_once` 的执行中 effect 标记为 `uncertain`。
 
+## 生产运维面
+
+`AgentRuntimeOperations` 提供独立于 Agent protocol 的运维接口。除 liveness 和
+readiness 外，所有入口都必须由调用方鉴权，并自动限制在返回 principal 的
+tenant：
+
+```ts
+import {
+  AgentRuntimeOperations,
+} from '@blade-ai/agent-sdk/server';
+
+const operations = new AgentRuntimeOperations({
+  store,
+  workers: () => [worker],
+  authorize: async (request, action) => {
+    const operator = await authenticateOperator(request, action);
+    return operator
+      ? { tenantId: operator.tenantId, subject: operator.id }
+      : null;
+  },
+});
+
+const response = await operations.handle(request);
+```
+
+默认路由：
+
+| 路由 | 作用 |
+|------|------|
+| `GET /v1/runtime/healthz` | 进程与 Worker liveness |
+| `GET /v1/runtime/readyz` | Store 与已配置 Worker 的 readiness |
+| `GET /v1/runtime/metrics` | tenant Session/effect backlog 与全局 Worker capacity |
+| `GET /v1/runtime/effects/uncertain` | 查询已脱敏的 uncertain effect |
+| `POST /v1/runtime/effects/:id/reconcile` | 人工收敛为 `completed` 或 `failed` |
+
+reconciliation body 必须是：
+
+```json
+{ "status": "completed", "result": { "receiptId": "provider-123" } }
+```
+
+或：
+
+```json
+{ "status": "failed", "error": { "reason": "provider_rejected" } }
+```
+
+HTTP 列表不会返回 effect payload 或 idempotency key。底层
+`reconcileEffect()` 仍只允许修改 `uncertain` effect。
+无需鉴权的 health/readiness 响应只返回聚合计数，不暴露 Worker ID、Session ID、
+Store 细节或 failure payload。未配置本地 Worker 时，readiness 只取决于 Store。
+
+`worker.getHealth()` 是无 I/O 的本地健康快照。`ready` 要求 Worker 处于
+`running` 且最近一次成功 heartbeat 未超过 worker TTL；`draining` 和
+`stopped` 保持 live，但不再 ready。
+
+## Worker OpenTelemetry
+
+```ts
+import {
+  OpenTelemetryAgentWorkerTelemetry,
+} from '@blade-ai/agent-sdk/server/otel';
+
+const worker = new AgentWorker({
+  // ...
+  telemetry: new OpenTelemetryAgentWorkerTelemetry(),
+});
+```
+
+adapter 导出 readiness、active Session、claim、成功/失败、恢复耗时和 uncertain
+effect 指标。默认不添加 worker ID，也不记录 prompt、effect payload、Session ID
+或凭据；只有显式设置 `includeWorkerIdAttribute: true` 才添加 worker ID。
+
 ## 故障边界
 
 - Session lease 与 effect lease 都使用单调 fencing token。

--- a/examples/README.md
+++ b/examples/README.md
@@ -20,6 +20,14 @@ route, executes the prompt in a network-disabled Docker container, and publishes
 the result through the durable SSE event log. `Ctrl+C` removes the PostgreSQL
 container, execution containers, volumes, and temporary files.
 
+The same process exposes runtime readiness and tenant-scoped queue metrics:
+
+```bash
+curl http://127.0.0.1:8787/v1/runtime/readyz
+curl -H 'Authorization: Bearer local-demo' \
+  http://127.0.0.1:8787/v1/runtime/metrics
+```
+
 For a non-interactive end-to-end check:
 
 ```bash

--- a/examples/production-stack/run.mjs
+++ b/examples/production-stack/run.mjs
@@ -10,6 +10,7 @@ import { build } from 'esbuild';
 import { AgentClient } from '@blade-ai/agent-sdk/browser';
 import { WorkerId } from '@blade-ai/agent-sdk/core';
 import {
+  AgentRuntimeOperations,
   AgentServer,
   AgentWorker,
 } from '@blade-ai/agent-sdk/server';
@@ -34,6 +35,7 @@ const generated = join(temporaryRoot, 'web');
 let store;
 let worker;
 let agent;
+let operations;
 let httpServer;
 let composeStarted = false;
 let cleanupStarted = false;
@@ -178,12 +180,28 @@ async function runSmoke(baseUrl) {
       async () =>
         (await store.getSessionRoute(tenantId, session.sessionId))?.state === 'idle',
     );
+    const headers = { authorization: 'Bearer local-demo' };
+    const [readyResponse, metricsResponse] = await Promise.all([
+      fetch(`${baseUrl}/v1/runtime/readyz`),
+      fetch(`${baseUrl}/v1/runtime/metrics`, { headers }),
+    ]);
+    if (!readyResponse.ok || !metricsResponse.ok) {
+      throw new Error(
+        `Runtime operations failed: ready=${readyResponse.status}, metrics=${metricsResponse.status}`,
+      );
+    }
+    const health = await readyResponse.json();
+    const metrics = await metricsResponse.json();
     await session.close();
     await events;
     return {
       sessionId: session.sessionId,
       firstResultMs,
       output: completed.output,
+      operations: {
+        health,
+        queue: metrics.queue,
+      },
       worker: worker.getSnapshot(),
     };
   } finally {
@@ -292,6 +310,19 @@ try {
     recoveryIntervalMs: 250,
   });
   await worker.start();
+  operations = new AgentRuntimeOperations({
+    store,
+    workers: () => [worker],
+    authorize(request) {
+      if (request.headers.get('authorization') !== 'Bearer local-demo') {
+        return null;
+      }
+      return {
+        tenantId,
+        subject: 'local-operator',
+      };
+    },
+  });
 
   await build({
     entryPoints: [join(webRoot, 'client.js')],
@@ -324,14 +355,18 @@ try {
         return;
       }
       const body = await requestBody(request);
-      const upstream = await agent.handle(
-        new Request(`http://127.0.0.1${request.url || '/'}`, {
+      const upstreamRequest = new Request(
+        `http://127.0.0.1${request.url || '/'}`,
+        {
           method: request.method,
           headers: request.headers,
           signal: requestController.signal,
           ...(body ? { body } : {}),
-        }),
+        },
       );
+      const upstream = url.pathname.startsWith('/v1/runtime/')
+        ? await operations.handle(upstreamRequest)
+        : await agent.handle(upstreamRequest);
       response.writeHead(upstream.status, Object.fromEntries(upstream.headers));
       if (!upstream.body) {
         response.end();

--- a/scripts/verify-entrypoints.mjs
+++ b/scripts/verify-entrypoints.mjs
@@ -174,7 +174,7 @@ const subpathOutput = run(process.execPath, [
     "console.log(core.PermissionMode.DEFAULT, core.DurableEventType.REQUEST_ACCEPTED, core.projectDurableSession([]).status, typeof core.DurableSessionJournal.open, typeof core.DurableSessionRecoveryCoordinator.open, typeof core.DurableEventSubscription.open, browser.PermissionMode.DEFAULT, typeof browser.AgentClient, typeof server.createSession, typeof server.AgentServer, typeof server.InProcessSessionExecutor, typeof postgres.PostgresRuntimeStore, typeof otel.OpenTelemetryAgentServerTelemetry, typeof testing.assertRuntimeStoreConformance, typeof tools.defineTool, typeof node.createSession, typeof node.getBuiltinTools, typeof node.JsonlDurableEventStore, typeof node.JsonlSessionRepository, protocol.AGENT_PROTOCOL_VERSION, typeof middleware.composeMiddleware, model.PROVIDER_TYPES.length);",
     "console.log(postgres.RUNTIME_SESSION_STATES.join(','), typeof postgres.effectLease, typeof server.WorkerRuntimeError);",
     "console.log(typeof server.EphemeralCredentialBroker, typeof server.ExecutionHostError, typeof node.DockerExecutionHost, core.ExecutionId('execution-1'), core.ExecutionCheckpointId('checkpoint-1'), core.CredentialLeaseId('credential-1'));",
-    "console.log(typeof server.AgentWorker, typeof server.EffectDispatcher, typeof server.SdkSessionRunner, typeof server.ExecutionHostSessionRunner);",
+    "console.log(typeof server.AgentWorker, typeof server.EffectDispatcher, typeof server.SdkSessionRunner, typeof server.ExecutionHostSessionRunner, typeof server.AgentRuntimeOperations, typeof otel.OpenTelemetryAgentWorkerTelemetry);",
   ].join(' '),
 ]);
 assertIncludes(
@@ -194,7 +194,7 @@ assertIncludes(
 );
 assertIncludes(
   subpathOutput,
-  'function function function function',
+  'function function function function function function',
   'server worker exports',
 );
 

--- a/src/server/AgentRuntimeOperations.ts
+++ b/src/server/AgentRuntimeOperations.ts
@@ -1,0 +1,356 @@
+import type { AgentWorkerHealth } from './AgentWorker.js';
+import { SdkError } from '../errors/SdkError.js';
+import type { JsonObject } from '../types/json.js';
+import type { RuntimeEffectRecord, RuntimeStore } from './RuntimeStore.js';
+import type { RuntimeEffectReconciliation, RuntimeQueueMetrics } from './WorkerRuntime.js';
+
+const DEFAULT_BASE_PATH = '/v1/runtime';
+const DEFAULT_MAX_REQUEST_BYTES = 64 * 1024;
+const DEFAULT_EFFECT_LIMIT = 100;
+
+export type RuntimeOperationsAction = 'metrics.read' | 'effects.read' | 'effects.reconcile';
+export type RuntimeOperationsErrorCode = 'RUNTIME_OPERATIONS_UNSUPPORTED';
+
+export class RuntimeOperationsError extends SdkError {
+  // biome-ignore lint/complexity/noUselessConstructor: narrows the public error-code contract
+  constructor(code: RuntimeOperationsErrorCode, message: string) {
+    super(code, message);
+  }
+}
+
+export interface RuntimeOperationsPrincipal {
+  readonly tenantId: string;
+  readonly subject: string;
+}
+
+export interface RuntimeOperationsWorker {
+  getHealth(): AgentWorkerHealth;
+}
+
+export interface AgentRuntimeOperationsOptions {
+  readonly store: RuntimeStore;
+  readonly authorize: (
+    request: Request,
+    action: RuntimeOperationsAction,
+  ) => RuntimeOperationsPrincipal | null | Promise<RuntimeOperationsPrincipal | null>;
+  readonly workers?:
+    | readonly RuntimeOperationsWorker[]
+    | (() => readonly RuntimeOperationsWorker[]);
+  readonly basePath?: string;
+  readonly maxRequestBytes?: number;
+}
+
+export interface RuntimeOperationsHealth {
+  readonly status: 'ready' | 'not_ready' | 'failed';
+  readonly live: boolean;
+  readonly ready: boolean;
+  readonly checkedAt: string;
+  readonly store: {
+    readonly ready: boolean;
+    readonly details?: JsonObject;
+  };
+  readonly workers: readonly AgentWorkerHealth[];
+}
+
+export interface RuntimeEffectOperationRecord {
+  readonly tenantId: string;
+  readonly sessionId: RuntimeEffectRecord['sessionId'];
+  readonly commandId: RuntimeEffectRecord['commandId'];
+  readonly effectId: string;
+  readonly type: string;
+  readonly status: RuntimeEffectRecord['status'];
+  readonly attempts: number;
+  readonly createdAt: string;
+  readonly completedAt?: string;
+  readonly error?: RuntimeEffectRecord['error'];
+}
+
+export interface RuntimeUncertainEffect extends RuntimeEffectOperationRecord {
+  readonly status: 'uncertain';
+}
+
+function json(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: {
+      'content-type': 'application/json; charset=utf-8',
+      'cache-control': 'no-store',
+    },
+  });
+}
+
+function isJsonObject(value: unknown): value is JsonObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function summarizeEffect(effect: RuntimeEffectRecord): RuntimeEffectOperationRecord {
+  return {
+    tenantId: effect.tenantId,
+    sessionId: effect.sessionId,
+    commandId: effect.commandId,
+    effectId: effect.effectId,
+    type: effect.type,
+    status: effect.status,
+    attempts: effect.attempts,
+    createdAt: effect.createdAt,
+    ...(effect.completedAt ? { completedAt: effect.completedAt } : {}),
+    ...(effect.error ? { error: structuredClone(effect.error) } : {}),
+  };
+}
+
+function statusForError(error: unknown): number {
+  const code =
+    typeof error === 'object' && error !== null && 'code' in error && typeof error.code === 'string'
+      ? error.code
+      : undefined;
+  switch (code) {
+    case 'EFFECT_NOT_FOUND':
+      return 404;
+    case 'EFFECT_RETRY_NOT_ALLOWED':
+      return 409;
+    case 'WORKER_INVALID':
+      return 400;
+    case 'RUNTIME_OPERATIONS_UNSUPPORTED':
+      return 501;
+    default:
+      return error instanceof RangeError ||
+        error instanceof TypeError ||
+        error instanceof SyntaxError ||
+        error instanceof URIError
+        ? 400
+        : 500;
+  }
+}
+
+function errorMessage(error: unknown, status: number): string {
+  if (status >= 500) {
+    return 'Runtime operations request failed';
+  }
+  return error instanceof Error ? error.message : String(error);
+}
+
+export class AgentRuntimeOperations {
+  private readonly basePath: string;
+  private readonly maxRequestBytes: number;
+
+  constructor(private readonly options: AgentRuntimeOperationsOptions) {
+    this.basePath = `/${(options.basePath ?? DEFAULT_BASE_PATH).replace(/^\/+|\/+$/g, '')}`;
+    this.maxRequestBytes = options.maxRequestBytes ?? DEFAULT_MAX_REQUEST_BYTES;
+    if (!Number.isSafeInteger(this.maxRequestBytes) || this.maxRequestBytes < 1) {
+      throw new RangeError('maxRequestBytes must be a positive safe integer');
+    }
+  }
+
+  async healthCheck(): Promise<RuntimeOperationsHealth> {
+    let storeHealth: Awaited<ReturnType<RuntimeStore['healthCheck']>>;
+    try {
+      storeHealth = await this.options.store.healthCheck();
+    } catch {
+      storeHealth = {
+        ready: false,
+        details: { error: 'runtime_store_unavailable' },
+      };
+    }
+    const workers = this.resolveWorkers().map((worker) => worker.getHealth());
+    const live = workers.length === 0 || workers.some((worker) => worker.live);
+    const workerReady = workers.length === 0 || workers.some((worker) => worker.ready);
+    const ready = storeHealth.ready && workerReady;
+    return {
+      status: !live ? 'failed' : ready ? 'ready' : 'not_ready',
+      live,
+      ready,
+      checkedAt: new Date().toISOString(),
+      store: {
+        ready: storeHealth.ready,
+        ...(storeHealth.details ? { details: structuredClone(storeHealth.details) } : {}),
+      },
+      workers,
+    };
+  }
+
+  getQueueMetrics(tenantId: string): Promise<RuntimeQueueMetrics> {
+    this.assertTenantId(tenantId);
+    if (!this.options.store.getQueueMetrics) {
+      throw new RuntimeOperationsError(
+        'RUNTIME_OPERATIONS_UNSUPPORTED',
+        'Runtime Store does not provide queue metrics',
+      );
+    }
+    return this.options.store.getQueueMetrics(tenantId);
+  }
+
+  async listUncertainEffects(
+    tenantId: string,
+    limit = DEFAULT_EFFECT_LIMIT,
+  ): Promise<readonly RuntimeUncertainEffect[]> {
+    this.assertTenantId(tenantId);
+    if (!Number.isSafeInteger(limit) || limit < 1 || limit > 1000) {
+      throw new RangeError('Effect list limit must be between 1 and 1000');
+    }
+    const effects = await this.options.store.listEffects(tenantId, {
+      status: 'uncertain',
+      limit,
+    });
+    return effects.map((effect) => {
+      if (effect.status !== 'uncertain') {
+        throw new TypeError(`Effect ${effect.effectId} is not uncertain`);
+      }
+      return summarizeEffect(effect) as RuntimeUncertainEffect;
+    });
+  }
+
+  async reconcileUncertainEffect(
+    tenantId: string,
+    effectId: string,
+    outcome: RuntimeEffectReconciliation,
+  ): Promise<RuntimeEffectRecord> {
+    this.assertTenantId(tenantId);
+    if (!effectId.trim()) {
+      throw new TypeError('effectId must not be empty');
+    }
+    return this.options.store.reconcileEffect(tenantId, effectId, outcome);
+  }
+
+  async handle(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    if (
+      request.method === 'GET' &&
+      (url.pathname === `${this.basePath}/healthz` || url.pathname === `${this.basePath}/readyz`)
+    ) {
+      let health: RuntimeOperationsHealth;
+      try {
+        health = await this.healthCheck();
+      } catch {
+        return json(
+          {
+            status: 'failed',
+            live: false,
+            ready: false,
+            checkedAt: new Date().toISOString(),
+            store: { ready: false },
+            workers: {
+              total: 0,
+              live: 0,
+              ready: 0,
+              failed: 0,
+            },
+          },
+          503,
+        );
+      }
+      const live = url.pathname.endsWith('/healthz');
+      return json(
+        {
+          status: health.status,
+          live: health.live,
+          ready: health.ready,
+          checkedAt: health.checkedAt,
+          store: { ready: health.store.ready },
+          workers: {
+            total: health.workers.length,
+            live: health.workers.filter((worker) => worker.live).length,
+            ready: health.workers.filter((worker) => worker.ready).length,
+            failed: health.workers.filter((worker) => worker.status === 'failed').length,
+          },
+        },
+        live ? (health.live ? 200 : 503) : health.ready ? 200 : 503,
+      );
+    }
+
+    let action: RuntimeOperationsAction;
+    if (request.method === 'GET' && url.pathname === `${this.basePath}/metrics`) {
+      action = 'metrics.read';
+    } else if (request.method === 'GET' && url.pathname === `${this.basePath}/effects/uncertain`) {
+      action = 'effects.read';
+    } else if (
+      request.method === 'POST' &&
+      new RegExp(`^${this.escapeRegExp(this.basePath)}/effects/[^/]+/reconcile$`).test(url.pathname)
+    ) {
+      action = 'effects.reconcile';
+    } else {
+      return json({ error: 'Route not found' }, 404);
+    }
+
+    let principal: RuntimeOperationsPrincipal | null;
+    try {
+      principal = await this.options.authorize(request, action);
+    } catch {
+      return json({ error: 'Runtime operations authorization failed' }, 500);
+    }
+    if (!principal) {
+      return json({ error: 'Authentication required' }, 401);
+    }
+    try {
+      this.assertTenantId(principal.tenantId);
+      if (action === 'metrics.read') {
+        return json({
+          queue: await this.getQueueMetrics(principal.tenantId),
+        });
+      }
+      if (action === 'effects.read') {
+        const rawLimit = url.searchParams.get('limit');
+        const limit = rawLimit === null ? DEFAULT_EFFECT_LIMIT : Number(rawLimit);
+        return json({
+          effects: await this.listUncertainEffects(principal.tenantId, limit),
+        });
+      }
+
+      const match = new RegExp(
+        `^${this.escapeRegExp(this.basePath)}/effects/([^/]+)/reconcile$`,
+      ).exec(url.pathname);
+      const effectId = match?.[1] ? decodeURIComponent(match[1]) : '';
+      const outcome = await this.parseReconciliation(request);
+      const effect = await this.reconcileUncertainEffect(principal.tenantId, effectId, outcome);
+      return json({ effect: summarizeEffect(effect) });
+    } catch (error) {
+      const status = statusForError(error);
+      return json({ error: errorMessage(error, status) }, status);
+    }
+  }
+
+  private async parseReconciliation(request: Request): Promise<RuntimeEffectReconciliation> {
+    const contentLength = Number(request.headers.get('content-length') ?? 0);
+    if (Number.isFinite(contentLength) && contentLength > this.maxRequestBytes) {
+      throw new RangeError('Reconciliation body is too large');
+    }
+    const text = await request.text();
+    if (new TextEncoder().encode(text).byteLength > this.maxRequestBytes) {
+      throw new RangeError('Reconciliation body is too large');
+    }
+    const value = JSON.parse(text) as unknown;
+    if (!isJsonObject(value)) {
+      throw new TypeError('Reconciliation body must be a JSON object');
+    }
+    if (value.status === 'completed') {
+      if (value.result !== undefined && !isJsonObject(value.result)) {
+        throw new TypeError('Completed reconciliation result must be a JSON object');
+      }
+      return {
+        status: 'completed',
+        ...(value.result ? { result: value.result } : {}),
+      };
+    }
+    if (value.status === 'failed' && isJsonObject(value.error)) {
+      return {
+        status: 'failed',
+        error: value.error,
+      };
+    }
+    throw new TypeError('Reconciliation requires completed/result or failed/error');
+  }
+
+  private resolveWorkers(): readonly RuntimeOperationsWorker[] {
+    const workers = this.options.workers;
+    return typeof workers === 'function' ? workers() : (workers ?? []);
+  }
+
+  private assertTenantId(tenantId: string): void {
+    if (!tenantId.trim()) {
+      throw new TypeError('tenantId must not be empty');
+    }
+  }
+
+  private escapeRegExp(value: string): string {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  }
+}

--- a/src/server/AgentWorker.ts
+++ b/src/server/AgentWorker.ts
@@ -12,6 +12,7 @@ import type {
   SessionRunResult,
 } from './SessionRunner.js';
 import type { RuntimeSessionClaim, RuntimeSessionRoute } from './WorkerRuntime.js';
+import type { AgentWorkerTelemetry } from './AgentWorkerTelemetry.js';
 
 const DEFAULT_WORKER_TTL_MS = 15_000;
 const DEFAULT_SESSION_LEASE_TTL_MS = 30_000;
@@ -39,9 +40,23 @@ export interface AgentWorkerMetrics {
 export interface AgentWorkerSnapshot {
   readonly workerId: WorkerId;
   readonly status: AgentWorkerStatus;
+  readonly health?: AgentWorkerHealth;
   readonly activeSessionIds: readonly SessionId[];
   readonly metrics: AgentWorkerMetrics;
   readonly effectMetrics?: ReturnType<EffectDispatcher['getMetrics']>;
+  readonly failure?: JsonObject;
+}
+
+export interface AgentWorkerHealth {
+  readonly workerId: WorkerId;
+  readonly status: 'ready' | 'not_ready' | 'failed';
+  readonly live: boolean;
+  readonly ready: boolean;
+  readonly workerStatus: AgentWorkerStatus;
+  readonly checkedAt: string;
+  readonly activeSessions: number;
+  readonly lastHeartbeatAt?: string;
+  readonly heartbeatAgeMs?: number;
   readonly failure?: JsonObject;
 }
 
@@ -60,6 +75,7 @@ export interface AgentWorkerOptions {
   readonly pollIntervalMs?: number;
   readonly recoveryIntervalMs?: number;
   readonly effectClaimLimit?: number;
+  readonly telemetry?: AgentWorkerTelemetry;
   readonly onSnapshot?: (snapshot: AgentWorkerSnapshot) => void;
   readonly onError?: (error: unknown) => void;
 }
@@ -137,6 +153,7 @@ export class AgentWorker {
   private externalAbortCleanup?: () => void;
   private failure?: JsonObject;
   private startedAtMs?: number;
+  private lastHeartbeatAtMs?: number;
   private firstClaimLatencyMs?: number;
   private sessionClaims = 0;
   private sessionsIdle = 0;
@@ -177,9 +194,38 @@ export class AgentWorker {
         pollIntervalMs: this.pollIntervalMs,
         claimLimit: options.effectClaimLimit,
         tenantId: options.tenantId,
-        onError: options.onError,
+        onError: (error) => this.reportError(error),
       });
     }
+  }
+
+  getHealth(): AgentWorkerHealth {
+    const checkedAtMs = Date.now();
+    const heartbeatAgeMs =
+      this.lastHeartbeatAtMs === undefined
+        ? undefined
+        : Math.max(0, checkedAtMs - this.lastHeartbeatAtMs);
+    const heartbeatFresh =
+      heartbeatAgeMs !== undefined && heartbeatAgeMs < this.workerTtlMs;
+    const ready =
+      this.status === 'running'
+      && heartbeatFresh
+      && this.failure === undefined;
+    const live = this.status !== 'failed';
+    return {
+      workerId: this.options.workerId,
+      status: ready ? 'ready' : this.status === 'failed' ? 'failed' : 'not_ready',
+      live,
+      ready,
+      workerStatus: this.status,
+      checkedAt: new Date(checkedAtMs).toISOString(),
+      activeSessions: this.activeSessions.size,
+      ...(this.lastHeartbeatAtMs !== undefined
+        ? { lastHeartbeatAt: new Date(this.lastHeartbeatAtMs).toISOString() }
+        : {}),
+      ...(heartbeatAgeMs !== undefined ? { heartbeatAgeMs } : {}),
+      ...(this.failure ? { failure: structuredClone(this.failure) } : {}),
+    };
   }
 
   getSnapshot(): AgentWorkerSnapshot {
@@ -189,6 +235,7 @@ export class AgentWorker {
     return {
       workerId: this.options.workerId,
       status: this.status,
+      health: this.getHealth(),
       activeSessionIds: [...this.activeSessions.values()].map(({ route }) => route.sessionId),
       metrics: {
         ...(this.startedAtMs !== undefined
@@ -225,6 +272,7 @@ export class AgentWorker {
       ttlMs: this.workerTtlMs,
       metadata: this.options.metadata,
     });
+    this.lastHeartbeatAtMs = Date.now();
     this.startedAtMs = Date.now();
     this.status = 'running';
     if (signal) {
@@ -308,6 +356,7 @@ export class AgentWorker {
       }
       this.failure = failureData(error);
       this.status = 'failed';
+      this.reportError(error);
       this.controller.abort(error);
       await Promise.allSettled(loops);
       await Promise.allSettled(
@@ -601,12 +650,14 @@ export class AgentWorker {
           this.options.workerId,
           this.workerTtlMs,
         );
+        this.lastHeartbeatAtMs = Date.now();
       } catch (error) {
         if (isFatalWorkerStateError(error)) {
           throw error;
         }
         this.reportError(error);
       }
+      this.publishSnapshot();
     }
   }
 
@@ -669,6 +720,16 @@ export class AgentWorker {
   }
 
   private reportError(error: unknown): void {
+    const errorCode = getErrorCode(error);
+    try {
+      this.options.telemetry?.recordError({
+        workerId: this.options.workerId,
+        workerStatus: this.status,
+        ...(errorCode ? { errorCode } : {}),
+      });
+    } catch {
+      // Telemetry is observational and cannot change worker state.
+    }
     try {
       this.options.onError?.(error);
     } catch {
@@ -677,8 +738,14 @@ export class AgentWorker {
   }
 
   private publishSnapshot(): void {
+    const snapshot = this.getSnapshot();
     try {
-      this.options.onSnapshot?.(this.getSnapshot());
+      this.options.telemetry?.recordSnapshot(snapshot);
+    } catch {
+      // Telemetry is observational and cannot change worker state.
+    }
+    try {
+      this.options.onSnapshot?.(snapshot);
     } catch {
       // Metrics are observational and cannot change worker state.
     }

--- a/src/server/AgentWorkerTelemetry.ts
+++ b/src/server/AgentWorkerTelemetry.ts
@@ -1,0 +1,17 @@
+import type { WorkerId } from '../types/identifiers.js';
+import type { AgentWorkerSnapshot, AgentWorkerStatus } from './AgentWorker.js';
+
+export interface AgentWorkerErrorMetric {
+  readonly workerId: WorkerId;
+  readonly workerStatus: AgentWorkerStatus;
+  readonly errorCode?: string;
+}
+
+/**
+ * Observational worker telemetry. Implementations must not throw into the
+ * worker lifecycle or retain Session input, effect payload, or credentials.
+ */
+export interface AgentWorkerTelemetry {
+  recordSnapshot(snapshot: AgentWorkerSnapshot): void;
+  recordError(metric: AgentWorkerErrorMetric): void;
+}

--- a/src/server/OpenTelemetryAgentWorkerTelemetry.ts
+++ b/src/server/OpenTelemetryAgentWorkerTelemetry.ts
@@ -1,0 +1,123 @@
+import { metrics, type Attributes, type Meter } from '@opentelemetry/api';
+import type { AgentWorkerSnapshot } from './AgentWorker.js';
+import type { AgentWorkerErrorMetric, AgentWorkerTelemetry } from './AgentWorkerTelemetry.js';
+
+export interface OpenTelemetryAgentWorkerOptions {
+  readonly meter?: Meter;
+  readonly meterName?: string;
+  readonly includeWorkerIdAttribute?: boolean;
+}
+
+interface WorkerMetricSnapshot {
+  readonly workerId?: string;
+  readonly status: AgentWorkerSnapshot['status'];
+  readonly ready: boolean;
+  readonly activeSessions: number;
+  readonly sessionClaims: number;
+  readonly sessionsCompleted: number;
+  readonly sessionsFailed: number;
+  readonly recoveryDurationMs: number;
+  readonly uncertainEffects: number;
+}
+
+/**
+ * Payload-free OpenTelemetry adapter for AgentWorker lifecycle and throughput.
+ */
+export class OpenTelemetryAgentWorkerTelemetry implements AgentWorkerTelemetry {
+  private readonly meter: Meter;
+  private readonly includeWorkerIdAttribute: boolean;
+  private readonly snapshots = new Map<string, WorkerMetricSnapshot>();
+  private readonly errorCounter;
+
+  constructor(options: OpenTelemetryAgentWorkerOptions = {}) {
+    this.meter =
+      options.meter ?? metrics.getMeter(options.meterName ?? '@blade-ai/agent-sdk/worker');
+    this.includeWorkerIdAttribute = options.includeWorkerIdAttribute ?? false;
+    this.errorCounter = this.meter.createCounter('blade.agent.worker.errors', {
+      description: 'Agent worker background and execution errors',
+    });
+
+    this.observe(
+      'blade.agent.worker.ready',
+      'Whether the worker is ready to claim Sessions',
+      (snapshot) => (snapshot.ready ? 1 : 0),
+    );
+    this.observe(
+      'blade.agent.worker.active_sessions',
+      'Sessions currently owned by the worker',
+      (snapshot) => snapshot.activeSessions,
+    );
+    this.observe(
+      'blade.agent.worker.session.claims',
+      'Cumulative Session claims by the worker',
+      (snapshot) => snapshot.sessionClaims,
+    );
+    this.observe(
+      'blade.agent.worker.session.completed',
+      'Cumulative idle or terminal successful Session runs',
+      (snapshot) => snapshot.sessionsCompleted,
+    );
+    this.observe(
+      'blade.agent.worker.session.failed',
+      'Cumulative failed Session runs',
+      (snapshot) => snapshot.sessionsFailed,
+    );
+    this.observe(
+      'blade.agent.worker.recovery.duration',
+      'Cumulative worker recovery scan duration',
+      (snapshot) => snapshot.recoveryDurationMs,
+      'ms',
+    );
+    this.observe(
+      'blade.agent.worker.effect.uncertain',
+      'Cumulative effects with an uncertain outcome',
+      (snapshot) => snapshot.uncertainEffects,
+    );
+  }
+
+  recordSnapshot(snapshot: AgentWorkerSnapshot): void {
+    this.snapshots.set(String(snapshot.workerId), {
+      ...(this.includeWorkerIdAttribute ? { workerId: snapshot.workerId } : {}),
+      status: snapshot.status,
+      ready: snapshot.health?.ready ?? false,
+      activeSessions: snapshot.metrics.activeSessions,
+      sessionClaims: snapshot.metrics.sessionClaims,
+      sessionsCompleted: snapshot.metrics.sessionsIdle + snapshot.metrics.sessionsCompleted,
+      sessionsFailed: snapshot.metrics.sessionsFailed,
+      recoveryDurationMs: snapshot.metrics.recoveryDurationMs,
+      uncertainEffects: snapshot.effectMetrics?.uncertain ?? 0,
+    });
+  }
+
+  recordError(metric: AgentWorkerErrorMetric): void {
+    this.errorCounter.add(1, {
+      'blade.agent.worker.status': metric.workerStatus,
+      ...(metric.errorCode ? { 'error.type': metric.errorCode } : {}),
+      ...(this.includeWorkerIdAttribute ? { 'blade.agent.worker.id': metric.workerId } : {}),
+    });
+  }
+
+  private observe(
+    name: string,
+    description: string,
+    value: (snapshot: WorkerMetricSnapshot) => number,
+    unit?: string,
+  ): void {
+    const gauge = this.meter.createObservableGauge(name, {
+      description,
+      ...(unit ? { unit } : {}),
+    });
+    gauge.addCallback((result) => {
+      for (const snapshot of this.snapshots.values()) {
+        result.observe(value(snapshot), this.attributes(snapshot));
+      }
+    });
+  }
+
+  private attributes(snapshot: WorkerMetricSnapshot): Attributes {
+    return {
+      'blade.agent.worker.status': snapshot.status,
+      ...(snapshot.workerId ? { 'blade.agent.worker.id': snapshot.workerId } : {}),
+    };
+  }
+}

--- a/src/server/PostgresRuntimeStore.ts
+++ b/src/server/PostgresRuntimeStore.ts
@@ -80,6 +80,7 @@ import type {
   RuntimeEffectFailureOptions,
   RuntimeEffectLease,
   RuntimeEffectReconciliation,
+  RuntimeQueueMetrics,
   RuntimeRecoveryResult,
   RuntimeSessionClaim,
   RuntimeSessionClaimOptions,
@@ -1005,6 +1006,10 @@ export class PostgresRuntimeStore implements RuntimeStore {
     workerId: WorkerId,
   ): Promise<readonly RuntimeSessionRoute[]> {
     return this.workerRuntime.listWorkerSessions(workerId);
+  }
+
+  getQueueMetrics(tenantId?: string): Promise<RuntimeQueueMetrics> {
+    return this.workerRuntime.getQueueMetrics(tenantId);
   }
 
   recoverExpiredWork(): Promise<RuntimeRecoveryResult> {

--- a/src/server/PostgresWorkerRuntime.ts
+++ b/src/server/PostgresWorkerRuntime.ts
@@ -25,8 +25,10 @@ import type {
   RuntimeEffectRecord,
   RuntimeEffectStatus,
 } from './RuntimeStore.js';
+import { RUNTIME_EFFECT_STATUSES } from './RuntimeStore.js';
 import {
   assertRuntimeSessionTransition,
+  type RuntimeQueueMetrics,
   type RuntimeEffectClaim,
   type RuntimeEffectClaimOptions,
   type RuntimeEffectExecutionMode,
@@ -39,8 +41,11 @@ import {
   type RuntimeSessionRoute,
   type RuntimeSessionSettlement,
   type RuntimeSessionState,
+  RUNTIME_SESSION_STATES,
   type RuntimeWorkerRecord,
   type RuntimeWorkerRegistration,
+  type RuntimeWorkerStatus,
+  RUNTIME_WORKER_STATUSES,
   WorkerRuntimeError,
   type WorkerRuntimeStore,
 } from './WorkerRuntime.js';
@@ -117,6 +122,25 @@ interface EffectRow extends QueryResultRow {
   error: unknown | null;
 }
 
+interface MetricCountRow extends QueryResultRow {
+  metric_state: string;
+  metric_count: string | number;
+}
+
+interface ClaimableMetricRow extends QueryResultRow {
+  claimable: string | number;
+  oldest_claimable_at: Date | string | null;
+  collected_at: Date | string;
+}
+
+interface WorkerMetricRow extends QueryResultRow {
+  active_workers: string | number;
+  draining_workers: string | number;
+  offline_workers: string | number;
+  capacity: string | number;
+  active_sessions: string | number;
+}
+
 interface ConstraintRow extends QueryResultRow {
   conname: string;
 }
@@ -141,6 +165,10 @@ function asNumber(value: string | number): number {
 
 function asIso(value: Date | string): string {
   return value instanceof Date ? value.toISOString() : new Date(value).toISOString();
+}
+
+function ageMs(collectedAt: string, oldestAt: string): number {
+  return Math.max(0, Date.parse(collectedAt) - Date.parse(oldestAt));
 }
 
 function asJsonObject(value: unknown): JsonObject {
@@ -1055,6 +1083,161 @@ export class PostgresWorkerRuntime implements WorkerRuntimeStore {
       [workerId],
     );
     return result.rows.map((row) => this.routeRecord(row));
+  }
+
+  async getQueueMetrics(tenantId?: string): Promise<RuntimeQueueMetrics> {
+    if (tenantId !== undefined && !tenantId.trim()) {
+      throw new WorkerRuntimeError('WORKER_INVALID', 'tenantId must not be empty');
+    }
+    await this.ensureInitialized();
+    return this.transaction(async (client) => {
+      const sessionCountsResult = await client.query<MetricCountRow>(
+        `SELECT state AS metric_state, COUNT(*) AS metric_count
+           FROM ${this.table('session_routes')}
+          WHERE ($1::text IS NULL OR tenant_id = $1)
+          GROUP BY state`,
+        [tenantId ?? null],
+      );
+      const sessionClaimableResult = await client.query<ClaimableMetricRow>(
+        `SELECT COUNT(*) AS claimable,
+                MIN(queued_at) AS oldest_claimable_at,
+                NOW() AS collected_at
+           FROM ${this.table('session_routes')}
+          WHERE state IN ('queued', 'suspended')
+            AND worker_id IS NULL
+            AND ($1::text IS NULL OR tenant_id = $1)`,
+        [tenantId ?? null],
+      );
+      const effectCountsResult = await client.query<MetricCountRow>(
+        `SELECT status AS metric_state, COUNT(*) AS metric_count
+           FROM ${this.table('outbox')}
+          WHERE ($1::text IS NULL OR tenant_id = $1)
+          GROUP BY status`,
+        [tenantId ?? null],
+      );
+      const effectClaimableResult = await client.query<ClaimableMetricRow>(
+        `SELECT COUNT(*) AS claimable,
+                MIN(available_at) AS oldest_claimable_at,
+                NOW() AS collected_at
+           FROM ${this.table('outbox')}
+          WHERE status = 'pending'
+            AND available_at <= NOW()
+            AND ($1::text IS NULL OR tenant_id = $1)`,
+        [tenantId ?? null],
+      );
+      const workerResult = await client.query<WorkerMetricRow>(
+        `WITH effective_workers AS (
+           SELECT worker_id,
+                  CASE
+                    WHEN lease_expires_at <= NOW() THEN 'offline'
+                    ELSE status
+                  END AS status,
+                  capacity
+             FROM ${this.table('workers')}
+         ),
+         active_sessions AS (
+           SELECT worker_id,
+                  COUNT(*) AS count
+             FROM ${this.table('session_routes')}
+            WHERE state = ANY($1::text[])
+              AND worker_id IS NOT NULL
+              AND lease_expires_at > NOW()
+            GROUP BY worker_id
+         )
+         SELECT COUNT(*) FILTER (WHERE status = 'active') AS active_workers,
+                COUNT(*) FILTER (WHERE status = 'draining') AS draining_workers,
+                COUNT(*) FILTER (WHERE status = 'offline') AS offline_workers,
+                COALESCE(
+                  SUM(capacity) FILTER (WHERE status = 'active'),
+                  0
+                ) AS capacity,
+                COALESCE(
+                  SUM(COALESCE(active_sessions.count, 0))
+                    FILTER (WHERE status = 'active'),
+                  0
+                ) AS active_sessions
+           FROM effective_workers
+           LEFT JOIN active_sessions USING (worker_id)`,
+        [ACTIVE_SESSION_STATES],
+      );
+
+      const sessionCounts = Object.fromEntries(
+        RUNTIME_SESSION_STATES.map((state) => [state, 0]),
+      ) as Record<RuntimeSessionState, number>;
+      for (const row of sessionCountsResult.rows) {
+        if (!RUNTIME_SESSION_STATES.includes(row.metric_state as RuntimeSessionState)) {
+          throw new WorkerRuntimeError(
+            'WORKER_INVALID',
+            `PostgreSQL returned an unknown Session state: ${row.metric_state}`,
+          );
+        }
+        sessionCounts[row.metric_state as RuntimeSessionState] = asNumber(row.metric_count);
+      }
+
+      const effectCounts = Object.fromEntries(
+        RUNTIME_EFFECT_STATUSES.map((status) => [status, 0]),
+      ) as Record<RuntimeEffectStatus, number>;
+      for (const row of effectCountsResult.rows) {
+        if (!RUNTIME_EFFECT_STATUSES.includes(row.metric_state as RuntimeEffectStatus)) {
+          throw new WorkerRuntimeError(
+            'WORKER_INVALID',
+            `PostgreSQL returned an unknown Effect status: ${row.metric_state}`,
+          );
+        }
+        effectCounts[row.metric_state as RuntimeEffectStatus] = asNumber(row.metric_count);
+      }
+
+      const workerCounts = Object.fromEntries(
+        RUNTIME_WORKER_STATUSES.map((status) => [status, 0]),
+      ) as Record<RuntimeWorkerStatus, number>;
+      workerCounts.active = asNumber(workerResult.rows[0]?.active_workers ?? 0);
+      workerCounts.draining = asNumber(workerResult.rows[0]?.draining_workers ?? 0);
+      workerCounts.offline = asNumber(workerResult.rows[0]?.offline_workers ?? 0);
+      const capacity = asNumber(workerResult.rows[0]?.capacity ?? 0);
+      const activeSessions = asNumber(workerResult.rows[0]?.active_sessions ?? 0);
+      const sessionClaimable = sessionClaimableResult.rows[0];
+      const effectClaimable = effectClaimableResult.rows[0];
+      const collectedAt = asIso(
+        sessionClaimable?.collected_at ?? new Date().toISOString(),
+      );
+      const oldestSessionAt = sessionClaimable?.oldest_claimable_at
+        ? asIso(sessionClaimable.oldest_claimable_at)
+        : undefined;
+      const oldestEffectAt = effectClaimable?.oldest_claimable_at
+        ? asIso(effectClaimable.oldest_claimable_at)
+        : undefined;
+
+      return {
+        collectedAt,
+        ...(tenantId ? { tenantId } : {}),
+        sessions: {
+          counts: sessionCounts,
+          claimable: asNumber(sessionClaimable?.claimable ?? 0),
+          ...(oldestSessionAt
+            ? {
+                oldestClaimableAt: oldestSessionAt,
+                oldestClaimableAgeMs: ageMs(collectedAt, oldestSessionAt),
+              }
+            : {}),
+        },
+        effects: {
+          counts: effectCounts,
+          claimable: asNumber(effectClaimable?.claimable ?? 0),
+          ...(oldestEffectAt
+            ? {
+                oldestClaimableAt: oldestEffectAt,
+                oldestClaimableAgeMs: ageMs(collectedAt, oldestEffectAt),
+              }
+            : {}),
+        },
+        workers: {
+          counts: workerCounts,
+          capacity,
+          activeSessions,
+          availableCapacity: Math.max(0, capacity - activeSessions),
+        },
+      };
+    });
   }
 
   async recoverExpiredWork(): Promise<RuntimeRecoveryResult> {

--- a/src/server/RuntimeStore.ts
+++ b/src/server/RuntimeStore.ts
@@ -20,6 +20,14 @@ import type {
 
 export const RUNTIME_STORE_SCHEMA_VERSION = 3 as const;
 export const RUNTIME_DOMAIN_EVENT_SCHEMA_VERSION = 1 as const;
+export const RUNTIME_EFFECT_STATUSES = [
+  'pending',
+  'claimed',
+  'executing',
+  'completed',
+  'failed',
+  'uncertain',
+] as const;
 
 export interface RuntimeDomainEventDraft {
   readonly eventId?: EventId;
@@ -48,13 +56,7 @@ export interface RuntimeEffectIntent {
   readonly executionMode?: RuntimeEffectExecutionMode;
 }
 
-export type RuntimeEffectStatus =
-  | 'pending'
-  | 'claimed'
-  | 'executing'
-  | 'completed'
-  | 'failed'
-  | 'uncertain';
+export type RuntimeEffectStatus = typeof RUNTIME_EFFECT_STATUSES[number];
 
 export interface RuntimeEffectRecord extends RuntimeEffectIntent {
   readonly tenantId: string;

--- a/src/server/WorkerRuntime.ts
+++ b/src/server/WorkerRuntime.ts
@@ -26,9 +26,38 @@ export const RUNTIME_SESSION_STATES = [
   'failed',
 ] as const;
 
+export const RUNTIME_WORKER_STATUSES = [
+  'active',
+  'draining',
+  'offline',
+] as const;
+
 export type RuntimeSessionState = typeof RUNTIME_SESSION_STATES[number];
-export type RuntimeWorkerStatus = 'active' | 'draining' | 'offline';
+export type RuntimeWorkerStatus = typeof RUNTIME_WORKER_STATUSES[number];
 export type RuntimeEffectExecutionMode = 'idempotent' | 'at_most_once';
+
+export interface RuntimeQueueMetrics {
+  readonly collectedAt: string;
+  readonly tenantId?: string;
+  readonly sessions: {
+    readonly counts: Readonly<Record<RuntimeSessionState, number>>;
+    readonly claimable: number;
+    readonly oldestClaimableAt?: string;
+    readonly oldestClaimableAgeMs?: number;
+  };
+  readonly effects: {
+    readonly counts: Readonly<Record<RuntimeEffectStatus, number>>;
+    readonly claimable: number;
+    readonly oldestClaimableAt?: string;
+    readonly oldestClaimableAgeMs?: number;
+  };
+  readonly workers: {
+    readonly counts: Readonly<Record<RuntimeWorkerStatus, number>>;
+    readonly capacity: number;
+    readonly activeSessions: number;
+    readonly availableCapacity: number;
+  };
+}
 
 export interface RuntimeWorkerRegistration {
   readonly workerId: WorkerId;
@@ -188,6 +217,7 @@ export interface WorkerRuntimeStore {
   listWorkerSessions(
     workerId: WorkerId,
   ): Promise<readonly RuntimeSessionRoute[]>;
+  getQueueMetrics?(tenantId?: string): Promise<RuntimeQueueMetrics>;
   recoverExpiredWork(): Promise<RuntimeRecoveryResult>;
   claimEffects(
     options: RuntimeEffectClaimOptions,

--- a/src/server/__tests__/AgentRuntimeOperations.test.ts
+++ b/src/server/__tests__/AgentRuntimeOperations.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, it, vi } from 'vitest';
+import { CommandId, SessionId, WorkerId } from '../../types/identifiers.js';
+import { AgentRuntimeOperations } from '../AgentRuntimeOperations.js';
+import type { AgentWorkerHealth } from '../AgentWorker.js';
+import type { RuntimeEffectRecord, RuntimeStore } from '../RuntimeStore.js';
+import type { RuntimeQueueMetrics } from '../WorkerRuntime.js';
+
+const tenantId = 'tenant-1';
+const now = '2026-08-26T00:00:00.000Z';
+
+function queueMetrics(): RuntimeQueueMetrics {
+  return {
+    collectedAt: now,
+    tenantId,
+    sessions: {
+      counts: {
+        queued: 2,
+        provisioning: 0,
+        running: 1,
+        waiting_approval: 0,
+        suspended: 0,
+        idle: 3,
+        completed: 4,
+        failed: 0,
+      },
+      claimable: 2,
+      oldestClaimableAt: now,
+      oldestClaimableAgeMs: 50,
+    },
+    effects: {
+      counts: {
+        pending: 1,
+        claimed: 0,
+        executing: 0,
+        completed: 3,
+        failed: 0,
+        uncertain: 1,
+      },
+      claimable: 1,
+      oldestClaimableAt: now,
+      oldestClaimableAgeMs: 25,
+    },
+    workers: {
+      counts: {
+        active: 1,
+        draining: 0,
+        offline: 0,
+      },
+      capacity: 4,
+      activeSessions: 1,
+      availableCapacity: 3,
+    },
+  };
+}
+
+function workerHealth(): AgentWorkerHealth {
+  return {
+    workerId: WorkerId('worker-1'),
+    status: 'ready',
+    live: true,
+    ready: true,
+    workerStatus: 'running',
+    checkedAt: now,
+    activeSessions: 1,
+    lastHeartbeatAt: now,
+    heartbeatAgeMs: 0,
+  };
+}
+
+function uncertainEffect(): RuntimeEffectRecord {
+  return {
+    tenantId,
+    sessionId: SessionId('session-1'),
+    commandId: CommandId('command-1'),
+    effectId: 'effect-1',
+    type: 'email.send',
+    payload: { secret: 'must-not-leak' },
+    idempotencyKey: 'effect-key',
+    executionMode: 'at_most_once',
+    status: 'uncertain',
+    attempts: 1,
+    createdAt: now,
+    completedAt: now,
+    error: { reason: 'worker_lost' },
+  };
+}
+
+function createOperations(options: { authorized?: boolean } = {}) {
+  const effect = uncertainEffect();
+  const store = {
+    healthCheck: vi.fn(async () => ({
+      ready: true,
+      details: { backend: 'sensitive-backend' },
+    })),
+    getQueueMetrics: vi.fn(async () => queueMetrics()),
+    listEffects: vi.fn(async () => [effect]),
+    reconcileEffect: vi.fn(async (_tenantId, _effectId, outcome) => ({
+      ...effect,
+      status: outcome.status,
+      ...(outcome.status === 'completed' ? { result: outcome.result } : { error: outcome.error }),
+    })),
+  } as unknown as RuntimeStore;
+  const authorize = vi.fn(async () =>
+    options.authorized === false ? null : { tenantId, subject: 'operator-1' },
+  );
+  const operations = new AgentRuntimeOperations({
+    store,
+    authorize,
+    workers: [
+      {
+        getHealth: workerHealth,
+      },
+    ],
+  });
+  return { authorize, effect, operations, store };
+}
+
+describe('AgentRuntimeOperations', () => {
+  it('reports store and worker readiness without authentication', async () => {
+    const { authorize, operations } = createOperations();
+    const response = await operations.handle(new Request('http://localhost/v1/runtime/readyz'));
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toMatchObject({
+      status: 'ready',
+      live: true,
+      ready: true,
+      store: { ready: true },
+      workers: {
+        total: 1,
+        live: 1,
+        ready: 1,
+        failed: 0,
+      },
+    });
+    expect(JSON.stringify(body)).not.toContain('worker-1');
+    expect(JSON.stringify(body)).not.toContain('sensitive-backend');
+    expect(authorize).not.toHaveBeenCalled();
+  });
+
+  it('protects metrics and scopes the queue snapshot to the operator tenant', async () => {
+    const unauthorized = createOperations({ authorized: false });
+    await expect(
+      unauthorized.operations.handle(new Request('http://localhost/v1/runtime/metrics')),
+    ).resolves.toMatchObject({ status: 401 });
+
+    const { authorize, operations, store } = createOperations();
+    const response = await operations.handle(new Request('http://localhost/v1/runtime/metrics'));
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toMatchObject({
+      queue: {
+        tenantId,
+        sessions: { claimable: 2 },
+        effects: { claimable: 1 },
+        workers: { availableCapacity: 3 },
+      },
+    });
+    expect(body).not.toHaveProperty('workers');
+    expect(authorize).toHaveBeenCalledWith(expect.any(Request), 'metrics.read');
+    expect(store.getQueueMetrics).toHaveBeenCalledWith(tenantId);
+  });
+
+  it('fails closed when authorization throws', async () => {
+    const { store } = createOperations();
+    const authorize = vi.fn(async () => {
+      throw new Error('identity provider unavailable');
+    });
+    const guarded = new AgentRuntimeOperations({
+      store,
+      authorize,
+    });
+
+    const response = await guarded.handle(new Request('http://localhost/v1/runtime/metrics'));
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Runtime operations authorization failed',
+    });
+  });
+
+  it('returns 501 when a compatible Store has no queue metrics capability', async () => {
+    const { operations, store } = createOperations();
+    Reflect.deleteProperty(store, 'getQueueMetrics');
+
+    const response = await operations.handle(new Request('http://localhost/v1/runtime/metrics'));
+
+    expect(response.status).toBe(501);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Runtime operations request failed',
+    });
+  });
+
+  it('lists redacted uncertain effects and reconciles an explicit outcome', async () => {
+    const { operations, store } = createOperations();
+    const listResponse = await operations.handle(
+      new Request('http://localhost/v1/runtime/effects/uncertain?limit=10'),
+    );
+    const listed = (await listResponse.json()) as {
+      effects: Record<string, unknown>[];
+    };
+
+    expect(listResponse.status).toBe(200);
+    expect(listed.effects[0]).toMatchObject({
+      effectId: 'effect-1',
+      status: 'uncertain',
+      error: { reason: 'worker_lost' },
+    });
+    expect(listed.effects[0]).not.toHaveProperty('payload');
+    expect(listed.effects[0]).not.toHaveProperty('idempotencyKey');
+
+    const reconcileResponse = await operations.handle(
+      new Request('http://localhost/v1/runtime/effects/effect-1/reconcile', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          status: 'completed',
+          result: { receiptId: 'receipt-1' },
+        }),
+      }),
+    );
+
+    expect(reconcileResponse.status).toBe(200);
+    await expect(reconcileResponse.json()).resolves.toMatchObject({
+      effect: {
+        effectId: 'effect-1',
+        status: 'completed',
+      },
+    });
+    expect(store.reconcileEffect).toHaveBeenCalledWith(tenantId, 'effect-1', {
+      status: 'completed',
+      result: { receiptId: 'receipt-1' },
+    });
+  });
+});

--- a/src/server/__tests__/AgentWorker.test.ts
+++ b/src/server/__tests__/AgentWorker.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { ExecutionLeaseId, FencingToken, SessionId, WorkerId } from '../../types/identifiers.js';
 import { AgentWorker } from '../AgentWorker.js';
+import type { AgentWorkerTelemetry } from '../AgentWorkerTelemetry.js';
 import type { RuntimeStore } from '../RuntimeStore.js';
 import type { SessionRunner } from '../SessionRunner.js';
 import type {
@@ -8,6 +9,7 @@ import type {
   RuntimeSessionRoute,
   RuntimeWorkerRecord,
 } from '../WorkerRuntime.js';
+import { WorkerRuntimeError } from '../WorkerRuntime.js';
 
 const workerId = WorkerId('worker-1');
 const sessionId = SessionId('session-1');
@@ -131,6 +133,103 @@ function createStore(sessionClaim: RuntimeSessionClaim) {
 }
 
 describe('AgentWorker', () => {
+  it('reports readiness and emits telemetry snapshots across its lifecycle', async () => {
+    const sessionClaim = claim();
+    const store = createStore(sessionClaim);
+    const telemetry: AgentWorkerTelemetry = {
+      recordSnapshot: vi.fn(),
+      recordError: vi.fn(),
+    };
+    const worker = new AgentWorker({
+      store,
+      workerId,
+      capacity: 1,
+      sessionRunner: {
+        async run(context) {
+          await context.transition('running');
+          return { status: 'completed' };
+        },
+      },
+      telemetry,
+      heartbeatIntervalMs: 50,
+      workerTtlMs: 500,
+      sessionLeaseTtlMs: 500,
+      pollIntervalMs: 10,
+      recoveryIntervalMs: 100,
+    });
+
+    expect(worker.getHealth()).toMatchObject({
+      status: 'not_ready',
+      live: true,
+      ready: false,
+      workerStatus: 'idle',
+    });
+    await worker.start();
+    await vi.waitFor(() => {
+      expect(worker.getSnapshot().metrics.sessionsCompleted).toBe(1);
+    });
+    expect(worker.getHealth()).toMatchObject({
+      status: 'ready',
+      live: true,
+      ready: true,
+      workerStatus: 'running',
+    });
+    await worker.shutdown();
+
+    expect(worker.getHealth()).toMatchObject({
+      status: 'not_ready',
+      live: true,
+      ready: false,
+      workerStatus: 'stopped',
+    });
+    expect(telemetry.recordSnapshot).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workerId,
+        health: expect.objectContaining({ ready: true }),
+      }),
+    );
+    expect(telemetry.recordError).not.toHaveBeenCalled();
+  });
+
+  it('refreshes telemetry after a successful heartbeat', async () => {
+    const store = createStore(claim());
+    vi.mocked(store.claimSession).mockResolvedValue(null);
+    const telemetry: AgentWorkerTelemetry = {
+      recordSnapshot: vi.fn(),
+      recordError: vi.fn(),
+    };
+    const worker = new AgentWorker({
+      store,
+      workerId,
+      capacity: 1,
+      sessionRunner: {
+        async run() {
+          return { status: 'completed' };
+        },
+      },
+      telemetry,
+      heartbeatIntervalMs: 100,
+      workerTtlMs: 500,
+      sessionLeaseTtlMs: 500,
+      pollIntervalMs: 100,
+      recoveryIntervalMs: 10_000,
+    });
+
+    await worker.start();
+    await vi.waitFor(() => {
+      expect(store.recoverExpiredWork).toHaveBeenCalledOnce();
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    vi.mocked(telemetry.recordSnapshot).mockClear();
+    await vi.waitFor(() => {
+      expect(store.heartbeatWorker).toHaveBeenCalled();
+      expect(telemetry.recordSnapshot).toHaveBeenCalledWith(
+        expect.objectContaining({ health: expect.objectContaining({ ready: true }) }),
+      );
+    });
+    await worker.shutdown();
+  });
+
   it('claims a Session, runs it under a lease, and releases it into idle', async () => {
     const sessionClaim = claim();
     const store = createStore(sessionClaim);
@@ -299,6 +398,50 @@ describe('AgentWorker', () => {
     expect(onError).toHaveBeenCalledWith(recoveryError);
     expect(onError).toHaveBeenCalledWith(effectError);
     await worker.shutdown();
+  });
+
+  it('reports a fatal heartbeat failure through health and telemetry', async () => {
+    const store = createStore(claim());
+    vi.mocked(store.claimSession).mockResolvedValue(null);
+    vi.mocked(store.heartbeatWorker).mockRejectedValue(
+      new WorkerRuntimeError('WORKER_NOT_FOUND', 'worker lease was removed'),
+    );
+    const telemetry: AgentWorkerTelemetry = {
+      recordSnapshot: vi.fn(),
+      recordError: vi.fn(),
+    };
+    const worker = new AgentWorker({
+      store,
+      workerId,
+      capacity: 1,
+      sessionRunner: {
+        async run() {
+          return { status: 'completed' };
+        },
+      },
+      telemetry,
+      heartbeatIntervalMs: 10,
+      workerTtlMs: 500,
+      sessionLeaseTtlMs: 500,
+      pollIntervalMs: 10,
+      recoveryIntervalMs: 100,
+    });
+
+    await worker.start();
+    await expect(worker.wait()).rejects.toMatchObject({
+      code: 'WORKER_NOT_FOUND',
+    });
+
+    expect(worker.getHealth()).toMatchObject({
+      status: 'failed',
+      live: false,
+      ready: false,
+    });
+    expect(telemetry.recordError).toHaveBeenCalledWith({
+      workerId,
+      workerStatus: 'failed',
+      errorCode: 'WORKER_NOT_FOUND',
+    });
   });
 
   it('treats an in-flight claim rejection during drain as normal shutdown', async () => {

--- a/src/server/__tests__/OpenTelemetryAgentWorkerTelemetry.test.ts
+++ b/src/server/__tests__/OpenTelemetryAgentWorkerTelemetry.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from 'vitest';
+import { SessionId, WorkerId } from '../../types/identifiers.js';
+import type { AgentWorkerSnapshot } from '../AgentWorker.js';
+import { OpenTelemetryAgentWorkerTelemetry } from '../OpenTelemetryAgentWorkerTelemetry.js';
+
+function snapshot(): AgentWorkerSnapshot {
+  return {
+    workerId: WorkerId('worker-secret'),
+    status: 'running',
+    health: {
+      workerId: WorkerId('worker-secret'),
+      status: 'ready',
+      live: true,
+      ready: true,
+      workerStatus: 'running',
+      checkedAt: '2026-08-26T00:00:00.000Z',
+      activeSessions: 1,
+      lastHeartbeatAt: '2026-08-26T00:00:00.000Z',
+      heartbeatAgeMs: 0,
+    },
+    activeSessionIds: [SessionId('session-secret')],
+    metrics: {
+      startedAt: '2026-08-26T00:00:00.000Z',
+      firstClaimLatencyMs: 10,
+      sessionClaims: 3,
+      sessionsIdle: 1,
+      sessionsCompleted: 1,
+      sessionsSuspended: 0,
+      sessionsFailed: 1,
+      recoveryRuns: 2,
+      recoveryDurationMs: 8,
+      activeSessions: 1,
+      elapsedMs: 100,
+      completedSessionsPerSecond: 20,
+    },
+    effectMetrics: {
+      claimed: 2,
+      completed: 1,
+      failed: 0,
+      retried: 0,
+      uncertain: 1,
+      handlerDurationMs: 4,
+    },
+  };
+}
+
+describe('OpenTelemetryAgentWorkerTelemetry', () => {
+  it('exports payload-free worker gauges and errors', () => {
+    const callbacks = new Map<
+      string,
+      (result: { observe(value: number, attributes?: Record<string, unknown>): void }) => void
+    >();
+    const add = vi.fn();
+    const meter = {
+      createCounter: vi.fn(() => ({ add })),
+      createObservableGauge: vi.fn((name: string) => ({
+        addCallback: (callback: typeof callbacks extends Map<string, infer T> ? T : never) => {
+          callbacks.set(name, callback);
+        },
+      })),
+    };
+    const telemetry = new OpenTelemetryAgentWorkerTelemetry({
+      meter: meter as never,
+    });
+
+    telemetry.recordSnapshot(snapshot());
+    const observations = Object.fromEntries(
+      [...callbacks].map(([name, callback]) => {
+        const observe = vi.fn();
+        callback({ observe });
+        return [name, observe];
+      }),
+    );
+    telemetry.recordError({
+      workerId: WorkerId('worker-secret'),
+      workerStatus: 'running',
+      errorCode: 'EFFECT_LEASE_LOST',
+    });
+
+    expect(Object.keys(observations)).toEqual([
+      'blade.agent.worker.ready',
+      'blade.agent.worker.active_sessions',
+      'blade.agent.worker.session.claims',
+      'blade.agent.worker.session.completed',
+      'blade.agent.worker.session.failed',
+      'blade.agent.worker.recovery.duration',
+      'blade.agent.worker.effect.uncertain',
+    ]);
+    for (const [name, value] of [
+      ['blade.agent.worker.ready', 1],
+      ['blade.agent.worker.active_sessions', 1],
+      ['blade.agent.worker.session.claims', 3],
+      ['blade.agent.worker.session.completed', 2],
+      ['blade.agent.worker.session.failed', 1],
+      ['blade.agent.worker.recovery.duration', 8],
+      ['blade.agent.worker.effect.uncertain', 1],
+    ] as const) {
+      expect(observations[name]).toHaveBeenCalledWith(value, {
+        'blade.agent.worker.status': 'running',
+      });
+    }
+    expect(add).toHaveBeenCalledWith(1, {
+      'blade.agent.worker.status': 'running',
+      'error.type': 'EFFECT_LEASE_LOST',
+    });
+    const exported = JSON.stringify({
+      observations: Object.fromEntries(
+        Object.entries(observations).map(([name, observe]) => [name, observe.mock.calls]),
+      ),
+      add: add.mock.calls,
+    });
+    expect(exported).not.toContain('session-secret');
+    expect(exported).not.toContain('worker-secret');
+  });
+});

--- a/src/server/__tests__/PostgresRuntimeStore.integration.test.ts
+++ b/src/server/__tests__/PostgresRuntimeStore.integration.test.ts
@@ -11,6 +11,7 @@ import {
   WorkerId,
 } from '../../types/identifiers.js';
 import { AgentServer } from '../AgentServer.js';
+import { AgentRuntimeOperations } from '../AgentRuntimeOperations.js';
 import { AgentWorker } from '../AgentWorker.js';
 import {
   EffectDispatcher,
@@ -92,6 +93,7 @@ describePostgres('PostgresRuntimeStore', () => {
       'atomic-runtime-commit',
       'transaction-rollback',
       'projection-checkpoint',
+      'queue-metrics',
       'worker-routing',
       'worker-recovery',
       'effect-delivery',
@@ -822,6 +824,95 @@ describePostgres('PostgresRuntimeStore', () => {
     }
   });
 
+  it('reports tenant-scoped queue metrics with global worker capacity', async () => {
+    const suffix = `metrics-${Date.now()}`;
+    const tenantId = `tenant-${suffix}`;
+    const otherTenantId = `tenant-other-${suffix}`;
+    const workerId = WorkerId(`worker-${suffix}`);
+    await store.registerWorker({
+      workerId,
+      capacity: 3,
+      ttlMs: 60_000,
+    });
+    await Promise.all([
+      store.enqueueSession(tenantId, SessionId(`session-a-${suffix}`)),
+      store.enqueueSession(tenantId, SessionId(`session-b-${suffix}`)),
+      store.enqueueSession(otherTenantId, SessionId(`session-other-${suffix}`)),
+    ]);
+    const commandId = CommandId(`command-${suffix}`);
+    await store.commitRuntimeTransaction({
+      tenantId,
+      sessionId: SessionId(`effect-session-${suffix}`),
+      command: {
+        commandId,
+        fingerprint: `fingerprint-${commandId}`,
+        result: {
+          protocolVersion: 1,
+          commandId,
+          ok: true,
+          data: {},
+        },
+      },
+      effects: [{
+        effectId: `effect-${suffix}`,
+        type: 'metrics',
+        payload: {},
+        idempotencyKey: `effect-${suffix}`,
+      }],
+    });
+
+    const metrics = await store.getQueueMetrics(tenantId);
+
+    expect(metrics).toMatchObject({
+      tenantId,
+      sessions: {
+        counts: { queued: 2 },
+        claimable: 2,
+      },
+      effects: {
+        counts: { pending: 1 },
+        claimable: 1,
+      },
+      workers: {
+        counts: {
+          active: expect.any(Number),
+          draining: expect.any(Number),
+          offline: expect.any(Number),
+        },
+        capacity: expect.any(Number),
+        activeSessions: expect.any(Number),
+        availableCapacity: expect.any(Number),
+      },
+    });
+    expect(metrics.sessions.oldestClaimableAgeMs).toBeGreaterThanOrEqual(0);
+    expect(metrics.effects.oldestClaimableAgeMs).toBeGreaterThanOrEqual(0);
+    expect(metrics.workers.capacity).toBeGreaterThanOrEqual(3);
+
+    const claimed = await store.claimSession({
+      tenantId,
+      ownerId: workerId,
+      leaseId: ExecutionLeaseId(`metrics-lease-${suffix}`),
+      ttlMs: 60_000,
+    });
+    expect(claimed).not.toBeNull();
+    const claimedMetrics = await store.getQueueMetrics(tenantId);
+    expect(claimedMetrics.workers.activeSessions).toBe(
+      metrics.workers.activeSessions + 1,
+    );
+    expect(claimedMetrics.workers.availableCapacity).toBe(
+      metrics.workers.availableCapacity - 1,
+    );
+
+    await store.drainWorker(workerId);
+    const drainingMetrics = await store.getQueueMetrics(tenantId);
+    expect(drainingMetrics.workers.capacity).toBe(
+      claimedMetrics.workers.capacity - 3,
+    );
+    expect(drainingMetrics.workers.activeSessions).toBe(
+      claimedMetrics.workers.activeSessions - 1,
+    );
+  });
+
   it('dispatches persisted effects with explicit terminal outcomes', async () => {
     const suffix = `dispatcher-${Date.now()}`;
     const tenantId = `tenant-${suffix}`;
@@ -896,6 +987,53 @@ describePostgres('PostgresRuntimeStore', () => {
           effectId: `uncertain-${suffix}`,
           status: 'uncertain',
           attempts: 1,
+        }),
+      ]),
+    );
+
+    const operations = new AgentRuntimeOperations({
+      store,
+      authorize: () => ({ tenantId, subject: 'operator' }),
+    });
+    const listResponse = await operations.handle(
+      new Request('http://localhost/v1/runtime/effects/uncertain'),
+    );
+    const listed = (await listResponse.json()) as {
+      effects: Record<string, unknown>[];
+    };
+    expect(listResponse.status).toBe(200);
+    expect(listed.effects).toEqual([
+      expect.objectContaining({
+        effectId: `uncertain-${suffix}`,
+        status: 'uncertain',
+      }),
+    ]);
+    expect(listed.effects[0]).not.toHaveProperty('payload');
+
+    const reconcileResponse = await operations.handle(
+      new Request(
+        `http://localhost/v1/runtime/effects/uncertain-${suffix}/reconcile`,
+        {
+          method: 'POST',
+          body: JSON.stringify({
+            status: 'completed',
+            result: { receiptId: `receipt-${suffix}` },
+          }),
+        },
+      ),
+    );
+    expect(reconcileResponse.status).toBe(200);
+    await expect(
+      store.listEffects(tenantId, {
+        sessionId,
+        status: 'completed',
+      }),
+    ).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          effectId: `uncertain-${suffix}`,
+          status: 'completed',
+          result: { receiptId: `receipt-${suffix}` },
         }),
       ]),
     );

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -21,6 +21,7 @@ export type {
 } from './AgentServerTelemetry.js';
 export {
   RUNTIME_DOMAIN_EVENT_SCHEMA_VERSION,
+  RUNTIME_EFFECT_STATUSES,
   RUNTIME_STORE_SCHEMA_VERSION,
   RuntimeStoreError,
   type RuntimeCommandCommit,
@@ -43,6 +44,7 @@ export {
   effectLease,
   isTerminalRuntimeEffectStatus,
   RUNTIME_SESSION_STATES,
+  RUNTIME_WORKER_STATUSES,
   type RuntimeEffectClaim,
   type RuntimeEffectClaimOptions,
   type RuntimeEffectExecutionMode,
@@ -50,6 +52,7 @@ export {
   type RuntimeEffectLease,
   type RuntimeEffectReconciliation,
   type RuntimeRecoveryResult,
+  type RuntimeQueueMetrics,
   type RuntimeSessionClaim,
   type RuntimeSessionClaimOptions,
   type RuntimeSessionRoute,
@@ -79,10 +82,27 @@ export {
 export {
   AgentWorker,
   type AgentWorkerMetrics,
+  type AgentWorkerHealth,
   type AgentWorkerOptions,
   type AgentWorkerSnapshot,
   type AgentWorkerStatus,
 } from './AgentWorker.js';
+export type {
+  AgentWorkerErrorMetric,
+  AgentWorkerTelemetry,
+} from './AgentWorkerTelemetry.js';
+export {
+  AgentRuntimeOperations,
+  type AgentRuntimeOperationsOptions,
+  type RuntimeEffectOperationRecord,
+  type RuntimeOperationsAction,
+  RuntimeOperationsError,
+  type RuntimeOperationsErrorCode,
+  type RuntimeOperationsHealth,
+  type RuntimeOperationsPrincipal,
+  type RuntimeOperationsWorker,
+  type RuntimeUncertainEffect,
+} from './AgentRuntimeOperations.js';
 export {
   EffectDispatcher,
   type EffectDispatcherMetrics,

--- a/src/server/otel.ts
+++ b/src/server/otel.ts
@@ -2,3 +2,7 @@ export {
   OpenTelemetryAgentServerTelemetry,
   type OpenTelemetryAgentServerOptions,
 } from './OpenTelemetryAgentServerTelemetry.js';
+export {
+  OpenTelemetryAgentWorkerTelemetry,
+  type OpenTelemetryAgentWorkerOptions,
+} from './OpenTelemetryAgentWorkerTelemetry.js';

--- a/src/server/postgres.ts
+++ b/src/server/postgres.ts
@@ -4,6 +4,7 @@ export {
 } from './PostgresRuntimeStore.js';
 export {
   RUNTIME_DOMAIN_EVENT_SCHEMA_VERSION,
+  RUNTIME_EFFECT_STATUSES,
   RUNTIME_STORE_SCHEMA_VERSION,
   RuntimeStoreError,
   type RuntimeCommandCommit,
@@ -26,6 +27,7 @@ export {
   effectLease,
   isTerminalRuntimeEffectStatus,
   RUNTIME_SESSION_STATES,
+  RUNTIME_WORKER_STATUSES,
   type RuntimeEffectClaim,
   type RuntimeEffectClaimOptions,
   type RuntimeEffectExecutionMode,
@@ -33,6 +35,7 @@ export {
   type RuntimeEffectLease,
   type RuntimeEffectReconciliation,
   type RuntimeRecoveryResult,
+  type RuntimeQueueMetrics,
   type RuntimeSessionClaim,
   type RuntimeSessionClaimOptions,
   type RuntimeSessionRoute,

--- a/src/server/testing/RuntimeStoreConformance.ts
+++ b/src/server/testing/RuntimeStoreConformance.ts
@@ -420,6 +420,23 @@ export async function assertRuntimeStoreConformance(
     capacity: 4,
     ttlMs: 10_000,
   });
+  if (store.getQueueMetrics) {
+    const queueMetrics = await store.getQueueMetrics(workerTenantId);
+    assert(
+      queueMetrics.tenantId === workerTenantId
+      && queueMetrics.sessions.claimable >= 2
+      && queueMetrics.sessions.counts.queued >= 1
+      && queueMetrics.sessions.counts.suspended >= 1,
+      'Queue metrics must report tenant-scoped claimable Sessions',
+    );
+    assert(
+      queueMetrics.effects.counts.pending === 0
+      && queueMetrics.workers.capacity >= 4
+      && queueMetrics.workers.availableCapacity >= 0,
+      'Queue metrics must report effect backlog and global worker capacity',
+    );
+    checks.push('queue-metrics');
+  }
   const secondClaim = await store.claimSession({
     tenantId: workerTenantId,
     ownerId: secondWorkerId,


### PR DESCRIPTION
## Summary

- add authenticated runtime health, tenant-scoped PostgreSQL queue metrics, and explicit uncertain-effect reconciliation
- add payload-free AgentWorker OpenTelemetry with heartbeat-aware readiness and fatal error reporting
- verify the operations surface in the single-command Browser → AgentServer → PostgreSQL → AgentWorker → Docker example
- keep `RuntimeStore.getQueueMetrics` and `AgentWorkerSnapshot.health` optional for 6.0.x source compatibility

## Security and isolation

- health/readiness HTTP responses expose aggregate state only
- metrics requests are authorized and scoped to the principal tenant
- uncertain-effect responses omit payloads and idempotency keys
- Worker OTel omits prompts, payloads, Session IDs, credentials, and Worker IDs by default

## Verification

- `pnpm type-check`
- `pnpm lint`
- `pnpm build`
- `pnpm docs:build`
- `pnpm changelog:check -- --base origin/main`
- `pnpm audit:prod`
- package entrypoint and minimal-install verification
- production stack smoke: first result in 7.85s
- real PostgreSQL integration: 15/15
- full suite: 1849 passed, 63 skipped (credential-gated live model tests)

## Release

Patch-only semantic release target: `v6.0.2`.