### PR TITLE
fix(cli): add progressive starter presets

### DIFF
--- a/.changes/starter-presets.json
+++ b/.changes/starter-presets.json
@@ -1,0 +1,5 @@
+{
+  "type": "fix",
+  "en": "Add dependency-minimal local and Web create-blade-agent presets while preserving the production default.",
+  "zh-CN": "为 create-blade-agent 增加依赖极简的 local 与 Web preset，同时保留 production 默认行为。"
+}

--- a/README.md
+++ b/README.md
@@ -19,22 +19,36 @@ npm install @blade-ai/agent-sdk
 pnpm add @blade-ai/agent-sdk
 ```
 
-## Create a Full-Stack Agent
+## Choose a Starting Point
 
-With Node.js 22.14+ and Docker running, generate, install, and verify a
-standalone production-topology project in one command:
+Create a local Node.js Agent without PostgreSQL or Docker:
 
 ```bash
 npm exec --yes --package=@blade-ai/agent-sdk@latest -- \
-  create-blade-agent my-agent --verify
+  create-blade-agent my-agent --preset local --verify
 ```
 
-The generated project includes a browser client, `AgentServer`, PostgreSQL,
-`AgentWorker`, `DockerExecutionHost`, health probes, queue metrics, and
-uncertain-effect operations. The `--verify` budget covers project generation,
-dependency installation, and the first Docker-produced result, and fails after
-five minutes. Omit `--verify` to generate and install without starting the
-stack; use `--skip-install` for files only.
+Create a Browser + AgentServer application with in-process Sessions:
+
+```bash
+npm exec --yes --package=@blade-ai/agent-sdk@latest -- \
+  create-blade-agent my-agent --preset web --verify
+```
+
+Create the complete production topology:
+
+```bash
+npm exec --yes --package=@blade-ai/agent-sdk@latest -- \
+  create-blade-agent my-agent --preset production --verify
+```
+
+All three presets use the same Session and protocol semantics. Their
+generation, installation, and real-smoke budgets are one minute for `local`,
+two minutes for `web`, and five minutes for `production`. The production
+preset includes the browser client, `AgentServer`, PostgreSQL, `AgentWorker`,
+`DockerExecutionHost`, and operations endpoints. Omitting `--preset` preserves
+the production default. Omit `--verify` to avoid running the smoke, or use
+`--skip-install` to write files only.
 
 ## Quick Start
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -19,20 +19,34 @@ npm install @blade-ai/agent-sdk
 pnpm add @blade-ai/agent-sdk
 ```
 
-## 创建完整生产拓扑 Agent
+## 选择起点
 
-本机具备 Node.js 22.14+ 和 Docker 时，可以用一条命令生成独立项目、安装依赖并
-完成验收：
+只需本地 Node.js、无需 PostgreSQL 或 Docker：
 
 ```bash
 npm exec --yes --package=@blade-ai/agent-sdk@latest -- \
-  create-blade-agent my-agent --verify
+  create-blade-agent my-agent --preset local --verify
 ```
 
-生成项目包含浏览器客户端、`AgentServer`、PostgreSQL、`AgentWorker`、
-`DockerExecutionHost`、健康检查、队列指标和 uncertain effect 运维入口。
-`--verify` 的五分钟预算覆盖项目生成、依赖安装和 Docker 首次结果；超时会直接
-失败。省略 `--verify` 时只生成并安装，使用 `--skip-install` 时只生成文件。
+创建 Browser + AgentServer 应用、使用进程内 Session：
+
+```bash
+npm exec --yes --package=@blade-ai/agent-sdk@latest -- \
+  create-blade-agent my-agent --preset web --verify
+```
+
+创建完整生产拓扑：
+
+```bash
+npm exec --yes --package=@blade-ai/agent-sdk@latest -- \
+  create-blade-agent my-agent --preset production --verify
+```
+
+三个 preset 使用同一套 Session 与协议语义。`local` 的首次结果预算为一分钟，
+`web` 为两分钟，`production` 为五分钟；预算均覆盖生成、依赖安装和实际 smoke。
+`production` 包含浏览器客户端、`AgentServer`、PostgreSQL、`AgentWorker`、
+`DockerExecutionHost` 和运维入口。省略 `--preset` 时仍生成 production
+拓扑；省略 `--verify` 时只生成并安装，使用 `--skip-install` 时只生成文件。
 
 ## 快速开始
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -7,8 +7,9 @@ OpenTelemetry、非内置 Provider adapter 与原生 Node 增强使用可选 pee
 `/server` 不再静态加载对应 adapter。部分依赖仍可能由基础依赖间接安装。
 
 包还提供 `create-blade-agent` 可执行文件。它通过
-`--preset <local|web|production>` 生成并验收独立项目；省略 `--preset` 时保持
-production 默认值。该 CLI 不属于 JavaScript package export；通过 npm bin 调用。
+`--preset <local|web|production>` 选择生成项目的拓扑，`--verify` 负责安装后
+验收；省略 `--preset` 时保持 production 默认值。该 CLI 不属于 JavaScript
+package export；通过 npm bin 调用。
 
 ## 包入口
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -6,8 +6,9 @@
 OpenTelemetry、非内置 Provider adapter 与原生 Node 增强使用可选 peer dependency；
 `/server` 不再静态加载对应 adapter。部分依赖仍可能由基础依赖间接安装。
 
-包还提供 `create-blade-agent` 可执行文件，用于生成并验收独立的完整生产拓扑项目。
-该 CLI 不属于 JavaScript package export；通过 npm bin 调用。
+包还提供 `create-blade-agent` 可执行文件。它通过
+`--preset <local|web|production>` 生成并验收独立项目；省略 `--preset` 时保持
+production 默认值。该 CLI 不属于 JavaScript package export；通过 npm bin 调用。
 
 ## 包入口
 

--- a/docs/en/api-reference.md
+++ b/docs/en/api-reference.md
@@ -8,9 +8,10 @@ enhancements are optional peers, and `/server` no longer statically loads their 
 Some packages can still be present transitively through base dependencies.
 
 The package also ships the `create-blade-agent` executable. Its
-`--preset <local|web|production>` option generates and verifies a standalone
-topology; omitting `--preset` preserves the production default. It is an npm
-binary, not a JavaScript package export.
+`--preset <local|web|production>` option selects the generated project
+topology, while `--verify` enables post-installation verification. Omitting
+`--preset` preserves the production default. It is an npm binary, not a
+JavaScript package export.
 
 ## Entry points
 

--- a/docs/en/api-reference.md
+++ b/docs/en/api-reference.md
@@ -7,9 +7,10 @@ PostgreSQL, OpenTelemetry, non-bundled provider adapters, and native Node
 enhancements are optional peers, and `/server` no longer statically loads their adapters.
 Some packages can still be present transitively through base dependencies.
 
-The package also ships the `create-blade-agent` executable for generating and
-verifying a standalone full production topology. It is an npm binary, not a
-JavaScript package export.
+The package also ships the `create-blade-agent` executable. Its
+`--preset <local|web|production>` option generates and verifies a standalone
+topology; omitting `--preset` preserves the production default. It is an npm
+binary, not a JavaScript package export.
 
 ## Entry points
 

--- a/docs/en/golden-paths.md
+++ b/docs/en/golden-paths.md
@@ -41,20 +41,41 @@ Session.
 
 ## Generate a standalone project
 
-The published SDK includes the `create-blade-agent` executable. This command
-temporarily installs the CLI, generates a standalone project, installs its
-dependencies, and runs the complete production smoke:
+The published SDK includes the `create-blade-agent` executable. Select the
+required topology with `--preset`:
+
+| Preset | Path | Extra infrastructure | First-result budget |
+|--------|------|----------------------|---------------------|
+| `local` | Node + in-memory Session | None | 1 minute |
+| `web` | Browser AgentClient → AgentServer → in-process Session | None | 2 minutes |
+| `production` | Browser → AgentServer → PostgreSQL → Worker → Docker | Docker | 5 minutes |
+
+Minimal local Agent:
 
 ```bash
 npm exec --yes --package=@blade-ai/agent-sdk@latest -- \
-  create-blade-agent my-agent --verify
+  create-blade-agent my-agent --preset local --verify
 ```
 
-The five-minute budget starts with the CLI and covers generation, installation,
-PostgreSQL orchestration, Worker startup, and the first Docker-produced result.
-PR and Release CI install the CLI from the current SDK tarball, run the same
-flow, and audit the generated production dependency tree. Omit `--verify` to
-avoid starting the stack; `--skip-install` writes files only.
+Web Agent:
+
+```bash
+npm exec --yes --package=@blade-ai/agent-sdk@latest -- \
+  create-blade-agent my-agent --preset web --verify
+```
+
+Complete production topology:
+
+```bash
+npm exec --yes --package=@blade-ai/agent-sdk@latest -- \
+  create-blade-agent my-agent --preset production --verify
+```
+
+Each budget starts with the CLI and covers generation, installation, and the
+first real smoke result. PR and Release CI install the CLI from the current SDK
+tarball, run all three presets, and audit every generated production dependency
+tree. Omitting `--preset` preserves the production default. Omit `--verify` to
+avoid running the smoke; `--skip-install` writes files only.
 
 ## Local CLI Agent
 

--- a/docs/golden-paths.md
+++ b/docs/golden-paths.md
@@ -37,18 +37,40 @@ Docker worker 生成的精确结果后才成功。
 
 ## 生成独立项目
 
-已发布的 SDK 自带 `create-blade-agent` 可执行文件。以下单命令会临时安装 CLI、
-生成独立项目、安装项目依赖并运行完整 production smoke：
+已发布的 SDK 自带 `create-blade-agent` 可执行文件。使用 `--preset` 选择所需
+拓扑：
+
+| Preset | 路径 | 额外基础设施 | 首次结果预算 |
+|--------|------|--------------|----------------|
+| `local` | Node + 进程内 Session | 无 | 1 分钟 |
+| `web` | Browser AgentClient → AgentServer → 进程内 Session | 无 | 2 分钟 |
+| `production` | Browser → AgentServer → PostgreSQL → Worker → Docker | Docker | 5 分钟 |
+
+最小本地 Agent：
 
 ```bash
 npm exec --yes --package=@blade-ai/agent-sdk@latest -- \
-  create-blade-agent my-agent --verify
+  create-blade-agent my-agent --preset local --verify
 ```
 
-五分钟预算从 CLI 启动开始计算，覆盖生成、安装、PostgreSQL 编排、Worker
-启动和首个 Docker 结果。PR 与 Release CI 会从当前 SDK tarball 安装 CLI，
-执行相同流程，并对生成项目运行 production dependency audit。省略 `--verify`
-时不会启动 stack；`--skip-install` 只生成文件。
+Web Agent：
+
+```bash
+npm exec --yes --package=@blade-ai/agent-sdk@latest -- \
+  create-blade-agent my-agent --preset web --verify
+```
+
+完整生产拓扑：
+
+```bash
+npm exec --yes --package=@blade-ai/agent-sdk@latest -- \
+  create-blade-agent my-agent --preset production --verify
+```
+
+预算从 CLI 启动开始计算，覆盖生成、安装和首个真实结果。PR 与 Release CI
+会从当前 SDK tarball 安装 CLI，执行三个 preset，并分别审计生成项目的
+production dependency tree。省略 `--preset` 时保持原有 production 默认值；
+省略 `--verify` 时不会执行 smoke；`--skip-install` 只生成文件。
 
 ## 本地 CLI Agent
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -38,15 +38,22 @@ pnpm verify:production-example
 The smoke command prints `firstResultMs` and fails unless the browser protocol
 receives the exact output produced by the Docker worker within five minutes.
 
-Generate this topology as an independent project from the published package:
+Generate any Golden Path as an independent project from the published package:
 
 ```bash
 npm exec --yes --package=@blade-ai/agent-sdk@latest -- \
-  create-blade-agent my-agent --verify
+  create-blade-agent my-agent --preset local --verify
+
+npm exec --yes --package=@blade-ai/agent-sdk@latest -- \
+  create-blade-agent my-agent --preset web --verify
+
+npm exec --yes --package=@blade-ai/agent-sdk@latest -- \
+  create-blade-agent my-agent --preset production --verify
 ```
 
-The CLI installs the generated dependencies and includes setup time in the
-five-minute first-result budget.
+The CLI installs the generated dependencies and includes setup time in each
+first-result budget: one minute for local, two minutes for Web, and five minutes
+for production. Omitting `--preset` keeps the production default.
 
 ## Local CLI Agent
 

--- a/examples/local-cli-agent/index.mjs
+++ b/examples/local-cli-agent/index.mjs
@@ -6,7 +6,8 @@ import {
 } from '@blade-ai/agent-sdk/node';
 
 const apiKey = process.env.OPENAI_API_KEY;
-const useDemoProvider = process.env.BLADE_DEMO_MODE === 'mock';
+const smoke = process.argv.includes('--smoke');
+const useDemoProvider = smoke || process.env.BLADE_DEMO_MODE === 'mock';
 if (!apiKey && !useDemoProvider) {
   throw new Error(
     'Set OPENAI_API_KEY, or set BLADE_DEMO_MODE=mock for an offline smoke test',
@@ -46,14 +47,21 @@ const demoProvider = new ProviderRegistry([{
   },
 }]);
 
-const promptArguments = process.argv.slice(2);
+const promptArguments = process.argv.slice(2).filter((argument) => argument !== '--smoke');
 const prompt =
   (promptArguments[0] === '--' ? promptArguments.slice(1) : promptArguments)
     .join(' ')
     .trim()
-  || 'Inspect this repository and summarize its public API.';
-const storagePath = resolve('.data/local-cli-agent');
-await mkdir(storagePath, { recursive: true });
+  || (smoke
+    ? 'minimal local starter smoke'
+    : 'Inspect this repository and summarize its public API.');
+const persistSession = true;
+const storagePath = persistSession
+  ? resolve('.data/local-cli-agent')
+  : undefined;
+if (storagePath) {
+  await mkdir(storagePath, { recursive: true });
+}
 
 const session = await createSession({
   provider: useDemoProvider
@@ -61,7 +69,7 @@ const session = await createSession({
     : { type: 'openai', apiKey },
   providerRegistry: useDemoProvider ? demoProvider : undefined,
   model: useDemoProvider ? 'demo' : process.env.OPENAI_MODEL || 'gpt-5-mini',
-  storagePath,
+  ...(storagePath ? { storagePath } : {}),
   defaultContext: {
     capabilities: {
       filesystem: {

--- a/examples/web-agent-server/server.mjs
+++ b/examples/web-agent-server/server.mjs
@@ -182,6 +182,7 @@ async function runSmoke(baseUrl) {
     resolveResult = resolve;
     rejectResult = reject;
   });
+  void resultReceived.catch(() => undefined);
   const events = (async () => {
     let output = '';
     try {

--- a/examples/web-agent-server/server.mjs
+++ b/examples/web-agent-server/server.mjs
@@ -4,12 +4,16 @@ import { dirname, join } from 'node:path';
 import { Readable } from 'node:stream';
 import { fileURLToPath } from 'node:url';
 import { build } from 'esbuild';
+import { AgentClient } from '@blade-ai/agent-sdk/browser';
 import {
   AgentServer,
   ProviderRegistry,
 } from '@blade-ai/agent-sdk/server';
 
 const apiKey = process.env.OPENAI_API_KEY;
+const smoke = process.argv.includes('--smoke');
+const startedAt = performance.now();
+const FIRST_RESULT_BUDGET_MS = 2 * 60 * 1_000;
 const demoProvider = new ProviderRegistry([{
   type: 'golden-path-demo',
   create(config) {
@@ -44,10 +48,11 @@ const demoProvider = new ProviderRegistry([{
 }]);
 
 const root = dirname(fileURLToPath(import.meta.url));
+const webRoot = root;
 const generated = join(root, '.generated');
 await mkdir(generated, { recursive: true });
 await build({
-  entryPoints: [join(root, 'client.js')],
+  entryPoints: [join(webRoot, 'client.js')],
   outfile: join(generated, 'client.js'),
   bundle: true,
   format: 'esm',
@@ -90,7 +95,7 @@ const server = createServer(async (request, response) => {
   try {
     const url = new URL(request.url || '/', 'http://127.0.0.1');
     if (request.method === 'GET' && url.pathname === '/') {
-      const html = await readFile(join(root, 'index.html'));
+      const html = await readFile(join(webRoot, 'index.html'));
       response.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
       response.end(html);
       return;
@@ -126,15 +131,147 @@ const server = createServer(async (request, response) => {
   }
 });
 
-const port = Number(process.env.PORT || 8787);
-server.listen(port, '127.0.0.1', () => {
-  process.stdout.write(`Web Agent example: http://127.0.0.1:${port}\n`);
-});
+function listen(port) {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(port, '127.0.0.1', () => {
+      server.removeListener('error', reject);
+      resolve();
+    });
+  });
+}
 
+function closeServer() {
+  return new Promise((resolve, reject) => {
+    if (!server.listening) {
+      resolve();
+      return;
+    }
+    server.close((error) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    });
+    server.closeAllConnections();
+  });
+}
+
+async function runSmoke(baseUrl) {
+  const client = new AgentClient({
+    baseUrl: `${baseUrl}/v1/agent`,
+    client: {
+      name: 'blade-web-starter-smoke',
+      version: '1.0.0',
+    },
+    headers: {
+      authorization: 'Bearer local-demo',
+    },
+  });
+  const session = await client.createSession({ source: 'web-starter-smoke' });
+  const eventController = new AbortController();
+  const deadline = setTimeout(
+    () => eventController.abort(new Error('Two-minute Web first-result budget exceeded')),
+    Math.max(1, FIRST_RESULT_BUDGET_MS - (performance.now() - startedAt)),
+  );
+  let resolveResult;
+  let rejectResult;
+  let resultSettled = false;
+  const resultReceived = new Promise((resolve, reject) => {
+    resolveResult = resolve;
+    rejectResult = reject;
+  });
+  const events = (async () => {
+    let output = '';
+    try {
+      for await (const event of session.events({ signal: eventController.signal })) {
+        if (event.type === 'session.stream' && event.data.type === 'content') {
+          output += event.data.delta;
+        }
+        if (event.type === 'session.stream' && event.data.type === 'result') {
+          resultSettled = true;
+          resolveResult({
+            output,
+            result: event.data,
+          });
+        }
+        if (event.type === 'session.closed') {
+          if (!resultSettled) {
+            rejectResult(new Error('Session closed before producing a result'));
+          }
+          return;
+        }
+      }
+      throw new Error('Session event stream ended before session.closed');
+    } catch (error) {
+      if (!resultSettled) {
+        rejectResult(error);
+      }
+      throw error;
+    }
+  })();
+  try {
+    const input = 'minimal web starter smoke';
+    await session.send(input);
+    const completed = await resultReceived;
+    const expected = `AgentServer received: ${input}`;
+    if (completed.output !== expected || completed.result.subtype !== 'success') {
+      throw new Error(`Unexpected Web starter result: ${JSON.stringify(completed)}`);
+    }
+    const firstResultMs = Math.round((performance.now() - startedAt) * 100) / 100;
+    if (firstResultMs > FIRST_RESULT_BUDGET_MS) {
+      throw new Error(`Web first result exceeded ${FIRST_RESULT_BUDGET_MS}ms`);
+    }
+    await session.close();
+    await events;
+    return {
+      firstResultMs,
+      output: completed.output,
+    };
+  } finally {
+    clearTimeout(deadline);
+    eventController.abort();
+    await events.catch(() => undefined);
+  }
+}
+
+let shutdownStarted = false;
 async function shutdown() {
-  server.close();
+  if (shutdownStarted) {
+    return;
+  }
+  shutdownStarted = true;
+  await closeServer();
   await agent.close();
 }
 
-process.once('SIGINT', shutdown);
-process.once('SIGTERM', shutdown);
+for (const signal of ['SIGINT', 'SIGTERM']) {
+  process.once(signal, () => {
+    void shutdown().then(
+      () => process.exit(0),
+      (error) => {
+        process.stderr.write(`${error instanceof Error ? error.stack : String(error)}\n`);
+        process.exit(1);
+      },
+    );
+  });
+}
+
+const requestedPort = smoke ? 0 : Number(process.env.PORT || 8787);
+await listen(requestedPort);
+const address = server.address();
+if (!address || typeof address === 'string') {
+  throw new Error('Web Agent example did not expose a TCP address');
+}
+const baseUrl = `http://127.0.0.1:${address.port}`;
+
+if (smoke) {
+  try {
+    process.stdout.write(`${JSON.stringify(await runSmoke(baseUrl), null, 2)}\n`);
+  } finally {
+    await shutdown();
+  }
+} else {
+  process.stdout.write(`Web Agent example: ${baseUrl}\n`);
+}

--- a/package.json
+++ b/package.json
@@ -83,8 +83,10 @@
   "files": [
     "dist",
     "examples/production-stack",
+    "examples/local-cli-agent/index.mjs",
     "examples/web-agent-server/client.js",
     "examples/web-agent-server/index.html",
+    "examples/web-agent-server/server.mjs",
     "vendor/ripgrep/**",
     "README.md",
     "README.zh-CN.md",

--- a/scripts/__tests__/golden-paths.test.ts
+++ b/scripts/__tests__/golden-paths.test.ts
@@ -88,7 +88,7 @@ describe('golden paths', () => {
     expect(html).not.toMatch(/(?:src|href)=["']https?:\/\//);
   });
 
-  it('documents the installed create-blade-agent verification path in both locales', () => {
+  it('documents every installed create-blade-agent preset in both locales', () => {
     for (const file of [
       'README.md',
       'README.zh-CN.md',
@@ -96,7 +96,11 @@ describe('golden paths', () => {
       'docs/en/golden-paths.md',
     ]) {
       const source = readFileSync(resolve(file), 'utf8');
-      expect(source, file).toContain('create-blade-agent my-agent --verify');
+      for (const preset of ['local', 'web', 'production']) {
+        expect(source, file).toContain(
+          `create-blade-agent my-agent --preset ${preset} --verify`,
+        );
+      }
       expect(source, file).toMatch(/five minutes|five-minute|五分钟/);
     }
   });

--- a/scripts/verify-create-blade-agent.mjs
+++ b/scripts/verify-create-blade-agent.mjs
@@ -14,12 +14,36 @@ const execFileAsync = promisify(execFile);
 const repoRoot = resolve(import.meta.dirname, '..');
 const temporaryRoot = await mkdtemp(join(tmpdir(), 'create-blade-agent-'));
 const launcherDirectory = join(temporaryRoot, 'launcher');
-const filesOnlyDirectory = join(temporaryRoot, 'files-only-agent');
-const projectDirectory = join(temporaryRoot, 'generated-agent');
-const budgetMs = 5 * 60 * 1_000;
-const startedAt = performance.now();
+const presetContracts = {
+  local: {
+    budgetMs: 60 * 1_000,
+    expectedOutput: 'Local Agent received: minimal local starter smoke',
+    files: ['README.md', 'src/index.mjs'],
+    dependencies: ['@blade-ai/agent-sdk'],
+  },
+  web: {
+    budgetMs: 2 * 60 * 1_000,
+    expectedOutput: 'AgentServer received: minimal web starter smoke',
+    files: ['README.md', 'src/server.mjs', 'web/index.html', 'web/client.js'],
+    dependencies: ['@blade-ai/agent-sdk', 'esbuild'],
+  },
+  production: {
+    budgetMs: 5 * 60 * 1_000,
+    expectedOutput: 'Docker worker received: single-command production path',
+    files: [
+      'compose.yaml',
+      'README.md',
+      'src/server.mjs',
+      'src/QueuedSessionExecutor.mjs',
+      'src/DockerPromptRunner.mjs',
+      'web/index.html',
+      'web/client.js',
+    ],
+    dependencies: ['@blade-ai/agent-sdk', 'esbuild', 'pg'],
+  },
+};
 
-async function run(command, args, cwd, timeout = budgetMs) {
+async function run(command, args, cwd, timeout = 5 * 60 * 1_000) {
   try {
     return await execFileAsync(command, args, {
       cwd,
@@ -41,6 +65,73 @@ async function run(command, args, cwd, timeout = budgetMs) {
       ].filter(Boolean).join('\n'),
     );
   }
+}
+
+async function verifyProject(directory, preset, tarball) {
+  const contract = presetContracts[preset];
+  const manifest = JSON.parse(
+    await readFile(join(directory, 'package.json'), 'utf8'),
+  );
+  if (manifest.dependencies?.['@blade-ai/agent-sdk'] !== `file:${tarball}`) {
+    throw new Error(`${preset} project did not use the requested SDK package`);
+  }
+  const dependencyNames = Object.keys(manifest.dependencies ?? {}).sort();
+  if (JSON.stringify(dependencyNames) !== JSON.stringify(contract.dependencies)) {
+    throw new Error(
+      `${preset} dependencies were ${JSON.stringify(dependencyNames)}; `
+      + `expected ${JSON.stringify(contract.dependencies)}`,
+    );
+  }
+  for (const path of contract.files) {
+    await readFile(join(directory, path));
+  }
+}
+
+async function verifyPreset(preset, tarball) {
+  const contract = presetContracts[preset];
+  const directory = join(temporaryRoot, `${preset}-agent`);
+  const startedAt = performance.now();
+  const result = await run(
+    'npm',
+    [
+      'exec',
+      '--',
+      'create-blade-agent',
+      directory,
+      '--preset',
+      preset,
+      '--package-manager',
+      'npm',
+      '--sdk-version',
+      `file:${tarball}`,
+      '--verify',
+    ],
+    launcherDirectory,
+    contract.budgetMs + 15_000,
+  );
+  const elapsedMs = Math.round((performance.now() - startedAt) * 100) / 100;
+  if (elapsedMs > contract.budgetMs) {
+    throw new Error(
+      `${preset} first result took ${elapsedMs}ms; budget is ${contract.budgetMs}ms`,
+    );
+  }
+  if (
+    !result.stdout.includes(contract.expectedOutput)
+    || !result.stdout.includes(`Verified ${preset} first result`)
+  ) {
+    throw new Error(`${preset} smoke output was incomplete:\n${result.stdout}`);
+  }
+  await verifyProject(directory, preset, tarball);
+  await run(
+    'npm',
+    ['audit', '--omit=dev', '--audit-level', 'low'],
+    directory,
+  );
+  return {
+    preset,
+    elapsedMs,
+    budgetMs: contract.budgetMs,
+  };
 }
 
 try {
@@ -70,6 +161,7 @@ try {
     ],
     launcherDirectory,
   );
+
   const expectedVersion = JSON.parse(
     await readFile(join(repoRoot, 'package.json'), 'utf8'),
   ).version;
@@ -85,6 +177,41 @@ try {
       `Installed create-blade-agent reported ${installedVersion}; expected ${expectedVersion}`,
     );
   }
+  const help = (
+    await run(
+      'npm',
+      ['exec', '--', 'create-blade-agent', '--help'],
+      launcherDirectory,
+    )
+  ).stdout;
+  if (!help.includes('--preset <local|web|production>')) {
+    throw new Error(`Installed CLI help did not document presets:\n${help}`);
+  }
+  let unsupportedPresetError;
+  try {
+    await run(
+      'npm',
+      [
+        'exec',
+        '--',
+        'create-blade-agent',
+        '--preset',
+        'edge',
+        '--skip-install',
+      ],
+      launcherDirectory,
+    );
+  } catch (error) {
+    unsupportedPresetError = error;
+  }
+  if (
+    !(unsupportedPresetError instanceof Error)
+    || !unsupportedPresetError.message.includes('Unsupported starter preset: edge')
+  ) {
+    throw new Error('Installed CLI accepted an unsupported starter preset');
+  }
+
+  const filesOnlyDirectory = join(temporaryRoot, 'files-only-agent');
   const filesOnly = await run(
     'npm',
     [
@@ -106,62 +233,17 @@ try {
   ) {
     throw new Error(`Files-only next steps were incomplete:\n${filesOnly.stdout}`);
   }
-  const remainingMs = Math.max(
-    1,
-    Math.floor(budgetMs - (performance.now() - startedAt)),
-  );
-  const result = await run(
-    'npm',
-    [
-      'exec',
-      '--',
-      'create-blade-agent',
-      projectDirectory,
-      '--package-manager',
-      'npm',
-      '--sdk-version',
-      `file:${tarball}`,
-      '--verify',
-    ],
-    launcherDirectory,
-    remainingMs,
-  );
+  await verifyProject(filesOnlyDirectory, 'production', tarball);
 
-  const manifest = JSON.parse(
-    await readFile(join(projectDirectory, 'package.json'), 'utf8'),
-  );
-  if (manifest.dependencies?.['@blade-ai/agent-sdk'] !== `file:${tarball}`) {
-    throw new Error('Generated project did not use the requested SDK package');
-  }
-  for (const path of [
-    'compose.yaml',
-    'README.md',
-    'src/server.mjs',
-    'src/QueuedSessionExecutor.mjs',
-    'src/DockerPromptRunner.mjs',
-    'web/index.html',
-    'web/client.js',
-  ]) {
-    await readFile(join(projectDirectory, path));
-  }
-  if (!result.stdout.includes('Docker worker received: single-command production path')) {
-    throw new Error(`Generated smoke output was incomplete:\n${result.stdout}`);
-  }
-  await run(
-    'npm',
-    ['audit', '--omit=dev', '--audit-level', 'low'],
-    projectDirectory,
-  );
-  const elapsedMs = Math.round((performance.now() - startedAt) * 100) / 100;
-  if (elapsedMs > budgetMs) {
-    throw new Error(`Generated first result took ${elapsedMs}ms; budget is ${budgetMs}ms`);
+  const results = [];
+  for (const preset of ['local', 'web', 'production']) {
+    results.push(await verifyPreset(preset, tarball));
   }
   process.stdout.write(
     `${JSON.stringify(
       {
         status: 'ok',
-        elapsedMs,
-        budgetMs,
+        presets: results,
       },
       null,
       2,

--- a/src/__tests__/packageEntrypoints.test.ts
+++ b/src/__tests__/packageEntrypoints.test.ts
@@ -106,9 +106,11 @@ describe('package entrypoints', () => {
     });
     expect(packageJson.files).toEqual(
       expect.arrayContaining([
+        'examples/local-cli-agent/index.mjs',
         'examples/production-stack',
         'examples/web-agent-server/client.js',
         'examples/web-agent-server/index.html',
+        'examples/web-agent-server/server.mjs',
       ]),
     );
     expect(existsSync(join(process.cwd(), 'src/cli/create-blade-agent.ts'))).toBe(true);

--- a/src/cli/__tests__/createBladeAgent.test.ts
+++ b/src/cli/__tests__/createBladeAgent.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -48,8 +48,10 @@ describe('createBladeAgent', () => {
     });
     expect(result).toMatchObject({
       packageManager: 'pnpm',
+      preset: 'production',
       installed: false,
       verified: false,
+      budgetMs: 300_000,
     });
 
     const server = await readFile(join(result.directory, 'src/server.mjs'), 'utf8');
@@ -60,6 +62,76 @@ describe('createBladeAgent', () => {
       '@blade-ai/agent-sdk/browser',
     );
     expect(await readFile(join(result.directory, 'README.md'), 'utf8')).toContain('pnpm run smoke');
+  });
+
+  it('generates a dependency-minimal local project', async () => {
+    const cwd = await temporaryDirectory();
+    const result = await createBladeAgent({
+      cwd,
+      directory: 'local-agent',
+      packageManager: 'npm',
+      preset: 'local',
+      sdkSpecifier: 'file:/tmp/blade-agent-sdk.tgz',
+      skipInstall: true,
+    });
+
+    const manifest = JSON.parse(await readFile(join(result.directory, 'package.json'), 'utf8'));
+    expect(manifest).toMatchObject({
+      scripts: {
+        start: 'node src/index.mjs',
+        smoke: 'node src/index.mjs --smoke',
+      },
+      dependencies: {
+        '@blade-ai/agent-sdk': 'file:/tmp/blade-agent-sdk.tgz',
+      },
+    });
+    expect(Object.keys(manifest.dependencies)).toEqual(['@blade-ai/agent-sdk']);
+    expect(result).toMatchObject({
+      preset: 'local',
+      budgetMs: 60_000,
+    });
+    const entrypoint = await readFile(join(result.directory, 'src/index.mjs'), 'utf8');
+    expect(entrypoint).toContain('@blade-ai/agent-sdk/node');
+    expect(entrypoint).toContain('const persistSession = false;');
+    expect(await readFile(join(result.directory, 'README.md'), 'utf8')).toMatch(
+      /no\s+PostgreSQL or Docker/,
+    );
+  });
+
+  it('generates a browser and in-process server project without PostgreSQL', async () => {
+    const cwd = await temporaryDirectory();
+    const result = await createBladeAgent({
+      cwd,
+      directory: 'web-agent',
+      packageManager: 'npm',
+      preset: 'web',
+      sdkSpecifier: 'file:/tmp/blade-agent-sdk.tgz',
+      skipInstall: true,
+    });
+
+    const manifest = JSON.parse(await readFile(join(result.directory, 'package.json'), 'utf8'));
+    expect(manifest).toMatchObject({
+      scripts: {
+        start: 'node src/server.mjs',
+        smoke: 'node src/server.mjs --smoke',
+      },
+      dependencies: {
+        '@blade-ai/agent-sdk': 'file:/tmp/blade-agent-sdk.tgz',
+        esbuild: '0.28.2',
+      },
+    });
+    expect(manifest.dependencies).not.toHaveProperty('pg');
+    expect(result).toMatchObject({
+      preset: 'web',
+      budgetMs: 120_000,
+    });
+    const server = await readFile(join(result.directory, 'src/server.mjs'), 'utf8');
+    expect(server).toContain("const webRoot = join(root, '../web');");
+    expect(server).toContain("const generated = join(root, '../.generated');");
+    expect(server).toContain('AgentServer');
+    expect(await readFile(join(result.directory, 'web/client.js'), 'utf8')).toContain(
+      '@blade-ai/agent-sdk/browser',
+    );
   });
 
   it('refuses to overwrite a non-empty target directory', async () => {
@@ -86,5 +158,15 @@ describe('createBladeAgent', () => {
         verify: true,
       }),
     ).rejects.toThrow('--verify cannot be combined with --skip-install');
+  });
+
+  it('rejects unsupported presets from JavaScript callers', async () => {
+    await expect(
+      createBladeAgent({
+        cwd: await temporaryDirectory(),
+        preset: 'edge' as never,
+        skipInstall: true,
+      }),
+    ).rejects.toThrow('Unsupported starter preset: edge');
   });
 });

--- a/src/cli/create-blade-agent.ts
+++ b/src/cli/create-blade-agent.ts
@@ -4,14 +4,16 @@ import {
   createBladeAgent,
   type CreateBladeAgentOptions,
   type CreateBladeAgentPackageManager,
+  type CreateBladeAgentPreset,
   getBladeAgentSdkVersion,
 } from './createBladeAgent.js';
 
 const HELP = `create-blade-agent [directory] [options]
 
-Create a runnable Browser → AgentServer → PostgreSQL → AgentWorker → Docker project.
+Create a runnable local, Web, or production Agent project.
 
 Options:
+  --preset <local|web|production>        Starter topology (default: production)
   --package-manager <npm|pnpm|yarn|bun>  Package manager used for installation
   --sdk-version <version-or-specifier>   SDK dependency (defaults to this CLI version)
   --skip-install                        Generate files without installing dependencies
@@ -41,9 +43,17 @@ function parsePackageManager(value: string): CreateBladeAgentPackageManager {
   throw new Error(`Unsupported package manager: ${value}`);
 }
 
+function parsePreset(value: string): CreateBladeAgentPreset {
+  if (value === 'local' || value === 'web' || value === 'production') {
+    return value;
+  }
+  throw new Error(`Unsupported starter preset: ${value}`);
+}
+
 export function parseCreateBladeAgentArgs(args: readonly string[]): ParsedArguments {
   let directory: string | undefined;
   let packageManager: CreateBladeAgentPackageManager | undefined;
+  let preset: CreateBladeAgentPreset | undefined;
   let sdkSpecifier: string | undefined;
   let skipInstall = false;
   let verify = false;
@@ -73,6 +83,11 @@ export function parseCreateBladeAgentArgs(args: readonly string[]): ParsedArgume
       index += 1;
       continue;
     }
+    if (argument === '--preset') {
+      preset = parsePreset(requiredValue(args, index, argument));
+      index += 1;
+      continue;
+    }
     if (argument === '--sdk-version') {
       sdkSpecifier = requiredValue(args, index, argument);
       index += 1;
@@ -80,6 +95,10 @@ export function parseCreateBladeAgentArgs(args: readonly string[]): ParsedArgume
     }
     if (argument?.startsWith('--package-manager=')) {
       packageManager = parsePackageManager(argument.slice('--package-manager='.length));
+      continue;
+    }
+    if (argument?.startsWith('--preset=')) {
+      preset = parsePreset(argument.slice('--preset='.length));
       continue;
     }
     if (argument?.startsWith('--sdk-version=')) {
@@ -101,6 +120,7 @@ export function parseCreateBladeAgentArgs(args: readonly string[]): ParsedArgume
     options: {
       ...(directory ? { directory } : {}),
       ...(packageManager ? { packageManager } : {}),
+      ...(preset ? { preset } : {}),
       ...(sdkSpecifier ? { sdkSpecifier } : {}),
       skipInstall,
       verify,
@@ -128,7 +148,7 @@ export async function runCreateBladeAgentCli(args = process.argv.slice(2)): Prom
     [
       `Created ${result.directory}`,
       result.verified
-        ? `Verified first result in ${(result.elapsedMs / 1000).toFixed(2)}s`
+        ? `Verified ${result.preset} first result in ${(result.elapsedMs / 1000).toFixed(2)}s`
         : [`Next in ${result.directory}:`, ...next].join('\n'),
       '',
     ].join('\n'),

--- a/src/cli/createBladeAgent.ts
+++ b/src/cli/createBladeAgent.ts
@@ -1,18 +1,25 @@
 import { spawn } from 'node:child_process';
-import { mkdir, readFile, readdir, writeFile } from 'node:fs/promises';
+import { mkdir, readdir, readFile, writeFile } from 'node:fs/promises';
 import { basename, dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const DEFAULT_DIRECTORY = 'blade-agent';
-const FIRST_SUCCESS_BUDGET_MS = 5 * 60 * 1_000;
+const DEFAULT_PRESET: CreateBladeAgentPreset = 'production';
+const FIRST_SUCCESS_BUDGET_MS: Readonly<Record<CreateBladeAgentPreset, number>> = {
+  local: 60 * 1_000,
+  web: 2 * 60 * 1_000,
+  production: 5 * 60 * 1_000,
+};
 const PACKAGE_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
 
 export type CreateBladeAgentPackageManager = 'npm' | 'pnpm' | 'yarn' | 'bun';
+export type CreateBladeAgentPreset = 'local' | 'web' | 'production';
 
 export interface CreateBladeAgentOptions {
   readonly directory?: string;
   readonly cwd?: string;
   readonly packageManager?: CreateBladeAgentPackageManager;
+  readonly preset?: CreateBladeAgentPreset;
   readonly sdkSpecifier?: string;
   readonly skipInstall?: boolean;
   readonly verify?: boolean;
@@ -21,8 +28,10 @@ export interface CreateBladeAgentOptions {
 export interface CreateBladeAgentResult {
   readonly directory: string;
   readonly packageManager: CreateBladeAgentPackageManager;
+  readonly preset: CreateBladeAgentPreset;
   readonly installed: boolean;
   readonly verified: boolean;
+  readonly budgetMs: number;
   readonly elapsedMs: number;
 }
 
@@ -37,10 +46,11 @@ interface ProcessOptions {
   readonly timeoutMs?: number;
 }
 
-function remainingFirstSuccessBudget(startedAt: number): number {
-  const remainingMs = Math.floor(FIRST_SUCCESS_BUDGET_MS - (performance.now() - startedAt));
+function remainingFirstSuccessBudget(startedAt: number, preset: CreateBladeAgentPreset): number {
+  const budgetMs = FIRST_SUCCESS_BUDGET_MS[preset];
+  const remainingMs = Math.floor(budgetMs - (performance.now() - startedAt));
   if (remainingMs <= 0) {
-    throw new Error('Project setup exceeded the five-minute first-success budget');
+    throw new Error(`${preset} project setup exceeded its ${budgetMs}ms first-success budget`);
   }
   return remainingMs;
 }
@@ -50,6 +60,14 @@ function detectPackageManager(
 ): CreateBladeAgentPackageManager {
   const name = userAgent?.split('/')[0];
   return name === 'pnpm' || name === 'yarn' || name === 'bun' ? name : 'npm';
+}
+
+function resolvePreset(preset: CreateBladeAgentPreset | undefined): CreateBladeAgentPreset {
+  const value = preset ?? DEFAULT_PRESET;
+  if (value === 'local' || value === 'web' || value === 'production') {
+    return value;
+  }
+  throw new TypeError(`Unsupported starter preset: ${String(value)}`);
 }
 
 function packageName(directory: string): string {
@@ -121,8 +139,13 @@ export async function getBladeAgentSdkVersion(): Promise<string> {
   return (await readManifest()).version;
 }
 
-async function copyTemplate(directory: string): Promise<void> {
-  const sourceRoot = join(PACKAGE_ROOT, 'examples');
+async function copyFile(sourceRoot: string, directory: string, source: string, target: string) {
+  const destination = join(directory, target);
+  await mkdir(dirname(destination), { recursive: true });
+  await writeFile(destination, await readFile(join(sourceRoot, source)));
+}
+
+async function copyProductionTemplate(sourceRoot: string, directory: string): Promise<void> {
   const files = [
     {
       source: 'production-stack/QueuedSessionExecutor.mjs',
@@ -147,9 +170,7 @@ async function copyTemplate(directory: string): Promise<void> {
   ] as const;
 
   for (const file of files) {
-    const target = join(directory, file.target);
-    await mkdir(dirname(target), { recursive: true });
-    await writeFile(target, await readFile(join(sourceRoot, file.source)));
+    await copyFile(sourceRoot, directory, file.source, file.target);
   }
 
   const runnerSource = await readFile(join(sourceRoot, 'production-stack/run.mjs'), 'utf8');
@@ -173,6 +194,54 @@ async function copyTemplate(directory: string): Promise<void> {
   await writeFile(join(directory, 'src/server.mjs'), runner);
 }
 
+async function copyWebTemplate(sourceRoot: string, directory: string): Promise<void> {
+  for (const file of [
+    ['web-agent-server/index.html', 'web/index.html'],
+    ['web-agent-server/client.js', 'web/client.js'],
+  ] as const) {
+    await copyFile(sourceRoot, directory, file[0], file[1]);
+  }
+  const serverSource = await readFile(join(sourceRoot, 'web-agent-server/server.mjs'), 'utf8');
+  for (const marker of ['const webRoot = root;', "const generated = join(root, '.generated');"]) {
+    if (!serverSource.includes(marker)) {
+      throw new Error(`Web template marker is missing: ${marker}`);
+    }
+  }
+  const server = serverSource
+    .replace('const webRoot = root;', "const webRoot = join(root, '../web');")
+    .replace(
+      "const generated = join(root, '.generated');",
+      "const generated = join(root, '../.generated');",
+    );
+  await mkdir(join(directory, 'src'), { recursive: true });
+  await writeFile(join(directory, 'src/server.mjs'), server);
+}
+
+async function copyTemplate(directory: string, preset: CreateBladeAgentPreset): Promise<void> {
+  const sourceRoot = join(PACKAGE_ROOT, 'examples');
+  if (preset === 'local') {
+    const localSource = await readFile(
+      join(sourceRoot, 'local-cli-agent/index.mjs'),
+      'utf8',
+    );
+    const marker = 'const persistSession = true;';
+    if (!localSource.includes(marker)) {
+      throw new Error(`Local template marker is missing: ${marker}`);
+    }
+    await mkdir(join(directory, 'src'), { recursive: true });
+    await writeFile(
+      join(directory, 'src/index.mjs'),
+      localSource.replace(marker, 'const persistSession = false;'),
+    );
+    return;
+  }
+  if (preset === 'web') {
+    await copyWebTemplate(sourceRoot, directory);
+    return;
+  }
+  await copyProductionTemplate(sourceRoot, directory);
+}
+
 function readDependency(
   dependencies: Readonly<Record<string, string>> | undefined,
   name: string,
@@ -184,11 +253,97 @@ function readDependency(
   return version;
 }
 
-function readme(name: string, packageManager: CreateBladeAgentPackageManager): string {
-  const run = packageManager === 'yarn' ? 'yarn' : `${packageManager} run`;
+function scripts(preset: CreateBladeAgentPreset): Readonly<Record<string, string>> {
+  if (preset === 'local') {
+    return {
+      start: 'node src/index.mjs',
+      smoke: 'node src/index.mjs --smoke',
+    };
+  }
+  return {
+    start: 'node src/server.mjs',
+    smoke: 'node src/server.mjs --smoke',
+  };
+}
+
+function dependencies(
+  preset: CreateBladeAgentPreset,
+  manifest: PackageManifest,
+  sdkSpecifier: string,
+): Readonly<Record<string, string>> {
+  return {
+    '@blade-ai/agent-sdk': sdkSpecifier,
+    ...(preset === 'web' || preset === 'production'
+      ? { esbuild: readDependency(manifest.devDependencies, 'esbuild') }
+      : {}),
+    ...(preset === 'production' ? { pg: readDependency(manifest.peerDependencies, 'pg') } : {}),
+  };
+}
+
+function localReadme(name: string, run: string): string {
   return `# ${name}
 
-Generated by \`create-blade-agent\`.
+Generated by \`create-blade-agent --preset local\`.
+
+Requires Node.js 22.14 or later. Run with OpenAI:
+
+\`\`\`bash
+OPENAI_API_KEY=... ${run} start -- "Summarize this repository"
+\`\`\`
+
+Run the offline first-result check:
+
+\`\`\`bash
+${run} smoke
+\`\`\`
+
+This preset uses \`@blade-ai/agent-sdk/node\` with an in-memory Session and no
+PostgreSQL or Docker. Move to the \`web\` or \`production\` preset when the
+Agent must serve remote clients.
+`;
+}
+
+function webReadme(name: string, run: string): string {
+  return `# ${name}
+
+Generated by \`create-blade-agent --preset web\`.
+
+Requires Node.js 22.14 or later.
+
+## Run
+
+\`\`\`bash
+${run} start
+\`\`\`
+
+Open the printed URL and send a prompt. Without \`OPENAI_API_KEY\`, the server
+uses a deterministic local provider. Set \`OPENAI_API_KEY\` and optionally
+\`OPENAI_MODEL\` to use OpenAI.
+
+Run the non-interactive two-minute acceptance check with:
+
+\`\`\`bash
+${run} smoke
+\`\`\`
+
+The request traverses:
+
+\`\`\`text
+Browser AgentClient
+→ AgentServer
+→ in-process Session
+→ SSE
+\`\`\`
+
+This scaffold is for local development. Replace the demo authentication
+callback before exposing it on a network.
+`;
+}
+
+function productionReadme(name: string, run: string): string {
+  return `# ${name}
+
+Generated by \`create-blade-agent --preset production\`.
 
 Requires Node.js 22.14 or later and Docker with the Compose plugin.
 
@@ -226,6 +381,21 @@ network.
 `;
 }
 
+function readme(
+  name: string,
+  packageManager: CreateBladeAgentPackageManager,
+  preset: CreateBladeAgentPreset,
+): string {
+  const run = packageManager === 'yarn' ? 'yarn' : `${packageManager} run`;
+  if (preset === 'local') {
+    return localReadme(name, run);
+  }
+  if (preset === 'web') {
+    return webReadme(name, run);
+  }
+  return productionReadme(name, run);
+}
+
 export async function createBladeAgent(
   options: CreateBladeAgentOptions = {},
 ): Promise<CreateBladeAgentResult> {
@@ -236,6 +406,7 @@ export async function createBladeAgent(
   const cwd = resolve(options.cwd ?? process.cwd());
   const directory = resolve(cwd, options.directory ?? DEFAULT_DIRECTORY);
   const packageManager = options.packageManager ?? detectPackageManager();
+  const preset = resolvePreset(options.preset);
   const manifest = await readManifest();
   const sdkSpecifier = options.sdkSpecifier ?? manifest.version;
   if (!sdkSpecifier.trim()) {
@@ -243,7 +414,7 @@ export async function createBladeAgent(
   }
 
   await assertEmptyDirectory(directory);
-  await copyTemplate(directory);
+  await copyTemplate(directory, preset);
   const name = packageName(directory);
   await writeFile(
     join(directory, 'package.json'),
@@ -256,45 +427,41 @@ export async function createBladeAgent(
         engines: {
           node: '>=22.14.0',
         },
-        scripts: {
-          start: 'node src/server.mjs',
-          smoke: 'node src/server.mjs --smoke',
-        },
-        dependencies: {
-          '@blade-ai/agent-sdk': sdkSpecifier,
-          esbuild: readDependency(manifest.devDependencies, 'esbuild'),
-          pg: readDependency(manifest.peerDependencies, 'pg'),
-        },
+        scripts: scripts(preset),
+        dependencies: dependencies(preset, manifest, sdkSpecifier),
       },
       null,
       2,
     )}\n`,
   );
-  await writeFile(join(directory, '.gitignore'), 'node_modules/\n.generated/\n.env\n*.log\n');
-  await writeFile(join(directory, 'README.md'), readme(name, packageManager));
+  await writeFile(
+    join(directory, '.gitignore'),
+    'node_modules/\n.data/\n.generated/\n.env\n*.log\n',
+  );
+  await writeFile(join(directory, 'README.md'), readme(name, packageManager, preset));
 
   if (!options.skipInstall) {
     const [command, args] = commandFor(packageManager);
     await runProcess(command, args, {
       cwd: directory,
-      ...(options.verify
-        ? { timeoutMs: remainingFirstSuccessBudget(startedAt) }
-        : {}),
+      ...(options.verify ? { timeoutMs: remainingFirstSuccessBudget(startedAt, preset) } : {}),
     });
   }
   if (options.verify) {
     const [command, args] = commandFor(packageManager, 'smoke');
     await runProcess(command, args, {
       cwd: directory,
-      timeoutMs: remainingFirstSuccessBudget(startedAt),
+      timeoutMs: remainingFirstSuccessBudget(startedAt, preset),
     });
   }
 
   return {
     directory,
     packageManager,
+    preset,
     installed: !options.skipInstall,
     verified: options.verify ?? false,
+    budgetMs: FIRST_SUCCESS_BUDGET_MS[preset],
     elapsedMs: Math.round((performance.now() - startedAt) * 100) / 100,
   };
 }


### PR DESCRIPTION
## Summary
- add `local`, `web`, and `production` presets to `create-blade-agent` while preserving the production default
- enforce preset-specific dependency surfaces and 1/2/5-minute first-result budgets
- verify every preset from the packed SDK, including production dependency audits
- document the progressive local → Web → production onboarding path in both locales

## Verification
- `pnpm run verify:create-agent`
  - local: 4.23s / 60s
  - web: 5.00s / 120s
  - production: 13.37s / 300s
- real browser: Browser AgentClient → AgentServer → SSE result rendered
- real PostgreSQL + Docker full suite: 1862 passed, 63 skipped
- `pnpm run lint`
- `pnpm run type-check`
- `pnpm run docs:build`
- package entrypoint and minimal-install verification
- production dependency audit


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `local`, `web`, and `production` starter presets to the project creation CLI.
  * Added preset-specific templates, dependencies, verification budgets, and generated documentation.
  * Added CLI support for selecting presets with `--preset`, while retaining production as the default.
  * Added smoke-test support for local and web examples, including streamed-result validation.

* **Documentation**
  * Updated English and Chinese guides with preset options, workflows, commands, and verification details.

* **Tests**
  * Expanded coverage to validate all presets, generated projects, CLI errors, and published example entry points.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->