### PR TITLE
fix(ci): gate complete runtime recovery metrics

### DIFF
--- a/.changes/runtime-regression-gates.json
+++ b/.changes/runtime-regression-gates.json
@@ -1,0 +1,5 @@
+{
+  "type": "fix",
+  "en": "Gate releases on complete failover RTO, throughput, event-loss, and four-point non-idempotent fault metrics with retained CI reports.",
+  "zh-CN": "将完整故障恢复 RTO、吞吐、事件丢失与四点非幂等故障指标纳入发布门禁，并保留 CI 报告。"
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,17 @@ jobs:
       - name: Verify production Golden Path
         run: pnpm run verify:production-example
 
+      - name: Verify Runtime regression metrics
+        run: pnpm run verify:runtime-regression
+
+      - name: Upload Runtime regression report
+        if: ${{ always() && hashFiles('artifacts/runtime-regression.json') != '' }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: runtime-regression-node-${{ matrix.node-version }}
+          path: artifacts/runtime-regression.json
+          retention-days: 30
+
       - name: Build documentation
         run: pnpm run docs:build
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,6 +87,17 @@ jobs:
       - name: Verify production Golden Path
         run: pnpm run verify:production-example
 
+      - name: Verify Runtime regression metrics
+        run: pnpm run verify:runtime-regression
+
+      - name: Upload Runtime regression report
+        if: ${{ always() && hashFiles('artifacts/runtime-regression.json') != '' }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: runtime-regression-release
+          path: artifacts/runtime-regression.json
+          retention-days: 90
+
       - name: Build documentation
         run: pnpm run docs:build
 

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ pnpm-debug.log*
 
 # Test coverage
 coverage/
+artifacts/
 
 # Temporary files
 *.tmp

--- a/benchmarks/fault-injection.mjs
+++ b/benchmarks/fault-injection.mjs
@@ -1,0 +1,304 @@
+import { spawn } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Pool } from 'pg';
+import {
+  AGENT_PROTOCOL_VERSION,
+  CommandId,
+  ExecutionLeaseId,
+  SessionId,
+  WorkerId,
+} from '@blade-ai/agent-sdk/core';
+import { effectLease } from '@blade-ai/agent-sdk/server';
+import { PostgresRuntimeStore } from '@blade-ai/agent-sdk/server/postgres';
+
+const connectionString = process.env.TEST_POSTGRES_URL;
+if (!connectionString) {
+  throw new Error('Set TEST_POSTGRES_URL to a disposable PostgreSQL database');
+}
+
+const root = dirname(fileURLToPath(import.meta.url));
+const workerPath = join(root, 'fixtures/effect-worker.mjs');
+const suffix = `${process.pid}_${Date.now()}`;
+const schema = `blade_fault_benchmark_${suffix}`;
+const tablePrefix = 'runtime';
+const pool = new Pool({ connectionString });
+const store = new PostgresRuntimeStore({
+  pool,
+  schema,
+  tablePrefix,
+});
+const activeChildren = new Set();
+const crashPoints = [
+  {
+    name: 'after_claim',
+    expectedExecutions: 1,
+    expectedStatus: 'completed',
+  },
+  {
+    name: 'after_start',
+    expectedExecutions: 0,
+    expectedStatus: 'uncertain',
+  },
+  {
+    name: 'after_side_effect',
+    expectedExecutions: 1,
+    expectedStatus: 'uncertain',
+  },
+  {
+    name: 'after_complete',
+    expectedExecutions: 1,
+    expectedStatus: 'completed',
+  },
+];
+
+function startWorker(tenantId, effectId, workerId, crashPoint) {
+  const child = spawn(process.execPath, [
+    workerPath,
+    connectionString,
+    schema,
+    tablePrefix,
+    tenantId,
+    effectId,
+    workerId,
+    crashPoint,
+  ], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  const running = { child, closed: undefined };
+  activeChildren.add(running);
+  let stdout = '';
+  let stderr = '';
+  child.stdout.setEncoding('utf8');
+  child.stderr.setEncoding('utf8');
+  child.stdout.on('data', (chunk) => {
+    stdout += chunk;
+  });
+  child.stderr.on('data', (chunk) => {
+    stderr += chunk;
+  });
+  const closed = new Promise((resolve, reject) => {
+    child.once('error', reject);
+    child.once('close', (code, signal) => {
+      activeChildren.delete(running);
+      if (signal === 'SIGKILL' || code === 0) {
+        resolve();
+        return;
+      }
+      reject(
+        new Error(
+          `Fault worker exited unexpectedly (${String(code)}/${String(signal)}): ${stderr}`,
+        ),
+      );
+    });
+  });
+  running.closed = closed;
+  void closed.catch(() => undefined);
+  return {
+    child,
+    closed,
+    async waitForCheckpoint() {
+      const deadline = Date.now() + 15_000;
+      const expected = `checkpoint:${crashPoint}\n`;
+      while (Date.now() < deadline) {
+        if (stdout.includes(expected)) {
+          return;
+        }
+        if (child.exitCode !== null) {
+          throw new Error(
+            `Fault worker exited before ${crashPoint}: ${stderr}`,
+          );
+        }
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+      throw new Error(
+        `Timed out waiting for ${crashPoint}; stdout=${stdout}; stderr=${stderr}`,
+      );
+    },
+  };
+}
+
+async function waitForDatabaseTime(timestamp, timeoutMs = 10_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const result = await pool.query(
+      'SELECT NOW() >= $1::timestamptz AS expired',
+      [timestamp],
+    );
+    if (result.rows[0]?.expired === true) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(`Database clock did not reach ${timestamp}`);
+}
+
+async function runCrashPoint(config, index) {
+  const tenantId = `fault-${config.name}-${suffix}`;
+  const sessionId = SessionId(`session-${config.name}-${suffix}`);
+  const effectId = `effect-${config.name}-${suffix}`;
+  const commandId = CommandId(`command-${config.name}-${suffix}`);
+  const childWorkerId = WorkerId(`worker-child-${config.name}-${suffix}`);
+  await store.commitRuntimeTransaction({
+    tenantId,
+    sessionId,
+    command: {
+      commandId,
+      fingerprint: `fingerprint-${commandId}`,
+      result: {
+        protocolVersion: AGENT_PROTOCOL_VERSION,
+        commandId,
+        ok: true,
+        data: {},
+      },
+    },
+    effects: [{
+      effectId,
+      type: 'benchmark.non-idempotent',
+      payload: { crashPoint: config.name },
+      idempotencyKey: `key-${effectId}`,
+      executionMode: 'at_most_once',
+    }],
+  });
+
+  const running = startWorker(
+    tenantId,
+    effectId,
+    childWorkerId,
+    config.name,
+  );
+  await running.waitForCheckpoint();
+  const failureInjectedAt = performance.now();
+  running.child.kill('SIGKILL');
+  await running.closed;
+
+  const worker = await store.getWorker(childWorkerId);
+  if (!worker) {
+    throw new Error(`Worker ${childWorkerId} disappeared before recovery`);
+  }
+  await waitForDatabaseTime(worker.leaseExpiresAt);
+  const scanStartedAt = performance.now();
+  const recovery = await store.recoverExpiredWork();
+  const scanCompletedAt = performance.now();
+
+  const recoveryWorkerId = WorkerId(`worker-recovery-${index}-${suffix}`);
+  await store.registerWorker({
+    workerId: recoveryWorkerId,
+    capacity: 1,
+    ttlMs: 5_000,
+  });
+  const [claim] = await store.claimEffects({
+    tenantId,
+    workerId: recoveryWorkerId,
+    leaseId: ExecutionLeaseId(`recovery-lease-${index}-${suffix}`),
+    ttlMs: 5_000,
+    limit: 1,
+  });
+  if (config.name === 'after_claim') {
+    if (!claim || claim.effectId !== effectId) {
+      throw new Error(`Effect ${effectId} was not reclaimed`);
+    }
+    const lease = effectLease(claim);
+    await store.startEffect(lease);
+    await pool.query(
+      `INSERT INTO "${schema}"."fault_effect_log" (
+         effect_id, worker_id
+       ) VALUES ($1, $2)`,
+      [effectId, recoveryWorkerId],
+    );
+    await store.completeEffect(lease, { delivered: true });
+  } else if (claim) {
+    throw new Error(`Effect ${effectId} was unexpectedly reclaimable`);
+  }
+
+  const recoveredAt = performance.now();
+  const executionsResult = await pool.query(
+    `SELECT COUNT(*)::int AS count
+       FROM "${schema}"."fault_effect_log"
+      WHERE effect_id = $1`,
+    [effectId],
+  );
+  const executions = executionsResult.rows[0]?.count ?? 0;
+  const [effect] = await store.listEffects(tenantId, { sessionId });
+  const status = effect?.status;
+  const duplicateExecutions = Math.max(
+    0,
+    executions - config.expectedExecutions,
+  );
+  const passed =
+    executions === config.expectedExecutions
+    && status === config.expectedStatus;
+
+  return {
+    crashPoint: config.name,
+    expectedExecutions: config.expectedExecutions,
+    executions,
+    duplicateExecutions,
+    expectedStatus: config.expectedStatus,
+    status,
+    passed,
+    metrics: {
+      failureDetectionMs:
+        Math.round((scanCompletedAt - failureInjectedAt) * 100) / 100,
+      recoveryScanMs:
+        Math.round((scanCompletedAt - scanStartedAt) * 100) / 100,
+      recoveryRtoMs:
+        Math.round((recoveredAt - failureInjectedAt) * 100) / 100,
+    },
+    recovery,
+  };
+}
+
+try {
+  await store.initialize();
+  await pool.query(
+    `CREATE TABLE "${schema}"."fault_effect_log" (
+       effect_id TEXT NOT NULL,
+       worker_id TEXT NOT NULL,
+       executed_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+     )`,
+  );
+
+  const matrix = [];
+  for (const [index, crashPoint] of crashPoints.entries()) {
+    matrix.push(await runCrashPoint(crashPoint, index));
+  }
+  const totalExpectedExecutions = matrix.reduce(
+    (total, result) => total + result.expectedExecutions,
+    0,
+  );
+  const totalDuplicateExecutions = matrix.reduce(
+    (total, result) => total + result.duplicateExecutions,
+    0,
+  );
+  const report = {
+    generatedAt: new Date().toISOString(),
+    sampleSize: {
+      crashPoints: matrix.length,
+      expectedExecutions: totalExpectedExecutions,
+    },
+    metrics: {
+      passRate:
+        matrix.filter((result) => result.passed).length / matrix.length,
+      duplicateRate:
+        totalExpectedExecutions === 0
+          ? 0
+          : totalDuplicateExecutions / totalExpectedExecutions,
+      maximumRecoveryRtoMs: Math.max(
+        ...matrix.map((result) => result.metrics.recoveryRtoMs),
+      ),
+    },
+    matrix,
+  };
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+} finally {
+  await Promise.allSettled(
+    [...activeChildren].map(async ({ child, closed }) => {
+      child.kill('SIGKILL');
+      await closed;
+    }),
+  );
+  await pool.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`)
+    .catch(() => undefined);
+  await pool.end();
+}

--- a/benchmarks/fixtures/effect-worker.mjs
+++ b/benchmarks/fixtures/effect-worker.mjs
@@ -1,0 +1,98 @@
+import { writeSync } from 'node:fs';
+import { Pool } from 'pg';
+import {
+  ExecutionLeaseId,
+  WorkerId,
+} from '@blade-ai/agent-sdk/core';
+import { PostgresRuntimeStore } from '@blade-ai/agent-sdk/server/postgres';
+import { effectLease } from '@blade-ai/agent-sdk/server';
+
+const [
+  connectionString,
+  schema,
+  tablePrefix,
+  tenantId,
+  effectId,
+  rawWorkerId,
+  crashPoint,
+] = process.argv.slice(2);
+
+if (
+  !connectionString
+  || !schema
+  || !tablePrefix
+  || !tenantId
+  || !effectId
+  || !rawWorkerId
+  || ![
+    'after_claim',
+    'after_start',
+    'after_side_effect',
+    'after_complete',
+  ].includes(crashPoint)
+  || !/^[A-Za-z_][A-Za-z0-9_]*$/.test(schema)
+) {
+  throw new Error(
+    'Usage: effect-worker.mjs <url> <schema> <prefix> '
+      + '<tenant> <effect> <worker> <crash-point>',
+  );
+}
+
+async function pause(checkpoint) {
+  writeSync(process.stdout.fd, `checkpoint:${checkpoint}\n`);
+  await new Promise(() => {
+    setInterval(() => undefined, 60_000);
+  });
+  throw new Error('Fault-injection worker resumed unexpectedly');
+}
+
+const workerId = WorkerId(rawWorkerId);
+const pool = new Pool({ connectionString });
+const store = new PostgresRuntimeStore({
+  pool,
+  schema,
+  tablePrefix,
+});
+
+try {
+  await store.initialize();
+  await store.registerWorker({
+    workerId,
+    capacity: 1,
+    ttlMs: 1_000,
+  });
+  const [claim] = await store.claimEffects({
+    tenantId,
+    workerId,
+    leaseId: ExecutionLeaseId(`effect-lease-${rawWorkerId}`),
+    ttlMs: 1_000,
+    limit: 1,
+  });
+  if (!claim || claim.effectId !== effectId) {
+    throw new Error(`Effect ${effectId} was not claimed`);
+  }
+  if (crashPoint === 'after_claim') {
+    await pause(crashPoint);
+  }
+
+  const lease = effectLease(claim);
+  await store.startEffect(lease);
+  if (crashPoint === 'after_start') {
+    await pause(crashPoint);
+  }
+
+  await pool.query(
+    `INSERT INTO "${schema}"."fault_effect_log" (
+       effect_id, worker_id
+     ) VALUES ($1, $2)`,
+    [effectId, workerId],
+  );
+  if (crashPoint === 'after_side_effect') {
+    await pause(crashPoint);
+  }
+
+  await store.completeEffect(lease, { delivered: true });
+  await pause('after_complete');
+} finally {
+  await pool.end();
+}

--- a/benchmarks/runtime-regression-policy.json
+++ b/benchmarks/runtime-regression-policy.json
@@ -1,0 +1,62 @@
+{
+  "schemaVersion": 1,
+  "minimumSampleSize": {
+    "sessions": 100,
+    "events": 1000,
+    "effects": 100,
+    "crashPoints": 4
+  },
+  "thresholds": {
+    "storeInitializationMs": {
+      "maximum": 5000
+    },
+    "firstClaimLatencyMs": {
+      "maximum": 2000
+    },
+    "sessionThroughputPerSecond": {
+      "minimum": 20
+    },
+    "sessionCompletionDurationMs": {
+      "maximum": 10000
+    },
+    "recoveryDurationMs": {
+      "maximum": 1000
+    },
+    "eventLossRate": {
+      "maximum": 0
+    },
+    "nonIdempotentDuplicateRate": {
+      "maximum": 0
+    },
+    "processTerminationMs": {
+      "maximum": 2000
+    },
+    "leaseExpiryWaitMs": {
+      "maximum": 2500
+    },
+    "failureDetectionMs": {
+      "maximum": 3500
+    },
+    "recoveryScanMs": {
+      "maximum": 1000
+    },
+    "reclaimAndRestoreMs": {
+      "maximum": 10000
+    },
+    "checkpointRestoreMs": {
+      "maximum": 5000
+    },
+    "fullRecoveryRtoMs": {
+      "maximum": 15000
+    },
+    "faultInjectionPassRate": {
+      "minimum": 1
+    },
+    "faultInjectionDuplicateRate": {
+      "maximum": 0
+    },
+    "maximumFaultRecoveryRtoMs": {
+      "maximum": 5000
+    }
+  }
+}

--- a/docs/en/runtime-benchmarks.md
+++ b/docs/en/runtime-benchmarks.md
@@ -22,6 +22,20 @@ The sample sizes are configurable:
 Each run creates an isolated schema and drops it on completion. The command
 prints JSON so CI or a historical metrics collector can retain and compare it.
 
+Run the complete CI regression gate with:
+
+```bash
+TEST_POSTGRES_URL=postgresql://postgres:postgres@127.0.0.1:5432/blade_agent_test \
+TEST_DOCKER_IMAGE=alpine@sha256:... \
+  pnpm verify:runtime-regression
+```
+
+This command runs the steady-state benchmark, a real Docker checkpoint
+failover, and the four-point `SIGKILL` fault matrix. It writes
+`artifacts/runtime-regression.json` and applies
+[`benchmarks/runtime-regression-policy.json`](https://github.com/echoVic/blade-agent-sdk/blob/main/benchmarks/runtime-regression-policy.json).
+PR CI retains the report for 30 days; Release CI retains it for 90 days.
+
 ## Metric definitions
 
 | Metric | Definition |
@@ -32,9 +46,48 @@ prints JSON so CI or a historical metrics collector can retain and compare it.
 | `recoveryDurationMs` | Time to recover and reclaim a Session after its lease is known to be expired |
 | `eventLossRate` | Difference between written events and cursor-paginated reads; a sequence gap also produces `1` |
 | `nonIdempotentDuplicateRate` | Duplicate at-most-once handler invocations with two concurrent dispatchers |
+| `processTerminationMs` | Time from sending `SIGKILL` until Worker process exit is observed |
+| `leaseExpiryWaitMs` | Time from process exit until the database lease expires |
+| `failureDetectionMs` | Time from `SIGKILL` until the recovery scan identifies the expired owner |
+| `recoveryScanMs` | Duration of the PostgreSQL recovery transaction |
+| `reclaimAndRestoreMs` | Time from recovery completion until Worker B restores the checkpoint and completes the Session |
+| `checkpointRestoreMs` | Isolated `DockerExecutionHost.restore()` duration |
+| `fullRecoveryRtoMs` | Time from `SIGKILL` until the recovered Session completes; this is the complete RTO |
+| `faultInjectionPassRate` | Share of crash points matching both expected executions and final status |
+| `faultInjectionDuplicateRate` | Excess non-idempotent effect executions across the fault matrix |
+| `maximumFaultRecoveryRtoMs` | Slowest kill-to-settlement time across the effect crash points |
 
 Session throughput is a Runtime upper-bound test and excludes model or external
 tool latency. `recoveryDurationMs` excludes the wait for the lease TTL itself.
+Capacity and recovery planning must use `fullRecoveryRtoMs`, not the legacy
+`recoveryDurationMs`.
+
+## CI gates
+
+CI requires at least `100` Sessions, `1000` events, `100` effects, and all four
+crash points:
+
+| Crash point | Expected executions | Expected status |
+|-------------|---------------------|-----------------|
+| `after_claim` | `1` | `completed` |
+| `after_start` | `0` | `uncertain` |
+| `after_side_effect` | `1` | `uncertain` |
+| `after_complete` | `1` | `completed` |
+
+Current absolute thresholds:
+
+- Session throughput is at least `20 sessions/s`; 100 Sessions complete within
+  `10s`.
+- Complete Docker failover RTO is at most `15s`, including failure detection
+  within `3.5s` and checkpoint restore within `5s`.
+- Kill-to-settlement RTO for every effect crash point is at most `5s`.
+- Event loss, normal concurrent duplicates, and fault-injection duplicates are
+  all exactly `0`.
+- Fault matrix pass rate is exactly `1`.
+
+These are intentionally broad absolute guardrails across CI runners, not
+machine-to-machine microbenchmark comparisons. Threshold changes require a
+reviewed policy update; sample counts cannot be reduced to bypass a gate.
 
 ## 2026-08-26 baseline
 
@@ -64,7 +117,7 @@ Raw JSON:
 
 Release regression gates:
 
-- `eventLossRate` must be `0`.
-- `nonIdempotentDuplicateRate` must be `0`.
-- Performance results must retain raw JSON and environment data. Results from
-  different machines are not directly comparable.
+- The historical JSON above is a development-machine baseline, not the sole CI
+  criterion.
+- CI applies the versioned absolute policy and retains one artifact containing
+  raw source reports, per-check results, and environment metadata.

--- a/docs/runtime-benchmarks.md
+++ b/docs/runtime-benchmarks.md
@@ -21,6 +21,19 @@ TEST_POSTGRES_URL=postgresql://postgres:postgres@127.0.0.1:5432/blade_agent_test
 脚本为每次运行创建独立 schema，并在结束时删除。它输出 JSON，CI 或历史采集器
 可以直接保存和比较结果。
 
+完整 CI 回归门禁：
+
+```bash
+TEST_POSTGRES_URL=postgresql://postgres:postgres@127.0.0.1:5432/blade_agent_test \
+TEST_DOCKER_IMAGE=alpine@sha256:... \
+  pnpm verify:runtime-regression
+```
+
+该命令执行稳态 benchmark、真实 Docker checkpoint failover 和四点 `SIGKILL`
+fault matrix，写入 `artifacts/runtime-regression.json`，再应用
+[`benchmarks/runtime-regression-policy.json`](https://github.com/echoVic/blade-agent-sdk/blob/main/benchmarks/runtime-regression-policy.json)。
+PR CI 保留报告 30 天，Release CI 保留 90 天。
+
 ## 指标定义
 
 | 指标 | 定义 |
@@ -31,9 +44,45 @@ TEST_POSTGRES_URL=postgresql://postgres:postgres@127.0.0.1:5432/blade_agent_test
 | `recoveryDurationMs` | 已确认 lease 过期后，执行恢复扫描并由第二个 worker 领取的耗时 |
 | `eventLossRate` | 写入事件数与按 cursor 分页读回事数量之差占比；sequence 不连续也记为 `1` |
 | `nonIdempotentDuplicateRate` | 两个 dispatcher 并发消费时，at-most-once effect 的重复 handler 调用占比 |
+| `processTerminationMs` | 发出 `SIGKILL` 到观察到 Worker 进程退出 |
+| `leaseExpiryWaitMs` | 进程退出到数据库 lease 到期 |
+| `failureDetectionMs` | 发出 `SIGKILL` 到 recovery scan 完成并识别失效 owner |
+| `recoveryScanMs` | PostgreSQL recovery transaction 本身耗时 |
+| `reclaimAndRestoreMs` | recovery scan 完成到第二个 Worker 恢复 checkpoint 并完成 Session |
+| `checkpointRestoreMs` | `DockerExecutionHost.restore()` 的独立耗时 |
+| `fullRecoveryRtoMs` | 发出 `SIGKILL` 到恢复后的 Session 完成；这是完整 RTO |
+| `faultInjectionPassRate` | 四个 crash point 的期望执行次数与终态全部匹配的比例 |
+| `faultInjectionDuplicateRate` | fault matrix 中超出期望次数的非幂等 effect 执行占比 |
+| `maximumFaultRecoveryRtoMs` | 四个 effect crash point 中最慢的 kill-to-settlement 耗时 |
 
 Session throughput 是运行时上限测试，不包含模型或外部工具延迟。
 `recoveryDurationMs` 不包含等待 lease TTL 到期的时间。
+容量规划和故障恢复应使用 `fullRecoveryRtoMs`，而不是旧的
+`recoveryDurationMs`。
+
+## CI 门禁
+
+CI 固定使用至少 `100` 个 Session、`1000` 个 event、`100` 个 effect，以及
+全部四个 crash point：
+
+| Crash point | 期望执行次数 | 期望终态 |
+|-------------|-------------|---------|
+| `after_claim` | `1` | `completed` |
+| `after_start` | `0` | `uncertain` |
+| `after_side_effect` | `1` | `uncertain` |
+| `after_complete` | `1` | `completed` |
+
+当前绝对阈值：
+
+- Session throughput 不低于 `20 sessions/s`；100 个 Session 在 `10s` 内完成。
+- 完整 Docker failover RTO 不超过 `15s`，其中 failure detection 不超过
+  `3.5s`、checkpoint restore 不超过 `5s`。
+- 每个 effect fault point 的 kill-to-settlement RTO 不超过 `5s`。
+- event loss、正常并发重复和 fault-injection 重复率都必须严格为 `0`。
+- fault matrix pass rate 必须为 `1`。
+
+这些是跨 CI runner 的宽松绝对 guardrail，不把不同机器上的微基准差异误判为
+回归。调整阈值必须修改版本化 policy 并接受代码审查；不能通过降低样本数绕过。
 
 ## 2026-08-26 基线
 
@@ -63,6 +112,6 @@ PostgreSQL 16.15（Colima）
 
 发布回归门槛：
 
-- `eventLossRate` 必须为 `0`。
-- `nonIdempotentDuplicateRate` 必须为 `0`。
-- 性能指标必须保留原始 JSON 和环境信息；跨机器结果不能直接比较。
+- 上述历史 JSON 是开发机基线，不是 CI 的唯一判据。
+- CI 使用版本化绝对 policy，并保留包含原始子报告、逐项 check 和环境信息的
+  完整 artifact。

--- a/examples/postgres-worker-recovery/run.mjs
+++ b/examples/postgres-worker-recovery/run.mjs
@@ -90,12 +90,15 @@ try {
   }
   const connectionString =
     `postgresql://postgres:postgres@127.0.0.1:${port}/blade_agent_example`;
-  await execFileAsync('docker', ['pull', 'alpine:3.22']);
-  const { stdout: imageOutput } = await execFileAsync(
-    'docker',
-    ['image', 'inspect', '--format', '{{index .RepoDigests 0}}', 'alpine:3.22'],
-  );
-  const image = imageOutput.trim();
+  let image = process.env.TEST_DOCKER_IMAGE;
+  if (!image) {
+    await execFileAsync('docker', ['pull', 'alpine:3.22']);
+    const { stdout: imageOutput } = await execFileAsync(
+      'docker',
+      ['image', 'inspect', '--format', '{{index .RepoDigests 0}}', 'alpine:3.22'],
+    );
+    image = imageOutput.trim();
+  }
 
   pool = new Pool({ connectionString });
   const store = new PostgresRuntimeStore({
@@ -110,8 +113,10 @@ try {
   const checkpoint = await waitForJsonLine(first);
   abandonedExecutionId = checkpoint.executionId;
   const closed = once(first, 'close');
+  const failureInjectedAt = performance.now();
   first.kill('SIGKILL');
   await closed;
+  const crashObservedAt = performance.now();
 
   const crashedRoute = await store.getSessionRoute(tenantId, sessionId);
   if (!crashedRoute?.leaseExpiresAt) {
@@ -122,16 +127,19 @@ try {
       resolve,
       Math.max(0, Date.parse(crashedRoute.leaseExpiresAt) - Date.now()) + 100,
     ));
-  const recoveryStartedAt = performance.now();
+  const leaseExpiredAt = performance.now();
+  const recoveryScanStartedAt = performance.now();
   await store.recoverExpiredWork();
+  const recoveryScanCompletedAt = performance.now();
 
   const second = startWorker('restore', connectionString, image);
-  const snapshot = await waitForJsonLine(second);
-  const [exitCode] = await once(second, 'close');
+  const secondClosed = once(second, 'close');
+  const restored = await waitForJsonLine(second);
+  const [exitCode] = await secondClosed;
   if (exitCode !== 0) {
     throw new Error(`Recovery worker exited with ${String(exitCode)}`);
   }
-  const recoveryDurationMs = performance.now() - recoveryStartedAt;
+  const recoveredAt = performance.now();
   const route = await store.getSessionRoute(tenantId, sessionId);
   process.stdout.write(JSON.stringify({
     sessionId,
@@ -139,8 +147,27 @@ try {
     finalState: route?.state,
     attempts: route?.attempt,
     fencingToken: route?.fencingToken,
-    recoveryDurationMs: Math.round(recoveryDurationMs * 100) / 100,
-    workerMetrics: snapshot.metrics,
+    metrics: {
+      processTerminationMs:
+        Math.round((crashObservedAt - failureInjectedAt) * 100) / 100,
+      leaseExpiryWaitMs:
+        Math.round((leaseExpiredAt - crashObservedAt) * 100) / 100,
+      failureDetectionMs:
+        Math.round(
+          (recoveryScanCompletedAt - failureInjectedAt) * 100,
+        ) / 100,
+      recoveryScanMs:
+        Math.round(
+          (recoveryScanCompletedAt - recoveryScanStartedAt) * 100,
+        ) / 100,
+      reclaimAndRestoreMs:
+        Math.round((recoveredAt - recoveryScanCompletedAt) * 100) / 100,
+      checkpointRestoreMs:
+        restored.executionMetrics?.checkpointRestoreMs,
+      fullRecoveryRtoMs:
+        Math.round((recoveredAt - failureInjectedAt) * 100) / 100,
+    },
+    workerMetrics: restored.snapshot?.metrics,
   }, null, 2) + '\n');
 } finally {
   const closingChildren = [...runningChildren].map(async (child) => {

--- a/examples/postgres-worker-recovery/worker.mjs
+++ b/examples/postgres-worker-recovery/worker.mjs
@@ -49,6 +49,21 @@ const host = new DockerExecutionHost({
   rootDirectory,
   checkpointDirectory,
 });
+const executionMetrics = {};
+const observedHost = {
+  provision: (request) => host.provision(request),
+  exec: (executionId, request) => host.exec(executionId, request),
+  checkpoint: (executionId, metadata) =>
+    host.checkpoint(executionId, metadata),
+  async restore(request) {
+    const startedAt = performance.now();
+    const execution = await host.restore(request);
+    executionMetrics.checkpointRestoreMs =
+      Math.round((performance.now() - startedAt) * 100) / 100;
+    return execution;
+  },
+  terminate: (executionId) => host.terminate(executionId),
+};
 const runner = new ExecutionHostSessionRunner({
   resolvePlan: () => ({
     provision: {
@@ -82,7 +97,7 @@ const worker = new AgentWorker({
   tenantId,
   capacity: 1,
   sessionRunner: runner,
-  executionHost: host,
+  executionHost: observedHost,
   workerTtlMs: 1_000,
   sessionLeaseTtlMs: 1_000,
   heartbeatIntervalMs: 200,
@@ -122,7 +137,10 @@ if (mode === 'park') {
     await new Promise((resolve) => setTimeout(resolve, 25));
   }
   await worker.shutdown();
-  process.stdout.write(JSON.stringify(worker.getSnapshot()) + '\n');
+  process.stdout.write(JSON.stringify({
+    snapshot: worker.getSnapshot(),
+    executionMetrics,
+  }) + '\n');
   await store.close();
   if (state !== 'completed') {
     throw new Error(`Restore Session ended in ${state ?? 'unknown'} state`);

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "verify:install": "pnpm run build && node scripts/verify-minimal-install.mjs",
     "verify:create-agent": "node scripts/verify-create-blade-agent.mjs",
     "verify:production-example": "node examples/production-stack/run.mjs --smoke",
+    "verify:runtime-regression": "node scripts/verify-runtime-regression.mjs",
     "changelog:check": "node scripts/semantic-release-bilingual-changelog.cjs --check",
     "release": "semantic-release",
     "release:dry": "semantic-release --dry-run --no-ci",

--- a/scripts/__tests__/node-version-policy.test.ts
+++ b/scripts/__tests__/node-version-policy.test.ts
@@ -48,6 +48,7 @@ describe('Node.js version policy', () => {
       'actions/configure-pages@v6',
       'actions/deploy-pages@v5',
       'actions/setup-node@v7',
+      'actions/upload-artifact@v6',
       'actions/upload-pages-artifact@v5',
       'pnpm/action-setup@v6',
     ]);

--- a/scripts/__tests__/runtime-benchmarks.test.ts
+++ b/scripts/__tests__/runtime-benchmarks.test.ts
@@ -19,6 +19,15 @@ interface RuntimeBenchmark {
   };
 }
 
+interface RuntimeRegressionPolicy {
+  schemaVersion: number;
+  minimumSampleSize: Record<string, number>;
+  thresholds: Record<
+    string,
+    { minimum?: number; maximum?: number }
+  >;
+}
+
 describe('runtime benchmark publication', () => {
   it('publishes a complete machine-readable baseline', () => {
     const baseline = JSON.parse(
@@ -51,5 +60,77 @@ describe('runtime benchmark publication', () => {
     expect(packageJson.scripts['benchmark:runtime']).toBe(
       'pnpm run build && node benchmarks/runtime.mjs',
     );
+    expect(packageJson.scripts['verify:runtime-regression']).toBe(
+      'node scripts/verify-runtime-regression.mjs',
+    );
+  });
+
+  it('gates the complete steady-state and failure metric set', () => {
+    const policy = JSON.parse(
+      readFileSync(
+        resolve('benchmarks/runtime-regression-policy.json'),
+        'utf8',
+      ),
+    ) as RuntimeRegressionPolicy;
+
+    expect(policy.schemaVersion).toBe(1);
+    expect(policy.minimumSampleSize).toEqual({
+      sessions: 100,
+      events: 1000,
+      effects: 100,
+      crashPoints: 4,
+    });
+    expect(Object.keys(policy.thresholds).sort()).toEqual([
+      'checkpointRestoreMs',
+      'eventLossRate',
+      'failureDetectionMs',
+      'faultInjectionDuplicateRate',
+      'faultInjectionPassRate',
+      'firstClaimLatencyMs',
+      'fullRecoveryRtoMs',
+      'leaseExpiryWaitMs',
+      'maximumFaultRecoveryRtoMs',
+      'nonIdempotentDuplicateRate',
+      'processTerminationMs',
+      'reclaimAndRestoreMs',
+      'recoveryDurationMs',
+      'recoveryScanMs',
+      'sessionCompletionDurationMs',
+      'sessionThroughputPerSecond',
+      'storeInitializationMs',
+    ]);
+    expect(policy.thresholds.eventLossRate?.maximum).toBe(0);
+    expect(policy.thresholds.nonIdempotentDuplicateRate?.maximum).toBe(0);
+    expect(policy.thresholds.faultInjectionDuplicateRate?.maximum).toBe(0);
+    expect(policy.thresholds.faultInjectionPassRate?.minimum).toBe(1);
+
+    const faultSource = readFileSync(
+      resolve('benchmarks/fault-injection.mjs'),
+      'utf8',
+    );
+    for (const crashPoint of [
+      'after_claim',
+      'after_start',
+      'after_side_effect',
+      'after_complete',
+    ]) {
+      expect(faultSource).toContain(`name: '${crashPoint}'`);
+    }
+
+    const recoverySource = readFileSync(
+      resolve('examples/postgres-worker-recovery/run.mjs'),
+      'utf8',
+    );
+    for (const metric of [
+      'processTerminationMs',
+      'leaseExpiryWaitMs',
+      'failureDetectionMs',
+      'recoveryScanMs',
+      'reclaimAndRestoreMs',
+      'checkpointRestoreMs',
+      'fullRecoveryRtoMs',
+    ]) {
+      expect(recoverySource).toContain(metric);
+    }
   });
 });

--- a/scripts/__tests__/runtime-regression-policy.test.ts
+++ b/scripts/__tests__/runtime-regression-policy.test.ts
@@ -1,0 +1,128 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+// @ts-expect-error The policy evaluator is an executable JavaScript module.
+import { evaluateRuntimeRegression } from '../runtime-regression-policy.mjs';
+
+const policy = JSON.parse(
+  readFileSync('benchmarks/runtime-regression-policy.json', 'utf8'),
+);
+
+interface SourceReports {
+  stable: {
+    sampleSize: {
+      sessions: number;
+      events: number;
+      effects: number;
+    };
+    metrics: Record<string, number>;
+  };
+  recovery: {
+    metrics: Record<string, number>;
+  };
+  faults: {
+    sampleSize: {
+      crashPoints: number;
+    };
+    metrics: Record<string, number>;
+    matrix: Array<{
+      crashPoint: string;
+      passed: boolean;
+    }>;
+  };
+}
+
+function sourceReports(): SourceReports {
+  return {
+    stable: {
+      sampleSize: {
+        sessions: 100,
+        events: 1_000,
+        effects: 100,
+      },
+      metrics: {
+        storeInitializationMs: 100,
+        firstClaimLatencyMs: 10,
+        sessionThroughputPerSecond: 100,
+        sessionCompletionDurationMs: 1_000,
+        recoveryDurationMs: 20,
+        eventLossRate: 0,
+        nonIdempotentDuplicateRate: 0,
+      },
+    },
+    recovery: {
+      metrics: {
+        processTerminationMs: 10,
+        leaseExpiryWaitMs: 1_000,
+        failureDetectionMs: 1_050,
+        recoveryScanMs: 20,
+        reclaimAndRestoreMs: 1_500,
+        checkpointRestoreMs: 500,
+        fullRecoveryRtoMs: 2_550,
+      },
+    },
+    faults: {
+      sampleSize: {
+        crashPoints: 4,
+      },
+      metrics: {
+        passRate: 1,
+        duplicateRate: 0,
+        maximumRecoveryRtoMs: 1_100,
+      },
+      matrix: [
+        { crashPoint: 'after_claim', passed: true },
+        { crashPoint: 'after_start', passed: true },
+        { crashPoint: 'after_side_effect', passed: true },
+        { crashPoint: 'after_complete', passed: true },
+      ],
+    },
+  };
+}
+
+describe('runtime regression policy', () => {
+  it('accepts a complete report within every threshold', () => {
+    const result = evaluateRuntimeRegression(policy, sourceReports());
+
+    expect(result.passed).toBe(true);
+    expect(result.failures).toEqual([]);
+    expect(
+      result.checks.every((check: { passed: boolean }) => check.passed),
+    ).toBe(true);
+  });
+
+  it('rejects reduced samples and metric regressions', () => {
+    const reports = sourceReports();
+    reports.stable.sampleSize.events = 999;
+    reports.stable.metrics.sessionThroughputPerSecond = 19;
+    reports.recovery.metrics.fullRecoveryRtoMs = 15_001;
+    reports.faults.metrics.duplicateRate = 0.01;
+
+    const result = evaluateRuntimeRegression(policy, reports);
+
+    expect(result.passed).toBe(false);
+    expect(result.failures).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('sampleSize.events=999'),
+        expect.stringContaining('sessionThroughputPerSecond=19'),
+        expect.stringContaining('fullRecoveryRtoMs=15001'),
+        expect.stringContaining('faultInjectionDuplicateRate=0.01'),
+      ]),
+    );
+  });
+
+  it('rejects an incomplete or failed crash matrix', () => {
+    const reports = sourceReports();
+    reports.faults.matrix = reports.faults.matrix.slice(0, 3);
+    reports.faults.metrics.passRate = 0.75;
+
+    const result = evaluateRuntimeRegression(policy, reports);
+
+    expect(result.passed).toBe(false);
+    expect(result.failures).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('faultInjectionPassRate=0.75'),
+        'Fault injection matrix is incomplete or contains a failed crash point',
+      ]),
+    );
+  });
+});

--- a/scripts/__tests__/semantic-release-config.test.ts
+++ b/scripts/__tests__/semantic-release-config.test.ts
@@ -92,6 +92,9 @@ describe('release workflow', () => {
     const releaseStep = steps.find((step: { run?: string }) =>
       step.run?.includes('semantic-release')
     );
+    const regressionArtifact = steps.find((step: { uses?: string }) =>
+      step.uses?.startsWith('actions/upload-artifact@')
+    );
 
     expect(commands).toEqual([
       'npm install -g npm@^11.5.1',
@@ -112,6 +115,7 @@ describe('release workflow', () => {
       ].join('\n'),
       'pnpm run verify:create-agent',
       'pnpm run verify:production-example',
+      'pnpm run verify:runtime-regression',
       'pnpm run docs:build',
       'pnpm run test',
       'pnpm exec semantic-release',
@@ -125,6 +129,14 @@ describe('release workflow', () => {
     });
     expect(releaseStep.env).not.toHaveProperty('NPM_TOKEN');
     expect(releaseStep.env).not.toHaveProperty('NPM_CONFIG_PROVENANCE');
+    expect(regressionArtifact).toMatchObject({
+      if: "${{ always() && hashFiles('artifacts/runtime-regression.json') != '' }}",
+      with: {
+        name: 'runtime-regression-release',
+        path: 'artifacts/runtime-regression.json',
+        'retention-days': 90,
+      },
+    });
   });
 });
 
@@ -136,6 +148,9 @@ describe('pull request workflow', () => {
     const steps = workflow.jobs.verify.steps;
     const checkout = steps.find((step: { uses?: string }) =>
       step.uses?.startsWith('actions/checkout@')
+    );
+    const regressionArtifact = steps.find((step: { uses?: string }) =>
+      step.uses?.startsWith('actions/upload-artifact@')
     );
     const commands = steps
       .map((step: { run?: string }) => step.run)
@@ -162,6 +177,15 @@ describe('pull request workflow', () => {
     );
     expect(commands).toContain('pnpm run verify:create-agent');
     expect(commands).toContain('pnpm run verify:production-example');
+    expect(commands).toContain('pnpm run verify:runtime-regression');
     expect(commands).toContain('pnpm run docs:build');
+    expect(regressionArtifact).toMatchObject({
+      if: "${{ always() && hashFiles('artifacts/runtime-regression.json') != '' }}",
+      with: {
+        name: 'runtime-regression-node-${{ matrix.node-version }}',
+        path: 'artifacts/runtime-regression.json',
+        'retention-days': 30,
+      },
+    });
   });
 });

--- a/scripts/runtime-regression-policy.mjs
+++ b/scripts/runtime-regression-policy.mjs
@@ -1,0 +1,163 @@
+const EXPECTED_CRASH_POINTS = [
+  'after_claim',
+  'after_start',
+  'after_side_effect',
+  'after_complete',
+];
+
+function requireNumber(value, name) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new Error(`Runtime regression metric ${name} is missing or non-finite`);
+  }
+  return value;
+}
+
+function evaluateMetric(name, value, threshold) {
+  const failures = [];
+  if (threshold.minimum !== undefined && value < threshold.minimum) {
+    failures.push(`${name}=${value} is below minimum ${threshold.minimum}`);
+  }
+  if (threshold.maximum !== undefined && value > threshold.maximum) {
+    failures.push(`${name}=${value} exceeds maximum ${threshold.maximum}`);
+  }
+  return {
+    name,
+    value,
+    ...threshold,
+    passed: failures.length === 0,
+    failures,
+  };
+}
+
+export function evaluateRuntimeRegression(policy, sourceReports) {
+  if (policy.schemaVersion !== 1) {
+    throw new Error(`Unsupported runtime regression policy ${policy.schemaVersion}`);
+  }
+  const { stable, recovery, faults } = sourceReports;
+  const metrics = {
+    storeInitializationMs: requireNumber(
+      stable.metrics?.storeInitializationMs,
+      'storeInitializationMs',
+    ),
+    firstClaimLatencyMs: requireNumber(
+      stable.metrics?.firstClaimLatencyMs,
+      'firstClaimLatencyMs',
+    ),
+    sessionThroughputPerSecond: requireNumber(
+      stable.metrics?.sessionThroughputPerSecond,
+      'sessionThroughputPerSecond',
+    ),
+    sessionCompletionDurationMs: requireNumber(
+      stable.metrics?.sessionCompletionDurationMs,
+      'sessionCompletionDurationMs',
+    ),
+    recoveryDurationMs: requireNumber(
+      stable.metrics?.recoveryDurationMs,
+      'recoveryDurationMs',
+    ),
+    eventLossRate: requireNumber(
+      stable.metrics?.eventLossRate,
+      'eventLossRate',
+    ),
+    nonIdempotentDuplicateRate: requireNumber(
+      stable.metrics?.nonIdempotentDuplicateRate,
+      'nonIdempotentDuplicateRate',
+    ),
+    processTerminationMs: requireNumber(
+      recovery.metrics?.processTerminationMs,
+      'processTerminationMs',
+    ),
+    leaseExpiryWaitMs: requireNumber(
+      recovery.metrics?.leaseExpiryWaitMs,
+      'leaseExpiryWaitMs',
+    ),
+    failureDetectionMs: requireNumber(
+      recovery.metrics?.failureDetectionMs,
+      'failureDetectionMs',
+    ),
+    recoveryScanMs: requireNumber(
+      recovery.metrics?.recoveryScanMs,
+      'recoveryScanMs',
+    ),
+    reclaimAndRestoreMs: requireNumber(
+      recovery.metrics?.reclaimAndRestoreMs,
+      'reclaimAndRestoreMs',
+    ),
+    checkpointRestoreMs: requireNumber(
+      recovery.metrics?.checkpointRestoreMs,
+      'checkpointRestoreMs',
+    ),
+    fullRecoveryRtoMs: requireNumber(
+      recovery.metrics?.fullRecoveryRtoMs,
+      'fullRecoveryRtoMs',
+    ),
+    faultInjectionPassRate: requireNumber(
+      faults.metrics?.passRate,
+      'faultInjectionPassRate',
+    ),
+    faultInjectionDuplicateRate: requireNumber(
+      faults.metrics?.duplicateRate,
+      'faultInjectionDuplicateRate',
+    ),
+    maximumFaultRecoveryRtoMs: requireNumber(
+      faults.metrics?.maximumRecoveryRtoMs,
+      'maximumFaultRecoveryRtoMs',
+    ),
+  };
+  const sampleSize = {
+    sessions: requireNumber(stable.sampleSize?.sessions, 'sampleSize.sessions'),
+    events: requireNumber(stable.sampleSize?.events, 'sampleSize.events'),
+    effects: requireNumber(stable.sampleSize?.effects, 'sampleSize.effects'),
+    crashPoints: requireNumber(
+      faults.sampleSize?.crashPoints,
+      'sampleSize.crashPoints',
+    ),
+  };
+  const sampleChecks = Object.entries(policy.minimumSampleSize).map(
+    ([name, minimum]) => ({
+      name: `sampleSize.${name}`,
+      value: sampleSize[name],
+      minimum,
+      passed: sampleSize[name] >= minimum,
+      failures:
+        sampleSize[name] >= minimum
+          ? []
+          : [`sampleSize.${name}=${sampleSize[name]} is below minimum ${minimum}`],
+    }),
+  );
+  const metricChecks = Object.entries(policy.thresholds).map(
+    ([name, threshold]) =>
+      evaluateMetric(name, metrics[name], threshold),
+  );
+  const faultInjectionMatrix = Array.isArray(faults.matrix)
+    ? faults.matrix
+    : [];
+  const observedCrashPoints = faultInjectionMatrix
+    .map((entry) => entry.crashPoint)
+    .sort();
+  const matrixCheck = {
+    name: 'faultInjectionMatrix',
+    value: observedCrashPoints,
+    expected: [...EXPECTED_CRASH_POINTS].sort(),
+    passed:
+      JSON.stringify(observedCrashPoints)
+      === JSON.stringify([...EXPECTED_CRASH_POINTS].sort())
+      && faultInjectionMatrix.every((entry) => entry.passed),
+    failures: [],
+  };
+  if (!matrixCheck.passed) {
+    matrixCheck.failures.push(
+      'Fault injection matrix is incomplete or contains a failed crash point',
+    );
+  }
+  const checks = [...sampleChecks, ...metricChecks, matrixCheck];
+  const failures = checks.flatMap((check) => check.failures);
+  return {
+    passed: failures.length === 0,
+    sampleSize,
+    metrics,
+    checks,
+    failures,
+    faultInjectionMatrix,
+  };
+}

--- a/scripts/verify-runtime-regression.mjs
+++ b/scripts/verify-runtime-regression.mjs
@@ -1,0 +1,83 @@
+import { execFile } from 'node:child_process';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { promisify } from 'node:util';
+import { evaluateRuntimeRegression } from './runtime-regression-policy.mjs';
+
+const execFileAsync = promisify(execFile);
+const root = resolve(import.meta.dirname, '..');
+const policyPath = resolve(root, 'benchmarks/runtime-regression-policy.json');
+const reportPath = resolve(
+  root,
+  process.env.RUNTIME_REGRESSION_REPORT_PATH
+    || 'artifacts/runtime-regression.json',
+);
+
+async function runJson(script, timeoutMs = 120_000) {
+  const { stdout, stderr } = await execFileAsync(
+    process.execPath,
+    [resolve(root, script)],
+    {
+      cwd: root,
+      env: process.env,
+      encoding: 'utf8',
+      maxBuffer: 10 * 1024 * 1024,
+      timeout: timeoutMs,
+    },
+  );
+  try {
+    return JSON.parse(stdout);
+  } catch (error) {
+    throw new Error(
+      `Could not parse JSON from ${script}: ${
+        error instanceof Error ? error.message : String(error)
+      }\nstdout=${stdout}\nstderr=${stderr}`,
+    );
+  }
+}
+
+const policy = JSON.parse(await readFile(policyPath, 'utf8'));
+const stable = await runJson('benchmarks/runtime.mjs');
+const recovery = await runJson(
+  'examples/postgres-worker-recovery/run.mjs',
+);
+const faults = await runJson('benchmarks/fault-injection.mjs');
+const evaluation = evaluateRuntimeRegression(policy, {
+  stable,
+  recovery,
+  faults,
+});
+const report = {
+  schemaVersion: 1,
+  generatedAt: new Date().toISOString(),
+  passed: evaluation.passed,
+  environment: {
+    ...stable.environment,
+    dockerImage: process.env.TEST_DOCKER_IMAGE,
+  },
+  sampleSize: evaluation.sampleSize,
+  metrics: evaluation.metrics,
+  policy,
+  checks: evaluation.checks,
+  faultInjectionMatrix: evaluation.faultInjectionMatrix,
+  sourceReports: {
+    stable,
+    recovery,
+    faults,
+  },
+};
+
+await mkdir(dirname(reportPath), { recursive: true });
+await writeFile(reportPath, `${JSON.stringify(report, null, 2)}\n`);
+process.stdout.write(`${JSON.stringify({
+  passed: report.passed,
+  reportPath,
+  sampleSize: report.sampleSize,
+  metrics: report.metrics,
+}, null, 2)}\n`);
+
+if (!evaluation.passed) {
+  throw new Error(
+    `Runtime regression gate failed:\n- ${evaluation.failures.join('\n- ')}`,
+  );
+}


### PR DESCRIPTION
## Summary

- gate PR and Release CI on a versioned absolute Runtime regression policy
- measure steady-state Session throughput, event loss, and concurrent at-most-once effect duplicates
- measure complete Docker failover RTO from SIGKILL through lease expiry, recovery scan, reclaim, checkpoint restore, and Session completion
- run all four non-idempotent effect crash points and require exact executions and final statuses
- upload the complete JSON report for 30 days in PR CI and 90 days in Release CI

## Required samples

- 100 Sessions
- 1,000 events
- 100 effects
- all four crash points: after_claim, after_start, after_side_effect, after_complete

## Local measured result

- Session throughput: 101.98 sessions/s
- complete Docker failover RTO: 2295.70ms
- checkpoint restore: 454.25ms
- maximum effect fault RTO: 1017.86ms
- event loss: 0
- normal concurrent duplicate rate: 0
- fault-injection duplicate rate: 0
- fault matrix pass rate: 1

## Verification

- `pnpm verify:runtime-regression`
- type-check, lint, docs build, changelog check
- policy positive and negative tests
- full suite: 1859 passed, 63 credential-gated live tests skipped

Patch-only semantic release target: `v6.0.4`.